### PR TITLE
Use pp_with as msg_with is being removed upstream.

### DIFF
--- a/mathcomp/ssreflect/plugin/trunk/ssreflect.ml4
+++ b/mathcomp/ssreflect/plugin/trunk/ssreflect.ml4
@@ -197,7 +197,7 @@ let guard_term ch1 s i = match s.[i] with
 (* The call 'guard s i' should return true if the contents of s *)
 (* starting at i need bracketing to avoid ambiguities.          *)
 let pr_guarded guard prc c =
-  msg_with Format.str_formatter (prc c);
+  pp_with Format.str_formatter (prc c);
   let s = Format.flush_str_formatter () ^ "$" in
   if guard s (skip_wschars s 0) then pr_paren prc c else prc c
 (* More sensible names for constr printers *)


### PR DESCRIPTION
We are proposing to deprecate `msg_with` as it has a different purpose than the rest of `msg_*` functions. This change has no functional impact (`Pp.pp_with` doesn't flush but the ssr code does flush just after use).