### PR TITLE
[travis] Add initial Travis CI support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+dist: trusty
+sudo: required
+language: c
+cache:
+  apt: true
+  directories:
+  - $HOME/.opam
+addons:
+  apt:
+    sources:
+    - avsm
+    packages:
+    - opam
+    - aspcud
+env:
+  global:
+  - NJOBS=2
+  # system is == 4.02.3
+  - COMPILER="system"
+  # Main test targets
+  matrix:
+  - TEST_TARGET="v8.5"
+  - TEST_TARGET="v8.6"
+  - TEST_TARGET="trunk"
+
+matrix:
+  allow_failures:
+  # v8.5 is too slow to build mathcomp
+  - env: TEST_TARGET="v8.5"
+
+install:
+- "[ -e .opam ] || opam init -j ${NJOBS} --compiler=${COMPILER} -n -y"
+- eval $(opam config env)
+- opam config var root
+- opam install -j ${NJOBS} -y ocamlfind camlp5 ${EXTRA_OPAM}
+- opam list
+# We could do "opam install coq=${TEST_TARGET}" but not so sure how
+# that does work for trunk.
+- git clone -b ${TEST_TARGET} git://scm.gforge.inria.fr/coq/coq.git coq-${TEST_TARGET}
+- cd coq-${TEST_TARGET}
+- ./configure -native-compiler no -local -coqide no
+- make -j ${NJOBS}
+- cd -
+
+script:
+- echo 'Building Mathcomp...' && echo -en 'travis_fold:start:mathcomp.build\\r'
+- export PATH=`pwd`/coq-${TEST_TARGET}/bin:$PATH
+- cd mathcomp
+# Full build takes too much time.
+- sed -i.bak '/odd_order/d' Make
+- make -j ${NJOBS}
+- echo -en 'travis_fold:end:mathcomp.build\\r'


### PR DESCRIPTION
This add travis CI to math-comp; caveats:

- only 8.6 and trunk are required to succeed, v8.5 is too slow to finish within Travis time limits.
- `odd_order` is not tested, only the main libraries, again due to Travis time limits.
