### PR TITLE
do not use `sed -i' in ssrcoqdep -- this is not portable

### DIFF
--- a/etc/utils/ssrcoqdep
+++ b/etc/utils/ssrcoqdep
@@ -13,7 +13,7 @@ case $key in
     *.v)
 	mkdir -p $(dirname bkpcoqdep/$key)
         cp $key bkpcoqdep/$key
-	sed "s/^From.*//" -i $key
+        sed "s/^From.*//" bkpcoqdep/$key > $key
     ;;
     *)
     ;;


### PR DESCRIPTION
This prevents compilation of ssreflect on OS-X/*BSD.