### PR TITLE
[field] Remove unnecessary use of `Program Definition` use

### DIFF
--- a/mathcomp/field/algC.v
+++ b/mathcomp/field/algC.v
@@ -445,8 +445,8 @@ rewrite -(fmorph_root CtoL_rmorphism) -map_poly_comp; congr (root _ _): pu0.
 by apply/esym/eq_map_poly; apply: fmorph_eq_rat.
 Qed.
 
-Program Definition conjMixin :=
-  ImaginaryMixin (svalP (imaginary_exists closedFieldType)) 
+Definition conjMixin :=
+  ImaginaryMixin (svalP (imaginary_exists closedFieldType))
                  (fun x => esym (normK x)).
 Canonical numClosedFieldType := NumClosedFieldType type conjMixin.
 


### PR DESCRIPTION
Simple `Definition` should work fine here.

This avoids the problem:

`Error: Library Coq.Program.Tactics has to be required first.`

in math-comp versions that depends on a minimal (or no) Coq stdlib.

Tested on 8.5/8.6