### PR TITLE
Enable parallel build, fix #88

### DIFF
--- a/mathcomp/Makefile
+++ b/mathcomp/Makefile
@@ -15,7 +15,9 @@ else
 COQDEP=$(COQBIN)coqdep
 endif
 
-OLD_MAKEFLAGS:=$(MAKEFLAGS)
+HAS_B:=$(filter -B B,$(MAKEFLAGS))
+# OLD_MAKEFLAGS must use =, not :=, to capture MAKEFLAGS at call time
+OLD_MAKEFLAGS=$(if $(HAS_B),$(MAKEFLAGS),$(filter-out -B B,$(MAKEFLAGS)))
 MAKEFLAGS+=-B
 
 .DEFAULT_GOAL := all


### PR DESCRIPTION
Apparently, the jobserver flags don't show up until we're actually
executing a rule.  So rather than save the old flags, we instead record
whether or not we've seen -B before adding it (actually, whether we've
seen -B or B, since it seems that make stores B rather than -B in
MAKEFLAGS?), and then, later, we filter out B and -B only if we didn't
see them before we added them.