### PR TITLE
fix Coq version detection on Windows, and in case there are warnings

### DIFF
--- a/mathcomp/ssreflect/Makefile.detect-coq-version
+++ b/mathcomp/ssreflect/Makefile.detect-coq-version
@@ -8,7 +8,7 @@ BRANCH_coq = $(shell $(COQBIN)coqtop -v | head -1 \
 	     | sed 's/.*version \([0-9]\.[0-9]\)[^ ]* .*/v\1/')
 endif
 
-HASH_coq = $(shell echo Quit. | $(COQBIN)coqtop 2>&1 | head -1 \
+HASH_coq = $(shell echo Quit. | $(COQBIN)coqtop 2>/dev/null | head -1 \
 	   | sed 's/^.*(\([a-f0-9]*\)).*/\1/' )
 
 HASH_coq_v85beta1 = eaa3d0b15adf4eb11ffb00ab087746a5b15c4d5d


### PR DESCRIPTION
stderr (where warnings go) should be thrown away, not kept around. This also happens to fix a strange and unexplainable Windows bug...

Fixes #142