### PR TITLE
[separable] put clear switch near view

### DIFF
--- a/mathcomp/field/separable.v
+++ b/mathcomp/field/separable.v
@@ -772,7 +772,7 @@ have sep_pKy: separable_poly (minPoly K y).
 have{sep_pKy} sep_q: separable_poly q by rewrite Dq separable_map in sep_pKy.
 have [r nz_r PETr] := large_field_PET nz_p px0 qy0 sep_q.
 have [[s [Us Ks /ltnW leNs]] | //] := finite_PET (size r).
-have{s Us Ks leNs} /allPn[t /Ks Kt nz_rt]: ~~ all (root r) s.
+have{s Us leNs} /allPn[t {Ks}/Ks Kt nz_rt]: ~~ all (root r) s.
   by apply: contraTN leNs; rewrite -ltnNge => /max_poly_roots->.
 have{PETr} [/= [p1 Dx] [q1 Dy]] := PETr (Subvs Kt) nz_rt.
 set z := t * y - x in Dx Dy; exists z; apply/eqP.


### PR DESCRIPTION
Dear devs, in an attempt to simplify the code of intro patterns we (@maximedenes & me) came up with a proposal that:
- simplifies the code of the plugin
- breaks only one line in the entire math-comp, the one fixed by this patch.

The code we want to simplify is the one deferring clear switches inside an intro pattern.
The implementation is tricky because just delaying the clear switch until the end of the pattern is not enough, for example:
```
move=> {x} /andP[x y].
```
In this case `x` is both cleared and used. In order to be able to use `x`, given that the clear has not been performed yet, we rename `x` into `_x_` (when `{x}` is executed) so that when `x` is later executed we can use the name `x`, and finally when `.` is executed we clear `_x_` instead of `x`.

Systematically "always rename now & clear later" seem to be OK, but it is not. The extra complication is that "rename" may break later intro pattern using terms as views. Eg
```
move=> {x} /andP[Ha Hb] /x.
```
What the code does today is:
- when `{x}` is executed look-ahead in the pattern and see if `x` is used as a name to be introduced
  - if so, "rename"
  - otherwise don't rename (just delay)

This way of doing things is not only complicated but also incomplete, Eg
```
move=> {x} /orP[x | /x].
```
would misbehave...

Anyway, the proposed behavior is:
- `{x}` always renames now and clears (the renamed) later
- `{clears}/views` is always "compiled" as `/views{clears}` (most of the occurrences in the library are OK with this simpler rule, but for the one fixed in this PR).
- bonus: support `{}/view` (as in `rewrite {}rule`) to signal that the immediately following `view` has to be cleared, that is `{}/v` compiles to `/v{v}`.

What do you think?