### PR TITLE
Add direct link to the archives to help google indexing.

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,8 @@ The Ssreflect language comes with a dedicated
 Interested?
 <a href="mailto:sympa@inria.fr?subject=SUBSCRIBE%20ssreflect">Subscribe to the ssreflect mailing list</a>
 and let us know what you are using our libraries for, ask questions, etc.
-You can also browse the <a href="https://sympa.inria.fr/sympa/info/ssreflect">archives of the list</a>.
+You can also browse the <a href="https://sympa.inria.fr/sympa/arc/ssreflect">archives of the list</a> or consult the
+<a href="https://sympa.inria.fr/sympa/info/ssreflect">general information page</a>.
 </p>
 <h3>
 <a id="authors-and-contributors" class="anchor" href="#authors-and-contributors" aria-hidden="true"><span class="octicon octicon-link"></span></a>Authors and Contributors</h3>


### PR DESCRIPTION
The information page is forbidden by INRIA robots so we may want to hint
google where the accessible archives are.