### PR TITLE
Add ssrmatching.v transitional file

### DIFF
--- a/mathcomp/Make
+++ b/mathcomp/Make
@@ -130,6 +130,7 @@ ssreflect/ssreflect.v
 ssreflect/ssrfun.v
 ssreflect/ssrnat.v
 ssreflect/ssrnotations.v
+ssreflect/ssrmatching.v
 ssreflect/tuple.v
 ssrtest/absevarprop.v
 ssrtest/abstract_var2.v

--- a/mathcomp/ssreflect/Make
+++ b/mathcomp/ssreflect/Make
@@ -18,6 +18,7 @@ path.v
 prime.v
 tuple.v
 ssrnotations.v
+ssrmatching.v
 
 -I .
 -R . mathcomp.ssreflect

--- a/mathcomp/ssreflect/Makefile.coq-makefile
+++ b/mathcomp/ssreflect/Makefile.coq-makefile
@@ -8,14 +8,14 @@ define coqmakefile
 		$$LN $(1)/plugin/$(V)/ssrmatching_plugin.mllib .;\
 		$$LN $(1)/plugin/$(V)/ssrmatching.mli .;\
 		$$LN $(1)/plugin/$(V)/ssrmatching.ml4 .;\
-		$$LN $(1)/plugin/$(V)/ssrmatching.v .;\
+		$$LN $(1)/plugin/$(V)/ssrmatching.v $(1)/;\
 		$$LN $(1)/plugin/$(V)/ssreflect_plugin.mllib .;\
 		$$LN $(1)/plugin/$(V)/ssreflect.ml4 .;\
 		$$LN $(1)/plugin/$(V)/ssrbool.v $(1)/;\
 		$$LN $(1)/plugin/$(V)/ssrfun.v $(1)/;\
 		$$LN $(1)/plugin/$(V)/ssreflect.v $(1)/;\
 		MLLIB="ssrmatching_plugin.mllib ssreflect_plugin.mllib";\
-		EXTRA="ssrmatching.mli ssrmatching.ml4 ssrmatching.v ssreflect.ml4";\
+		EXTRA="ssrmatching.mli ssrmatching.ml4 ssreflect.ml4";\
 	;;\
 	v8.6*)\
 		$$LN $(1)/plugin/$(V)/ssreflect_plugin.mlpack .;\

--- a/mathcomp/ssreflect/plugin/v8.6/ssreflect.v
+++ b/mathcomp/ssreflect/plugin/v8.6/ssreflect.v
@@ -1,7 +1,7 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 Require Import Bool. (* For bool_scope delimiter 'bool'. *)
-Require Import ssrmatching.
+From Coq Require Import ssrmatching.
 Declare ML Module "ssreflect_plugin".
 Set SsrAstVersion.
 

--- a/mathcomp/ssreflect/ssrmatching.v
+++ b/mathcomp/ssreflect/ssrmatching.v
@@ -1,0 +1,1 @@
+From Coq Require Export ssrmatching.


### PR DESCRIPTION
Dear math-comp devs,

As suggested in #63 I propose to add this version of file `ssrmatching.v` directly in folder `ssreflect`.

The content of this file is similar to that of [`ssrfun.v`](https://github.com/math-comp/math-comp/blob/master/mathcomp/ssreflect/ssrfun.v) and aims to increase compatibility with Coq 8.6+ for third-party libraries that depend on both math-comp and `ssrmatching.v`