### PR TITLE
using opam in travis before_install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: required
 language: c
 cache:
   apt: true
-  directories:
-  - $HOME/.opam
 addons:
   apt:
     sources:
@@ -19,29 +17,24 @@ env:
   - COMPILER="system"
   # Main test targets
   matrix:
-  - TEST_TARGET="v8.5"
-  - TEST_TARGET="v8.6"
-  - TEST_TARGET="v8.7"
-  - TEST_TARGET="master"
+  - TEST_TARGET="8.5.dev"
+  - TEST_TARGET="8.6.dev"
+  - TEST_TARGET="8.7.dev"
+  - TEST_TARGET="dev"
 
 # matrix:
-#   allow_failures:
-  # v8.5 was too slow to build mathcomp
-  # - env: TEST_TARGET="v8.5"
+#  allow_failures:
+  # 8.5.dev is too slow to build mathcomp
+  # - env: TEST_TARGET="8.5.dev"
 
 install:
 - opam init -j ${NJOBS} --compiler=${COMPILER} -n -y
 - eval $(opam config env)
 - opam config var root
-- opam install -j ${NJOBS} -y ocamlfind camlp5 ${EXTRA_OPAM}
+- opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev || true
+- opam pin add -y -n coq -k version ${TEST_TARGET}
+- opam install -y -v -j ${NJOBS} coq ${EXTRA_OPAM}
 - opam list
-# We could do "opam install coq=${TEST_TARGET}" but not so sure how
-# that does work for trunk.
-- git clone --depth 1 -b ${TEST_TARGET} git://scm.gforge.inria.fr/coq/coq.git coq-${TEST_TARGET}
-- cd coq-${TEST_TARGET}
-- ./configure -native-compiler no -local -coqide no
-- make -j ${NJOBS}
-- cd -
 
 script:
 - echo 'Building Mathcomp...' && echo -en 'travis_fold:start:mathcomp.build\\r'


### PR DESCRIPTION
- simplifies the travis script 
- no caching as discussed in https://github.com/math-comp/math-comp/pull/104