### PR TITLE
Removing calls of "Context.Named.Declaration.{of,to}_tuple" functions

### DIFF
--- a/mathcomp/ssreflect/plugin/trunk/ssreflect.ml4
+++ b/mathcomp/ssreflect/plugin/trunk/ssreflect.ml4
@@ -2090,15 +2090,11 @@ let abs_wgen keep_let ist f gen (gl,args,c) =
   match gen with
   | _, Some ((x, mode), None) when mode = "@" || (mode = " " && keep_let) ->
      let x = hoi_id x in
-     (match pf_get_hyp gl x with
-     | LocalAssum (_,ty) ->
-         gl,
-         mkVar x :: args,
-         mkProd_or_LetIn (RelDecl.LocalAssum (Name (f x),ty)) (subst_var x c)
-     | LocalDef (_,b,ty) ->
-         gl,
-         args,
-         mkProd_or_LetIn (RelDecl.LocalDef (Name (f x),b,ty)) (subst_var x c))
+     let decl = pf_get_hyp gl x in
+     gl,
+     (if NamedDecl.is_local_def decl then args else mkVar x :: args),
+     mkProd_or_LetIn (decl |> NamedDecl.to_rel |> RelDecl.set_name (Name (f x)))
+                     (subst_var x c)
   | _, Some ((x, _), None) ->
      let x = hoi_id x in
      gl, mkVar x :: args, mkProd (Name (f x),pf_get_hyp_typ gl x, subst_var x c)


### PR DESCRIPTION
Coq trunk currently provides these two functions:
```
Context.Named.Declaration.of_tuple
Context.Named.Declaration.to_tuple
```

These were temporarily defined to enable safe transition from the old definition of the `Context.Named.t` datatype to the new one. These functions now are no longer either necessary or beneficial.

In this pull-request I propose one possible way how to get rid of them and get the full benefit of the new representation. Primarily, __the reader__ will have zero doubt:
- what is being constructed
- what is being destructed (and the meaning of particular bound variables).