### PR TITLE
adding forms and spectral theorems

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -202,8 +202,80 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemmas `linear0l`, `linearNl`, `linearDl`, `linearBl`, `linearMnl`,
     `linearMNnl`, `linear_sumlz`, `linearZl_LR`, `linearPl`, `linearZl`,
     `linearZr`, `linearZlr`, `linearZrl`
-  
+  + lemma `mulmx_is_bilinear`
+  + definition `form`
+  + lemmas `form0l`, `form0r`, `formDl`, `formDr`, `formZr`, `formZl`,
+    `formNl`, `formNr`, `formee`, `form0_eq0`
+  + mixin `isHermitianSesquilinear`, structure `Hermitian`, notation `{hermitian _ fo _ & _}`
+  + definitions `orthomx`, `sesqui`, fact `sesqui_key`, canonical `sesqui_keyed`, notation `_.-sesqui`
+  + lemmas `sesquiE`, `sesquiP`, `trmx_sesqui`, `maptrmx_sesqui`, `formC`, `form_eq0C`
+  + definition `ortho`
+  + lemmas `normalE`, `form_eq0P`, `normalP`, `normalC`, `normal_ortho_mx`,
+    `normal_mx_ortho`, `rank_normal`
+  + defintion `rad`
+  + lemmas `rad_ker`, `formDd`, `formZ`, `formN`, `form_sign`, `formD`, `formB`, `formBd`
+  + notations `symmetric_form`, `skew`, `hermitian`
+  + mixin `isDotProduct`, structure `Dot`, notation `{dot _ for theta _}`
+  + notations `{symmetric _}`, `{skew_symmetric _}`, `{hermitian_sym _ for _}`
+  + definitions `is_skew`, `is_sym`, `is_hermsym`
+  + lemmas `hermC`, `hnormN`, `hnorm_sign`, `hnormD`, `hnormB`, `hnormDd`, `hnormBd`
+  + definition `ortho_rec`, fixpoint `pair_ortho_rec`, defintions `pairwise_orthogonal`, `orthogonal`,
+    `orthonormal`
+  + lemmas `orthogonal_cons`, `orthonormal_not0`, `orthonormalE`, `orthonormal_orthogonal`
+  + definitions `isometry`, `isometry_from_to`
+  + lemma `herm_eq0C`
+  + definition `orthov`
+  + lemmass `mem_orthovPn`, `mem_orthovP`, `orthov1E`, `orthovP`, `orthov_sym`, `mem_orthov1`,
+    `orthov11`, `mem_orthov1_sym`, `orthov0`, `mem_orthov_sym`, `leq_dim_orthov1`, `dim_img_form_eq1`,
+    `eq_dim_orthov1`, `dim_img_form_eq0`, `neq_dim_orthov1`, `leqif_dim_orthov1`, `leqif_dim_orthov1_full`,
+    `orthogonal1P`, `orthogonalP`, `orthogonal_oppr`, `orthogonalE`, `orthovE`, `orthoDv`,
+    `orthovD`
+  + definitons `nondegenerate`, `is_symplectic`, `is_orthogonal`, `is_unitary`
+  + lemmas `dnorm_geiff0`, `dnorm_ge0`, `dnorm_eq0`, `dnorm_gt0`, `sqrt_dnorm_ge0`,
+    `sqrt_dnorm_eq0`, `sqrt_dnorm_gt0`, `dnormZ`, `dnormD`, `dnormB`, `pairwise_orthogonalP`,
+    `pairwise_orthogonal_cat`, `orthonormal_cat`, `orthonormalP`, `sub_orthonormal`,
+    `orthonormal2P`, `orthonormal2P`, `orthogonal_free`, `filter_pairwise_orthogonal`,
+    `orthonormal_free`, `CauchySchwarzP`, `CauchySchwarz_sqrt`, `orthoP`, `orthoPl`,
+    `orthogonal_sym`, `orthoPr`, `orthogonal_catl`, `orthogonal_catr`, `eq_pairwise_orthogonal`,
+    `eq_orthonormal`, `orthogonal_oppl`, `triangle_lerif`, `span_orthogonal`, `orthogonal_split`,
+  + definitions `normf1`, `normf2`
+  + lemmas `isometry_of_dnorm`, `isometry_of_free`, `isometry_raddf_inj`
+  + definitons `form_of_matrix`, `matrix_of_form`, `form_of_matrixr`
+  + lemma `matrix_of_formE`, `form_of_matrix_is_bilinear`, `rV_formee`, `rV_form0_eq0`, `matrix_of_formK`
+  + definition `hermitianmx`, fact `hermitianmx_key`, canonical `hermitianmx_keyed`, structure `hermitian_matrix`
+  + lemmas `is_hermitianmxE`, `is_hermitianmxP`, `hermitianmxE`, `trmx_hermitian`, `maptrmx_hermitian`,
+    `form_of_matrix_is_hermitian`, `orthomxE`, `hermmx_eq0P`, `orthomxP`, `orthomx_sym`,
+    `ortho_ortho_mx`, `ortho_mx_ortho`, `rank_orthomx`, `radmxE`, `orthoNmx`, `orthomxN`, `orthoDmx`,
+    `orthomxD`, `orthoZmx`, `orthomxZ`, `eqmx_ortho`, `genmx_ortho`
+  + notations `symmetricmx`, `skewmx`, `hermsymmx`
+  + lemma `hermitian1mx_subproof`, canonical `hermitian1mx`
+
 - new file `spectral.v`
+  + lemmas `eigenvalue_closed`, `common_eigenvector`, `common_eigenvector2`
+  + notation `^t*`, `realmx`
+  + lemmas `trmxCK`, `realmxC`, `realmxD`, `Remx_rect`, `Immx_rect`, `eqmx_ReiIm`,
+    `realsym_hermsym`, `real_similar`
+  + definition `unitarymx`, fact `unitarymx_key`, canonical `unitarymx_keyed`
+  + lemmas `unitarymxP`, `mulmxtVK`, `unitarymx_unit`, `invmx_unitary`, `mulmxKtV`,
+    `mxrank_unitary`, `mul_unitarymx`, `pinvmx_unitary`, `conjymx`, `trmx_unitary`,
+    `conjC_unitary`, `trmxC_unitary`
+  + definition `normalmx`, fact `normalmx_key`, canonical `normalmx_keyed`
+  + lemmas `normalmxP`, `hermitian_normalmx`, `symmetric_normalmx`
+  + definition `dotmx`
+  + lemmas `dotmxE`, `row_unitarymxP`, `dotmx_is_dotmx`, `orthomx1E`, `orthomx1P`,
+    `orthomx_disj`, `orthomx_ortho_disj`, `rank_ortho`, `add_rank_ortho`, `addsmx_ortho`,
+    `ortho_id`, `submx_ortho`
+  + definition `proj_ortho`
+  + lemmas `sub_adds_genmx_ortho`, `cap_genmx_ortho`, `proj_ortho_sub`, `proj_ortho_compl_sub`,
+    `proj_ortho_id`, `proj_ortho_0`, `add_proj_ortho`, `proj_ortho_proj`, `proj_orthoE`,
+    `orthomx_proj_mx_ortho`
+  + lemma `schmidt_subproof`, definition `schmidt`
+  + lemmas `schmidt_unitarymx`, `row_schmidt_sub`, `form1_row_schmidt`, `schmidt_sub`,
+    `eqmx_schmidt_full`, `eqmx_schmidt_free`
+  + definiton `schmidt_complete`
+  + lemmas `schmidt_complete_unitarymx`, `cotrigonalization`, `Schur`, `cotrigonalization2`
+  + lemma `orthomx_spectral_subproof`, definitions `spectralmx`, `spectral_diag
+  + lemmas `spectral_unitarymx`, `spectral_unit`, `orthomx_spectralP`, `hermitian_spectral_diag_real`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -155,6 +155,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + `archiRealDomainType` instance for `int` (moved from `ssrint.v`)
 - in `intdiv.v`
   + lemma `irreducible_rat_int`
+- new file `mxred.v` which contains the theory of diagonalization. To
+  that effect, we define `conjmx`, `restrictmx`, `similar_to`,
+  `similar`, `similar_in`, `similar_in_to`, `all_similar_to`,
+  `similar_diag`, `diagonalizable_in`, `diagonalizable`,
+  `codiagonalizable_in`, `codiagonalizable`, `similar_trig`,
+  `trigonalizable_in`, `trigonalizable`, `cotrigonalizable_in`, and
+  `cotrigonalizable`; and their theory: `stablemx_comp`,
+  `stablemx_restrict`, `conjmxM`, `conjMmx`, `conjuMmx`, `conjMumx`,
+  `conjuMumx`, `conjmx_scalar`, `conj0mx`, `conjmx0`, `conjumx`,
+  `conj1mx`, `conjVmx`, `conjmxK`, `conjmxVK`, `horner_mx_conj`,
+  `horner_mx_uconj`, `horner_mx_uconjC`, `mxminpoly_conj`,
+  `mxminpoly_uconj`, `sub_kermxpoly_conjmx`, `sub_eigenspace_conjmx`,
+  `eigenpoly_conjmx`, `eigenvalue_conjmx`, `conjmx_eigenvalue`,
+  `similarPp`, `similarW`, `similarP`, `similarRL`, `similarLR`,
+  `similar_mxminpoly`, `similar_diag_row_base`, `similar_diagPp`,
+  `similar_diagP`, `similar_diagPex`, `similar_diagLR`,
+  `similar_diag_mxminpoly`, `similar_diag_sum`, `codiagonalizable1`,
+  `codiagonalizable_on`, `diagonalizable_diag`,
+  `diagonalizable_scalar`, `diagonalizable0`, `diagonalizablePeigen`,
+  `diagonalizableP`, `diagonalizable_conj_diag`, and
+  `codiagonalizableP`.
+
+Remark that even though `trigonalization` is defined, its theory is
+not here yet.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -155,30 +155,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + `archiRealDomainType` instance for `int` (moved from `ssrint.v`)
 - in `intdiv.v`
   + lemma `irreducible_rat_int`
-- new file `mxred.v` which contains the theory of diagonalization. To
-  that effect, we define `conjmx`, `restrictmx`, `similar_to`,
-  `similar`, `similar_in`, `similar_in_to`, `all_similar_to`,
-  `similar_diag`, `diagonalizable_in`, `diagonalizable`,
-  `codiagonalizable_in`, `codiagonalizable`, `similar_trig`,
-  `trigonalizable_in`, `trigonalizable`, `cotrigonalizable_in`, and
-  `cotrigonalizable`; and their theory: `stablemx_comp`,
-  `stablemx_restrict`, `conjmxM`, `conjMmx`, `conjuMmx`, `conjMumx`,
-  `conjuMumx`, `conjmx_scalar`, `conj0mx`, `conjmx0`, `conjumx`,
-  `conj1mx`, `conjVmx`, `conjmxK`, `conjmxVK`, `horner_mx_conj`,
-  `horner_mx_uconj`, `horner_mx_uconjC`, `mxminpoly_conj`,
-  `mxminpoly_uconj`, `sub_kermxpoly_conjmx`, `sub_eigenspace_conjmx`,
-  `eigenpoly_conjmx`, `eigenvalue_conjmx`, `conjmx_eigenvalue`,
-  `similarPp`, `similarW`, `similarP`, `similarRL`, `similarLR`,
-  `similar_mxminpoly`, `similar_diag_row_base`, `similar_diagPp`,
-  `similar_diagP`, `similar_diagPex`, `similar_diagLR`,
-  `similar_diag_mxminpoly`, `similar_diag_sum`, `codiagonalizable1`,
-  `codiagonalizable_on`, `diagonalizable_diag`,
-  `diagonalizable_scalar`, `diagonalizable0`, `diagonalizablePeigen`,
-  `diagonalizableP`, `diagonalizable_conj_diag`, and
-  `codiagonalizableP`.
 
-Remark that even though `trigonalization` is defined, its theory is
-not here yet.
+- new file `mxred.v`
+  + definition `conjmx`
+  + lemmas `stablemx_comp`, `stablemx_restrict`, `conjmxM`, `conjMmx`,
+    `conjuMmx`, `conjMumx`, `conjuMumx`, `conjmx_scalar`, `conj0mx`,
+    `conjmx0`, `conjumx`, `conj1mx`, `conjVmx`, `conjmxK`, `conjmxVK`,
+    `horner_mx_conj`, `horner_mx_uconj`, `horner_mx_uconjC`, `mxminpoly_conj`,
+    `mxminpoly_uconj`, `sub_kermxpoly_conjmx`, `sub_eigenspace_conjmx`,
+    `eigenpoly_conjmx`, `eigenvalue_conjmx`, `conjmx_eigenvalue`
+  + notation `restrictmx`
+  + definition `similar_to`
+  + notations `similar`, `similar_in`, `similar_in_to`, `all_similar_to`,
+    `similar_diag`, `diagonalizable_in`, `diagonalizable`,
+    `codiagonalizable_in`, `codiagonalizable`, `similar_trig`,
+    `trigonalizable_in`, `trigonalizable`, `cotrigonalizable_in`,
+    `cotrigonalizable`
+  + lemmas `similarPp`, `similarW`, `similarP`, `similarRL`, `similarLR`,
+    `similar_mxminpoly`, `similar_diag_row_base`, `similar_diagPp`,
+    `similar_diagP`, `similar_diagPex`, `similar_diagLR`,
+    `similar_diag_mxminpoly`, `similar_diag_sum`, `codiagonalizable1`,
+    `codiagonalizablePfull`, `codiagonalizable_on`, `diagonalizable_diag`,
+    `diagonalizable_scalar`, `diagonalizable0`, `diagonalizablePeigen`,
+    `diagonalizableP`, `diagonalizable_conj_diag`, `codiagonalizableP`.
+
+- new file `sesquilinear.v`
+  + notations ``` ``_ ```, `e_`, `^`, `^t`
+  + lemma `eq_map_mx_id`
+  + mixin `InvolutiveRMorphism`
+  + lemma `rmorphK`
+  + definition `conjC`
+  + lemma `map_mxCK`
+  + mixin `isBilinear`
+  + structure `Bilinear`
+  + definition `bilinear_for`
+  + factory `bilinear_isBilinear`
+  + module `Bilinear` (contents not documented in the changelog)
+  + notations `{bilinear _ -> _ -> _ | _ & _}`,
+    `{bilinear _ -> _ -> _ | _}`, `{bilinear _ -> _ -> _}`,
+    `{biscalar _}`
+  + definition `applyr_head`, notation `applyr`
+  + (coercions and canonicals not documented in the changelog)
+  + lemmas `linear0r`, `linearNr`, `linearDr`, `linearBr`, `linearMnr`,
+    `linearMNnr`, `linear_sumr`, `linearZr_LR`, `linearPr`
+  + lemma `applyrE`
+  + lemmas `linear0l`, `linearNl`, `linearDl`, `linearBl`, `linearMnl`,
+    `linearMNnl`, `linear_sumlz`, `linearZl_LR`, `linearPl`, `linearZl`,
+    `linearZr`, `linearZlr`, `linearZrl`
+  
+- new file `spectral.v`
 
 ### Changed
 

--- a/mathcomp/Make
+++ b/mathcomp/Make
@@ -8,6 +8,7 @@ algebra/interval.v
 algebra/matrix.v
 algebra/mxalgebra.v
 algebra/mxpoly.v
+algebra/mxred.v
 algebra/polydiv.v
 algebra/poly.v
 algebra/polyXY.v

--- a/mathcomp/Make
+++ b/mathcomp/Make
@@ -20,7 +20,7 @@ algebra/ssrint.v
 algebra/ssrnum.v
 algebra/vector.v
 algebra/zmodp.v
-algebra/forms.v
+algebra/sesquilinear.v
 algebra/spectral.v
 all/all.v
 character/all_character.v

--- a/mathcomp/Make
+++ b/mathcomp/Make
@@ -20,6 +20,8 @@ algebra/ssrint.v
 algebra/ssrnum.v
 algebra/vector.v
 algebra/zmodp.v
+algebra/forms.v
+algebra/spectral.v
 all/all.v
 character/all_character.v
 character/character.v

--- a/mathcomp/algebra/Make
+++ b/mathcomp/algebra/Make
@@ -8,6 +8,7 @@ interval.v
 matrix.v
 mxalgebra.v
 mxpoly.v
+mxred.v
 polydiv.v
 poly.v
 polyXY.v

--- a/mathcomp/algebra/Make
+++ b/mathcomp/algebra/Make
@@ -20,6 +20,8 @@ ssrint.v
 ssrnum.v
 vector.v
 zmodp.v
+spectral.v
+forms.v
 
 -R . mathcomp.algebra
 

--- a/mathcomp/algebra/Make
+++ b/mathcomp/algebra/Make
@@ -20,8 +20,8 @@ ssrint.v
 ssrnum.v
 vector.v
 zmodp.v
+sesquilinear.v
 spectral.v
-forms.v
 
 -R . mathcomp.algebra
 

--- a/mathcomp/algebra/all_algebra.v
+++ b/mathcomp/algebra/all_algebra.v
@@ -14,6 +14,7 @@ Require Export interval.
 Require Export matrix.
 Require Export mxpoly.
 Require Export mxalgebra.
+Require Export mxred.
 Require Export vector.
 Require Export ring_quotient.
 Require Export fraction.

--- a/mathcomp/algebra/all_algebra.v
+++ b/mathcomp/algebra/all_algebra.v
@@ -19,5 +19,5 @@ Require Export vector.
 Require Export ring_quotient.
 Require Export fraction.
 Require Export zmodp.
-Require Export forms.
+Require Export sesquilinear.
 Require Export spectral.

--- a/mathcomp/algebra/all_algebra.v
+++ b/mathcomp/algebra/all_algebra.v
@@ -19,3 +19,5 @@ Require Export vector.
 Require Export ring_quotient.
 Require Export fraction.
 Require Export zmodp.
+Require Export forms.
+Require Export spectral.

--- a/mathcomp/algebra/forms.v
+++ b/mathcomp/algebra/forms.v
@@ -1,0 +1,1335 @@
+From mathcomp
+Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div choice fintype.
+From mathcomp
+Require Import tuple bigop ssralg finset fingroup zmodp poly order ssrnum.
+From mathcomp
+Require Import matrix mxalgebra vector.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Local Open Scope ring_scope.
+Import GRing.Theory Order.Theory Num.Theory.
+
+Reserved Notation "'[ u , v ]"
+  (at level 2, format "'[hv' ''[' u , '/ '  v ] ']'").
+Reserved Notation "'[ u , v ]_ M"
+         (at level 2, format "'[hv' ''[' u , '/ '  v ]_ M ']'").
+Reserved Notation "'[ u ]_ M" (at level 2, format "''[' u ]_ M").
+Reserved Notation "'[ u ]" (at level 2, format "''[' u ]").
+Reserved Notation "u '``_' i"
+    (at level 3, i at level 2, left associativity, format "u '``_' i").
+Reserved Notation "A ^!"    (at level 2, format "A ^!").
+Reserved Notation "A _|_ B" (at level 69, format "A  _|_  B").
+
+Module InvolutiveMorphism.
+
+Section ClassDef.
+
+Variables (R : ringType).
+
+Record class_of (f : R -> R) : Type :=
+  Class {base : rmorphism f; mixin : involutive f}.
+Local Coercion base : class_of >-> rmorphism.
+
+Structure map (phR : phant R) := Pack {apply; _ : class_of apply}.
+Local Coercion apply : map >-> Funclass.
+
+Variables (phR : phant R) (f g : R -> R) (cF : map phR).
+
+Definition class := let: Pack _ c as cF' := cF return class_of cF' in c.
+
+Definition clone fM of phant_id g (apply cF) & phant_id fM class :=
+  @Pack phR f fM.
+
+Definition pack (fM : involutive f) :=
+  fun (phRR : phant (R -> R)) (bF : GRing.RMorphism.map phRR) fA
+      of phant_id (GRing.RMorphism.class bF) fA =>
+  Pack phR (Class fA fM).
+
+Canonical additive := GRing.Additive.Pack (Phant (R -> R)) class.
+Canonical rmorphism := GRing.RMorphism.Pack (Phant (R -> R)) class.
+
+End ClassDef.
+
+Module Exports.
+Notation involutive_rmorphism f := (class_of f).
+Coercion base : involutive_rmorphism >-> GRing.RMorphism.class_of.
+Coercion mixin : involutive_rmorphism >-> involutive.
+Coercion apply : map >-> Funclass.
+Notation InvolutiveRMorphism fM := (pack (Phant _) fM id).
+Notation "{ 'involutive_rmorphism' fRS }" := (map (Phant fRS))
+  (at level 0, format "{ 'involutive_rmorphism'  fRS }") : ring_scope.
+Notation "[ 'involutive_rmorphism' 'of' f 'as' g ]" := (@clone _ _ f g _ _ idfun id)
+  (at level 0, format "[ 'involutive_rmorphism'  'of'  f  'as'  g ]") : form_scope.
+Notation "[ 'involutive_rmorphism' 'of' f ]" := (@clone _ _ f f _ _ id id)
+  (at level 0, format "[ 'involutive_rmorphism'  'of'  f ]") : form_scope.
+Coercion additive : map >-> GRing.Additive.map.
+Canonical additive.
+Coercion rmorphism : map >-> GRing.RMorphism.map.
+Canonical rmorphism.
+End Exports.
+
+End InvolutiveMorphism.
+Include InvolutiveMorphism.Exports.
+
+Section InvolutiveTheory.
+
+Variable (R : ringType).
+
+Lemma idfunK : involutive (@idfun R). Proof. by []. Qed.
+Canonical idfun_involutive := InvolutiveRMorphism idfunK.
+
+Variable (f : {involutive_rmorphism R}).
+Lemma rmorphK : involutive f. Proof. by case: f => [? []]. Qed.
+
+End InvolutiveTheory.
+
+(** Contents *)
+
+Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
+  fun_of_revop :> X -> Y -> Z;
+  _ : forall x, f x =1 fun_of_revop^~ x
+}.
+Notation "[ 'revop' revop 'of' op ]" :=
+  (@RevOp _ _ _ revop op (fun _ _ => erefl))
+  (at level 0, format "[ 'revop'  revop  'of'  op ]") : form_scope.
+
+(* Fact applyr_key : unit. Proof. exact. Qed. *)
+Definition applyr_head U U' V t (f : U -> U' -> V) u v := let: tt := t in f v u.
+Notation applyr := (@applyr_head _ _ _ tt).
+
+Module Bilinear.
+
+Section ClassDef.
+
+Variables (R : ringType) (U U' : lmodType R) (V : zmodType) (s s' : R -> V -> V).
+Implicit Type phUU'V : phant (U -> U' -> V).
+
+Local Coercion GRing.Scale.op : GRing.Scale.law >-> Funclass.
+Definition axiom (f : U -> U' -> V) (s_law : GRing.Scale.law s) (eqs : s = s_law)
+                                    (s'_law : GRing.Scale.law s') (eqs' : s' = s'_law) :=
+  ((forall u', GRing.Linear.axiom (f^~ u') eqs)
+  * (forall u, GRing.Linear.axiom (f u) eqs'))%type.
+
+Record class_of (f : U -> U' -> V) : Prop := Class {
+  basel : forall u', GRing.Linear.class_of s (f^~ u');
+  baser : forall u, GRing.Linear.class_of s' (f u)
+}.
+
+Lemma class_of_axiom f s_law s'_law Ds Ds' :
+   @axiom f s_law Ds s'_law Ds' -> class_of f.
+Proof.
+by pose coa := GRing.Linear.class_of_axiom; move=> [/(_ _) /coa ? /(_ _) /coa].
+Qed.
+
+Structure map phUU'V := Pack {apply; _ : class_of apply}.
+Local Coercion apply : map >-> Funclass.
+
+Definition class (phUU'V : _)  (cF : map phUU'V) :=
+   let: Pack _ c as cF' := cF return class_of cF' in c.
+
+Canonical additiver phU'V phUU'V (u : U) cF := GRing.Additive.Pack phU'V
+  (baser (@class phUU'V cF) u).
+Canonical linearr phU'V  phUU'V (u : U) cF := GRing.Linear.Pack phU'V
+  (baser (@class phUU'V cF) u).
+
+Canonical additivel phUV phUU'V (u' : U') (cF : map _) :=
+  @GRing.Additive.Pack _ _ phUV (applyr cF u') (basel (@class phUU'V cF) u').
+Canonical linearl phUV phUU'V  (u' : U') (cF : map _) :=
+  @GRing.Linear.Pack _ _ _ _ phUV (applyr cF u') (basel (@class phUU'V cF) u').
+
+Definition pack (phUV : phant (U -> V)) (phU'V : phant (U' -> V))
+           (revf : U' -> U -> V) (rf : revop revf) f (g : U -> U' -> V) of (g = fun_of_revop rf) :=
+  fun (bFl : U' -> GRing.Linear.map s phUV) flc of (forall u', revf u' = bFl u') &
+      (forall u', phant_id (GRing.Linear.class (bFl u')) (flc u')) =>
+  fun (bFr : U -> GRing.Linear.map s' phU'V) frc of (forall u, g u = bFr u) &
+      (forall u, phant_id (GRing.Linear.class (bFr u)) (frc u)) =>
+  @Pack (Phant _) f (Class flc frc).
+
+
+(* Support for right-to-left rewriting with the generic linearZ rule. *)
+Notation mapUUV := (map (Phant (U -> U' -> V))).
+Definition map_class := mapUUV.
+Definition map_at_left (a : R) := mapUUV.
+Definition map_at_right (b : R) := mapUUV.
+Definition map_at_both (a b : R) := mapUUV.
+Structure map_for_left a s_a := MapForLeft {map_for_left_map : mapUUV; _ : s a = s_a }.
+Structure map_for_right b s'_b := MapForRight {map_for_right_map : mapUUV; _ : s' b = s'_b }.
+Structure map_for_both a b s_a s'_b :=
+  MapForBoth {map_for_both_map : mapUUV; _ : s a = s_a ; _ : s' b = s'_b }.
+Definition unify_map_at_left a (f : map_at_left a) := MapForLeft f (erefl (s a)).
+Definition unify_map_at_right b (f : map_at_right b) := MapForRight f (erefl (s' b)).
+Definition unify_map_at_both a b (f : map_at_both a b) :=
+   MapForBoth f (erefl (s a)) (erefl (s' b)).
+Structure wrapped := Wrap {unwrap : mapUUV}.
+Definition wrap (f : map_class) := Wrap f.
+
+End ClassDef.
+
+Module Exports.
+Notation bilinear_for s s' f := (axiom f (erefl s) (erefl s')).
+Notation bilinear f := (bilinear_for *:%R *:%R f).
+Notation biscalar f := (bilinear_for *%R *%R f).
+Notation bilmorphism_for s s' f := (class_of s s' f).
+Notation bilmorphism f := (bilmorphism_for *:%R *:%R f).
+Coercion baser : bilmorphism_for >-> Funclass.
+Coercion apply : map >-> Funclass.
+Notation "{ 'bilinear' fUV | s & s' }" := (map s s' (Phant fUV))
+  (at level 0, format "{ 'bilinear'  fUV  |  s  &  s' }") : ring_scope.
+Notation "{ 'bilinear' fUV | s }" := (map s.1 s.2 (Phant fUV))
+  (at level 0, format "{ 'bilinear'  fUV  |  s }") : ring_scope.
+Notation "{ 'bilinear' fUV }" := {bilinear fUV | *:%R & *:%R}
+  (at level 0, format "{ 'bilinear'  fUV }") : ring_scope.
+Notation "{ 'biscalar' U }" := {bilinear U -> U -> _ | *%R & *%R}
+  (at level 0, format "{ 'biscalar'  U }") : ring_scope.
+Notation "[ 'bilinear' 'of' f 'as' g ]" :=
+  (@pack  _ _ _ _ _ _ _ _ _ _ f g erefl _ _
+         (fun=> erefl) (fun=> idfun) _ _ (fun=> erefl) (fun=> idfun)).
+Notation "[ 'bilinear' 'of' f ]" :=  [bilinear of f as f]
+  (at level 0, format "[ 'bilinear'  'of'  f ]") : form_scope.
+Canonical additiver.
+Canonical linearr.
+Canonical additivel.
+Canonical linearl.
+Notation biapplyr := (@applyr_head _ _ _ _ tt).
+
+Coercion map_for_left_map : map_for_left >-> map.
+Coercion map_for_right_map : map_for_right >-> map.
+Coercion map_for_both_map : map_for_both >-> map.
+Coercion unify_map_at_left : map_at_left >-> map_for_left.
+Coercion unify_map_at_right : map_at_right >-> map_for_right.
+Coercion unify_map_at_both : map_at_both >-> map_for_both.
+Canonical unify_map_at_left.
+Canonical unify_map_at_right.
+Canonical unify_map_at_both.
+Coercion unwrap : wrapped >-> map.
+Coercion wrap : map_class >-> wrapped.
+Canonical wrap.
+End Exports.
+
+End Bilinear.
+Include Bilinear.Exports.
+
+Section BilinearTheory.
+
+Variable R : ringType.
+
+Section GenericProperties.
+
+Variables (U U' : lmodType R) (V : zmodType) (s : R -> V -> V) (s' : R -> V -> V).
+Variable f : {bilinear U -> U' -> V | s & s'}.
+
+Lemma linear0r z : f z 0 = 0. Proof. by rewrite linear0. Qed.
+Lemma linearNr z : {morph f z : x / - x}. Proof. exact: raddfN. Qed.
+Lemma linearDr z : {morph f z : x y / x + y}. Proof. exact: raddfD. Qed.
+Lemma linearBr z : {morph f z : x y / x - y}. Proof. exact: raddfB. Qed.
+Lemma linearMnr z n : {morph f z : x / x *+ n}. Proof. exact: raddfMn. Qed.
+Lemma linearMNnr z n : {morph f z : x / x *- n}. Proof. exact: raddfMNn. Qed.
+Lemma linear_sumr z I r (P : pred I) E :
+  f z (\sum_(i <- r | P i) E i) = \sum_(i <- r | P i) f z (E i).
+Proof. exact: raddf_sum. Qed.
+
+Lemma linearZr_LR z : scalable_for s' (f z). Proof. exact: linearZ_LR. Qed.
+Lemma linearPr z a : {morph f z : u v / a *: u + v >-> s' a u + v}.
+Proof. exact: linearP. Qed.
+
+Lemma applyrE x : applyr f x =1 f^~ x. Proof. by []. Qed.
+
+Lemma linear0l z : f 0 z = 0. Proof. by rewrite -applyrE raddf0. Qed.
+Lemma linearNl z : {morph f^~ z : x / - x}.
+Proof. by move=> ?; rewrite -applyrE raddfN. Qed.
+Lemma linearDl z : {morph f^~ z : x y / x + y}.
+Proof. by move=> ??; rewrite -applyrE raddfD. Qed.
+Lemma linearBl z : {morph f^~ z : x y / x - y}.
+Proof. by move=> ??; rewrite -applyrE raddfB. Qed.
+Lemma linearMnl z n : {morph f^~ z : x / x *+ n}.
+Proof. by move=> ?; rewrite -applyrE raddfMn. Qed.
+Lemma linearMNnl z n : {morph f^~ z : x / x *- n}.
+Proof. by move=> ?; rewrite -applyrE raddfMNn. Qed.
+Lemma linear_suml z I r (P : pred I) E :
+  f (\sum_(i <- r | P i) E i) z = \sum_(i <- r | P i) f (E i) z.
+Proof. by rewrite -applyrE raddf_sum. Qed.
+
+Lemma linearZl_LR z : scalable_for s (f^~ z).
+Proof. by move=> ??; rewrite -applyrE linearZ_LR. Qed.
+Lemma linearPl z a : {morph f^~ z : u v / a *: u + v >-> s a u + v}.
+Proof. by move=> ??; rewrite -applyrE linearP. Qed.
+
+End GenericProperties.
+
+Section BidirectionalLinearZ.
+
+Variables (U U' : lmodType R) (V : zmodType) (s s' : R -> V -> V).
+Variables (S : ringType) (h h' : S -> V -> V).
+Variables (h_law : GRing.Scale.law h) (h'_law : GRing.Scale.law h').
+
+Lemma linearZl z c a (h_c := GRing.Scale.op h_law c)
+    (f : Bilinear.map_for_left U U' s s' a h_c) u :
+  f (a *: u) z = h_c (Bilinear.wrap f u z).
+Proof. by rewrite linearZl_LR; case: f => f /= ->. Qed.
+
+Lemma linearZr z c' b (h'_c' := GRing.Scale.op h'_law c')
+    (f : Bilinear.map_for_right U U' s s' b h'_c') u :
+  f z (b *: u) = h'_c' (Bilinear.wrap f z u).
+Proof. by rewrite linearZ_LR; case: f => f /= ->. Qed.
+
+Lemma linearZlr c c' a b (h_c := GRing.Scale.op h_law c) (h'_c' := GRing.Scale.op h'_law c')
+    (f : Bilinear.map_for_both U U' s s' a b h_c h'_c') u v :
+  f (a *: u) (b *: v) = h_c (h'_c' (Bilinear.wrap f u v)).
+Proof. by rewrite linearZl_LR linearZ_LR; case: f => f /= -> ->. Qed.
+
+Lemma linearZrl c c' a b (h_c := GRing.Scale.op h_law c) (h'_c' := GRing.Scale.op h'_law c')
+    (f : Bilinear.map_for_both U U' s s' a b h_c h'_c') u v :
+  f (a *: u) (b *: v) = h'_c' (h_c (Bilinear.wrap f u v)).
+Proof. by rewrite linearZ_LR/= linearZl_LR; case: f => f /= -> ->. Qed.
+
+End BidirectionalLinearZ.
+
+End BilinearTheory.
+
+Canonical rev_mulmx (R : ringType) m n p := [revop mulmxr of @mulmx R m n p].
+Canonical mulmx_bilinear (R : comRingType) m n p := [bilinear of @mulmx R m n p].
+
+Module Hermitian.
+
+Section ClassDef.
+
+Variables (R : ringType) (U : lmodType R) (eps : bool) (theta : R -> R).
+Implicit Types phU : phant U.
+
+Local Coercion GRing.Scale.op : GRing.Scale.law >-> Funclass.
+Definition axiom (f : U -> U -> R) :=
+  forall x y : U, f x y = (-1) ^+ eps * theta (f y x).
+
+Record class_of (f : U -> U -> R) : Prop := Class {
+  base : Bilinear.class_of ( *%R) (theta \; *%R) f;
+  mixin : axiom f
+}.
+
+Structure map phU := Pack {apply; _ : class_of apply}.
+Local Coercion apply : map >-> Funclass.
+
+Variables (phU : phant U) (cF : map phU).
+
+Definition class := let: Pack _ c as cF' := cF return class_of cF' in c.
+
+Canonical additiver (u : U) := Additive (base class u).
+Canonical linearr (u : U) := Linear (base class u).
+Canonical additivel (u' : U) := @GRing.Additive.Pack _ _ (Phant (U -> R))
+  (applyr cF u') (Bilinear.basel (base class) u').
+Canonical linearl (u' : U) := @GRing.Linear.Pack _ _ _ _ (Phant (U -> R))
+  (applyr cF u') (Bilinear.basel (base class) u').
+Canonical bilinear := @Bilinear.Pack _ _ _ _ _ _ (Phant (U -> U -> R)) cF (base class).
+
+Definition clone (f g : U -> U -> R) :=
+ fun fM of phant_id g (apply cF) & phant_id fM class => @Pack phU f fM.
+
+Definition pack f fM :=
+  fun b s s' (phUUR : phant (U -> U -> R)) (bF : Bilinear.map s s' phUUR)
+      of phant_id (Bilinear.class bF) b =>
+  @Pack phU f (Class b fM).
+
+End ClassDef.
+
+Module Exports.
+Notation "{ 'hermitian' U 'for' eps & theta }" := (map eps theta (Phant U))
+  (at level 0, format "{ 'hermitian'  U  'for'  eps  &  theta }") : ring_scope.
+Coercion base : class_of >-> bilmorphism_for.
+Coercion apply : map >-> Funclass.
+Notation "[ 'hermitian' 'of' f 'as' g ]" := (@clone _ _ _ _ _ _ f g _ idfun idfun)
+  (at level 0, format "[ 'hermitian'  'of'  f  'as'  g ]") : form_scope.
+Notation "[ 'hermitian' 'of' f ]" := (@clone _ _ _ _ _ _ f f _ idfun idfun)
+  (at level 0, format "[ 'hermitian'  'of'  f ]") : form_scope.
+Notation hermitian_for := Hermitian.axiom.
+Notation Hermitian fM := (pack (Phant _) fM idfun).
+Canonical additiver.
+Canonical linearr.
+Canonical additivel.
+Canonical linearl.
+Canonical bilinear.
+Notation hermapplyr := (@applyr_head _ _ _ _ tt).
+End Exports.
+
+End Hermitian.
+Include Hermitian.Exports.
+
+Module Dot.
+
+Section ClassDef.
+
+Variables (R : numDomainType) (U : lmodType R) (theta : R -> R).
+Implicit Types phU : phant U.
+
+Local Coercion GRing.Scale.op : GRing.Scale.law >-> Funclass.
+Definition axiom (f : U -> U -> R) := forall u, u != 0 -> 0 < f u u.
+
+Record class_of (f : U -> U -> R) : Prop := Class {
+  base : Hermitian.class_of false theta f;
+  mixin : axiom f
+}.
+
+Structure map phU := Pack {apply; _ : class_of apply}.
+Local Coercion apply : map >-> Funclass.
+
+Variables (phU : phant U) (cF : map phU).
+
+Definition class := let: Pack _ c as cF' := cF return class_of cF' in c.
+
+Canonical additiver (u : U) := Additive (base class u).
+Canonical linearr (u : U) := Linear (base class u).
+Canonical additivel (u' : U) := @GRing.Additive.Pack _ _ (Phant (U -> R))
+  (applyr cF u') (Bilinear.basel (base class) u').
+Canonical linearl (u' : U) := @GRing.Linear.Pack _ _ _ _ (Phant (U -> R))
+  (applyr cF u') (Bilinear.basel (base class) u').
+Canonical bilinear := @Bilinear.Pack _ _ _ _ _ _ (Phant (U -> U -> R)) cF (base class).
+Canonical hermitian := @Hermitian.Pack _ _ _ _ (Phant U) cF (base class).
+
+Definition clone (f g : U -> U -> R) :=
+ fun fM of phant_id g (apply cF) & phant_id fM class => @Pack phU f fM.
+
+
+Definition pack f fM :=
+  fun b s s' (bF : Hermitian.map s s' phU) of phant_id (Hermitian.class bF) b =>
+  @Pack phU f (Class b fM).
+
+End ClassDef.
+
+
+Module Exports.
+Notation "{ 'dot' U 'for' theta }" := (map theta (Phant U))
+  (at level 0, format "{ 'dot'  U  'for'  theta }") : ring_scope.
+Coercion base : class_of >-> Hermitian.class_of.
+Coercion apply : map >-> Funclass.
+Notation "[ 'dot' 'of' f 'as' g ]" := (@clone _ _ _ _ _ f g _ idfun idfun)
+  (at level 0, format "[ 'dot'  'of'  f  'as'  g ]") : form_scope.
+Notation "[ 'dot' 'of' f ]" := (@clone _ _ _ _ _ f f _ idfun idfun)
+  (at level 0, format "[ 'dot'  'of'  f ]") : form_scope.
+Notation Dot fM := (pack fM idfun).
+Notation is_dot := Dot.axiom.
+Canonical additiver.
+Canonical linearr.
+Canonical additivel.
+Canonical linearl.
+Canonical bilinear.
+Canonical hermitian.
+Coercion hermitian: map >-> Hermitian.map.
+Coercion bilinear: map >-> Bilinear.map.
+End Exports.
+
+End Dot.
+Include Dot.Exports.
+
+Definition symmetric_map (R : ringType) (U : lmodType R) (phU : phant U) :=
+  Eval simpl in Hermitian.map false idfun phU.
+Notation "{ 'symmetric' U }" := (symmetric_map (Phant U))
+  (at level 0, format "{ 'symmetric'  U }") : ring_scope.
+
+Definition skew_symmetric_map (R : ringType) (U : lmodType R) (phU : phant U) :=
+  Eval simpl in Hermitian.map true idfun phU.
+Notation "{ 'skew_symmetric' U }" := (skew_symmetric_map (Phant U))
+  (at level 0, format "{ 'skew_symmetric'  U }") : ring_scope.
+
+Definition hermitian_sym_map (R : ringType) (U : lmodType R)
+  theta (phU : phant U) :=
+  Eval simpl in Hermitian.map false theta phU.
+Notation "{ 'hermitian_sym' U 'for' theta }" := (hermitian_sym_map theta (Phant U))
+  (at level 0, format "{ 'hermitian_sym'  U  'for'  theta }") : ring_scope.
+
+Definition is_skew (R : ringType) (eps : bool) (theta : R -> R)
+  (U : lmodType R) (form : {hermitian U for eps & theta}) :=
+  (eps = true) /\ (theta =1 id).
+Definition is_sym (R : ringType) (eps : bool) (theta : R -> R)
+  (U : lmodType R) (form : {hermitian U for eps & theta}) :=
+  (eps = false) /\ (theta =1 id).
+Definition is_hermsym  (R : ringType) (eps : bool) (theta : R -> R)
+  (U : lmodType R) (form : {hermitian U for eps & theta}) :=
+  (eps = false).
+
+Section HermitianModuleTheory.
+
+Variables (R : ringType) (eps : bool) (theta : {rmorphism R -> R}).
+Variable (U : lmodType R) (form : {hermitian U for eps & theta}).
+
+Local Notation "''[' u , v ]" := (form u%R v%R) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+
+Lemma hermC u v : '[u, v] = (-1) ^+ eps * theta '[v, u].
+Proof. by case: form => [? []]. Qed.
+
+Lemma hnormN u : '[- u] = '[u].
+Proof. by rewrite linearNl raddfN opprK. Qed.
+
+Lemma hnorm_sign n u : '[(-1) ^+ n *: u] = '[u].
+Proof. by rewrite -signr_odd scaler_sign; case: (odd n); rewrite ?hnormN. Qed.
+
+Lemma hnormD u v :
+  let d := '[u, v] in '[u + v] = '[u] + '[v] + (d + (-1) ^+ eps * theta d).
+Proof. by rewrite /= addrAC -hermC linearDl /= !linearD !addrA. Qed.
+
+Lemma hnormB u v :
+  let d := '[u, v] in '[u - v] = '[u] + '[v] - (d + (-1) ^+ eps * theta d).
+Proof. by rewrite /= hnormD hnormN linearN rmorphN /= mulrN -opprD. Qed.
+
+Lemma hnormDd u v : '[u, v] = 0 -> '[u + v] = '[u] + '[v].
+Proof. by move=> ouv; rewrite hnormD ouv rmorph0 mulr0 !addr0. Qed.
+
+Lemma hnormBd u v : '[u, v] = 0 -> '[u - v] = '[u] + '[v].
+Proof. by move=> ouv; rewrite hnormDd ?hnormN // linearN /= ouv oppr0. Qed.
+
+Local Notation "u _|_ v" := ('[u, v] == 0) : ring_scope.
+
+Definition ortho_rec S1 S2 :=
+  all [pred u | all [pred v | u _|_ v] S2] S1.
+
+Fixpoint pair_ortho_rec S :=
+  if S is v :: S' then ortho_rec [:: v] S' && pair_ortho_rec S' else true.
+
+(* We exclude 0 from pairwise orthogonal sets. *)
+Definition pairwise_orthogonal S := (0 \notin S) && pair_ortho_rec S.
+
+Definition orthonormal S := all [pred v | '[v] == 1] S && pair_ortho_rec S.
+
+Definition orthogonal S1 S2 := nosimpl (@ortho_rec S1 S2).
+
+Lemma orthogonal_cons u us vs :
+  orthogonal (u :: us) vs = orthogonal [:: u] vs && orthogonal us vs.
+Proof. by rewrite /orthogonal /= andbT. Qed.
+
+Lemma orthonormal_not0 S : orthonormal S -> 0 \notin S.
+Proof.
+by case/andP=> /allP S1 _; rewrite (contra (S1 _)) //= linear0r eq_sym oner_eq0.
+Qed.
+
+Lemma orthonormalE S :
+  orthonormal S = all [pred phi | '[phi] == 1] S && pairwise_orthogonal S.
+Proof. by rewrite -(andb_idl (@orthonormal_not0 S)) andbCA. Qed.
+
+Lemma orthonormal_orthogonal S : orthonormal S -> pairwise_orthogonal S.
+Proof. by rewrite orthonormalE => /andP[_]. Qed.
+
+
+End HermitianModuleTheory.
+Arguments orthogonal {R eps theta U} form S1 S2.
+Arguments pairwise_orthogonal {R eps theta U} form S.
+Arguments orthonormal {R eps theta U} form S.
+
+Section HermitianIsometry.
+
+Variables (R : ringType) (eps : bool) (theta : {rmorphism R -> R}).
+Variables (U1 U2: lmodType R) (form1 : {hermitian U1 for eps & theta})
+          (form2 : {hermitian U2 for eps & theta}).
+
+Local Notation "''[' u , v ]_1" := (form1 u%R v%R) : ring_scope.
+Local Notation "''[' u , v ]_2" := (form2 u%R v%R) : ring_scope.
+Local Notation "''[' u ]_1" := (form1 u%R u%R)  : ring_scope.
+Local Notation "''[' u ]_2" := (form2 u%R u%R): ring_scope.
+Definition isometry tau := forall u v, (form1 (tau u) (tau v))= (form2 u%R v%R).
+
+
+Definition isometry_from_to mD tau mR :=
+   prop_in2 mD (inPhantom (isometry tau))
+  /\ prop_in1 mD (inPhantom (forall u, in_mem (tau u) mR)).
+
+Notation "{ 'in' D , 'isometry' tau , 'to' R }" :=
+    (isometry_from_to (mem D) tau (mem R))
+  (at level 0, format "{ 'in'  D ,  'isometry'  tau ,  'to'  R }")
+     : type_scope.
+
+End  HermitianIsometry.
+
+Section HermitianVectTheory.
+
+Variables (R : fieldType) (eps : bool) (theta : {rmorphism R -> R}).
+Variable (U : lmodType R) (form : {hermitian U for eps & theta}).
+
+Local Notation "''[' u , v ]" := (form u%R v%R) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+
+Lemma herm_eq0C u v : ('[u, v] == 0) = ('[v, u] == 0).
+Proof. by rewrite hermC mulf_eq0 signr_eq0 /= fmorph_eq0. Qed.
+
+End HermitianVectTheory.
+
+Section HermitianFinVectTheory.
+
+Variables (F : fieldType) (eps : bool) (theta : {rmorphism F -> F}).
+Variable (vT : vectType F) (form : {hermitian vT for eps & theta}).
+Let n := \dim {:vT}.
+Implicit Types (u v : vT) (U V : {vspace vT}).
+
+Local Notation "''[' u , v ]" := (form u%R v%R) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+
+Let alpha v := (linfun (applyr form v : vT -> F^o)).
+
+Definition orthov V := (\bigcap_(i < \dim V) lker (alpha (vbasis V)`_i))%VS.
+
+Local Notation "U _|_ V" := (U <= orthov V)%VS : vspace_scope.
+
+Lemma mem_orthovPn V u : reflect (exists2 v, v \in V & '[u, v] != 0) (u \notin orthov V).
+Proof.
+apply: (iffP idP) => [u_orthovV|[v /coord_vbasis-> uvNorthov]]; last first.
+  apply/subv_bigcapP => uP; rewrite linear_sum big1 ?eqxx //= in uvNorthov.
+  move=> i _; have := uP i isT.
+  by rewrite -memvE memv_ker lfunE linearZ => /eqP/=->; rewrite mulr0.
+suff /existsP [i ui_neq0] : [exists i : 'I_(\dim V), '[u, (vbasis V)`_i] != 0].
+  by exists (vbasis V)`_i => //; rewrite vbasis_mem ?mem_nth ?size_tuple.
+apply: contraNT u_orthovV; rewrite negb_exists => /forallP ui_eq0.
+by apply/subv_bigcapP => i _; rewrite -memvE memv_ker lfunE /= -[_ == _]negbK.
+Qed.
+
+Lemma mem_orthovP V u : reflect {in V, forall v, '[u, v] = 0} (u \in orthov V).
+Proof.
+apply: (iffP idP) => [/mem_orthovPn orthovNu v vV|/(_ _ _)/eqP orthov_u].
+  by apply/eqP/negP=> /negP Northov_uv; apply: orthovNu; exists v.
+by apply/mem_orthovPn => -[v /orthov_u->].
+Qed.
+
+Lemma orthov1E u : orthov <[u]> = lker (alpha u).
+Proof.
+apply/eqP; rewrite eqEsubv; apply/andP.
+split; apply/subvP=> v; rewrite memv_ker lfunE /=.
+   by move=> /mem_orthovP-> //; rewrite ?memv_line.
+move=> vu_eq0; apply/mem_orthovP => w /vlineP[k->].
+by apply/eqP; rewrite linearZ mulf_eq0 vu_eq0 orbT.
+Qed.
+
+Lemma orthovP U V : reflect {in U & V, forall u v, '[u, v] = 0} (U _|_ V)%VS.
+Proof.
+apply: (iffP subvP); last by move=> H ??; apply/mem_orthovP=> ??; apply: H.
+by move=> /(_ _ _)/mem_orthovP; move=> H ????; apply: H.
+Qed.
+
+Lemma orthov_sym U V : (U _|_ V)%VS = (V _|_ U)%VS.
+Proof. by apply/orthovP/orthovP => eq0 ????; apply/eqP; rewrite herm_eq0C eq0. Qed.
+
+Lemma mem_orthov1 v u : (u \in orthov <[v]>) = ('[u, v] == 0).
+Proof. by rewrite orthov1E memv_ker lfunE. Qed.
+
+Lemma orthov11 u v : (<[u]> _|_ <[v]>)%VS = ('[u, v] == 0).
+Proof. exact: mem_orthov1. Qed.
+
+Lemma mem_orthov1_sym v u : (u \in orthov <[v]>) = (v \in orthov <[u]>).
+Proof. exact: orthov_sym. Qed.
+
+Lemma orthov0 : orthov 0 = fullv.
+Proof.
+apply/eqP; rewrite eqEsubv subvf.
+by apply/subvP => x _; rewrite mem_orthov1 linear0.
+Qed.
+
+Lemma mem_orthov_sym V u : (u \in orthov V) = (V <= orthov <[u]>)%VS.
+Proof. exact: orthov_sym. Qed.
+
+Lemma leq_dim_orthov1 u V : ((\dim V).-1 <= \dim (V :&: orthov <[u]>))%N.
+Proof.
+rewrite -(limg_ker_dim (alpha u) V) -orthov1E.
+have := dimvS (subvf (alpha u @: V)); rewrite dimvf addnC.
+by case: (\dim _) => [|[]] // _; rewrite leq_pred.
+Qed.
+
+Lemma dim_img_form_eq1 u V : u \notin orthov V -> \dim (alpha u @: V)%VS = 1%N.
+Proof.
+move=> /mem_orthovPn [v vV Northov_uv]; apply/eqP; rewrite eqn_leq /=.
+rewrite -[1%N as X in (_ <= X)%N](dimvf [vectType F of F^o]) dimvS ?subvf//=.
+have := @dimvS _ _ <['[v, u] : F^o]> (alpha u @: V).
+rewrite -memvE dim_vline herm_eq0C Northov_uv; apply.
+by apply/memv_imgP; exists v; rewrite ?memvf// !lfunE /=.
+Qed.
+
+Lemma eq_dim_orthov1 u V : u \notin orthov V -> (\dim V).-1 = \dim (V :&: orthov <[u]>).
+Proof.
+rewrite -(limg_ker_dim (alpha u) V) => /dim_img_form_eq1->.
+by rewrite -orthov1E addn1.
+Qed.
+
+Lemma dim_img_form_eq0 u V : u \in orthov V -> \dim (alpha u @: V)%VS = 0%N.
+Proof. by move=> uV; apply/eqP; rewrite dimv_eq0 -lkerE -orthov1E orthov_sym. Qed.
+
+Lemma neq_dim_orthov1 u V : (\dim V > 0)%N ->
+  u \in orthov V -> ((\dim V).-1 < \dim (V :&: orthov <[u]>))%N.
+Proof.
+move=> V_gt0; rewrite -(limg_ker_dim (alpha u) V) -orthov1E => u_in.
+rewrite dim_img_form_eq0 // addn0 (capv_idPl _) 1?orthov_sym //.
+by case: (\dim _) V_gt0.
+Qed.
+
+Lemma leqif_dim_orthov1 u V : (\dim V > 0)%N ->
+   ((\dim V).-1 <= \dim (V :&: orthov <[u]>) ?= iff (u \notin orthov V))%N.
+Proof.
+move=> Vr_gt0; apply/leqifP.
+by case: (boolP (u \in _)) => /= [/neq_dim_orthov1->|/eq_dim_orthov1->].
+Qed.
+
+Lemma leqif_dim_orthov1_full u : (n > 0)%N ->
+   ((\dim {:vT}).-1 <= \dim (orthov <[u]>) ?= iff (u \notin orthov fullv))%N.
+Proof.
+by move=> n_gt0; have := @leqif_dim_orthov1 u fullv; rewrite capfv; apply.
+Qed.
+
+(* Link between orthov and orthovgonality of sequences *)
+Lemma orthogonal1P u v : reflect ('[u, v] = 0) (orthogonal form [:: u] [:: v]).
+Proof. by rewrite /orthogonal /= !andbT; apply: eqP. Qed.
+
+Lemma orthogonalP us vs :
+  reflect {in us & vs, forall u v, '[u, v] = 0} (orthogonal form us vs).
+Proof.
+apply: (iffP allP) => ousvs u => [v /ousvs/allP opus /opus/eqP // | /ousvs opus].
+by apply/allP=> v /= /opus->.
+Qed.
+
+Lemma orthogonal_oppr S R : orthogonal form S (map -%R R) = orthogonal form S R.
+Proof.
+wlog suffices IH: S R / orthogonal form S R -> orthogonal form S (map -%R R).
+  by apply/idP/idP=> /IH; rewrite ?mapK //; apply: opprK.
+move/orthogonalP=> oSR; apply/orthogonalP=> xi1 _ Sxi1 /mapP[xi2 Rxi2 ->].
+by rewrite linearNr /= oSR ?oppr0.
+Qed.
+
+Lemma orthogonalE us vs : (orthogonal form us vs) = (<<us>> _|_ <<vs>>)%VS.
+Proof.
+apply/orthogonalP/orthovP => uvsP u v; last first.
+  by move=> uus vvs; rewrite uvsP // memv_span.
+rewrite -[us]in_tupleE -[vs]in_tupleE => /coord_span-> /coord_span->.
+rewrite linear_sum big1 //= => i _; rewrite linear_suml big1 //= => j _.
+by rewrite linearZlr/= uvsP ?mulr0// mem_nth.
+Qed.
+
+Lemma orthovE U V : (U _|_ V)%VS = orthogonal form (vbasis U) (vbasis V).
+Proof. by rewrite orthogonalE !(span_basis (vbasisP _)). Qed.
+
+Notation radv := (orthov fullv).
+
+Lemma orthoDv U V W : (U + V _|_ W)%VS = (U _|_ W)%VS && (V _|_ W)%VS.
+Proof. by rewrite subv_add. Qed.
+
+Lemma orthovD U V W : (U _|_ V + W)%VS = (U _|_ V)%VS && (U _|_ W)%VS.
+Proof. by rewrite ![(U _|_ _)%VS]orthov_sym orthoDv. Qed.
+
+Definition nondegenerate := radv == 0%VS.
+Definition is_symplectic := [/\ nondegenerate, is_skew form &
+                                2 \in [char F] -> forall u, '[u, u] = 0].
+Definition is_orthogonal := [/\ nondegenerate, is_sym form &
+                                2 \in [char F] -> forall u, '[u, u] = 0].
+Definition is_unitary := nondegenerate /\ (is_hermsym form).
+
+End HermitianFinVectTheory.
+
+Arguments orthogonalP {F eps theta vT form us vs}.
+Arguments orthovP {F eps theta vT form U V}.
+Arguments mem_orthovPn {F eps theta vT form V u}.
+Arguments mem_orthovP {F eps theta vT form V u}.
+
+Section DotVectTheory.
+
+Variables (C : numClosedFieldType).
+Variable (U : lmodType C) (form : {dot U for conjC}).
+
+Local Notation "''[' u , v ]" := (form u%R v%R) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+
+Let neq0_dnorm_gt0 u : u != 0 -> 0 < '[u].
+Proof. by case: form => [?[?]] /=; apply. Qed.
+
+Lemma dnorm_geiff0 u : 0 <= '[u] ?= iff (u == 0).
+Proof.
+by apply/leifP; have [->|uN0] := altP eqP; rewrite ?linear0 ?neq0_dnorm_gt0.
+Qed.
+
+Lemma dnorm_ge0 u : 0 <= '[u]. Proof. by rewrite dnorm_geiff0. Qed.
+
+Lemma dnorm_eq0 u : ('[u] == 0) = (u == 0).
+Proof. by rewrite -dnorm_geiff0 eq_sym. Qed.
+
+Lemma dnorm_gt0 u : (0 < '[u]) = (u != 0).
+Proof. by rewrite lt_def dnorm_eq0 dnorm_ge0 andbT. Qed.
+
+Lemma sqrt_dnorm_ge0 u : 0 <= sqrtC '[u].
+Proof. by rewrite sqrtC_ge0 dnorm_ge0. Qed.
+
+Lemma sqrt_dnorm_eq0 u : (sqrtC '[u] == 0) = (u == 0).
+Proof. by rewrite sqrtC_eq0 dnorm_eq0. Qed.
+
+Lemma sqrt_dnorm_gt0 u : (sqrtC '[u] > 0) = (u != 0).
+Proof. by rewrite sqrtC_gt0 dnorm_gt0. Qed.
+
+Lemma dnormZ a u : '[a *: u]= `|a| ^+ 2 * '[u].
+Proof. by rewrite linearZlr/= mulrA normCK. Qed.
+
+Lemma dnormD u v : let d := '[u, v] in '[u + v] = '[u] + '[v] + (d + d^*).
+Proof. by rewrite hnormD mul1r. Qed.
+
+Lemma dnormB u v : let d := '[u, v] in '[u - v] = '[u] + '[v] - (d + d^*).
+Proof. by rewrite hnormB mul1r. Qed.
+
+End DotVectTheory.
+
+Section HermitianTheory.
+
+Variables (C : numClosedFieldType) (eps : bool) (theta : {rmorphism C -> C}).
+(* Variable (U : lmodType C) (form : {hermitian U for eps & theta}). *)
+Variable (U : lmodType C)  (form : {dot U for conjC}).
+Local Notation "''[' u , v ]" := (form u%R v%R) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+
+Lemma pairwise_orthogonalP  S :
+  reflect (uniq (0 :: S)
+             /\ {in S &, forall phi psi, phi != psi -> '[phi, psi] = 0})
+          (pairwise_orthogonal form S).
+Proof.
+rewrite /pairwise_orthogonal /=; case notS0: (~~ _); last by right; case.
+elim: S notS0 => [|phi S IH] /=; first by left.
+rewrite inE eq_sym andbT => /norP[nz_phi {}/IH IH].
+have [opS | not_opS] := allP; last first.
+  right=> [[/andP[notSp _] opS]]; case: not_opS => psi Spsi /=.
+  by rewrite opS ?mem_head 1?mem_behead // (memPnC notSp).
+rewrite (contra (opS _)) /= ?dnorm_eq0 //.
+apply: (iffP IH) => [] [uniqS oSS]; last first.
+  by split=> //; apply: sub_in2 oSS => psi Spsi; apply: mem_behead.
+split=> // psi xi; rewrite !inE => /predU1P[-> // | Spsi].
+  by case/predU1P=> [-> | /opS] /eqP.
+case/predU1P=> [-> _ | Sxi /oSS-> //].
+ apply/eqP; rewrite hermC.
+by move:(opS psi   Spsi) => /= /eqP ->; rewrite rmorph0 mulr0.
+Qed.
+
+Lemma pairwise_orthogonal_cat R S :
+  pairwise_orthogonal form (R ++ S) =
+    [&& pairwise_orthogonal form R, pairwise_orthogonal form  S & orthogonal form R S].
+Proof.
+rewrite /pairwise_orthogonal mem_cat negb_or -!andbA; do !bool_congr.
+elim: R => [|phi R /= ->]; rewrite ?andbT // orthogonal_cons all_cat -!andbA /=.
+by do !bool_congr.
+Qed.
+
+
+
+Lemma orthonormal_cat R S :
+  orthonormal form (R ++ S) = [&& orthonormal form R, orthonormal form S & orthogonal form R S].
+Proof.
+rewrite !orthonormalE pairwise_orthogonal_cat all_cat -!andbA.
+by do !bool_congr.
+Qed.
+
+
+
+Lemma orthonormalP S :
+  reflect (uniq S /\ {in S &, forall phi psi, '[phi, psi] = (phi == psi)%:R})
+          (orthonormal form S).
+Proof.
+rewrite orthonormalE; have [/= normS | not_normS] := allP; last first.
+  by right=> [[_ o1S]]; case: not_normS => phi Sphi; rewrite /= o1S ?eqxx.
+apply: (iffP (pairwise_orthogonalP S)) => [] [uniqS oSS].
+  split=> // [|phi psi]; first by case/andP: uniqS.
+  by have [-> _ /normS/eqP | /oSS] := altP eqP.
+split=> // [|phi psi Sphi Spsi /negbTE]; last by rewrite oSS // => ->.
+by rewrite /= (contra (normS _)) // linear0r  eq_sym oner_eq0.
+Qed.
+
+
+
+Lemma sub_orthonormal S1 S2 :
+  {subset S1 <= S2} -> uniq S1 -> orthonormal form S2 -> orthonormal form S1.
+Proof.
+move=> sS12 uniqS1 /orthonormalP[_ oS1].
+by apply/orthonormalP; split; last apply: sub_in2 sS12 _ _.
+Qed.
+
+
+Lemma orthonormal2P phi psi :
+  reflect [/\ '[phi, psi] = 0, '[phi] = 1 & '[psi] = 1]
+          (orthonormal form [:: phi; psi]).
+Proof.
+rewrite /orthonormal /= !andbT andbC.
+by apply: (iffP and3P) => [] []; do 3!move/eqP->.
+Qed.
+
+End HermitianTheory.
+
+Section DotFinVectTheory.
+
+Variables (C : numClosedFieldType).
+Variable (U : vectType C) (form : {dot U for conjC}).
+
+Local Notation "''[' u , v ]" := (form u%R v%R) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+
+Lemma sub_pairwise_orthogonal S1 S2 :
+    {subset S1 <= S2} ->  uniq S1 ->
+  pairwise_orthogonal form S2 -> pairwise_orthogonal form S1.
+Proof.
+move=> sS12 uniqS1 /pairwise_orthogonalP[/andP[notS2_0 _] oS2].
+apply/pairwise_orthogonalP; rewrite /= (contra (sS12 0)) //.
+by split=> //; apply: sub_in2 oS2.
+Qed.
+
+Lemma orthogonal_free S : pairwise_orthogonal form S -> free  S.
+Proof.
+case/pairwise_orthogonalP=> [/=/andP[notS0 uniqS] oSS].
+rewrite -(in_tupleE S); apply/freeP => a aS0 i.
+have S_i: S`_i \in S by apply: mem_nth.
+have /eqP: '[S`_i, 0] = 0 := linear0r _ _.
+rewrite -{2}aS0 raddf_sum /= (bigD1 i) //= big1 => [|j neq_ji]; last 1 first.
+  by rewrite linearZ /= oSS ?mulr0 ?mem_nth // eq_sym nth_uniq.
+rewrite addr0 linearZ mulf_eq0 conjC_eq0 dnorm_eq0.
+by case/pred2P=> // Si0; rewrite -Si0 S_i in notS0.
+Qed.
+
+Lemma filter_pairwise_orthogonal S p :
+  pairwise_orthogonal form S -> pairwise_orthogonal form (filter p S).
+Proof.
+move=> orthoS; apply: sub_pairwise_orthogonal (orthoS).
+  exact: mem_subseq (filter_subseq p S).
+exact/filter_uniq/free_uniq/orthogonal_free.
+Qed.
+
+Lemma orthonormal_free S : orthonormal form  S -> free S.
+Proof. by move/orthonormal_orthogonal/orthogonal_free. Qed.
+
+Theorem CauchySchwarz (u v : U) :
+  `|'[u, v]| ^+ 2 <= '[u] * '[v] ?= iff ~~ free [:: u; v].
+Proof.
+rewrite free_cons span_seq1 seq1_free -negb_or negbK orbC.
+have [-> | nz_v] /= := altP (v =P 0).
+  by apply/leifP; rewrite /= !linear0 normCK mul0r mulr0.
+without loss ou: u / '[u, v] = 0.
+  move=> IHo; pose a := '[u, v] / '[v]; pose u1 := u - a *: v.
+  have ou: '[u1, v] = 0.
+    by rewrite linearBl/= linearZl/= divfK ?dnorm_eq0 ?subrr.
+  rewrite (canRL (subrK _) (erefl u1)) rpredDr ?rpredZ ?memv_line //.
+  rewrite linearDl /= ou add0r linearZl/= normrM (ger0_norm (dnorm_ge0 _ _)).
+  rewrite exprMn mulrA -dnormZ hnormDd/=; last by rewrite linearZ/= ou mulr0.
+  by have:= IHo _ ou; rewrite mulrDl -leif_subLR subrr ou normCK mul0r.
+rewrite ou normCK mul0r; split; first by rewrite mulr_ge0 ?dnorm_ge0.
+rewrite eq_sym mulf_eq0 orbC dnorm_eq0 (negPf nz_v) /=.
+apply/idP/idP=> [|/vlineP[a {2}->]]; last by rewrite linearZ/= ou mulr0.
+by rewrite dnorm_eq0 => /eqP->; apply: rpred0.
+Qed.
+
+Lemma CauchySchwarz_sqrt u v :
+  `|'[u, v]| <= sqrtC '[u] * sqrtC '[v] ?= iff ~~ free [:: u; v].
+Proof.
+rewrite -(sqrCK (normr_ge0 _)) -sqrtCM ?qualifE ?dnorm_ge0 //.
+rewrite (mono_in_leif (@ler_sqrtC _)) 1?rpredM ?qualifE;
+by rewrite ?normr_ge0 ?dnorm_ge0 //; apply: CauchySchwarz.
+Qed.
+
+Lemma orthoP phi psi : reflect ('[phi, psi] = 0) (orthogonal form  [:: phi] [:: psi]).
+Proof. by rewrite /orthogonal /= !andbT; apply: eqP. Qed.
+
+Lemma orthoPl phi S :
+  reflect {in S, forall psi, '[phi, psi] = 0} (orthogonal form [:: phi] S).
+Proof.
+by rewrite [orthogonal form _ S]andbT /=; apply: (iffP allP) => ophiS ? /ophiS/eqP.
+Qed.
+Arguments orthoPl {phi S}.
+
+Lemma orthogonal_sym : symmetric (orthogonal form).
+Proof.
+apply: symmetric_from_pre => R S /orthogonalP oRS.
+by apply/orthogonalP=> phi psi Rpsi Sphi; rewrite hermC /= oRS  ?rmorph0 ?mulr0.
+Qed.
+
+Lemma orthoPr S psi :
+  reflect {in S, forall phi, '[phi, psi] = 0} (orthogonal form S [:: psi]).
+Proof.
+rewrite orthogonal_sym.
+by apply: (iffP orthoPl) => oSpsi phi Sphi; rewrite hermC /= oSpsi //= conjC0 mulr0.
+Qed.
+
+Lemma orthogonal_catl R1 R2 S :
+  orthogonal form (R1 ++ R2) S = orthogonal form R1 S && orthogonal form R2 S.
+Proof. exact: all_cat. Qed.
+
+Lemma orthogonal_catr R S1 S2 :
+  orthogonal form R (S1 ++ S2) = orthogonal form R S1 && orthogonal form R S2.
+Proof. by rewrite !(orthogonal_sym R) orthogonal_catl. Qed.
+
+Lemma eq_pairwise_orthogonal R S :
+  perm_eq R S -> pairwise_orthogonal form R = pairwise_orthogonal form  S.
+Proof.
+apply: catCA_perm_subst R S => R S S'.
+rewrite !pairwise_orthogonal_cat !orthogonal_catr (orthogonal_sym R S) -!andbA.
+by do !bool_congr.
+Qed.
+
+
+Lemma eq_orthonormal S0 S : perm_eq S0 S -> orthonormal form S0 = orthonormal form S.
+Proof.
+move=> eqRS; rewrite !orthonormalE (eq_all_r (perm_mem eqRS)).
+by rewrite (eq_pairwise_orthogonal eqRS).
+Qed.
+
+
+Lemma orthogonal_oppl S R : orthogonal form  (map -%R S) R = orthogonal form S R.
+Proof. by rewrite -!(orthogonal_sym R) orthogonal_oppr. Qed.
+
+
+Lemma triangle_lerif u v :
+  sqrtC '[u + v] <= sqrtC '[u] + sqrtC '[v]
+           ?= iff ~~ free [:: u; v] && (0 <= coord [tuple v] 0 u).
+Proof.
+rewrite -(mono_in_leif ler_sqr) ?rpredD ?qualifE ?sqrtC_ge0 ?dnorm_ge0 //.
+rewrite andbC sqrrD !sqrtCK addrAC dnormD (mono_leif (ler_add2l _))/=.
+rewrite -mulr_natr -[_ + _](divfK (negbT (pnatr_eq0 C 2))) -/('Re _).
+rewrite (mono_leif (ler_pmul2r _)) ?ltr0n //.
+have:= leif_trans (leif_Re_Creal '[u, v]) (CauchySchwarz_sqrt u v).
+congr (_ <= _ ?= iff _); apply: andb_id2r.
+rewrite free_cons span_seq1 seq1_free -negb_or negbK orbC.
+have [-> | nz_v] := altP (v =P 0); first by rewrite linear0 coord0.
+case/vlineP=> [x ->]; rewrite linearZl linearZ/= pmulr_lge0 ?dnorm_gt0 //=.
+by rewrite (coord_free 0) ?seq1_free // eqxx mulr1.
+Qed.
+
+Lemma span_orthogonal S1 S2 phi1 phi2 :
+    orthogonal form S1 S2 -> phi1 \in <<S1>>%VS -> phi2 \in <<S2>>%VS ->
+ '[phi1, phi2] = 0.
+Proof.
+move/orthogonalP=> oS12; do 2!move/(@coord_span _ _ _ (in_tuple _))->.
+rewrite linear_suml big1 // => i _; rewrite linear_sumr big1 // => j _.
+by rewrite linearZlr/= oS12 ?mem_nth ?mulr0.
+Qed.
+
+Lemma orthogonal_split S beta :
+  {X: U  & X \in <<S>>%VS &
+      {Y:U | [/\ beta = X + Y, '[X, Y] = 0 & orthogonal form  [:: Y]  S]}}.
+Proof.
+suffices [X S_X [Y -> oYS]]:
+  {X : _ & X \in <<S>>%VS & {Y | beta = X + Y & orthogonal form [:: Y] S}}.
+- exists X => //; exists Y.
+  by rewrite hermC /= (span_orthogonal oYS) ?memv_span1 ?conjC0 // mulr0.
+elim: S beta => [|phi S IHS] beta.
+  by exists 0; last exists beta; rewrite ?mem0v ?add0r.
+have [[UU S_U [V -> oVS]] [X S_X [Y -> oYS]]] := (IHS phi, IHS beta).
+pose Z := '[Y, V] / '[V] *: V; exists (X + Z).
+  rewrite /Z -{4}(addKr UU V) scalerDr scalerN addrA addrC span_cons.
+  by rewrite memv_add ?memvB ?memvZ ?memv_line.
+exists (Y - Z); first by rewrite addrCA !addrA addrK addrC.
+apply/orthoPl=> psi; rewrite !inE => /predU1P[-> | Spsi]; last first.
+  by rewrite linearBl linearZl /= (orthoPl oVS _ Spsi) mulr0 subr0 (orthoPl oYS).
+rewrite linearBl !linearDr /= (span_orthogonal oYS) // ?memv_span ?mem_head //.
+rewrite !linearZl /= (span_orthogonal oVS _ S_U) ?mulr0 ?memv_span ?mem_head //.
+have [-> | nzV] := eqVneq V 0; first by rewrite linear0r !mul0r subrr.
+by rewrite divfK ?dnorm_eq0 ?subrr.
+Qed.
+
+End DotFinVectTheory.
+
+Arguments orthoP {C U form phi psi}.
+Arguments pairwise_orthogonalP {C U form S}.
+Arguments orthonormalP {C U form S}.
+Arguments orthoPl {C U form phi S}.
+Arguments orthoPr {C U form S psi}.
+
+Local Notation "u '``_' i" := (u (GRing.zero (Zp_zmodType O)) i) : ring_scope.
+Local Notation "''e_' i" := (delta_mx 0 i)
+ (format "''e_' i", at level 3) : ring_scope.
+
+Local Notation "M ^ phi" := (map_mx phi M).
+Local Notation "M ^t phi" := (map_mx phi (M ^T)) (phi at level 30, at level 30).
+
+Section  BuildIsometries.
+
+Variables (C : numClosedFieldType).
+Variables (U U1 U2: vectType C).
+Variables (form : {dot U for conjC}) (form1 : {dot U1 for conjC}) (form2 : {dot U2 for conjC}).
+
+Definition normf1 := fun u => form1 u u.
+Definition normf2 := fun u => form2 u u.
+
+Lemma isometry_of_dnorm S tauS :
+    pairwise_orthogonal form1 S -> pairwise_orthogonal form2 tauS ->
+    map normf2 tauS = map normf1 S ->
+  {tau : {linear U1 -> U2} | map tau S = tauS
+                                   & {in <<S>>%VS &, isometry form2 form1 tau}}.
+Proof.
+move=> oS oT eq_nST; have freeS := orthogonal_free oS.
+have eq_sz: size tauS = size S by have:= congr1 size eq_nST; rewrite !size_map.
+have [tau defT] := linear_of_free S tauS; rewrite -[S]/(tval (in_tuple S)).
+exists tau => [|u v /coord_span-> /coord_span->]; rewrite ?raddf_sum ?defT //=.
+apply: eq_bigr => i _ /=; rewrite !linearZ/= !linear_suml; congr (_ * _).
+apply: eq_bigr => j _ /=; rewrite linearZ !linearZl; congr (_ * _).
+rewrite -!(nth_map 0 0 tau) ?{}defT //; have [-> | neq_ji] := eqVneq j i.
+  by rewrite /=  -[RHS](nth_map 0 0 normf1) -?[LHS](nth_map 0 0 normf2) ?eq_sz // eq_nST.
+have{oS} [/=/andP[_ uS] oS] := pairwise_orthogonalP oS.
+have{oT} [/=/andP[_ uT] oT] := pairwise_orthogonalP oT.
+by rewrite oS ?oT ?mem_nth ?nth_uniq ?eq_sz.
+Qed.
+
+
+Lemma isometry_of_free S f :
+    free S -> {in S &, isometry form2 form1 f} ->
+  {tau : {linear U1 -> U2} |
+    {in S, tau =1 f} & {in <<S>>%VS &, isometry form2 form1 tau}}.
+Proof.
+move=> freeS If; have defS := free_span freeS.
+have [tau /(_ freeS (size_map f S))Dtau] := linear_of_free S (map f S).
+have {}Dtau: {in S, tau =1 f}.
+  by move=> _ /(nthP 0)[i ltiS <-]; rewrite -!(nth_map 0 0) ?Dtau.
+exists tau => // _ _ /defS[a -> _] /defS[b -> _] /=.
+rewrite  2!{1}linear_sum /= !{1}linear_suml /=;  apply/eq_big_seq=> xi1 Sxi1.
+rewrite !{1}linear_sumr; apply/eq_big_seq=> xi2 Sxi2 /=.
+by rewrite !linearZ /= !linearZl !Dtau //= If.
+Qed.
+
+
+Lemma isometry_raddf_inj  (tau : {additive U1 -> U2}) :
+    {in U1 &, isometry form2 form1 tau} ->
+    {in U1 &, forall u v, u - v \in U1} ->
+  {in U1 &, injective tau}.
+Proof.
+move=> Itau linU phi psi Uphi Upsi /eqP; rewrite -subr_eq0 -raddfB.
+by rewrite -(dnorm_eq0 form2)  Itau ?linU // dnorm_eq0 subr_eq0 => /eqP.
+Qed.
+
+
+End BuildIsometries.
+
+Section MatrixForms.
+
+Variables (R : fieldType) (n : nat).
+Implicit Types (a b : R) (u v : 'rV[R]_n).
+Implicit Types (M N P Q : 'M[R]_n).
+
+Section Def.
+Variable (theta : R -> R).
+
+Definition form_of_matrix m M (U  V : 'M_(m, n)) := \tr (U *m M *m (V ^t theta)).
+Definition matrix_of_form (form : 'rV[R]_n -> 'rV[R]_n -> R) : 'M[R]_n :=
+  \matrix_(i, j) form 'e_i 'e_j.
+Definition orthomx m M (B : 'M_(m,n)) : 'M_n := (kermx (M *m (B ^t theta))).
+
+Implicit Type form : {bilinear 'rV[R]_n -> 'rV[R]_n -> R | *%R & theta \; *%R}.
+
+Lemma matrix_of_formE form i j : matrix_of_form form i j = form 'e_i 'e_j.
+Proof. by rewrite mxE. Qed.
+End Def.
+
+Section FormOfMatrix.
+Variables (m : nat) (M : 'M[R]_n).
+Implicit Types (U V : 'M[R]_(m, n)).
+Variables (theta : {rmorphism R -> R}).
+
+Local Notation "''[' U , V ]" := (form_of_matrix theta M U%R V%R) : ring_scope.
+Local Notation "''[' U ]" := '[U, U]%R : ring_scope.
+
+Lemma form_of_matrix_is_linear U :
+  linear_for (theta \; *%R) (form_of_matrix theta M U).
+Proof.
+rewrite /form_of_matrix => k v w; rewrite -linearP/=.
+by rewrite linearP map_mxD map_mxZ !mulmxDr !scalemxAr.
+Qed.
+Canonical form_of_matrix_additive U := Additive (form_of_matrix_is_linear U).
+Canonical form_of_matrix_linear U := Linear (form_of_matrix_is_linear U).
+
+Definition form_of_matrixr U := (form_of_matrix theta M)^~U.
+Lemma form_of_matrixr_is_linear U : linear_for *%R (form_of_matrixr U).
+Proof.
+rewrite /form_of_matrixr /form_of_matrix => k v w.
+by rewrite -linearP /= !mulmxDl -!scalemxAl.
+Qed.
+Canonical form_of_matrixr_additive U := Additive (form_of_matrixr_is_linear U).
+Canonical form_of_matrixr_linear U := Linear (form_of_matrixr_is_linear U).
+Canonical form_of_matrixr_rev :=
+  [revop form_of_matrixr of form_of_matrix theta M].
+Canonical form_of_matrix_is_bilinear := [bilinear of form_of_matrix theta M].
+
+End FormOfMatrix.
+
+Section FormOfMatrix1.
+Variables (M : 'M[R]_n).
+Variables (theta : {rmorphism R -> R}).
+
+Local Notation "''[' u , v ]" := (form_of_matrix theta M u%R v%R) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+
+Lemma formee i j : '['e_i :'rV__, 'e_j] = M i j.
+Proof.
+rewrite /form_of_matrix -rowE -map_trmx map_delta_mx -[M in LHS]trmxK.
+by rewrite -tr_col -trmx_mul -rowE trace_mx11 !mxE.
+Qed.
+
+Lemma form_of_matrixK : matrix_of_form (form_of_matrix theta M) = M.
+Proof. by apply/matrixP => i j; rewrite !mxE formee. Qed.
+
+Lemma form0_eq0 : M = 0 -> forall u v, '[u, v] = 0.
+Proof.
+by rewrite /form_of_matrix => -> u v; rewrite mulmx0 mul0mx trace_mx11 mxE.
+Qed.
+
+End FormOfMatrix1.
+
+Section MatrixOfForm.
+Variable (theta : {rmorphism R -> R}).
+Variable (form : {bilinear 'rV[R]_n -> 'rV[R]_n -> R | *%R & theta \; *%R}).
+
+Lemma matrix_of_formK : form_of_matrix theta (matrix_of_form form) =2 form.
+Proof.
+set f := (X in X =2 _); have f_eq i j : f 'e_i 'e_j = form 'e_i 'e_j.
+  by rewrite /f formee mxE.
+move=> u v; rewrite [u]row_sum_delta [v]row_sum_delta /f.
+rewrite !linear_sum/=; apply: eq_bigr => j _.
+rewrite !linear_suml/=; apply: eq_bigr => i _.
+by rewrite !linearZlr/= -f_eq.
+Qed.
+
+End MatrixOfForm.
+
+Section HermitianMx.
+Variable (eps : bool).
+
+Section HermitianMxDef.
+Variable (theta : R -> R).
+
+Definition hermitianmx :=
+  [qualify M : 'M_n | M == ((-1) ^+ eps) *: M ^t theta].
+Fact hermitianmx_key : pred_key hermitianmx. Proof. by []. Qed.
+Canonical hermitianmx_keyed := KeyedQualifier hermitianmx_key.
+
+Structure hermitian_matrix := HermitianMx {
+  mx_of_hermitian :> 'M[R]_n;
+  _ : mx_of_hermitian \is hermitianmx
+}.
+
+Lemma is_hermitianmxE M :
+  (M \is hermitianmx) = (M == (-1) ^+ eps *: M ^t theta).
+Proof. by rewrite qualifE. Qed.
+
+Lemma is_hermitianmxP M :
+   reflect (M = (-1) ^+ eps *: M ^t theta) (M \is hermitianmx).
+Proof. by rewrite is_hermitianmxE; apply/eqP. Qed.
+
+Lemma hermitianmxE (M : hermitian_matrix) :
+  M = ((-1) ^+ eps) *: M ^t theta :> 'M__.
+Proof. by apply/eqP; case: M. Qed.
+
+Lemma trmx_hermitian (M : hermitian_matrix) :
+  M^T = ((-1) ^+ eps) *: M ^ theta :> 'M__.
+Proof. by rewrite {1}hermitianmxE linearZ /= map_trmx trmxK. Qed.
+
+End HermitianMxDef.
+
+Section HermitianMxTheory.
+Variables (theta : {involutive_rmorphism R}) (M : hermitian_matrix theta).
+
+Lemma maptrmx_hermitian : M^t theta = (-1) ^+ eps *: (M : 'M__).
+Proof.
+rewrite trmx_hermitian map_mxZ rmorph_sign -map_mx_comp.
+by rewrite (map_mx_id (rmorphK _)).
+Qed.
+
+Lemma form_of_matrix_is_hermitian m :
+  hermitian_for eps theta (@form_of_matrix theta m M).
+Proof.
+move=> /= u v; rewrite {1}hermitianmxE /form_of_matrix.
+rewrite -!(scalemxAr, scalemxAl) linearZ/=; congr (_ * _).
+rewrite -mxtrace_tr -trace_map_mx !(trmx_mul, map_mxM, map_trmx, trmxK).
+by rewrite -mulmxA -!map_mx_comp !(map_mx_id (rmorphK _)).
+Qed.
+
+Canonical form_of_matrix_hermitian m :=
+ (Hermitian (@form_of_matrix_is_hermitian m)).
+
+Local Notation "''[' u , v ]" := (form_of_matrix theta M u%R v%R) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+Local Notation "B ^!" := (orthomx theta M B) : matrix_set_scope.
+Local Notation "A _|_ B" := (A%MS <= B%MS^!)%MS : matrix_set_scope.
+
+Lemma orthomxE u v : (u _|_ v)%MS = ('[u, v] == 0).
+Proof.
+rewrite (sameP sub_kermxP eqP) mulmxA.
+by rewrite [_ *m _^t _]mx11_scalar -trace_mx11 fmorph_eq0.
+Qed.
+
+Lemma hermmx_eq0P {u v} : reflect ('[u, v] = 0) (u _|_ v)%MS.
+Proof. by rewrite orthomxE; apply/eqP. Qed.
+
+Lemma orthomxP p q (A : 'M_(p, n)) (B :'M_(q, n)) :
+  reflect (forall (u v : 'rV_n), u <= A -> v <= B -> u _|_ v)%MS
+          (A _|_ B)%MS.
+Proof.
+apply: (iffP idP) => AnB.
+  move=> u v uA vB; rewrite (submx_trans uA) // (submx_trans AnB) //.
+  apply/sub_kermxP; have /submxP [w ->] := vB.
+  rewrite trmx_mul map_mxM !mulmxA -[kermx _ *m _ *m _]mulmxA.
+  by rewrite [kermx _ *m _](sub_kermxP _) // mul0mx.
+apply/rV_subP => u /AnB /(_ _) /sub_kermxP uMv; apply/sub_kermxP.
+suff: forall m (v : 'rV[R]_m),
+  (forall i, v *m 'e_i ^t theta = 0 :> 'M_1) -> v = 0.
+  apply => i; rewrite !mulmxA -!mulmxA -map_mxM -trmx_mul uMv //.
+  by apply/submxP; exists 'e_i.
+move=> /= m v Hv; apply: (can_inj (@trmxK _ _ _)).
+rewrite trmx0; apply/row_matrixP=> i; rewrite row0 rowE.
+apply: (can_inj (@trmxK _ _ _)); rewrite trmx0 trmx_mul trmxK.
+by rewrite -(map_delta_mx theta) map_trmx Hv.
+Qed.
+
+Lemma orthomx_sym p q (A : 'M_(p, n)) (B :'M_(q, n)) :
+  (A _|_ B)%MS = (B _|_ A)%MS.
+Proof.
+gen have nC : p q A B / (A _|_ B -> B _|_ A)%MS; last by apply/idP/idP; apply/nC.
+move=> AnB; apply/orthomxP => u v ? ?; rewrite orthomxE.
+rewrite hermC mulf_eq0 ?fmorph_eq0 ?signr_eq0 /=.
+by rewrite -orthomxE (orthomxP _ _ AnB).
+Qed.
+
+Lemma ortho_ortho_mx p (A : 'M_(p, n)) : (A^! _|_ A)%MS.
+Proof. by []. Qed.
+
+Lemma ortho_mx_ortho p (A : 'M_(p, n)) : (A _|_ A^!)%MS.
+Proof. by rewrite orthomx_sym. Qed.
+
+Lemma rank_orthomx u : (\rank (u ^!) >= n.-1)%N.
+Proof.
+rewrite mxrank_ker -subn1 leq_sub2l //.
+by rewrite (leq_trans (mxrankM_maxr  _ _)) // rank_leq_col.
+Qed.
+
+Notation radmx := (1%:M^!)%MS.
+
+Lemma radmxE : radmx = kermx M.
+Proof. by rewrite /orthomx /orthomx trmx1 map_mx1 mulmx1. Qed.
+
+Lemma orthoNmx k m (A : 'M[R]_(k, n)) (B : 'M[R]_(m, n)) :
+  ((- A) _|_ B)%MS = (A _|_ B)%MS.
+Proof. by rewrite eqmx_opp. Qed.
+
+Lemma orthomxN k m (A : 'M[R]_(k, n)) (B : 'M[R]_(m, n)) :
+  (A _|_ (- B))%MS = (A _|_ B)%MS.
+Proof. by rewrite ![(A _|_ _)%MS]orthomx_sym orthoNmx. Qed.
+
+Lemma orthoDmx k m p (A : 'M[R]_(k, n)) (B : 'M[R]_(m, n)) (C : 'M[R]_(p, n)) :
+  (A + B _|_ C)%MS = (A _|_ C)%MS && (B _|_ C)%MS.
+Proof. by rewrite addsmxE !(sameP sub_kermxP eqP) mul_col_mx col_mx_eq0. Qed.
+
+Lemma orthomxD  k m p (A : 'M[R]_(k, n)) (B : 'M[R]_(m, n)) (C : 'M[R]_(p, n)) :
+  (A _|_ B + C)%MS = (A _|_ B)%MS && (A _|_ C)%MS.
+Proof. by rewrite ![(A _|_ _)%MS]orthomx_sym orthoDmx. Qed.
+
+Lemma orthoZmx p m a (A : 'M[R]_(p, n)) (B : 'M[R]_(m, n)) : a != 0 ->
+  (a *: A _|_ B)%MS = (A _|_ B)%MS.
+Proof. by move=> a_neq0; rewrite eqmx_scale. Qed.
+
+Lemma orthomxZ p m a (A : 'M[R]_(p, n)) (B : 'M[R]_(m, n)) : a != 0 ->
+  (A _|_ (a *: B))%MS = (A _|_ B)%MS.
+Proof. by move=> a_neq0; rewrite ![(A _|_ _)%MS]orthomx_sym orthoZmx. Qed.
+
+Lemma eqmx_ortho p m (A : 'M[R]_(p, n)) (B : 'M[R]_(m, n)) :
+  (A :=: B)%MS -> (A^! :=: B^!)%MS.
+Proof.
+move=> eqAB; apply/eqmxP.
+by rewrite orthomx_sym -eqAB ortho_mx_ortho orthomx_sym eqAB ortho_mx_ortho.
+Qed.
+
+Lemma genmx_ortho p (A : 'M[R]_(p, n)) : (<<A>>^! :=: A^!)%MS.
+Proof. exact: (eqmx_ortho (genmxE _)). Qed.
+
+End HermitianMxTheory.
+End HermitianMx.
+End MatrixForms.
+
+Notation symmetricmx := (hermitianmx _ false idfun).
+Notation skewmx := (hermitianmx _ true idfun).
+Notation hermsymmx := (hermitianmx _ false (@conjC _)).

--- a/mathcomp/algebra/forms.v
+++ b/mathcomp/algebra/forms.v
@@ -446,6 +446,48 @@ HB.structure Definition Hermitian (R : ringType) (U : lmodType R)
     (eps : bool) (theta : R -> R) :=
   {f of ??? & @isHermitian R U eps theta f}.*)
 
+(*Variables (R : ringType) (U : lmodType R) (eps : bool) (theta : R -> R).
+Implicit Types phU : phant U.
+
+Local Coercion GRing.Scale.op : GRing.Scale.law >-> Funclass.
+Definition axiom (f : U -> U -> R) :=
+  forall x y : U, f x y = (-1) ^+ eps * theta (f y x).
+
+Record class_of (f : U -> U -> R) : Prop := Class {
+  base : Bilinear.class_of ( *%R) (theta \; *%R) f;
+  mixin : axiom f
+}.*)
+
+(*Canonical additiver (u : U) := Additive (base class u).
+Canonical linearr (u : U) := Linear (base class u).
+Canonical additivel (u' : U) := @GRing.Additive.Pack _ _ (Phant (U -> R))
+  (applyr cF u') (Bilinear.basel (base class) u').
+Canonical linearl (u' : U) := @GRing.Linear.Pack _ _ _ _ (Phant (U -> R))
+  (applyr cF u') (Bilinear.basel (base class) u').
+Canonical bilinear := @Bilinear.Pack _ _ _ _ _ _ (Phant (U -> U -> R)) cF (base class).*)
+
+(*Module Exports.
+Notation "{ 'hermitian' U 'for' eps & theta }" := (map eps theta (Phant U))
+  (at level 0, format "{ 'hermitian'  U  'for'  eps  &  theta }") : ring_scope.
+Coercion base : class_of >-> bilmorphism_for.
+Coercion apply : map >-> Funclass.
+Notation "[ 'hermitian' 'of' f 'as' g ]" := (@clone _ _ _ _ _ _ f g _ idfun idfun)
+  (at level 0, format "[ 'hermitian'  'of'  f  'as'  g ]") : form_scope.
+Notation "[ 'hermitian' 'of' f ]" := (@clone _ _ _ _ _ _ f f _ idfun idfun)
+  (at level 0, format "[ 'hermitian'  'of'  f ]") : form_scope.
+Notation hermitian_for := Hermitian.axiom.
+Notation Hermitian fM := (pack (Phant _) fM idfun).
+Canonical additiver.
+Canonical linearr.
+Canonical additivel.
+Canonical linearl.
+Canonical bilinear.
+Notation hermapplyr := (@applyr_head _ _ _ _ tt).
+End Exports.
+
+End Hermitian.
+Include Hermitian.Exports.*)
+
 Section Sesquilinear.
 
 Variable R : fieldType.
@@ -640,48 +682,6 @@ Notation "eps_theta .-sesqui" := (sesqui _ eps_theta) : ring_scope.
 Notation symmetric_form := (false, idfun).-sesqui.
 Notation skew := (true, idfun).-sesqui.
 Notation hermitian := (false, @Num.conj_op _).-sesqui.
-
-(*Variables (R : ringType) (U : lmodType R) (eps : bool) (theta : R -> R).
-Implicit Types phU : phant U.
-
-Local Coercion GRing.Scale.op : GRing.Scale.law >-> Funclass.
-Definition axiom (f : U -> U -> R) :=
-  forall x y : U, f x y = (-1) ^+ eps * theta (f y x).
-
-Record class_of (f : U -> U -> R) : Prop := Class {
-  base : Bilinear.class_of ( *%R) (theta \; *%R) f;
-  mixin : axiom f
-}.*)
-
-(*Canonical additiver (u : U) := Additive (base class u).
-Canonical linearr (u : U) := Linear (base class u).
-Canonical additivel (u' : U) := @GRing.Additive.Pack _ _ (Phant (U -> R))
-  (applyr cF u') (Bilinear.basel (base class) u').
-Canonical linearl (u' : U) := @GRing.Linear.Pack _ _ _ _ (Phant (U -> R))
-  (applyr cF u') (Bilinear.basel (base class) u').
-Canonical bilinear := @Bilinear.Pack _ _ _ _ _ _ (Phant (U -> U -> R)) cF (base class).*)
-
-Module Exports.
-Notation "{ 'hermitian' U 'for' eps & theta }" := (map eps theta (Phant U))
-  (at level 0, format "{ 'hermitian'  U  'for'  eps  &  theta }") : ring_scope.
-Coercion base : class_of >-> bilmorphism_for.
-Coercion apply : map >-> Funclass.
-Notation "[ 'hermitian' 'of' f 'as' g ]" := (@clone _ _ _ _ _ _ f g _ idfun idfun)
-  (at level 0, format "[ 'hermitian'  'of'  f  'as'  g ]") : form_scope.
-Notation "[ 'hermitian' 'of' f ]" := (@clone _ _ _ _ _ _ f f _ idfun idfun)
-  (at level 0, format "[ 'hermitian'  'of'  f ]") : form_scope.
-Notation hermitian_for := Hermitian.axiom.
-Notation Hermitian fM := (pack (Phant _) fM idfun).
-Canonical additiver.
-Canonical linearr.
-Canonical additivel.
-Canonical linearl.
-Canonical bilinear.
-Notation hermapplyr := (@applyr_head _ _ _ _ tt).
-End Exports.
-
-End Hermitian.
-Include Hermitian.Exports.
 
 Module Dot.
 

--- a/mathcomp/algebra/mxred.v
+++ b/mathcomp/algebra/mxred.v
@@ -1,0 +1,533 @@
+(* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
+(* Distributed under the terms of CeCILL-B.                                  *)
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
+From mathcomp Require Import choice fintype finfun bigop fingroup perm order.
+From mathcomp Require Import ssralg zmodp matrix mxalgebra poly polydiv mxpoly.
+
+(*****************************************************************************)
+(* In this file, we prove diagonalization theorems, for this purpose, we     *)
+(* define conjugation, similarity and diagonalizability.                     *)
+(*                                                                           *)
+(*      conjmx V f  := V *m f *m pinvmx V                                    *)
+(*                  == the conjugation of f by V, i.e. "the" matrix of f     *)
+(*                     in the basis of row vectors of V.                     *)
+(*                     Although this makes sense only when f stabilizes V,   *)
+(*                     the definition can be stated more generally.          *)
+(* similar_to P A C == where P is a base change matrix, A is a matrix,       *)
+(*                     and C is a class of matrices,                         *)
+(*                     this states that conjmx P A is in C,                  *)
+(*                     which means A is similar to a matrix in C.            *)
+(*                                                                           *)
+(* From the latter, we derive serveral related notions:                      *)
+(*         similar P A B := similar_to P A (pred1 B)                         *)
+(*                       == A is similar to B, with base change matrix P     *)
+(*      similar_in D A B == A is similar to B,                               *)
+(*                          with a base change matrix in D                   *)
+(*   similar_in_to D A C == A is similar to a matrix in the class C,         *)
+(*                          with a base change matrix in D                   *)
+(* all_similar_to D As C == all the matrices in the sequence As are similar  *)
+(*                          to some matrix in the class C,                   *)
+(*                          with a base change matrix in D.                  *)
+(*                                                                           *)
+(* We also specialize the class C, to diagonalizability:                     *)
+(*          similar_diag P A := (similar_to P A is_diag_mx).                 *)
+(*     diagonalizable_in D A := (similar_in_to D A is_diag_mx).              *)
+(*          diagonalizable A := (diagonalizable_in unitmx A).                *)
+(*  codiagonalizable_in D As := (all_similar_to D As is_diag_mx).            *)
+(*       codiagonalizable As := (codiagonalizable_in unitmx As).             *)
+(*                                                                           *)
+(* The main results of this file are:                                        *)
+(*   diagonalizablePeigen:                                                   *)
+(*     a matrix is diagonalizable iff there is a sequence                    *)
+(*     of scalars r, such that the sum of the associated                     *)
+(*     eigenspaces is full.                                                  *)
+(*   diagonalizableP:                                                        *)
+(*     a matrix is diagonalizable iff its minimal polynomial                 *)
+(*     divides a split polynomial with simple roots.                         *)
+(*   codiagonalizableP:                                                      *)
+(*     a sequence of matrices are diagonalizable in the same basis           *)
+(*     iff they are all diagonalizable and commute pairwize.                 *)
+(*                                                                           *)
+(* We also specialize the class C, to trigonalizablility:                    *)
+(*          similar_trig P A := (similar_to P A is_trig_mx).                 *)
+(*     trigonalizable_in D A := (similar_in_to D A is_trig_mx).              *)
+(*          trigonalizable A := (trigonalizable_in unitmx A).                *)
+(*  cotrigonalizable_in D As := (all_similar_to D As is_trig_mx).            *)
+(*       cotrigonalizable As := (cotrigonalizable_in unitmx As).             *)
+(* The theory of trigonalization is however not developed in this file.      *)
+(*****************************************************************************)
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Import GRing.Theory.
+Import Monoid.Theory.
+
+Local Open Scope ring_scope.
+
+Section ConjMx.
+Context {F : fieldType}.
+
+Definition conjmx (m n : nat)
+ (V : 'M_(m, n)) (f : 'M[F]_n) : 'M_m :=  V *m f *m pinvmx V.
+Notation restrictmx V := (conjmx (row_base V)).
+
+Lemma stablemx_comp (m n p : nat) (V : 'M[F]_(m, n)) (W : 'M_(n, p)) (f : 'M_p) :
+  stablemx W f -> stablemx V (conjmx W f) -> stablemx (V *m W) f.
+Proof. by move=> Wf /(submxMr W); rewrite -mulmxA mulmxKpV// mulmxA. Qed.
+
+Lemma stablemx_restrict m n (A : 'M[F]_n) (V : 'M_n) (W : 'M_(m, \rank V)):
+  stablemx V A -> stablemx W (restrictmx V A) = stablemx (W *m row_base V) A.
+Proof.
+move=> A_stabV; rewrite mulmxA -[in RHS]mulmxA.
+rewrite -(submxMfree _ W (row_base_free V)) mulmxKpV //.
+by rewrite mulmx_sub ?stablemx_row_base.
+Qed.
+
+Lemma conjmxM (m n : nat) (V : 'M[F]_(m, n)) :
+   {in [pred f | stablemx V f] &, {morph conjmx V : f g / f *m g}}.
+Proof.
+move=> f g; rewrite !inE => Vf Vg /=.
+by rewrite /conjmx 2!mulmxA mulmxA mulmxKpV ?stablemx_row_base.
+Qed.
+
+Lemma conjMmx (m n p : nat) (V : 'M[F]_(m, n)) (W : 'M_(n, p)) (f : 'M_p) :
+  row_free (V *m W) -> stablemx W f -> stablemx V (conjmx W f) ->
+  conjmx (V *m W) f = conjmx V (conjmx W f).
+Proof.
+move=> rfVW Wf VWf; apply: (row_free_inj rfVW); rewrite mulmxKpV ?stablemx_comp//.
+by rewrite mulmxA mulmxKpV// -[RHS]mulmxA mulmxKpV ?mulmxA.
+Qed.
+
+Lemma conjuMmx (m n : nat) (V : 'M[F]_m) (W : 'M_(m, n)) (f : 'M_n) :
+  V \in unitmx -> row_free W -> stablemx W f ->
+  conjmx (V *m W) f = conjmx V (conjmx W f).
+Proof.
+move=> Vu rfW Wf; rewrite conjMmx ?stablemx_unit//.
+by rewrite /row_free mxrankMfree// -/(row_free V) row_free_unit.
+Qed.
+
+Lemma conjMumx (m n : nat) (V : 'M[F]_(m, n)) (W f : 'M_n) :
+  W \in unitmx -> row_free V -> stablemx V (conjmx W f) ->
+  conjmx (V *m W) f = conjmx V (conjmx W f).
+Proof.
+move=> Wu rfW Wf; rewrite conjMmx ?stablemx_unit//.
+by rewrite /row_free mxrankMfree ?row_free_unit.
+Qed.
+
+Lemma conjuMumx (n : nat) (V W f : 'M[F]_n) :
+  V \in unitmx -> W \in unitmx ->
+  conjmx (V *m W) f = conjmx V (conjmx W f).
+Proof. by move=> Vu Wu; rewrite conjuMmx ?stablemx_unit ?row_free_unit. Qed.
+
+Lemma conjmx_scalar (m n : nat) (V : 'M[F]_(m, n)) (a : F) :
+  row_free V -> conjmx V a%:M = a%:M.
+Proof. by move=> rfV; rewrite /conjmx scalar_mxC mulmxKp. Qed.
+
+Lemma conj0mx (m n : nat) f : conjmx (0 : 'M[F]_(m, n)) f = 0.
+Proof. by rewrite /conjmx !mul0mx. Qed.
+
+Lemma conjmx0 (m n : nat) (V : 'M[F]_(m, n)) : conjmx V 0 = 0.
+Proof. by rewrite /conjmx mulmx0 mul0mx. Qed.
+
+Lemma conjumx (n : nat) (V : 'M_n) (f : 'M[F]_n) : V \in unitmx ->
+  conjmx V f = V *m f *m invmx V.
+Proof. by move=> uV; rewrite /conjmx pinvmxE. Qed.
+
+Lemma conj1mx (n : nat) (f : 'M[F]_n) : conjmx 1%:M f = f.
+Proof. by rewrite conjumx ?unitmx1// invmx1 mulmx1 mul1mx. Qed.
+
+Lemma conjVmx (n : nat) (V : 'M_n) (f : 'M[F]_n) : V \in unitmx ->
+  conjmx (invmx V) f = invmx V *m f *m V.
+Proof. by move=> Vunit; rewrite conjumx ?invmxK ?unitmx_inv. Qed.
+
+Lemma conjmxK (n : nat) (V f : 'M[F]_n) :
+  V \in unitmx -> conjmx (invmx V) (conjmx V f) = f.
+Proof. by move=> Vu; rewrite -conjuMumx ?unitmx_inv// mulVmx ?conj1mx. Qed.
+
+Lemma conjmxVK (n : nat) (V f : 'M[F]_n) :
+  V \in unitmx -> conjmx V (conjmx (invmx V) f) = f.
+Proof. by move=> Vu; rewrite -conjuMumx ?unitmx_inv// mulmxV ?conj1mx. Qed.
+
+Lemma horner_mx_conj m n p (B : 'M[F]_(n.+1, m.+1)) (f : 'M_m.+1) :
+   row_free B -> stablemx B f ->
+   horner_mx (conjmx B f) p = conjmx B (horner_mx f p).
+Proof.
+move=> B_free B_stab; rewrite/conjmx; elim/poly_ind: p => [|p c].
+  by rewrite !rmorph0 mulmx0 mul0mx.
+rewrite !(rmorphD, rmorphM)/= !(horner_mx_X, horner_mx_C) => ->.
+rewrite [_ * _]mulmxA [_ *m (B *m _)]mulmxA mulmxKpV ?horner_mx_stable//.
+apply: (row_free_inj B_free); rewrite [_ *m B]mulmxDl.
+pose stablemxE := (stablemxD, stablemxM, stablemxC, horner_mx_stable).
+by rewrite !mulmxKpV -?[B *m _ *m _]mulmxA ?stablemxE// mulmxDr -scalar_mxC.
+Qed.
+
+Lemma horner_mx_uconj n p (B : 'M[F]_(n.+1)) (f : 'M_n.+1) :
+   B \is a GRing.unit ->
+   horner_mx (B *m f *m invmx B) p = B *m horner_mx f p *m invmx B.
+Proof.
+move=> B_unit; rewrite -!conjumx//.
+by rewrite horner_mx_conj ?row_free_unit ?stablemx_unit.
+Qed.
+
+Lemma horner_mx_uconjC n p (B : 'M[F]_(n.+1)) (f : 'M_n.+1) :
+   B \is a GRing.unit ->
+   horner_mx (invmx B *m f *m B) p = invmx B *m horner_mx f p *m B.
+Proof.
+move=> B_unit; rewrite -[X in _ *m X](invmxK B).
+by rewrite horner_mx_uconj ?invmxK ?unitmx_inv.
+Qed.
+
+Lemma mxminpoly_conj m n (V : 'M[F]_(m.+1, n.+1)) (f : 'M_n.+1) :
+  row_free V -> stablemx V f -> mxminpoly (conjmx V f) %| mxminpoly f.
+Proof.
+by move=> *; rewrite mxminpoly_min// horner_mx_conj// mx_root_minpoly conjmx0.
+Qed.
+
+Lemma mxminpoly_uconj n (V : 'M[F]_(n.+1)) (f : 'M_n.+1) :
+  V \in unitmx -> mxminpoly (conjmx V f) = mxminpoly f.
+Proof.
+have simp := (row_free_unit, stablemx_unit, unitmx_inv, unitmx1).
+move=> Vu; apply/eqP; rewrite -eqp_monic ?mxminpoly_monic// /eqp.
+apply/andP; split; first by rewrite mxminpoly_conj ?simp.
+by rewrite -[f in X in X %| _](conjmxK _ Vu) mxminpoly_conj ?simp.
+Qed.
+
+Section fixed_stablemx_space.
+
+Variables (m n : nat).
+
+Implicit Types (V : 'M[F]_(m, n)) (f : 'M[F]_n).
+Implicit Types (a : F) (p : {poly F}).
+
+Section Sub.
+Variable (k : nat).
+Implicit Types (W : 'M[F]_(k, m)).
+
+Lemma sub_kermxpoly_conjmx V f p W : stablemx V f -> row_free V ->
+  (W <= kermxpoly (conjmx V f) p)%MS = (W *m V <= kermxpoly f p)%MS.
+Proof.
+case: n m => [|n'] [|m']// in V f W * => fV rfV; rewrite ?thinmx0//.
+   by rewrite mul0mx !sub0mx.
+apply/sub_kermxP/sub_kermxP; rewrite horner_mx_conj//; last first.
+  by move=> /(congr1 (mulmxr (pinvmx V)))/=; rewrite mul0mx !mulmxA.
+move=> /(congr1 (mulmxr V))/=; rewrite ![W *m _]mulmxA ?mul0mx mulmxKpV//.
+by rewrite -mulmxA mulmx_sub// horner_mx_stable//.
+Qed.
+
+Lemma sub_eigenspace_conjmx V f a W : stablemx V f -> row_free V ->
+  (W <= eigenspace (conjmx V f) a)%MS = (W *m V <= eigenspace f a)%MS.
+Proof. by move=> fV rfV; rewrite !eigenspace_poly sub_kermxpoly_conjmx. Qed.
+End Sub.
+
+Lemma eigenpoly_conjmx V f : stablemx V f -> row_free V ->
+  {subset eigenpoly (conjmx V f) <= eigenpoly f}.
+Proof.
+move=> fV rfV a /eigenpolyP [x]; rewrite sub_kermxpoly_conjmx//.
+move=> xV_le_fa x_neq0; apply/eigenpolyP.
+by exists (x *m V); rewrite ?mulmx_free_eq0.
+Qed.
+
+Lemma eigenvalue_conjmx V f : stablemx V f -> row_free V ->
+  {subset eigenvalue (conjmx V f) <= eigenvalue f}.
+Proof.
+by move=> fV rfV a; rewrite ![_ \in _]eigenvalue_poly; apply: eigenpoly_conjmx.
+Qed.
+
+Lemma conjmx_eigenvalue a V f : (V <= eigenspace f a)%MS -> row_free V ->
+ conjmx V f = a%:M.
+Proof.
+by move=> /eigenspaceP Vfa rfV; rewrite /conjmx Vfa -mul_scalar_mx mulmxKp.
+Qed.
+
+End fixed_stablemx_space.
+End ConjMx.
+Notation restrictmx V := (conjmx (row_base V)).
+
+Definition similar_to {F : fieldType} {m n} (P : 'M_(m, n)) A (C : {pred 'M[F]_m}) :=
+   C (conjmx P A).
+
+Notation similar P A B := (similar_to P A (PredOfSimpl.coerce (pred1 B))).
+Notation similar_in D A B := (exists2 P, P \in D & similar P A B).
+Notation similar_in_to D A C := (exists2 P, P \in D & similar_to P A C).
+Notation all_similar_to D As C := (exists2 P, P \in D & all [pred A | similar_to P A C] As).
+
+Notation similar_diag P A := (similar_to P A is_diag_mx).
+Notation diagonalizable_in D A := (similar_in_to D A is_diag_mx).
+Notation diagonalizable A := (diagonalizable_in unitmx A).
+Notation codiagonalizable_in D As := (all_similar_to D As is_diag_mx).
+Notation codiagonalizable As := (codiagonalizable_in unitmx As).
+
+Notation similar_trig P A := (similar_to P A is_trig_mx).
+Notation trigonalizable_in D A := (similar_in_to D A is_trig_mx).
+Notation trigonalizable A := (trigonalizable_in unitmx A).
+Notation cotrigonalizable_in D As := (all_similar_to D As is_trig_mx).
+Notation cotrigonalizable As := (cotrigonalizable_in unitmx As).
+
+Section Similarity.
+Context {F : fieldType}.
+
+Lemma similarPp m n {P : 'M[F]_(m, n)} {A B} :
+  stablemx P A -> similar P A B -> P *m A = B *m P.
+Proof. by move=> stablemxPA /eqP <-; rewrite mulmxKpV. Qed.
+
+Lemma similarW m n {P : 'M[F]_(m, n)} {A B} : row_free P ->
+  P *m A = B *m P -> similar P A B.
+Proof. by rewrite /similar_to/= /conjmx => fP ->; rewrite mulmxKp. Qed.
+
+Section Similar.
+
+Context {n : nat}.
+Implicit Types (f g p : 'M[F]_n) (fs : seq 'M[F]_n) (d : 'rV[F]_n).
+
+Lemma similarP {p f g} : p \in unitmx ->
+  reflect (p *m f = g *m p) (similar p f g).
+Proof.
+move=> p_unit; apply: (iffP idP); first exact/similarPp/stablemx_unit.
+by apply: similarW; rewrite row_free_unit.
+Qed.
+
+Lemma similarRL {p f g} : p \in unitmx ->
+  reflect (g = p *m f *m invmx p) (similar p f g).
+Proof. by move=> ?; apply: (iffP eqP); rewrite conjumx. Qed.
+
+Lemma similarLR {p f g} : p \in unitmx ->
+  reflect (f = conjmx (invmx p) g) (similar p f g).
+Proof.
+by move=> pu; rewrite conjVmx//; apply: (iffP (similarRL pu)) => ->;
+   rewrite !mulmxA ?(mulmxK, mulmxKV, mulVmx, mulmxV, mul1mx, mulmx1).
+Qed.
+
+End Similar.
+
+Lemma similar_mxminpoly {n} {p f g : 'M[F]_n.+1} : p \in unitmx ->
+  similar p f g -> mxminpoly f = mxminpoly g.
+Proof. by move=> pu /eqP<-; rewrite mxminpoly_uconj. Qed.
+
+Lemma similar_diag_row_base m n (P : 'M[F]_(m, n)) (A : 'M_n) :
+  similar_diag (row_base P) A = is_diag_mx (restrictmx P A).
+Proof. by []. Qed.
+
+Lemma similar_diagPp m n (P : 'M[F]_(m, n)) A :
+  reflect (forall i j : 'I__, i != j :> nat -> conjmx P A i j = 0)
+          (similar_diag P A).
+Proof. exact: @is_diag_mxP. Qed.
+
+Lemma similar_diagP n (P : 'M[F]_n) A : P \in unitmx ->
+  reflect (forall i j : 'I__, i != j :> nat -> (P *m A *m invmx P) i j = 0)
+          (similar_diag P A).
+Proof. by move=> Pu; rewrite -conjumx//; exact: is_diag_mxP. Qed.
+
+Lemma similar_diagPex {m} {n} {P : 'M[F]_(m, n)} {A} :
+  reflect (exists D, similar P A (diag_mx D)) (similar_diag P A).
+Proof. by apply: (iffP (diag_mxP _)) => -[D]/eqP; exists D. Qed.
+
+Lemma similar_diagLR n {P : 'M[F]_n} {A} : P \in unitmx ->
+  reflect (exists D, A = conjmx (invmx P) (diag_mx D)) (similar_diag P A).
+Proof.
+by move=> Punit; apply: (iffP similar_diagPex) => -[D /(similarLR Punit)]; exists D.
+Qed.
+
+Lemma similar_diag_mxminpoly {n} {p f : 'M[F]_n.+1}
+  (rs := undup [seq conjmx p f i i | i <- enum 'I_n.+1]) :
+  p \in unitmx -> similar_diag p f ->
+  mxminpoly f = \prod_(r <- rs) ('X - r%:P).
+Proof.
+rewrite /rs => pu /(similar_diagLR pu)[d {f rs}->].
+rewrite mxminpoly_uconj ?unitmx_inv// mxminpoly_diag.
+by rewrite (@eq_map _ _ _ (d 0))// => i; rewrite conjmxVK// mxE eqxx.
+Qed.
+
+End Similarity.
+
+Lemma similar_diag_sum (F : fieldType) (m n : nat) (p_ : 'I_n -> nat)
+      (V_ : forall i, 'M[F]_(p_ i, m)) (f : 'M[F]_m) :
+    mxdirect (\sum_i <<V_ i>>) ->
+    (forall i, stablemx (V_ i) f) ->
+    (forall i, row_free (V_ i)) ->
+  similar_diag (\mxcol_i V_ i) f = [forall i, similar_diag (V_ i) f].
+Proof.
+move=> Vd Vf rfV; have aVf : stablemx (\mxcol_i V_ i) f.
+  rewrite (eqmx_stable _ (eqmx_col _)) stablemx_sums//.
+  by move=> i; rewrite (eqmx_stable _ (genmxE _)).
+apply/similar_diagPex/'forall_similar_diagPex => /=
+    [[D /(similarPp aVf) +] i|/(_ _)/sigW Dof].
+  rewrite mxcol_mul -[D]submxrowK diag_mxrow mul_mxdiag_mxcol.
+  move=> /eq_mxcolP/(_ i); set D0 := (submxrow _ _) => VMeq.
+  by exists D0; apply/similarW.
+exists (\mxrow_i tag (Dof i)); apply/similarW.
+   rewrite -row_leq_rank eqmx_col (mxdirectP Vd)/=.
+   by under [X in (_ <= X)%N]eq_bigr do rewrite genmxE (eqP (rfV _)).
+rewrite mxcol_mul diag_mxrow mul_mxdiag_mxcol; apply: eq_mxcol => i.
+by case: Dof => /= k /(similarPp); rewrite Vf => /(_ isT) ->.
+Qed.
+
+Section Diag.
+Variable (F : fieldType).
+
+Lemma codiagonalizable1 n (A : 'M[F]_n) :
+  codiagonalizable [:: A] <-> diagonalizable A.
+Proof. by split=> -[P Punit PA]; exists P; move: PA; rewrite //= andbT. Qed.
+
+Definition codiagonalizablePfull n (As : seq 'M[F]_n) :
+  codiagonalizable As <-> exists m,
+    exists2 P : 'M_(m, n), row_full P & all [pred A | similar_diag P A] As.
+Proof.
+split => [[P Punit SPA]|[m [P Pfull SPA]]].
+  by exists n => //; exists P; rewrite ?row_full_unit.
+have Qfull := fullrowsub_unit Pfull.
+exists (rowsub (fullrankfun Pfull) P) => //; apply/allP => A AAs/=.
+have /allP /(_ _ AAs)/= /similar_diagPex[d /similarPp] := SPA.
+rewrite submx_full// => /(_ isT) PA_eq.
+apply/similar_diagPex; exists (colsub (fullrankfun Pfull) d).
+apply/similarP => //; apply/row_matrixP => i.
+rewrite !row_mul row_diag_mx -scalemxAl -rowE !row_rowsub !mxE.
+have /(congr1 (row (fullrankfun Pfull i))) := PA_eq.
+by rewrite !row_mul row_diag_mx -scalemxAl -rowE => ->.
+Qed.
+
+Lemma codiagonalizable_on m n (V_ : 'I_n -> 'M[F]_m) (As : seq 'M[F]_m) :
+  (\sum_i V_ i :=: 1%:M)%MS -> mxdirect (\sum_i V_ i) ->
+  (forall i, all (fun A => stablemx (V_ i) A) As) ->
+  (forall i, codiagonalizable (map (restrictmx (V_ i)) As)) -> codiagonalizable As.
+Proof.
+move=> V1 Vdirect /(_ _)/allP AV /(_ _) /sig2W/= Pof.
+pose P_ i := tag (Pof i).
+have P_unit i : P_ i \in unitmx by rewrite /P_; case: {+}Pof.
+have P_diag i A : A \in As -> similar_diag (P_ i *m row_base (V_ i)) A.
+  move=> AAs; rewrite /P_; case: {+}Pof => /= P Punit.
+  rewrite all_map => /allP/(_ A AAs); rewrite /similar_to/=.
+  by rewrite conjuMmx ?row_base_free ?stablemx_row_base ?AV.
+pose P := \mxcol_i (P_ i *m row_base (V_ i)).
+have P_full i : row_full (P_ i) by rewrite row_full_unit.
+have PrV i : (P_ i *m row_base (V_ i) :=: V_ i)%MS.
+  exact/(eqmx_trans _ (eq_row_base _))/eqmxMfull.
+apply/codiagonalizablePfull; eexists _; last exists P; rewrite /=.
+- rewrite -sub1mx eqmx_col.
+  by under eq_bigr do rewrite (eq_genmx (PrV _)); rewrite -genmx_sums genmxE V1.
+apply/allP => A AAs /=; rewrite similar_diag_sum.
+- by apply/forallP => i; apply: P_diag.
+- rewrite mxdirectE/=.
+  under eq_bigr do rewrite (eq_genmx (PrV _)); rewrite -genmx_sums genmxE V1.
+  by under eq_bigr do rewrite genmxE PrV; rewrite  -(mxdirectP Vdirect)//= V1.
+- by move=> i; rewrite (eqmx_stable _ (PrV _)) ?AV.
+- by move=> i; rewrite /row_free eqmxMfull ?eq_row_base ?row_full_unit.
+Qed.
+
+Lemma diagonalizable_diag {n} (d : 'rV[F]_n) : diagonalizable (diag_mx d).
+Proof.
+by exists 1%:M; rewrite ?unitmx1// /similar_to conj1mx diag_mx_is_diag.
+Qed.
+Hint Resolve diagonalizable_diag : core.
+
+Lemma diagonalizable_scalar {n} (a : F) : diagonalizable (a%:M : 'M_n).
+Proof. by rewrite -diag_const_mx. Qed.
+Hint Resolve diagonalizable_scalar : core.
+
+Lemma diagonalizable0 {n} : diagonalizable (0 : 'M[F]_n).
+Proof.
+by rewrite (_ : 0 = 0%:M)//; apply/matrixP => i j; rewrite !mxE// mul0rn.
+Qed.
+Hint Resolve diagonalizable0 : core.
+
+Lemma diagonalizablePeigen {n} {f : 'M[F]_n} :
+  diagonalizable f <->
+  exists2 rs, uniq rs & (\sum_(r <- rs) eigenspace f r :=: 1%:M)%MS.
+Proof.
+split=> [df|[rs urs rsP]].
+  suff [rs rsP] : exists rs, (\sum_(r <- rs) eigenspace f r :=: 1%:M)%MS.
+    exists (undup rs); rewrite ?undup_uniq//; apply: eqmx_trans rsP.
+    elim: rs => //= r rs IHrs; rewrite big_cons.
+    case: ifPn => in_rs; rewrite ?big_cons; last exact: adds_eqmx.
+    apply/(eqmx_trans IHrs)/eqmx_sym/addsmx_idPr.
+    have rrs : (index r rs < size rs)%N by rewrite index_mem.
+    rewrite (big_nth 0) big_mkord (sumsmx_sup (Ordinal rrs)) ?nth_index//.
+  move: df => [P Punit /(similar_diagLR Punit)[d ->]].
+  exists [seq d 0 i | i <- enum 'I_n]; rewrite big_image/=.
+  apply: (@eqmx_trans _ _ _ _ _ _ P); apply/eqmxP;
+    rewrite ?sub1mx ?submx1 ?row_full_unit//.
+  rewrite submx_full ?row_full_unit//=.
+  apply/row_subP => i; rewrite rowE (sumsmx_sup i)//.
+  apply/eigenspaceP; rewrite conjVmx// !mulmxA mulmxK//.
+  by rewrite -rowE row_diag_mx scalemxAl.
+have mxdirect_eigenspaces : mxdirect (\sum_(i < size rs) eigenspace f rs`_i).
+  apply: mxdirect_sum_eigenspace => i j _ _ rsij; apply/val_inj.
+  by apply: uniqP rsij; rewrite ?inE.
+rewrite (big_nth 0) big_mkord in rsP; rewrite -codiagonalizable1.
+apply/(codiagonalizable_on _ mxdirect_eigenspaces) => // i/=.
+  case: n => [|n] in f {mxdirect_eigenspaces} rsP *.
+    by rewrite thinmx0 sub0mx.
+  by rewrite comm_mx_stable_eigenspace.
+rewrite codiagonalizable1.
+by rewrite (@conjmx_eigenvalue _ _ _ rs`_i) ?eq_row_base ?row_base_free.
+Qed.
+
+Lemma diagonalizableP n' (n := n'.+1) (f : 'M[F]_n) :
+  diagonalizable f <->
+  exists2 rs, uniq rs & mxminpoly f %| \prod_(x <- rs) ('X - x%:P).
+Proof.
+split=> [[P Punit /similar_diagPex[d /(similarLR Punit)->]]|].
+  rewrite mxminpoly_uconj ?unitmx_inv// mxminpoly_diag.
+  by eexists; [|by []]; rewrite undup_uniq.
+rewrite diagonalizablePeigen => -[rs rsu rsP].
+exists rs; rewrite // !(big_nth 0) !big_mkord in rsP *.
+rewrite (eq_bigr _ (fun _ _ => eigenspace_poly _ _)).
+apply: (eqmx_trans (eqmx_sym (kermxpoly_prod _ _)) (kermxpoly_min _)) => //.
+by move=> i j _ _; rewrite coprimep_XsubC root_XsubC nth_uniq.
+Qed.
+
+Lemma diagonalizable_conj_diag m n (V : 'M[F]_(m, n)) (d : 'rV[F]_n) :
+  stablemx V (diag_mx d) -> row_free V -> diagonalizable (conjmx V (diag_mx d)).
+Proof.
+case: m n => [|m] [|n]// in V d * => Vd rdV; rewrite ?thinmx0//=.
+apply/diagonalizableP; pose u := undup [seq d 0 i | i <- enum 'I_n.+1].
+exists u; first by rewrite undup_uniq.
+by rewrite (dvdp_trans (mxminpoly_conj _ _))// mxminpoly_diag.
+Qed.
+
+Lemma codiagonalizableP n (fs : seq 'M[F]_n) :
+  {in fs &, forall f g, comm_mx f g} /\ (forall f, f \in fs -> diagonalizable f)
+  <-> codiagonalizable fs.
+Proof.
+split => [cdfs|[P Punit /allP/= fsD]]/=; last first.
+  split; last by exists P; rewrite // fsD.
+  move=> f g ffs gfs; move=> /(_ _ _)/similar_diagPex/sigW in fsD.
+  have [[df /similarLR->//] [dg /similarLR->//]] := (fsD _ ffs, fsD _ gfs).
+  by rewrite /comm_mx -!conjmxM 1?diag_mxC// inE stablemx_unit ?unitmx_inv.
+move: cdfs; rewrite (rwP (all_comm_mxP _)) => cdfs.
+have [k] := ubnP (size fs); elim: k => [|k IHk]//= in n fs cdfs *.
+case: fs cdfs => [|f fs]//=; first by exists 1%:M; rewrite ?unitmx1.
+rewrite ltnS all_comm_mx_cons => -[/andP[/allP/(_ _ _)/eqP ffsC fsC dffs]] fsk.
+have /diagonalizablePeigen [rs urs rs1] := dffs _ (mem_head _ _).
+rewrite (big_nth 0) big_mkord in rs1.
+have efg (i : 'I_(size rs)) g : g \in f :: fs -> stablemx (eigenspace f rs`_i) g.
+   case: n => [|n'] in g f fs ffsC fsC {dffs rs1 fsk} * => g_ffs.
+      by rewrite thinmx0 sub0mx.
+  rewrite comm_mx_stable_eigenspace//.
+  by move: g_ffs; rewrite !inE => /predU1P [->//|/ffsC].
+apply/(@codiagonalizable_on _ _ _ (_ :: _) rs1) => [|i|i /=].
+- apply: mxdirect_sum_eigenspace => i j _ _ rsij; apply/val_inj.
+  by apply: uniqP rsij; rewrite ?inE.
+- by apply/allP => g g_ffs; rewrite efg.
+rewrite (@conjmx_eigenvalue _ _ _ rs`_i) ?eq_row_base ?row_base_free//.
+set gs := map _ _; suff [P Punit /= Pgs] : codiagonalizable gs.
+  exists P; rewrite /= ?Pgs ?andbT// /similar_to.
+  by rewrite conjmx_scalar ?mx_scalar_is_diag// row_free_unit.
+apply: IHk; rewrite ?size_map/= ?ltnS//; split.
+  apply/all_comm_mxP => _ _ /mapP[/= g gfs ->] /mapP[/= h hfs ->].
+  rewrite -!conjmxM ?inE ?stablemx_row_base ?efg ?inE ?gfs ?hfs ?orbT//.
+  by rewrite (all_comm_mxP _ fsC).
+move=> _ /mapP[/= g gfs ->].
+have: stablemx (row_base (eigenspace f rs`_i)) g.
+  by rewrite stablemx_row_base efg// inE gfs orbT.
+have := dffs g; rewrite inE gfs orbT => /(_ isT) [P Punit].
+move=> /similar_diagPex[D /(similarLR Punit)->] sePD.
+have rfeP : row_free (row_base (eigenspace f rs`_i) *m invmx P).
+  by rewrite /row_free mxrankMfree ?row_free_unit ?unitmx_inv// eq_row_base.
+rewrite -conjMumx ?unitmx_inv ?row_base_free//.
+apply/diagonalizable_conj_diag => //.
+by rewrite stablemx_comp// stablemx_unit ?unitmx_inv.
+Qed.
+
+End Diag.

--- a/mathcomp/algebra/mxred.v
+++ b/mathcomp/algebra/mxred.v
@@ -208,12 +208,13 @@ Implicit Types (W : 'M[F]_(k, m)).
 Lemma sub_kermxpoly_conjmx V f p W : stablemx V f -> row_free V ->
   (W <= kermxpoly (conjmx V f) p)%MS = (W *m V <= kermxpoly f p)%MS.
 Proof.
-case: n m => [|n'] [|m']// in V f W * => fV rfV; rewrite ?thinmx0//.
-   by rewrite mul0mx !sub0mx.
-apply/sub_kermxP/sub_kermxP; rewrite horner_mx_conj//; last first.
-  by move=> /(congr1 (mulmxr (pinvmx V)))/=; rewrite mul0mx !mulmxA.
-move=> /(congr1 (mulmxr V))/=; rewrite ![W *m _]mulmxA ?mul0mx mulmxKpV//.
-by rewrite -mulmxA mulmx_sub// horner_mx_stable//.
+move: n m => [|n'] [|m']// in V f W *; rewrite ?thinmx0// => fV rfV.
+- by rewrite /row_free mxrank0 in rfV.
+- by rewrite mul0mx !sub0mx.
+- apply/sub_kermxP/sub_kermxP; rewrite horner_mx_conj//; last first.
+    by move=> /(congr1 (mulmxr (pinvmx V)))/=; rewrite mul0mx !mulmxA.
+  move=> /(congr1 (mulmxr V))/=; rewrite ![W *m _]mulmxA ?mul0mx mulmxKpV//.
+  by rewrite -mulmxA mulmx_sub// horner_mx_stable//.
 Qed.
 
 Lemma sub_eigenspace_conjmx V f a W : stablemx V f -> row_free V ->
@@ -336,7 +337,7 @@ Lemma similar_diag_mxminpoly {n} {p f : 'M[F]_n.+1}
 Proof.
 rewrite /rs => pu /(similar_diagLR pu)[d {f rs}->].
 rewrite mxminpoly_uconj ?unitmx_inv// mxminpoly_diag.
-by rewrite (@eq_map _ _ _ (d 0))// => i; rewrite conjmxVK// mxE eqxx.
+by rewrite [in RHS](@eq_map _ _ _ (d 0))// => i; rewrite conjmxVK// mxE eqxx.
 Qed.
 
 End Similarity.
@@ -471,19 +472,21 @@ split=> [[P Punit /similar_diagPex[d /(similarLR Punit)->]]|].
   rewrite mxminpoly_uconj ?unitmx_inv// mxminpoly_diag.
   by eexists; [|by []]; rewrite undup_uniq.
 rewrite diagonalizablePeigen => -[rs rsu rsP].
-exists rs; rewrite // !(big_nth 0) !big_mkord in rsP *.
-rewrite (eq_bigr _ (fun _ _ => eigenspace_poly _ _)).
-apply: (eqmx_trans (eqmx_sym (kermxpoly_prod _ _)) (kermxpoly_min _)) => //.
-by move=> i j _ _; rewrite coprimep_XsubC root_XsubC nth_uniq.
+exists rs => //.
+rewrite (big_nth 0) big_mkord (eq_bigr _ (fun _ _ => eigenspace_poly _ _)).
+apply: (eqmx_trans (eqmx_sym (kermxpoly_prod _ _)) (kermxpoly_min _)).
+  by move=> i j _ _; rewrite coprimep_XsubC root_XsubC nth_uniq.
+by rewrite (big_nth 0) big_mkord in rsP.
 Qed.
 
 Lemma diagonalizable_conj_diag m n (V : 'M[F]_(m, n)) (d : 'rV[F]_n) :
   stablemx V (diag_mx d) -> row_free V -> diagonalizable (conjmx V (diag_mx d)).
 Proof.
-case: m n => [|m] [|n]// in V d * => Vd rdV; rewrite ?thinmx0//=.
-apply/diagonalizableP; pose u := undup [seq d 0 i | i <- enum 'I_n.+1].
-exists u; first by rewrite undup_uniq.
-by rewrite (dvdp_trans (mxminpoly_conj _ _))// mxminpoly_diag.
+move: m n => [|m] [|n] in V d *; rewrite ?thinmx0; [by []|by []| |] => Vd rdV.
+- by rewrite /row_free mxrank0 in rdV.
+- apply/diagonalizableP; pose u := undup [seq d 0 i | i <- enum 'I_n.+1].
+  exists u; first by rewrite undup_uniq.
+  by rewrite (dvdp_trans (mxminpoly_conj rdV _))// mxminpoly_diag.
 Qed.
 
 Lemma codiagonalizableP n (fs : seq 'M[F]_n) :

--- a/mathcomp/algebra/mxred.v
+++ b/mathcomp/algebra/mxred.v
@@ -5,7 +5,7 @@ From mathcomp Require Import choice fintype finfun bigop fingroup perm order.
 From mathcomp Require Import ssralg zmodp matrix mxalgebra poly polydiv mxpoly.
 
 (*****************************************************************************)
-(* In this file, we prove diagonalization theorems, for this purpose, we     *)
+(* In this file, we prove diagonalization theorems. For this purpose, we     *)
 (* define conjugation, similarity and diagonalizability.                     *)
 (*                                                                           *)
 (*      conjmx V f  := V *m f *m pinvmx V                                    *)
@@ -195,9 +195,7 @@ by rewrite -[f in X in X %| _](conjmxK _ Vu) mxminpoly_conj ?simp.
 Qed.
 
 Section fixed_stablemx_space.
-
 Variables (m n : nat).
-
 Implicit Types (V : 'M[F]_(m, n)) (f : 'M[F]_n).
 Implicit Types (a : F) (p : {poly F}).
 
@@ -246,8 +244,8 @@ End fixed_stablemx_space.
 End ConjMx.
 Notation restrictmx V := (conjmx (row_base V)).
 
-Definition similar_to {F : fieldType} {m n} (P : 'M_(m, n)) A (C : {pred 'M[F]_m}) :=
-   C (conjmx P A).
+Definition similar_to {F : fieldType} {m n} (P : 'M_(m, n)) A
+  (C : {pred 'M[F]_m}) := C (conjmx P A).
 
 Notation similar P A B := (similar_to P A (PredOfSimpl.coerce (pred1 B))).
 Notation similar_in D A B := (exists2 P, P \in D & similar P A B).
@@ -371,7 +369,7 @@ Lemma codiagonalizable1 n (A : 'M[F]_n) :
   codiagonalizable [:: A] <-> diagonalizable A.
 Proof. by split=> -[P Punit PA]; exists P; move: PA; rewrite //= andbT. Qed.
 
-Definition codiagonalizablePfull n (As : seq 'M[F]_n) :
+Lemma codiagonalizablePfull n (As : seq 'M[F]_n) :
   codiagonalizable As <-> exists m,
     exists2 P : 'M_(m, n), row_full P & all [pred A | similar_diag P A] As.
 Proof.

--- a/mathcomp/algebra/sesquilinear.v
+++ b/mathcomp/algebra/sesquilinear.v
@@ -4,13 +4,13 @@ From mathcomp Require Import choice fintype tuple bigop ssralg finset fingroup.
 From mathcomp Require Import zmodp poly order ssrnum matrix mxalgebra vector.
 
 (******************************************************************************)
-(* {bilinear fUV | s & s'} == the type of bilinear forms                      *)
-(*                            f has type U -> U' -> V                         *)
-(*                            f u is linear, f ^~ u' is linear                *)
-(*                            s and s' are two scaling operations             *)
-(*     {bilinear fUV | s } := {bilinear fUV | s.1 & s.2}                      *)
-(*         {bilinear fUV}  := {bilinear fUV | *:%R & *:%R }                   *)
-(*           {biscalar U}  := {bilinear U -> U -> _ | *%R & *%R }             *)
+(* {bilinear U -> V -> W | s & s'} == the type of bilinear forms which are    *)
+(*                                    essentially functions of type           *)
+(*                                    U -> V -> W                             *)
+(*                                    s and s' are two scaling operations     *)
+(*     {bilinear U -> V -> W | s } := {bilinear U -> V -> W | s.1 & s.2}      *)
+(*         {bilinear U -> V -> W}  := {bilinear U -> V -> W | *:%R & *:%R }   *)
+(*                   {biscalar U}  := {bilinear U -> U -> _ | *%R & *%R }     *)
 (*                                                                            *)
 (* {hermitian U for eps & theta} == hermitian/skew-hermitian form             *)
 (*                            eps is a boolean flag (false -> hermitian form, *)
@@ -1222,7 +1222,7 @@ apply/pairwise_orthogonalP; rewrite /= (contra (sS12 0)) //.
 by split=> //; apply: sub_in2 oS2.
 Qed.
 
-Lemma orthogonal_free S : pairwise_orthogonal form S -> free  S.
+Lemma orthogonal_free S : pairwise_orthogonal form S -> free S.
 Proof.
 case/pairwise_orthogonalP=> [/=/andP[notS0 uniqS] oSS].
 rewrite -(in_tupleE S); apply/freeP => a aS0 i.
@@ -1509,9 +1509,10 @@ split=> [u'|u] a x y /=.
 Qed.
 
 HB.instance Definition _ :=
-  bilinear_isBilinear.Build R
-    _ _
-    _ _ _ _
+  bilinear_isBilinear.Build R _ _ _
+    (GRing.Scale.Law.clone _ _ ( *%R ) _)
+    (GRing.Scale.Law.clone _ _ (theta \; *%R ) _)
+    (@form_of_matrix theta m M)
     form_of_matrix_is_bilinear.
 (*Canonical form_of_matrix_is_bilinear := [the @bilinear _ _ _ _ of form_of_matrix theta M].*)
 
@@ -1712,4 +1713,5 @@ End MatrixForms.
 
 Notation symmetricmx := (hermitianmx _ false idfun).
 Notation skewmx := (hermitianmx _ true idfun).
-Notation hermsymmx := (hermitianmx _ false (fun x => x^* (*NB: was @conjC _*) )).
+Definition conjC {C : numClosedFieldType} (c : C) : C := c^*.
+Notation hermsymmx := (hermitianmx _ false conjC).

--- a/mathcomp/algebra/sesquilinear.v
+++ b/mathcomp/algebra/sesquilinear.v
@@ -534,7 +534,9 @@ Variable eps_theta : bool * {rmorphism R -> R}.
 Definition sesqui :=
   [qualify M : 'M_n | M == ((-1) ^+ eps_theta.1) *: M ^t eps_theta.2].
 Fact sesqui_key : pred_key sesqui. Proof. by []. Qed.
+
 Canonical sesqui_keyed := KeyedQualifier sesqui_key.
+
 End Def.
 
 Local Notation "eps_theta .-sesqui" := (sesqui eps_theta).
@@ -753,6 +755,7 @@ Notation "{ 'skew_symmetric' U }" := ({hermitian U for true & idfun})
   (at level 0, format "{ 'skew_symmetric'  U }") : ring_scope.
 Notation "{ 'hermitian_sym' U 'for' theta }" := ({hermitian U for false & theta})
   (at level 0, format "{ 'hermitian_sym'  U  'for'  theta }") : ring_scope.
+
 Definition is_skew (R : ringType) (eps : bool) (theta : R -> R)
   (U : lmodType R) (form : {hermitian U for eps & theta}) :=
   (eps = true) /\ (theta =1 id).
@@ -1375,7 +1378,7 @@ rewrite !{1}linear_sumr; apply/eq_big_seq=> xi2 Sxi2 /=.
 by rewrite !linearZ /= !linearZl !Dtau //= If.
 Qed.
 
-Lemma isometry_raddf_inj  (tau : {additive U1 -> U2}) :
+Lemma isometry_raddf_inj (tau : {additive U1 -> U2}) :
     {in U1 &, isometry form2 form1 tau} ->
     {in U1 &, forall u v, u - v \in U1} ->
   {in U1 &, injective tau}.
@@ -1609,7 +1612,7 @@ rewrite mxrank_ker -subn1 leq_sub2l //.
 by rewrite (leq_trans (mxrankM_maxr  _ _)) // rank_leq_col.
 Qed.
 
-Notation radmx := (1%:M^!)%MS.
+Local Notation radmx := (1%:M^!)%MS.
 
 Lemma radmxE : radmx = kermx M.
 Proof. by rewrite /orthomx /orthomx trmx1 map_mx1 mulmx1. Qed.

--- a/mathcomp/algebra/sesquilinear.v
+++ b/mathcomp/algebra/sesquilinear.v
@@ -273,7 +273,8 @@ HB.instance Definition _ (R : ringType) (U U' : lmodType R) (V : zmodType)
   := @GRing.isScalable.Build _ _ _ _ (f u) (@linearr_subproof _ _ _ _ _ _ f u).
 
 Section applyr.
-Variables (R : ringType) (U U' : lmodType R) (V : zmodType) (s s' : R -> V -> V).
+Variables (R : ringType) (U U' : lmodType R) (V : zmodType)
+  (s s' : R -> V -> V).
 
 Definition applyr_head t (f : U -> U' -> V) u v := let: tt := t in f v u.
 
@@ -330,7 +331,6 @@ End GenericPropertiesr.
 Lemma applyrE x : applyr f x =1 f^~ x. Proof. by []. Qed.
 
 Section GenericPropertiesl.
-
 Variable z : U'.
 
 HB.instance Definition _ :=
@@ -363,7 +363,6 @@ End GenericPropertiesl.
 End GenericProperties.
 
 Section BidirectionalLinearZ.
-
 Variables (U U' : lmodType R) (V : zmodType) (s s' : R -> V -> V).
 Variables (S : ringType) (h : GRing.Scale.law S V) (h' : GRing.Scale.law S V).
 

--- a/mathcomp/algebra/spectral.v
+++ b/mathcomp/algebra/spectral.v
@@ -1,0 +1,667 @@
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype choice ssrnat.
+From mathcomp Require Import seq div fintype bigop ssralg finset fingroup zmodp.
+From mathcomp Require Import poly polydiv order ssrnum matrix mxalgebra vector.
+From mathcomp Require Import mxpoly mxred forms.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Import GRing.Theory Order.Theory Num.Theory.
+Local Open Scope ring_scope.
+
+Notation realmx := (mxOver Num.real).
+
+Section Spectral.
+
+Variable (C : numClosedFieldType).
+Set Default Proof Using "C".
+
+Local Notation "M ^ phi" := (map_mx phi M).
+Local Notation "M ^t*" := (map_mx (GRing.RMorphism.apply conjC) (M ^T)) (at level 30).
+
+Lemma realmxC m n (A : 'M[C]_(m, n)) : A \is a mxOver Num.real -> A ^ conjC = A.
+Proof.
+by move=> ?; apply/matrixP => x y; rewrite mxE (CrealP _) ?(mxOverP _).
+Qed.
+
+Lemma Remx_rect m n :
+  {in realmx &, forall (X Y : 'M[C]_(m,n)), (X + 'i *: Y) ^ (@Re _) = X}.
+Proof.
+move=> X Y Xreal Yreal; apply/matrixP=> i j; rewrite !mxE.
+by rewrite Re_rect // (mxOverP _ _).
+Qed.
+
+Lemma Immx_rect m n :
+  {in realmx &, forall (X Y : 'M[C]_(m,n)), (X + 'i *: Y) ^ (@Im _) = Y}.
+Proof.
+move=> /= X Y Xreal Yreal; apply/matrixP=> i j; rewrite !mxE.
+by rewrite Im_rect // (mxOverP _ _).
+Qed.
+
+Lemma eqmx_ReiIm m n (X Y X' Y' : 'M[C]_(m,n)) :
+    X \is a realmx -> Y \is a realmx ->
+    X' \is a realmx -> Y' \is a realmx ->
+  (X + 'i *: Y) = (X' + 'i *: Y') -> (X, Y) = (X', Y').
+Proof.
+move=> XRe YRe X'Im Y'Im eqXY.
+have /(congr1 (fun X => X ^ (@Im _))) := eqXY.
+have /(congr1 (fun X => X ^ (@Re _))) := eqXY.
+by rewrite !Remx_rect// !Immx_rect// => -> ->.
+Qed.
+
+Lemma map_mxCK m n (M : 'M[C]_(m, n)) : (M ^ conjC) ^ conjC = M.
+Proof. by apply/matrixP=> i j; rewrite !mxE conjCK. Qed.
+
+Lemma trmxCK m n (M : 'M[C]_(m, n)) : M ^t* ^t* = M.
+Proof. by apply/matrixP=> i j; rewrite !mxE conjCK. Qed.
+
+Definition unitarymx {m n} := [qualify M : 'M[C]_(m, n) | M *m M ^t* == 1%:M].
+Fact unitarymx_key m n : pred_key (@unitarymx m n). Proof. by []. Qed.
+Canonical unitarymx_keyed m n := KeyedQualifier (unitarymx_key m n).
+
+Definition normalmx {n} := [qualify M : 'M[C]_n | M *m M ^t* == M ^t* *m M].
+Fact normalmx_key n : pred_key (@normalmx n). Proof. by []. Qed.
+Canonical normalmx_keyed n := KeyedQualifier (normalmx_key n).
+
+Lemma normalmxP {n} {M: 'M[C]_n} :
+  reflect (M *m M ^t* = M ^t* *m M) (M \is normalmx).
+Proof. exact: eqP. Qed.
+
+Definition conjCfun (C : numClosedFieldType) := conjC : C -> C.
+Arguments conjCfun _ _ /.
+Canonical conjCfun_rmorphism (C : numClosedFieldType) :=
+  [rmorphism of (@conjCfun C)].
+Canonical conjCfun_involutive (C : numClosedFieldType) :=
+  InvolutiveRMorphism (@conjCK C : involutive (@conjCfun C)).
+
+Notation dotmx_def := (form_of_matrix (@conjCfun _) 1%:M).
+Definition dotmx n (u v : 'rV[C]_n) := dotmx_def u%R v%R.
+
+Local Notation "''[' u , v ]" := (dotmx u v) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+
+Fact dotmx_is_hermitian n : (1%:M : 'M[C]_n) \is hermsymmx.
+Proof.
+by rewrite qualifE /= expr0 scale1r tr_scalar_mx map_scalar_mx conjC1.
+Qed.
+Canonical hermitian1mx n := HermitianMx (dotmx_is_hermitian n).
+Canonical dotmx_bilinear n := [bilinear of @dotmx n as dotmx_def].
+Canonical dotmx_hermsym n := [hermitian of (@dotmx n) as dotmx_def].
+
+Lemma dotmxE n (u v : 'rV_n) : '[u, v] = (u *m v ^t*) 0 0.
+Proof. by rewrite /dotmx /form_of_matrix mulmx1 /= trace_mx11. Qed.
+
+Fact dotmx_is_dotmx n : is_dot (@dotmx n).
+Proof.
+move=> /= u u_neq0; rewrite dotmxE mxE.
+suff /existsP[i ui_neq0] : [exists i, u 0 i != 0].
+  rewrite (bigD1 i) //= ltr_paddr// ?sumr_ge0// ?mxE ?mul_conjC_gt0//.
+  by move=> j _; rewrite !mxE mul_conjC_ge0.
+apply: contraNT u_neq0; rewrite negb_exists => /forallP uNN0.
+by apply/eqP/rowP=> j; rewrite mxE; apply/eqP; rewrite -[_ == _]negbK uNN0.
+Qed.
+Canonical dotmx_dot n := Dot (@dotmx_is_dotmx n).
+
+Local Notation "B ^!" :=
+  (orthomx (@conjCfun C) (mx_of_hermitian (hermitian1mx _)) B) : matrix_set_scope.
+Local Notation "A _|_ B" := (A%MS <= B^!)%MS : bool_scope.
+
+Lemma orthomx1E m n p (A : 'M[C]_(m, n)) (B : 'M_(p, n)) :
+  (A _|_ B)%MS = (A *m B^t* == 0).
+Proof. by apply/sub_kermxP/eqP; rewrite !mul1mx. Qed.
+
+Lemma orthomx1P {m n p : nat} {A : 'M[C]_(m, n)} {B : 'M_(p, n)} :
+  reflect (A *m B^t* = 0) (A _|_ B).
+Proof. by rewrite orthomx1E; apply: eqP. Qed.
+
+Lemma orthomx_disj n p q (A : 'M[C]_(p, n)) (B :'M_(q, n)) :
+  A _|_ B -> (A :&: B = 0)%MS.
+Proof.
+move=> nAB; apply/eqP/rowV0Pn => [[v]]; rewrite sub_capmx => /andP [vA vB].
+apply/negP; rewrite negbK -(dnorm_eq0 (dotmx_dot n)) -orthomxE.
+by rewrite (orthomxP _ _ _ nAB).
+Qed.
+
+Lemma orthomx_ortho_disj n p (A : 'M[C]_(p, n)) : (A :&: A^! = 0)%MS.
+Proof. by apply/orthomx_disj/ortho_mx_ortho. Qed.
+
+Lemma rank_ortho p n (A : 'M[C]_(p, n)) : \rank A^! = (n - \rank A)%N.
+Proof. by rewrite mxrank_ker mul1mx mxrank_map mxrank_tr. Qed.
+
+Lemma add_rank_ortho p n (A : 'M[C]_(p, n)) : (\rank A + \rank A^!)%N = n.
+Proof. by rewrite rank_ortho subnKC ?rank_leq_col. Qed.
+
+Lemma addsmx_ortho p n (A : 'M[C]_(p, n)) : (A + A^! :=: 1%:M)%MS.
+Proof.
+apply/eqmxP/andP; rewrite submx1; split=> //.
+rewrite -mxrank_leqif_sup ?submx1 ?mxrank1 ?(mxdirectP _) /= ?add_rank_ortho //.
+by rewrite mxdirect_addsE /= ?mxdirectE ?orthomx_ortho_disj !eqxx.
+Qed.
+
+Lemma ortho_id p n (A : 'M[C]_(p, n)) : (A^!^! :=: A)%MS.
+Proof.
+apply/eqmx_sym/eqmxP.
+by rewrite -mxrank_leqif_eq 1?orthomx_sym // !rank_ortho subKn // ?rank_leq_col.
+Qed.
+
+Lemma submx_ortho (p m n : nat) (U : 'M[C]_(p, n)) (V : 'M_(m, n)) :
+  (U^! <= V^!)%MS = (V <= U)%MS.
+Proof. by rewrite orthomx_sym ortho_id. Qed.
+
+Definition proj_ortho p n (U : 'M[C]_(p, n)) := proj_mx <<U>>%MS U^!%MS.
+
+Let sub_adds_genmx_ortho (p m n : nat) (U : 'M[C]_(p, n))  (W : 'M_(m, n)) :
+  (W <= <<U>> + U^!)%MS.
+Proof.
+by rewrite !(adds_eqmx (genmxE _) (eqmx_refl _)) addsmx_ortho submx1.
+Qed.
+
+Let cap_genmx_ortho (p n : nat) (U : 'M[C]_(p, n)) : (<<U>> :&: U^!)%MS = 0.
+Proof.
+apply/eqmx0P; rewrite !(cap_eqmx (genmxE _) (eqmx_refl _)).
+by rewrite orthomx_ortho_disj; apply/eqmx0P.
+Qed.
+
+Lemma proj_ortho_sub (p m n : nat) (U : 'M_(p, n)) (W : 'M_(m, n)) :
+   (W *m proj_ortho U <= U)%MS.
+Proof. by rewrite (submx_trans (proj_mx_sub _ _ _)) // genmxE. Qed.
+
+Lemma proj_ortho_compl_sub (p m n : nat) (U : 'M_(p, n)) (W : 'M_(m, n)) :
+  (W - W *m proj_ortho U <= U^!)%MS.
+Proof. by rewrite proj_mx_compl_sub // addsmx_ortho submx1. Qed.
+
+Lemma proj_ortho_id (p m n : nat) (U : 'M_(p, n)) (W : 'M_(m, n)) :
+   (W <= U)%MS -> W *m proj_ortho U = W.
+Proof. by move=> WU; rewrite proj_mx_id ?genmxE. Qed.
+
+Lemma proj_ortho_0 (p m n : nat) (U : 'M_(p, n)) (W : 'M_(m, n)) :
+    (W <= U^!)%MS -> W *m proj_ortho U = 0.
+Proof. by move=> WUo; rewrite proj_mx_0. Qed.
+
+Lemma add_proj_ortho (p m n : nat) (U : 'M_(p, n)) (W : 'M_(m, n)) :
+  W *m proj_ortho U + W *m proj_ortho U^!%MS = W.
+Proof.
+rewrite -[W in LHS](@add_proj_mx _ _ _ <<U>>%MS U^!%MS W) //.
+rewrite !mulmxDl proj_ortho_id ?proj_ortho_sub //.
+rewrite proj_ortho_0 ?proj_mx_sub // addr0.
+rewrite proj_ortho_0 ?ortho_id ?proj_ortho_sub // add0r.
+by rewrite proj_ortho_id ?proj_mx_sub // add_proj_mx.
+Qed.
+
+Lemma proj_ortho_proj (m n : nat) (U : 'M_(m, n)) :
+   let P := proj_ortho U in P *m P = P.
+Proof. by rewrite /= proj_mx_proj. Qed.
+
+Lemma proj_orthoE (p n : nat) (U : 'M_(p, n)) : (proj_ortho U :=: U)%MS.
+Proof.
+apply/eqmxP/andP; split; first by rewrite -proj_ortho_proj proj_ortho_sub.
+by rewrite -[X in (X <= _)%MS](proj_ortho_id (submx_refl U)) mulmx_sub.
+Qed.
+
+Lemma orthomx_proj_mx_ortho (p p' m m' n : nat)
+  (A : 'M_(p, n)) (A' : 'M_(p', n))
+  (W : 'M_(m, n)) (W' : 'M_(m', n)) :
+  A _|_ A' -> W *m proj_ortho A _|_ W' *m proj_ortho A'.
+Proof.
+rewrite orthomx_sym => An.
+rewrite mulmx_sub // orthomx_sym (eqmx_ortho _ (proj_orthoE _)).
+by rewrite (submx_trans _ An) // proj_ortho_sub.
+Qed.
+
+Lemma unitarymxP  {m} {n} {M : 'M[C]_(m, n)} :
+  reflect (M *m M^t* = 1%:M) (M \is unitarymx).
+Proof. by apply: (iffP eqP). Qed.
+
+Lemma mxrank_unitary m n (M : 'M[C]_(m, n)) : M \is unitarymx -> \rank M = m.
+Proof.
+rewrite qualifE => /eqP /(congr1 mxrank); rewrite mxrank1 => rkM.
+apply/eqP; rewrite eqn_leq rank_leq_row /= -[X in (X <= _)%N]rkM.
+by rewrite mxrankM_maxl.
+Qed.
+
+Lemma row_unitarymxP {m n} {M : 'M[C]_(m, n)} :
+  reflect (forall i j, '[row i M, row j M] = (i == j)%:R) (M \is unitarymx).
+Proof.
+apply: (iffP eqP).
+  move=> Mo i j; have /matrixP /(_ i j) := Mo; rewrite !mxE => <-.
+  by rewrite dotmxE !mxE; apply: eq_bigr => /= k _; rewrite !mxE.
+move=> Mo; apply/matrixP=> i j; rewrite !mxE.
+have := Mo i j; rewrite dotmxE !mxE => <-.
+by apply: eq_bigr => /= k _; rewrite !mxE.
+Qed.
+
+Lemma mul_unitarymx m n p (A : 'M[C]_(m, n)) (B : 'M[C]_(n, p)) :
+  A \is unitarymx -> B \is unitarymx -> A *m B \is unitarymx.
+Proof.
+move=> Aunitary Bunitary; apply/unitarymxP; rewrite trmx_mul map_mxM.
+by rewrite mulmxA -[A *m _ *m _]mulmxA !(unitarymxP _, mulmx1).
+Qed.
+
+Lemma unitarymx_unit n (M : 'M[C]_n) : M \is unitarymx -> M \in unitmx.
+Proof. by move=> /unitarymxP /mulmx1_unit []. Qed.
+
+Lemma invmx_unitary n (M : 'M[C]_n) : M \is unitarymx -> invmx M = M^t*.
+Proof.
+move=> Munitary; apply: (@row_full_inj _ _ _ _ M).
+  by rewrite row_full_unit unitarymx_unit.
+by rewrite mulmxV ?unitarymx_unit ?(unitarymxP _).
+Qed.
+
+Lemma pinvmx_unitary n (M : 'M[C]_n) : M \is unitarymx -> pinvmx M = M^t*.
+Proof. by move=> Munitary; rewrite pinvmxE ?unitarymx_unit// invmx_unitary. Qed.
+
+Lemma conjymx n (P M : 'M[C]_n) : P \is unitarymx -> conjmx P M = P *m M *m P^t*.
+Proof. by move=> Munitary; rewrite conjumx ?invmx_unitary ?unitarymx_unit. Qed.
+
+Lemma trmx_unitary {n} {M : 'M[C]_n} : (M ^T \is unitarymx) = (M \is unitarymx).
+Proof.
+apply/unitarymxP/unitarymxP; rewrite -?map_trmx -trmx_mul.
+  by rewrite -trmx1 => /trmx_inj /mulmx1C->; rewrite trmx1.
+by move=> /mulmx1C->; rewrite trmx1.
+Qed.
+
+Lemma conjC_unitary {m n} {M : 'M[C]_(m, n)} :
+  (M ^ conjC \is unitarymx) = (M \is unitarymx).
+Proof.
+apply/unitarymxP/unitarymxP; rewrite -?map_mxM ?map_trmx; last first.
+  by move=> ->; rewrite map_mx1.
+by rewrite -[1%:M](map_mx1 conjC) => /map_mx_inj ->; rewrite map_mx1.
+Qed.
+
+Lemma trmxC_unitary {n} {M : 'M[C]_n} : (M ^t* \is unitarymx) = (M \is unitarymx).
+Proof. by rewrite conjC_unitary trmx_unitary. Qed.
+
+Lemma schmidt_subproof m n (A : 'M[C]_(m, n)) : (m <= n)%N ->
+  exists2 B : 'M_(m, n), B \is unitarymx & [forall i : 'I_m,
+   (row i A <= (\sum_(k < m | (k <= i)%N) <<row k B>>))%MS
+   && ('[row i A, row i B] >= 0) ].
+Proof.
+elim: m A => [|m IHm].
+  exists (pid_mx n); first by rewrite qualifE !thinmx0.
+  by apply/forallP=> -[].
+rewrite -addn1 => A leq_Sm_n.
+have lemSm: (m <= m + 1)%N by rewrite addn1.
+have ltmSm: (m < m + 1)%N by rewrite addn1.
+have lemn : (m <= n)%N by rewrite ltnW // -addn1.
+have [B Bortho] := IHm (usubmx A) lemn.
+move=> /forallP /= subAB.
+have [v /and4P [vBn v_neq0 dAv_ge0 dAsub]] :
+  exists v, [&& B _|_ v, v != 0, '[dsubmx A, v] >= 0 & (dsubmx A <= B + v)%MS].
+  have := add_proj_ortho B (dsubmx A).
+  set BoSn := (_ *m proj_ortho _^!%MS) => pBE.
+  have [BoSn_eq0|BoSn_neq0] := eqVneq BoSn 0.
+    rewrite BoSn_eq0 addr0 in pBE.
+    have /rowV0Pn [v vBn v_neq0] : B^!%MS != 0.
+      rewrite -mxrank_eq0 rank_ortho -lt0n subn_gt0.
+      by rewrite mxrank_unitary // -addn1.
+    rewrite orthomx_sym in vBn.
+    exists v; rewrite vBn v_neq0 -pBE.
+      rewrite ['[_, _]](hermmx_eq0P _ _) ?lexx //=.
+      rewrite (submx_trans (proj_ortho_sub _ _)) //.
+      by rewrite -{1}[B]addr0 addmx_sub_adds ?sub0mx.
+    by rewrite (submx_trans _ vBn) // proj_ortho_sub.
+  pose c := (sqrtC '[BoSn])^-1; have c_gt0 : c > 0.
+    by rewrite invr_gt0 sqrtC_gt0 lt_def ?dnorm_eq0 ?dnorm_ge0 BoSn_neq0.
+  exists BoSn; apply/and4P; split => //.
+  - by rewrite orthomx_sym ?proj_ortho_sub // /gtr_eqF.
+  - rewrite -pBE linearDl // [X in X + '[_]](hermmx_eq0P _ _) ?add0r ?dnorm_ge0 //.
+    by rewrite orthomx_proj_mx_ortho // orthomx_sym.
+  - by rewrite -pBE addmx_sub_adds // proj_ortho_sub.
+wlog nv_eq1 : v vBn v_neq0 dAv_ge0 dAsub / '[v] = 1.
+  pose c := (sqrtC '[v])^-1.
+  have c_gt0 : c > 0 by rewrite invr_gt0 sqrtC_gt0 ?dnorm_gt0.
+  have [c_ge0 c_eq0F] := (ltW c_gt0, gt_eqF c_gt0).
+  move=> /(_ (c *: v)); apply.
+  - by rewrite orthomxZ ?c_eq0F.
+  - by rewrite scaler_eq0 c_eq0F.
+  - by rewrite linearZr mulr_ge0 // conjC_ge0.
+  - by rewrite (submx_trans dAsub) // addsmxS // eqmx_scale // c_eq0F.
+  - rewrite dnormZ normfV ger0_norm ?sqrtC_ge0 ?dnorm_ge0 //.
+    by rewrite exprVn rootCK ?mulVf // dnorm_eq0.
+exists (col_mx B v).
+  apply/row_unitarymxP => i j.
+  case: (split_ordP i) (split_ordP j) => [] i' -> [] j' ->; rewrite eq_shift;
+  rewrite ?(rowKu, rowKd, row_id, ord1) -?val_eqE /= ?(row_unitarymxP _) //= ?addn0.
+    by rewrite ['[_, _]](hermmx_eq0P _ _)//= (submx_trans _ vBn)// row_sub.
+  by rewrite ['[_, _]](hermmx_eq0P _ _)//= orthomx_sym (submx_trans _ vBn) // row_sub.
+apply/forallP => i; case: (split_ordP i) => j -> /=.
+  have /andP [sABj dot_gt0] := subAB j.
+  rewrite rowKu -row_usubmx (submx_trans sABj) //=.
+  rewrite (eq_rect _ (submx _) (submx_refl _)) //.
+  rewrite [in RHS](reindex (lshift 1)) /=.
+    by apply: eq_bigr=> k k_le; rewrite rowKu.
+  exists (fun k => insubd j k) => k; rewrite inE /= => le_kj;
+  by apply/val_inj; rewrite /= insubdK // -topredE /= (leq_ltn_trans le_kj).
+rewrite rowKd -row_dsubmx !row_id ord1 ?dAv_ge0 ?andbT {j} addn0.
+rewrite (bigD1 (rshift _ ord0)) /= ?addn0 ?rowKd ?row_id // addsmxC.
+rewrite (submx_trans dAsub) // addsmxS ?genmxE //.
+apply/row_subP => j; apply/(sumsmx_sup (lshift _ j)) => //=.
+  by rewrite ltnW ?ltn_ord //= -val_eqE /= addn0 ltn_eqF.
+by rewrite rowKu genmxE.
+Qed.
+
+Definition schmidt m n (A : 'M[C]_(m, n)) :=
+  if (m <= n)%N =P true is ReflectT le_mn
+  then projT1 (sig2_eqW (schmidt_subproof A (le_mn)))
+  else A.
+
+Lemma schmidt_unitarymx m n (A : 'M[C]_(m, n)) : (m <= n)%N ->
+  schmidt A \is unitarymx.
+Proof. by rewrite /schmidt; case: eqP => // ?; case: sig2_eqW. Qed.
+Hint Resolve schmidt_unitarymx : core.
+
+Lemma row_schmidt_sub m n (A : 'M[C]_(m, n)) i :
+  (row i A <= (\sum_(k < m | (k <= i)%N) <<row k (schmidt A)>>))%MS.
+Proof.
+rewrite /schmidt; case: eqP => // ?.
+   by case: sig2_eqW => ? ? /= /forallP /(_ i) /andP[].
+by apply/(sumsmx_sup i) => //; rewrite genmxE.
+Qed.
+
+Lemma form1_row_schmidt m n (A : 'M[C]_(m, n)) i :
+  '[row i A, row i (schmidt A)] >= 0.
+Proof.
+rewrite /schmidt; case: eqP => // ?; rewrite ?dnorm_ge0 //.
+by case: sig2_eqW => ? ? /= /forallP /(_ i) /andP[].
+Qed.
+
+Lemma schmidt_sub m n (A : 'M[C]_(m, n)) : (A <= schmidt A)%MS.
+Proof.
+apply/row_subP => i; rewrite (submx_trans (row_schmidt_sub _ _)) //.
+by apply/sumsmx_subP => /= j le_ji; rewrite genmxE row_sub.
+Qed.
+Hint Resolve schmidt_sub : core.
+
+Lemma eqmx_schmidt_full m n (A : 'M[C]_(m, n)) :
+  row_full A -> (schmidt A :=: A)%MS.
+Proof.
+move=> Afull; apply/eqmx_sym/eqmxP; rewrite -mxrank_leqif_eq //.
+by rewrite eqn_leq mxrankS //= (@leq_trans n) ?rank_leq_col ?col_leq_rank.
+Qed.
+
+Lemma eqmx_schmidt_free m n (A : 'M[C]_(m, n)) :
+  row_free A -> (schmidt A :=: A)%MS.
+Proof.
+move=> Afree; apply/eqmx_sym/eqmxP; rewrite -mxrank_leqif_eq //.
+by rewrite eqn_leq mxrankS //= (@leq_trans m) ?rank_leq_row // ?row_leq_rank.
+Qed.
+
+Definition schmidt_complete m n (V : 'M[C]_(m, n)) :=
+  col_mx (schmidt (row_base V)) (schmidt (row_base V^!%MS)).
+
+Lemma schmidt_complete_unitarymx m n (V : 'M[C]_(m, n)) :
+  schmidt_complete V \is unitarymx.
+Proof.
+apply/unitarymxP; rewrite tr_col_mx map_row_mx mul_col_row.
+rewrite !(unitarymxP _) ?schmidt_unitarymx ?rank_leq_col //.
+move=> [:nsV]; rewrite !(orthomx1P _) -?scalar_mx_block //;
+  [abstract: nsV|]; last by rewrite orthomx_sym.
+by do 2!rewrite eqmx_schmidt_free ?eq_row_base ?row_base_free // orthomx_sym.
+Qed.
+
+Lemma eigenvalue_closed n (A : 'M[C]_n) : (n > 0)%N ->
+   exists a, eigenvalue A a.
+Proof.
+move=> n_gt0; have /closed_rootP [a rAa] : size (char_poly A) != 1%N.
+  by rewrite size_char_poly; case: (n) n_gt0.
+by exists a; rewrite eigenvalue_root_char.
+Qed.
+
+Lemma common_eigenvector n (As : seq 'M[C]_n) :
+  (n > 0)%N -> {in As &, forall A B, comm_mx A B} ->
+  exists2 v : 'rV_n, v != 0 & all (fun A => stablemx v A) As.
+Proof.
+move=> n_gt0 /all_comm_mxP; have [k sAsk] := ubnP (size As).
+elim: k n n_gt0 As sAsk => [//|k IHk]  n n_gt0 [|A As].
+  exists (const_mx 1) => //; apply/negP => /eqP/rowP/(_ (Ordinal n_gt0)).
+  by rewrite !mxE => /eqP; rewrite oner_eq0.
+rewrite ltnS all_comm_mx_cons => sAsk /andP[].
+move=> /allP/(_ _ _)/eqP/= A_comm /all_comm_mxP As_comm.
+have [a a_eigen] := eigenvalue_closed A n_gt0.
+have [] := IHk _ _ [seq restrictmx (eigenspace A a) B | B <- As].
+- by rewrite lt0n mxrank_eq0.
+- by rewrite size_map.
+- apply/all_comm_mxP; move=> _ _ /= /mapP /= [B B_in ->] /mapP /= [B' B'_in ->].
+  rewrite -?conjmxM ?inE ?stablemx_row_base ?comm_mx_stable_eigenspace//;
+  by [rewrite As_comm | apply: As_comm | apply: A_comm].
+move=> v vN0 /allP /= vP; exists (v *m (row_base (eigenspace A a))).
+  by rewrite mulmx_free_eq0 ?row_base_free.
+apply/andP; split.
+  by apply/eigenvectorP; exists a; rewrite mulmx_sub // eq_row_base.
+apply/allP => B B_in; rewrite -stablemx_restrict ?vP //.
+  by apply/mapP; exists B => //.
+by rewrite comm_mx_stable_eigenspace //; apply: A_comm.
+Qed.
+
+Lemma common_eigenvector2 n (A B : 'M[C]_n) : (n > 0)%N -> A *m B = B *m A ->
+  exists2 v : 'rV_n, v != 0 & (stablemx v A) && (stablemx v B).
+Proof.
+move=> n_gt0 AB_comm; have [] := @common_eigenvector _ [:: A; B] n_gt0.
+  by move=> A' B'; rewrite !inE => /orP [] /eqP-> /orP [] /eqP->.
+by move=> v v_neq0 /allP vP; exists v; rewrite ?vP ?(mem_head, in_cons, orbT).
+Qed.
+
+Lemma mulmxtVK (m1 m2 n : nat) (A : 'M[C]_(m1, n)) (B : 'M[C]_(n, m2)) :
+  B \is unitarymx -> A *m B *m B^t* = A.
+Proof. by move=> B_unitary; rewrite -mulmxA (unitarymxP _) ?mulmx1. Qed.
+
+Lemma mulmxKtV (m1 m2 n : nat) (A : 'M[C]_(m1, n)) (B : 'M[C]_(m2, n)) :
+  B \is unitarymx -> m2 = n -> A *m B^t* *m B = A.
+Proof.
+move=> B_unitary m2E; case: _ / (esym m2E) in B B_unitary *.
+by rewrite -invmx_unitary // mulmxKV //; apply: unitarymx_unit.
+Qed.
+
+Lemma cotrigonalization n (As : seq 'M[C]_n) :
+  {in As &, forall A B, comm_mx A B} ->
+  cotrigonalizable_in (@unitarymx n n) As.
+Proof.
+elim: n {-2}n (leqnn n) As => [|N IHN] n.
+  rewrite leqn0 => /eqP n_eq0.
+  exists 1%:M; first by rewrite qualifE mul1mx trmx1 map_mx1.
+  apply/allP => ? ?; apply/is_trig_mxP => i j.
+  by suff: False by []; move: i; rewrite n_eq0 => -[].
+rewrite leq_eqVlt => /predU1P [n_eqSN|/IHN//].
+have /andP [n_gt0 n_small] : (n > 0)%N && (n - 1 <= N)%N.
+  by rewrite n_eqSN /= subn1.
+move=> As As_comm;
+have [v vN0 /allP /= vP] := common_eigenvector n_gt0 As_comm.
+suff: exists2 P : 'M[C]_(\rank v + \rank v^!, n), P \is unitarymx &
+  all (fun A => is_trig_mx (P *m A *m (P^t*))) As.
+  rewrite add_rank_ortho // => -[P P_unitary] /=; rewrite -invmx_unitary//.
+  by under eq_all do rewrite -conjumx ?unitarymx_unit//; exists P.
+pose S := schmidt_complete v.
+pose r A := S *m A *m S^t*.
+have vSvo X : stablemx v X ->
+  schmidt (row_base v) *m X *m schmidt (row_base v^!%MS) ^t* = 0.
+  move=> /eigenvectorP [a v_in].
+  rewrite (eigenspaceP (_ : (_ <= _ a))%MS); last first.
+    by rewrite eqmx_schmidt_free ?row_base_free ?eq_row_base.
+  rewrite -scalemxAl (orthomx1P _) ?scaler0 //.
+  by do 2!rewrite eqmx_schmidt_free ?row_base_free ?eq_row_base // orthomx_sym.
+have drrE X : drsubmx (r X) =
+  schmidt (row_base v^!%MS) *m X *m schmidt (row_base v^!%MS) ^t*.
+  by rewrite /r mul_col_mx tr_col_mx map_row_mx mul_col_row block_mxKdr.
+have vSv X a : (v <= eigenspace X a)%MS ->
+  schmidt (row_base v) *m X *m schmidt (row_base v) ^t* = a%:M.
+  move=> vXa; rewrite (eigenspaceP (_ : (_ <= _ a)%MS)); last first.
+    by rewrite eqmx_schmidt_free ?row_base_free ?eq_row_base.
+  by rewrite -scalemxAl (unitarymxP _) ?scalemx1 ?schmidt_unitarymx ?rank_leq_col.
+have [] := IHN _ _ [seq drsubmx (r A) | A <- As].
+- by rewrite rank_ortho rank_rV vN0.
+- move=> _ _ /mapP[/= A A_in ->] /mapP[/= B B_in ->].
+  have : (r A) *m (r B) = (r B) *m (r A).
+    rewrite /r !mulmxA !mulmxKtV // ?schmidt_complete_unitarymx //;
+    rewrite ?add_rank_ortho // -![S *m _ *m _]mulmxA.
+    by rewrite As_comm.
+  rewrite -[r A in X in X -> _]submxK -[r B  in X in X -> _]submxK.
+  rewrite 2!mulmx_block => /eq_block_mx [_ _ _].
+  suff urr_eq0 X : X \in As -> ursubmx (r X) = 0.
+    by rewrite !urr_eq0 ?mulmx0 ?add0r.
+  rewrite /r /S ![schmidt_complete _ *m _]mul_col_mx.
+  rewrite !tr_col_mx !map_row_mx !mul_col_row !block_mxKur.
+  by move=> X_in; rewrite vSvo // vP.
+move=> P' P'_unitary /allP /= P'P.
+exists ((block_mx 1%:M 0 0 P') *m S).
+  rewrite mul_unitarymx ?schmidt_complete_unitarymx //.
+  apply/unitarymxP; rewrite tr_block_mx map_block_mx mulmx_block.
+  rewrite !trmx0 !map_mx0 !tr_scalar_mx !map_scalar_mx ?conjC1.
+  rewrite !(mulmx1, mul1mx, mulmx0, mul0mx, addr0, add0r).
+  by rewrite (unitarymxP _) -?scalar_mx_block //.
+apply/allP => /= A A_in.
+rewrite trmx_mul map_mxM tr_block_mx map_block_mx.
+rewrite !trmx0 !map_mx0 !tr_scalar_mx !map_scalar_mx ?conjC1.
+rewrite mulmxA -[_ *m S *m _]mulmxA -[_ *m _ *m S^t*]mulmxA.
+rewrite /S ![schmidt_complete _ *m _]mul_col_mx.
+rewrite !tr_col_mx !map_row_mx !mul_col_row !mulmx_block.
+rewrite !(mulmx1, mul1mx, mulmx0, mul0mx, addr0, add0r).
+apply/is_trig_mxP => /= i j lt_ij; rewrite mxE.
+case: splitP => //= i' i_eq; rewrite !mxE;
+case: splitP => //= j' j_eq.
+- have /vP /eigenvectorP [a v_in] := A_in.
+  by rewrite (vSv _ _ v_in) mxE -val_eqE ltn_eqF //= -i_eq -j_eq.
+- by rewrite vSvo ?mul0mx ?mxE // vP //.
+- move: lt_ij; rewrite i_eq j_eq ltnNge -ltnS (leq_trans (ltn_ord j')) //.
+  by rewrite -addnS leq_addr.
+- set A' := _ *m A *m _; rewrite -invmx_unitary // -conjumx ?unitarymx_unit//.
+  have /(_ _) /is_trig_mxP -> // := P'P A'; last first.
+    by move: lt_ij; rewrite i_eq j_eq ltn_add2l.
+  by apply/mapP; exists A; rewrite //= drrE.
+Qed.
+
+Theorem Schur n (A : 'M[C]_n) : (n > 0)%N -> trigonalizable_in (@unitarymx n n) A.
+Proof.
+case: n => [//|n] in A * => _; have [] := @cotrigonalization _ [:: A].
+  by move=> ? ? /=; rewrite !in_cons !orbF => /eqP-> /eqP->.
+by move=> P P_unitary /=; rewrite andbT=> A_trigo; exists P.
+Qed.
+
+Lemma cotrigonalization2 n (A B : 'M[C]_n) : A *m B = B *m A ->
+  exists2 P : 'M[C]_n, P \is unitarymx &
+    similar_trig P A && similar_trig P B.
+Proof.
+move=> AB_comm; have [] := @cotrigonalization _ [:: A; B].
+  by move=> ??; rewrite !inE => /orP[]/eqP->/orP[]/eqP->.
+move=> P Punitary /allP /= PP; exists P => //.
+by rewrite !PP ?(mem_head, in_cons, orbT).
+Qed.
+
+Theorem orthomx_spectral_subproof {n} {A : 'M[C]_n} : reflect
+  (exists2 sp : 'M_n * 'rV_n,
+                sp.1 \is unitarymx &
+                A = invmx sp.1 *m diag_mx sp.2 *m sp.1)
+  (A \is normalmx).
+Proof.
+apply: (iffP normalmxP); last first.
+  move=> [[/= P D] P_unitary ->].
+  rewrite !trmx_mul !map_mxM !mulmxA invmx_unitary //.
+  rewrite !trmxCK ![_ *m P *m _]mulmxtVK //.
+  by rewrite -[X in X *m P]mulmxA tr_diag_mx map_diag_mx diag_mxC mulmxA.
+move=> /cotrigonalization2 [P Punitary /andP[]] PA PATC.
+have Punit := unitarymx_unit Punitary.
+suff: similar_diag P A.
+  move=> /similar_diagPex[D] PAD; exists (P, D) => //=.
+  by rewrite -conjVmx//; apply/similarLR.
+apply/similar_diagPp => // i j; case: ltngtP => // [lt_ij|lt_ji] _.
+  by have /is_trig_mxP-> := PA.
+have /is_trig_mxP -/(_ j i lt_ji)/eqP := PATC.
+rewrite !conjumx// invmx_unitary// -[P as X in X *m _]trmxCK.
+by rewrite -!map_mxM -!trmx_mul mulmxA 2!mxE conjC_eq0 => /eqP.
+Qed.
+
+Definition spectralmx n (A : 'M[C]_n) : 'M[C]_n :=
+  if @orthomx_spectral_subproof _ A is ReflectT P
+  then (projT1 (sig2_eqW P)).1 else 1%:M.
+
+Definition spectral_diag n (A : 'M[C]_n) : 'rV_n :=
+  if @orthomx_spectral_subproof _ A is ReflectT P
+  then (projT1 (sig2_eqW P)).2 else 0.
+
+Lemma spectral_unitarymx n (A : 'M[C]_n) : spectralmx A \is unitarymx.
+Proof.
+rewrite /spectralmx; case: orthomx_spectral_subproof; last first.
+  by move=> _; apply/unitarymxP; rewrite trmx1 map_mx1 mulmx1.
+by move=> ?; case: sig2_eqW.
+Qed.
+
+Lemma spectral_unit  n (A : 'M[C]_n) : spectralmx A \in unitmx.
+Proof. exact/unitarymx_unit/spectral_unitarymx. Qed.
+
+Theorem orthomx_spectralP {n} {A : 'M[C]_n}
+  (P := spectralmx A) (sp := spectral_diag A) :
+  reflect (A = invmx P *m diag_mx sp *m P) (A \is normalmx).
+Proof.
+rewrite /P /sp /spectralmx /spectral_diag.
+case: orthomx_spectral_subproof.
+  by move=> Psp; case: sig2_eqW => //=; constructor.
+move=> /orthomx_spectral_subproof Ann; constructor; apply/eqP.
+apply: contra Ann; rewrite invmx1 mul1mx mulmx1 => /eqP->.
+suff -> : diag_mx 0 = 0 by rewrite qualifE trmx0 map_mx0.
+by move=> ??; apply/matrixP=> i j; rewrite !mxE mul0rn.
+Qed.
+
+Lemma hermitian_normalmx n (A : 'M[C]_n) : A \is hermsymmx -> A \is normalmx.
+Proof.
+move=> Ahermi; apply/normalmxP.
+by rewrite (trmx_hermitian (HermitianMx Ahermi)) scale1r map_mxCK.
+Qed.
+
+Lemma realsym_hermsym n (A : 'M[C]_n) :
+  A \is symmetricmx -> A \is a realmx -> A \is hermsymmx.
+Proof.
+move=> Asym Areal; apply/is_hermitianmxP.
+by rewrite (trmx_hermitian (HermitianMx Asym))/= !scale1r ?realmxC ?map_mx_id.
+Qed.
+
+Lemma symmetric_normalmx n (A : 'M[C]_n) : A \is symmetricmx ->
+  A \is a realmx -> A \is normalmx.
+Proof. by move=> Asym Areal; rewrite hermitian_normalmx// realsym_hermsym. Qed.
+
+Lemma hermitian_spectral_diag_real n (A : 'M[C]_n) : A \is hermsymmx ->
+  spectral_diag A \is a realmx.
+Proof.
+move=> Ahermi; have /hermitian_normalmx /orthomx_spectralP A_eq := Ahermi.
+have /(congr1 (fun X => X^t*)) := A_eq.
+rewrite invmx_unitary ?spectral_unitarymx //.
+rewrite !trmx_mul !map_mxM map_trmx trmxK -map_mx_comp.
+rewrite tr_diag_mx map_diag_mx (map_mx_id (@conjCK _)).
+rewrite -[in RHS]invmx_unitary ?spectral_unitarymx //.
+have := is_hermitianmxP _ _ _ Ahermi; rewrite expr0 scale1r => <-; rewrite {1}A_eq.
+rewrite mulmxA; move=> /(congr1 (mulmx^~ (invmx (spectralmx A)))).
+rewrite !mulmxK ?spectral_unit //.
+move=> /(congr1 (mulmx (spectralmx A))); rewrite !mulKVmx ?spectral_unit //.
+move=> eq_A_conjA; apply/mxOverP => i j; rewrite ord1 {i}.
+have /matrixP /(_ j j) := eq_A_conjA; rewrite !mxE eqxx !mulr1n.
+by move=> /esym /CrealP.
+Qed.
+
+Lemma real_similar n (A B : 'M[C]_n) : similar_in unitmx A B ->
+  A \is a realmx -> B \is a realmx -> similar_in [predI realmx & unitmx] A B.
+Proof.
+case=> [P /=]; pose Pr := P ^ (@Re _); pose Pi := P ^ (@Im _).
+have Pr_real : Pr \is a realmx by apply/mxOverP=> i j; rewrite !mxE Creal_Re.
+have Pi_real : Pi \is a realmx by apply/mxOverP=> i j; rewrite !mxE Creal_Im.
+pose Q x := P ^ (@Re _) + x *: P ^ (@Im _).
+have -> : P = Q 'i by apply/matrixP=> i j; rewrite !mxE -Crect.
+move=> Qi_unit eq_AP_PB Areal Breal.
+pose p := \det (Pr ^ polyC + 'X *: Pi ^ polyC).
+have horner_evaliC x : horner_eval (x : C) \o polyC =1 id := fun=> hornerC _ _.
+have Qunit x : Q x \in unitmx = (p.[x] != 0).
+  rewrite /p -horner_evalE -det_map_mx map_mxD map_mxZ/= horner_evalE hornerX.
+  by rewrite -![(_ ^ polyC) ^ _]map_mx_comp !map_mx_id// unitmxE unitfE.
+have p_neq0 : p != 0.
+  by move: Qi_unit; rewrite Qunit; apply: contra_neq => ->; rewrite hornerE.
+have [a a_real rootNa] : exists2 a, a \is Num.real &  ~~ root p a.
+  have rs_uniq : uniq [seq (i%:R : C) | i <- iota 0 (size p)].
+    by rewrite map_inj_uniq ?iota_uniq //; apply: mulrIn; rewrite oner_eq0.
+  have := contraNN (fun x => max_poly_roots p_neq0 x rs_uniq).
+  rewrite size_map size_iota ltnn => /(_ isT) /allPn[a a_in rootNpa].
+  by exists a => //; by move: a_in => /mapP [i _ ->]; rewrite realn.
+exists (Q a); first by rewrite ?inE Qunit rootNa rpredD// mxOverZ//.
+apply/similarP; rewrite ?Qunit//; move: eq_AP_PB => /(similarP Qi_unit).
+rewrite !mulmxDl !mulmxDr -!scalemxAr -!scalemxAl => /eqmx_ReiIm.
+by rewrite !mxOverM// => /(_ isT isT isT isT) [-> ->].
+Qed.
+
+End Spectral.

--- a/mathcomp/algebra/spectral.v
+++ b/mathcomp/algebra/spectral.v
@@ -267,7 +267,7 @@ Section Spectral.
 Variable (C : numClosedFieldType).
 Set Default Proof Using "C".
 
-Notation dotmx_def := (form_of_matrix (@conjC _) 1%:M).
+Local Notation dotmx_def := (form_of_matrix (@conjC _) 1%:M).
 Definition dotmx n (u v : 'rV[C]_n) := dotmx_def u%R v%R.
 
 (*
@@ -426,8 +426,8 @@ elim: m A => [|m IHm].
   exists (pid_mx n); first by rewrite qualifE !thinmx0.
   by apply/forallP=> -[].
 rewrite -addn1 => A leq_Sm_n.
-have lemSm: (m <= m + 1)%N by rewrite addn1.
-have ltmSm: (m < m + 1)%N by rewrite addn1.
+have lemSm : (m <= m + 1)%N by rewrite addn1.
+have ltmSm : (m < m + 1)%N by rewrite addn1.
 have lemn : (m <= n)%N by rewrite ltnW // -addn1.
 have [B Bortho] := IHm (usubmx A) lemn.
 move=> /forallP /= subAB.

--- a/mathcomp/algebra/spectral.v
+++ b/mathcomp/algebra/spectral.v
@@ -4,6 +4,33 @@ From mathcomp Require Import seq div fintype bigop ssralg finset fingroup zmodp.
 From mathcomp Require Import poly polydiv order ssrnum matrix mxalgebra vector.
 From mathcomp Require Import mxpoly mxred sesquilinear.
 
+(******************************************************************************)
+(*                             Spectral theory                                *)
+(*                                                                            *)
+(* This file provides a formalization of Gram-Schmidt orthonormalization,     *)
+(* Schur decomposition, etc.                                                   *)
+(*                                                                            *)
+(*                 M ^t* := M ^t conjC                                        *)
+(*                                                                            *)
+(*       M \is unitarymx == M is a unitary matrix                             *)
+(*                          M : 'M[C]_(m, n) with C : numClosedFieldType      *)
+(*        M \is normalmx == M is a normal matrix                              *)
+(*                          M : 'M[C]_n with C : numClosedFieldType           *)
+(*                                                                            *)
+(*             dotmx u v == dot product                                       *)
+(*                          u and v are row vectors over a numClosedFieldType *)
+(*                          Local notations: '[u, v] := dotmx u v,            *)
+(*                          '[u] := '[u, u]                                   *)
+(*          proj_ortho Y := proj_mx <<U>>%MS U^!%MS                           *)
+(*                          where U^! is a 1-orthogonal completement of U     *)
+(*             schmidt A == Gram-Schmidt basis                                *)
+(*                          A : 'M[C]_(m, n)                                  *)
+(*    schmidt_complete V := col_mx (schmidt (row_base V))                     *)
+(*                                 (schmidt (row_base V^!%MS))                *)
+(* spectralmx A, spectral_diag A == (M,X) s.t. A = M^-1 *m diag_mx X *m M     *)
+(*                          A : 'M[C]_n                                       *)
+(******************************************************************************)
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
@@ -11,127 +38,300 @@ Unset Printing Implicit Defensive.
 Import GRing.Theory Order.Theory Num.Theory.
 Local Open Scope ring_scope.
 
-Notation realmx := (mxOver Num.real).
-
-Section Spectral.
-
-Variable (C : numClosedFieldType).
-Set Default Proof Using "C".
-
-Local Notation "M ^ phi" := (map_mx phi M).
-Local Notation "M ^t*" := (map_mx conjC (M ^T)) (at level 30).
-
-Lemma realmxC m n (A : 'M[C]_(m, n)) : A \is a mxOver Num.real -> A ^ conjC = A.
+(* TODO: move? *)
+Lemma eigenvalue_closed {C : numClosedFieldType} n (A : 'M[C]_n) : (n > 0)%N ->
+  exists a, eigenvalue A a.
 Proof.
-move=> ?; apply/matrixP => x y; rewrite mxE.
-exact/CrealP/mxOverP.
+move=> n_gt0; have /closed_rootP [a rAa] : size (char_poly A) != 1%N.
+  by rewrite size_char_poly; case: (n) n_gt0.
+by exists a; rewrite eigenvalue_root_char.
 Qed.
 
-Lemma Remx_rect m n :
-  {in realmx &, forall (X Y : 'M[C]_(m,n)), (X + 'i *: Y) ^ (@Re _) = X}.
+(* TODO: move? *)
+Lemma common_eigenvector {C : numClosedFieldType} n (As : seq 'M[C]_n) :
+  (n > 0)%N -> {in As &, forall A B, comm_mx A B} ->
+  exists2 v : 'rV_n, v != 0 & all (fun A => stablemx v A) As.
 Proof.
-move=> X Y Xreal Yreal; apply/matrixP=> i j; rewrite !mxE.
+move=> n_gt0 /all_comm_mxP; have [k sAsk] := ubnP (size As).
+elim: k n n_gt0 As sAsk => [//|k IHk]  n n_gt0 [|A As].
+  exists (const_mx 1) => //; apply/negP => /eqP/rowP/(_ (Ordinal n_gt0)).
+  by rewrite !mxE => /eqP; rewrite oner_eq0.
+rewrite ltnS all_comm_mx_cons => sAsk /andP[].
+move=> /allP/(_ _ _)/eqP/= A_comm /all_comm_mxP As_comm.
+have [a a_eigen] := eigenvalue_closed A n_gt0.
+have [] := IHk _ _ [seq restrictmx (eigenspace A a) B | B <- As].
+- by rewrite lt0n mxrank_eq0.
+- by rewrite size_map.
+- apply/all_comm_mxP; move=> _ _ /= /mapP /= [B B_in ->] /mapP /= [B' B'_in ->].
+  rewrite -?conjmxM ?inE ?stablemx_row_base ?comm_mx_stable_eigenspace//;
+  by [rewrite As_comm | apply: As_comm | apply: A_comm].
+move=> v vN0 /allP /= vP; exists (v *m (row_base (eigenspace A a))).
+  by rewrite mulmx_free_eq0 ?row_base_free.
+apply/andP; split.
+  by apply/eigenvectorP; exists a; rewrite mulmx_sub // eq_row_base.
+apply/allP => B B_in; rewrite -stablemx_restrict ?vP //.
+  by apply/mapP; exists B.
+by rewrite comm_mx_stable_eigenspace //; exact: A_comm.
+Qed.
+
+(* TODO: move? *)
+Lemma common_eigenvector2 {C : numClosedFieldType}n  (A B : 'M[C]_n) :
+  (n > 0)%N -> A *m B = B *m A ->
+  exists2 v : 'rV_n, v != 0 & (stablemx v A) && (stablemx v B).
+Proof.
+move=> n_gt0 AB_comm; have [] := @common_eigenvector _ _ [:: A; B] n_gt0.
+  by move=> A' B'; rewrite !inE => /orP [] /eqP-> /orP [] /eqP->.
+by move=> v v_neq0 /allP vP; exists v; rewrite ?vP ?(mem_head, in_cons, orbT).
+Qed.
+
+Notation "M ^t*" := (M ^t conjC) (at level 30).
+Notation realmx := (mxOver Num.real).
+
+Lemma trmxCK {C : numClosedFieldType} m n (A : 'M[C]_(m, n)) : A ^t* ^t* = A.
+Proof. by apply/matrixP=> i j; rewrite !mxE conjCK. Qed.
+
+Section realmx.
+Context {C : numClosedFieldType} {m n : nat}.
+Implicit Types A B : 'M[C]_(m, n).
+
+Lemma realmxC A : A \is a realmx -> A ^ conjC = A.
+Proof.
+by move=> ?; apply/matrixP => x y; rewrite mxE; exact/CrealP/mxOverP.
+Qed.
+
+Lemma realmxD A B : A \is a realmx -> B \is a realmx -> A + B \is a realmx.
+Proof.
+rewrite !qualifE/= => /'forall_forallP realA /'forall_forallP realB.
+by apply/'forall_forallP => i j; rewrite mxE realD.
+Qed.
+
+Lemma Remx_rect : {in realmx &, forall A B, (A + 'i *: B) ^ (@Re _) = A}.
+Proof.
+move=> A B Areal Breal; apply/matrixP=> i j; rewrite !mxE.
 by rewrite Re_rect // (mxOverP _ _).
 Qed.
 
-Lemma Immx_rect m n :
-  {in realmx &, forall (X Y : 'M[C]_(m,n)), (X + 'i *: Y) ^ (@Im _) = Y}.
+Lemma Immx_rect : {in realmx &, forall A B, (A + 'i *: B) ^ (@Im _) = B}.
 Proof.
-move=> /= X Y Xreal Yreal; apply/matrixP=> i j; rewrite !mxE.
+move=> /= A B Areal Breal; apply/matrixP=> i j; rewrite !mxE.
 by rewrite Im_rect // (mxOverP _ _).
 Qed.
 
-Lemma eqmx_ReiIm m n (X Y X' Y' : 'M[C]_(m,n)) :
-    X \is a realmx -> Y \is a realmx ->
-    X' \is a realmx -> Y' \is a realmx ->
-  (X + 'i *: Y) = (X' + 'i *: Y') -> (X, Y) = (X', Y').
+Lemma eqmx_ReiIm A B A' B' :
+  A \is a realmx -> B \is a realmx -> A' \is a realmx -> B' \is a realmx ->
+  (A + 'i *: B) = (A' + 'i *: B') -> (A, B) = (A', B').
 Proof.
-move=> XRe YRe X'Im Y'Im eqXY.
-have /(congr1 (fun X => X ^ (@Im _))) := eqXY.
-have /(congr1 (fun X => X ^ (@Re _))) := eqXY.
+move=> ARe BRe A'Im B'Im eqAB.
+have /(congr1 (fun A => A ^ (@Im _))) := eqAB.
+have /(congr1 (fun A => A ^ (@Re _))) := eqAB.
 by rewrite !Remx_rect// !Immx_rect// => -> ->.
 Qed.
 
-Lemma map_mxCK m n (M : 'M[C]_(m, n)) : (M ^ conjC) ^ conjC = M.
-Proof. by apply/matrixP=> i j; rewrite !mxE /conjC conjCK. Qed.
+End realmx.
 
-Lemma trmxCK m n (M : 'M[C]_(m, n)) : M ^t* ^t* = M.
-Proof. by apply/matrixP=> i j; rewrite !mxE /conjC conjCK. Qed.
+Lemma realsym_hermsym {C : numClosedFieldType} {n} (A : 'M[C]_n) :
+  A \is symmetricmx -> A \is a realmx -> A \is hermsymmx.
+Proof.
+move=> Asym Areal; apply/is_hermitianmxP.
+by rewrite (trmx_hermitian (HermitianMx Asym))/= !scale1r ?realmxC ?map_mx_id.
+Qed.
 
-Definition unitarymx {m n} := [qualify M : 'M[C]_(m, n) | M *m M ^t* == 1%:M].
+Lemma real_similar {C : numClosedFieldType} {n} (A B : 'M[C]_n) :
+  similar_in unitmx A B ->
+  A \is a realmx -> B \is a realmx -> similar_in [predI realmx & unitmx] A B.
+Proof.
+case=> [P /=]; pose Pr := P ^ (@Re _); pose Pi := P ^ (@Im _).
+have Pr_real : Pr \is a realmx by apply/mxOverP=> i j; rewrite !mxE Creal_Re.
+have Pi_real : Pi \is a realmx by apply/mxOverP=> i j; rewrite !mxE Creal_Im.
+pose Q x := P ^ (@Re _) + x *: P ^ (@Im _).
+have -> : P = Q 'i by apply/matrixP=> i j; rewrite !mxE -Crect.
+move=> Qi_unit eq_AP_PB Areal Breal.
+pose p := \det (Pr ^ polyC + 'X *: Pi ^ polyC).
+have horner_evaliC x : horner_eval (x : C) \o polyC =1 id := fun=> hornerC _ _.
+have Qunit x : Q x \in unitmx = (p.[x] != 0).
+  rewrite /p -horner_evalE -det_map_mx map_mxD map_mxZ/= horner_evalE hornerX.
+  by rewrite -![(_ ^ polyC) ^ _]map_mx_comp !map_mx_id// unitmxE unitfE.
+have p_neq0 : p != 0.
+  by move: Qi_unit; rewrite Qunit; apply: contra_neq => ->; rewrite hornerE.
+have [a a_real rootNa] : exists2 a, a \is Num.real &  ~~ root p a.
+  have rs_uniq : uniq [seq (i%:R : C) | i <- iota 0 (size p)].
+    by rewrite map_inj_uniq ?iota_uniq //; apply: mulrIn; rewrite oner_eq0.
+  have := contraNN (fun x => max_poly_roots p_neq0 x rs_uniq).
+  rewrite size_map size_iota ltnn => /(_ isT) /allPn[a a_in rootNpa].
+  by exists a => //; by move: a_in => /mapP [i _ ->]; rewrite realn.
+exists (Q a).
+  rewrite inE Qunit rootNa andbT.
+  rewrite /Q/=.
+  by rewrite realmxD// mxOverZ.
+apply/similarP; rewrite ?Qunit//; move: eq_AP_PB => /(similarP Qi_unit).
+rewrite !mulmxDl !mulmxDr -!scalemxAr -!scalemxAl => /eqmx_ReiIm.
+by rewrite !mxOverM// => /(_ isT isT isT isT) [-> ->].
+Qed.
+
+Section unitarymx.
+Context {C : numClosedFieldType}.
+
+Definition unitarymx {m n} := [qualify X : 'M[C]_(m, n) | X *m X ^t* == 1%:M].
 Fact unitarymx_key m n : pred_key (@unitarymx m n). Proof. by []. Qed.
 Canonical unitarymx_keyed m n := KeyedQualifier (unitarymx_key m n).
 
-Definition normalmx {n} := [qualify M : 'M[C]_n | M *m M ^t* == M ^t* *m M].
-Fact normalmx_key n : pred_key (@normalmx n). Proof. by []. Qed.
-Canonical normalmx_keyed n := KeyedQualifier (normalmx_key n).
+Lemma unitarymxP m n {M : 'M[C]_(m, n)} :
+  reflect (M *m M^t* = 1%:M) (M \is unitarymx).
+Proof. by apply: (iffP eqP). Qed.
 
-Lemma normalmxP {n} {M: 'M[C]_n} :
+Lemma mulmxtVK m1 m2 n (A : 'M[C]_(m1, n)) (B : 'M[C]_(n, m2)) :
+  B \is unitarymx -> A *m B *m B^t* = A.
+Proof. by move=> B_unitary; rewrite -mulmxA (unitarymxP _) ?mulmx1. Qed.
+
+Lemma unitarymx_unit n (M : 'M[C]_n) : M \is unitarymx -> M \in unitmx.
+Proof. by move=> /unitarymxP /mulmx1_unit []. Qed.
+
+Lemma invmx_unitary n (M : 'M[C]_n) : M \is unitarymx -> invmx M = M^t*.
+Proof.
+move=> Munitary; apply: (@row_full_inj _ _ _ _ M).
+  by rewrite row_full_unit unitarymx_unit.
+by rewrite mulmxV ?unitarymx_unit ?(unitarymxP _).
+Qed.
+
+Lemma mulmxKtV m1 m2 n (A : 'M[C]_(m1, n)) (B : 'M[C]_(m2, n)) :
+  B \is unitarymx -> m2 = n -> A *m B^t* *m B = A.
+Proof.
+move=> B_unitary m2E; case: _ / (esym m2E) in B B_unitary *.
+by rewrite -invmx_unitary // mulmxKV //; exact: unitarymx_unit.
+Qed.
+
+Lemma mxrank_unitary m n (M : 'M[C]_(m, n)) : M \is unitarymx -> \rank M = m.
+Proof.
+rewrite qualifE => /eqP /(congr1 mxrank); rewrite mxrank1 => rkM.
+apply/eqP; rewrite eqn_leq rank_leq_row /= -[X in (X <= _)%N]rkM.
+by rewrite mxrankM_maxl.
+Qed.
+
+Lemma mul_unitarymx m n p (A : 'M[C]_(m, n)) (B : 'M[C]_(n, p)) :
+  A \is unitarymx -> B \is unitarymx -> A *m B \is unitarymx.
+Proof.
+move=> Aunitary Bunitary; apply/unitarymxP; rewrite trmx_mul map_mxM.
+by rewrite mulmxA -[A *m _ *m _]mulmxA !(unitarymxP _, mulmx1).
+Qed.
+
+Lemma pinvmx_unitary n (M : 'M[C]_n) : M \is unitarymx -> pinvmx M = M^t*.
+Proof. by move=> Munitary; rewrite pinvmxE ?unitarymx_unit// invmx_unitary. Qed.
+
+Lemma conjymx n (P M : 'M[C]_n) : P \is unitarymx -> conjmx P M = P *m M *m P^t*.
+Proof. by move=> Munitary; rewrite conjumx ?invmx_unitary ?unitarymx_unit. Qed.
+
+Lemma trmx_unitary n (M : 'M[C]_n) : (M ^T \is unitarymx) = (M \is unitarymx).
+Proof.
+apply/unitarymxP/unitarymxP; rewrite -?map_trmx -trmx_mul.
+  by rewrite -trmx1 => /trmx_inj /mulmx1C->; rewrite trmx1.
+by move=> /mulmx1C->; rewrite trmx1.
+Qed.
+
+Lemma conjC_unitary m n (M : 'M[C]_(m, n)) :
+  (M ^ conjC \is unitarymx) = (M \is unitarymx).
+Proof.
+apply/unitarymxP/unitarymxP; rewrite -?map_mxM ?map_trmx; last first.
+  by move=> ->; rewrite map_mx1.
+by rewrite -[1%:M](map_mx1 conjC) => /map_mx_inj ->; rewrite map_mx1.
+Qed.
+
+Lemma trmxC_unitary n (M : 'M[C]_n) : (M ^t* \is unitarymx) = (M \is unitarymx).
+Proof. by rewrite conjC_unitary trmx_unitary. Qed.
+
+End unitarymx.
+
+Section normalmx.
+Context {C : numClosedFieldType} {n : nat}.
+
+Definition normalmx := [qualify M : 'M[C]_n | M *m M ^t* == M ^t* *m M].
+Fact normalmx_key : pred_key normalmx. Proof. by []. Qed.
+Canonical normalmx_keyed := KeyedQualifier normalmx_key.
+
+Lemma normalmxP {M : 'M[C]_n} :
   reflect (M *m M ^t* = M ^t* *m M) (M \is normalmx).
 Proof. exact: eqP. Qed.
 
-Definition conjCfun (C : numClosedFieldType) := conjC : C -> C.
-Arguments conjCfun _ _ /.
-HB.instance Definition _ := GRing.RMorphism.on (@conjCfun C).
-Let conjCfun_involutive : involutive (@conjCfun C).
-Proof. exact: conjCK. Qed.
-HB.instance Definition _ :=
-  isInvolutive.Build _ (@conjCfun C) conjCfun_involutive.
+Lemma hermitian_normalmx (A : 'M[C]_n) : A \is hermsymmx -> A \is normalmx.
+Proof.
+move=> Ahermi; apply/normalmxP.
+by rewrite (trmx_hermitian (HermitianMx Ahermi)) scale1r map_mxCK.
+Qed.
 
-Notation dotmx_def := (form_of_matrix (@conjCfun _) 1%:M).
+Lemma symmetric_normalmx (A : 'M[C]_n) : A \is symmetricmx ->
+  A \is a realmx -> A \is normalmx.
+Proof. by move=> Asym Areal; rewrite hermitian_normalmx// realsym_hermsym. Qed.
+
+End normalmx.
+
+Section Spectral.
+Variable (C : numClosedFieldType).
+Set Default Proof Using "C".
+
+Notation dotmx_def := (form_of_matrix (@conjC _) 1%:M).
 Definition dotmx n (u v : 'rV[C]_n) := dotmx_def u%R v%R.
+
+(*
+TODO: bug report
+we were expecting
+HB.instance Definition _ n := Bilinear.on (@dotmx n).
+to be sufficient to equip dotmx with the bilinear structure
+but needed to use .copy in the end as in:
+*)
+HB.instance Definition _ n := Bilinear.copy (@dotmx n) dotmx_def.
 
 Local Notation "''[' u , v ]" := (dotmx u v) : ring_scope.
 Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
 
-Fact dotmx_is_hermitian n : (1%:M : 'M[C]_n) \is hermsymmx.
-Proof.
-by rewrite qualifE /= expr0 scale1r tr_scalar_mx map_scalar_mx conjC1.
-Qed.
-Canonical hermitian1mx n := HermitianMx (dotmx_is_hermitian n).
+HB.instance Definition _ n := Hermitian.copy (@dotmx n) dotmx_def.
 
-(* TODO
-Canonical dotmx_bilinear n := [bilinear of @dotmx n as dotmx_def].
-Canonical dotmx_hermsym n := [hermitian of (@dotmx n) as dotmx_def].
-*)
-
-Lemma dotmxE n (u v : 'rV_n) : '[u, v] = (u *m v ^t*) 0 0.
+Lemma dotmxE n (u v : 'rV[C]_n) : '[u, v] = (u *m v ^t*) 0 0.
 Proof. by rewrite /dotmx /form_of_matrix mulmx1 /= trace_mx11. Qed.
 
-Fact dotmx_is_dotmx n :forall u, u != 0 -> 0 < (@dotmx n) u u.
+Lemma row_unitarymxP m n {M : 'M[C]_(m, n)} :
+  reflect (forall i j, '[row i M, row j M] = (i == j)%:R) (M \is unitarymx).
 Proof.
-move=> /= u u_neq0; rewrite dotmxE mxE.
-suff /existsP[i ui_neq0] : [exists i, u 0 i != 0].
+apply: (iffP eqP) => [Mo i j|Mo].
+  have /matrixP/(_ i j) := Mo; rewrite !mxE => <-.
+  by rewrite dotmxE !mxE; apply: eq_bigr => /= k _; rewrite !mxE.
+apply/matrixP=> i j; rewrite !mxE; have := Mo i j; rewrite dotmxE !mxE => <-.
+by apply: eq_bigr => /= k _; rewrite !mxE.
+Qed.
+
+Fact dotmx_is_dotmx n (u : 'rV[C]_n) : u != 0 -> 0 < '[u].
+Proof.
+move=> u_neq0; rewrite dotmxE mxE.
+suff /existsP[i ui_neq0] : [exists i, u ``_ i != 0].
   rewrite (bigD1 i) //= ltr_wpDr// ?sumr_ge0// ?mxE ?mul_conjC_gt0//.
   by move=> j _; rewrite !mxE mul_conjC_ge0.
 apply: contraNT u_neq0; rewrite negb_exists => /forallP uNN0.
 by apply/eqP/rowP=> j; rewrite mxE; apply/eqP; rewrite -[_ == _]negbK uNN0.
 Qed.
-(* TODO: probably that failed *)
-HB.instance Definition _ n := isDotProduct.Build _ _ _ (@dotmx_is_dotmx n).
+
+HB.instance Definition _ n := isDotProduct.Build _ _ (@dotmx n)
+  (@dotmx_is_dotmx n).
 
 Local Notation "B ^!" :=
-  (orthomx (@conjCfun C) (mx_of_hermitian (hermitian1mx _)) B) : matrix_set_scope.
+  (orthomx (@conjC C) (mx_of_hermitian (hermitian1mx _)) B) : matrix_set_scope.
 Local Notation "A _|_ B" := (A%MS <= B^!)%MS : bool_scope.
 
 Lemma orthomx1E m n p (A : 'M[C]_(m, n)) (B : 'M_(p, n)) :
   (A _|_ B)%MS = (A *m B^t* == 0).
 Proof. by apply/sub_kermxP/eqP; rewrite !mul1mx. Qed.
 
-Lemma orthomx1P {m n p : nat} {A : 'M[C]_(m, n)} {B : 'M_(p, n)} :
+Lemma orthomx1P m n p {A : 'M[C]_(m, n)} {B : 'M_(p, n)} :
   reflect (A *m B^t* = 0) (A _|_ B).
-Proof. by rewrite orthomx1E; apply: eqP. Qed.
+Proof. by rewrite orthomx1E; exact/eqP. Qed.
 
 Lemma orthomx_disj n p q (A : 'M[C]_(p, n)) (B :'M_(q, n)) :
   A _|_ B -> (A :&: B = 0)%MS.
 Proof.
 move=> nAB; apply/eqP/rowV0Pn => [[v]]; rewrite sub_capmx => /andP [vA vB].
-apply/negP; rewrite negbK -(dnorm_eq0 (dotmx_dot n)) -orthomxE.
-by rewrite (orthomxP _ _ _ nAB).
+apply/negP; rewrite negbK.
+by rewrite -(dnorm_eq0 (@dotmx n)) -orthomxE (orthomxP _ _ _ nAB).
 Qed.
 
 Lemma orthomx_ortho_disj n p (A : 'M[C]_(p, n)) : (A :&: A^! = 0)%MS.
-Proof. by apply/orthomx_disj/ortho_mx_ortho. Qed.
+Proof. exact/orthomx_disj/ortho_mx_ortho. Qed.
 
 Lemma rank_ortho p n (A : 'M[C]_(p, n)) : \rank A^! = (n - \rank A)%N.
 Proof. by rewrite mxrank_ker mul1mx mxrank_map mxrank_tr. Qed.
@@ -152,61 +352,62 @@ apply/eqmx_sym/eqmxP.
 by rewrite -mxrank_leqif_eq 1?orthomx_sym // !rank_ortho subKn // ?rank_leq_col.
 Qed.
 
-Lemma submx_ortho (p m n : nat) (U : 'M[C]_(p, n)) (V : 'M_(m, n)) :
+Lemma submx_ortho p m n (U : 'M[C]_(p, n)) (V : 'M_(m, n)) :
   (U^! <= V^!)%MS = (V <= U)%MS.
 Proof. by rewrite orthomx_sym ortho_id. Qed.
 
 Definition proj_ortho p n (U : 'M[C]_(p, n)) := proj_mx <<U>>%MS U^!%MS.
 
-Let sub_adds_genmx_ortho (p m n : nat) (U : 'M[C]_(p, n))  (W : 'M_(m, n)) :
+Lemma sub_adds_genmx_ortho (p m n : nat) (U : 'M[C]_(p, n))  (W : 'M_(m, n)) :
   (W <= <<U>> + U^!)%MS.
 Proof.
 by rewrite !(adds_eqmx (genmxE _) (eqmx_refl _)) addsmx_ortho submx1.
 Qed.
+Local Hint Resolve sub_adds_genmx_ortho : core.
 
-Let cap_genmx_ortho (p n : nat) (U : 'M[C]_(p, n)) : (<<U>> :&: U^!)%MS = 0.
+Lemma cap_genmx_ortho p n (U : 'M[C]_(p, n)) : (<<U>> :&: U^!)%MS = 0.
 Proof.
 apply/eqmx0P; rewrite !(cap_eqmx (genmxE _) (eqmx_refl _)).
-by rewrite orthomx_ortho_disj; apply/eqmx0P.
+by rewrite orthomx_ortho_disj; exact/eqmx0P.
 Qed.
+Local Hint Resolve cap_genmx_ortho : core.
 
-Lemma proj_ortho_sub (p m n : nat) (U : 'M_(p, n)) (W : 'M_(m, n)) :
-   (W *m proj_ortho U <= U)%MS.
+Lemma proj_ortho_sub p m n (U : 'M_(p, n)) (W : 'M_(m, n)) :
+  (W *m proj_ortho U <= U)%MS.
 Proof. by rewrite (submx_trans (proj_mx_sub _ _ _)) // genmxE. Qed.
 
-Lemma proj_ortho_compl_sub (p m n : nat) (U : 'M_(p, n)) (W : 'M_(m, n)) :
+Lemma proj_ortho_compl_sub p m n (U : 'M_(p, n)) (W : 'M_(m, n)) :
   (W - W *m proj_ortho U <= U^!)%MS.
 Proof. by rewrite proj_mx_compl_sub // addsmx_ortho submx1. Qed.
 
-Lemma proj_ortho_id (p m n : nat) (U : 'M_(p, n)) (W : 'M_(m, n)) :
-   (W <= U)%MS -> W *m proj_ortho U = W.
+Lemma proj_ortho_id p m n (U : 'M_(p, n)) (W : 'M_(m, n)) :
+  (W <= U)%MS -> W *m proj_ortho U = W.
 Proof. by move=> WU; rewrite proj_mx_id ?genmxE. Qed.
 
-Lemma proj_ortho_0 (p m n : nat) (U : 'M_(p, n)) (W : 'M_(m, n)) :
-    (W <= U^!)%MS -> W *m proj_ortho U = 0.
+Lemma proj_ortho_0 p m n (U : 'M_(p, n)) (W : 'M_(m, n)) :
+  (W <= U^!)%MS -> W *m proj_ortho U = 0.
 Proof. by move=> WUo; rewrite proj_mx_0. Qed.
 
-Lemma add_proj_ortho (p m n : nat) (U : 'M_(p, n)) (W : 'M_(m, n)) :
+Lemma add_proj_ortho p m n (U : 'M_(p, n)) (W : 'M_(m, n)) :
   W *m proj_ortho U + W *m proj_ortho U^!%MS = W.
 Proof.
-rewrite -[W in LHS](@add_proj_mx _ _ _ <<U>>%MS U^!%MS W) //.
+rewrite -[W in LHS](@add_proj_mx _ _ _ <<U>>%MS U^!%MS W)//.
 rewrite !mulmxDl proj_ortho_id ?proj_ortho_sub //.
 rewrite proj_ortho_0 ?proj_mx_sub // addr0.
 rewrite proj_ortho_0 ?ortho_id ?proj_ortho_sub // add0r.
-by rewrite proj_ortho_id ?proj_mx_sub // add_proj_mx.
+by rewrite proj_ortho_id ?proj_mx_sub// add_proj_mx.
 Qed.
 
-Lemma proj_ortho_proj (m n : nat) (U : 'M_(m, n)) :
-   let P := proj_ortho U in P *m P = P.
+Lemma proj_ortho_proj m n (U : 'M_(m, n)) : let P := proj_ortho U in P *m P = P.
 Proof. by rewrite /= proj_mx_proj. Qed.
 
-Lemma proj_orthoE (p n : nat) (U : 'M_(p, n)) : (proj_ortho U :=: U)%MS.
+Lemma proj_orthoE p n (U : 'M_(p, n)) : (proj_ortho U :=: U)%MS.
 Proof.
 apply/eqmxP/andP; split; first by rewrite -proj_ortho_proj proj_ortho_sub.
 by rewrite -[X in (X <= _)%MS](proj_ortho_id (submx_refl U)) mulmx_sub.
 Qed.
 
-Lemma orthomx_proj_mx_ortho (p p' m m' n : nat)
+Lemma orthomx_proj_mx_ortho p p' m m' n
   (A : 'M_(p, n)) (A' : 'M_(p', n))
   (W : 'M_(m, n)) (W' : 'M_(m', n)) :
   A _|_ A' -> W *m proj_ortho A _|_ W' *m proj_ortho A'.
@@ -215,69 +416,6 @@ rewrite orthomx_sym => An.
 rewrite mulmx_sub // orthomx_sym (eqmx_ortho _ (proj_orthoE _)).
 by rewrite (submx_trans _ An) // proj_ortho_sub.
 Qed.
-
-Lemma unitarymxP  {m} {n} {M : 'M[C]_(m, n)} :
-  reflect (M *m M^t* = 1%:M) (M \is unitarymx).
-Proof. by apply: (iffP eqP). Qed.
-
-Lemma mxrank_unitary m n (M : 'M[C]_(m, n)) : M \is unitarymx -> \rank M = m.
-Proof.
-rewrite qualifE => /eqP /(congr1 mxrank); rewrite mxrank1 => rkM.
-apply/eqP; rewrite eqn_leq rank_leq_row /= -[X in (X <= _)%N]rkM.
-by rewrite mxrankM_maxl.
-Qed.
-
-Lemma row_unitarymxP {m n} {M : 'M[C]_(m, n)} :
-  reflect (forall i j, '[row i M, row j M] = (i == j)%:R) (M \is unitarymx).
-Proof.
-apply: (iffP eqP).
-  move=> Mo i j; have /matrixP /(_ i j) := Mo; rewrite !mxE => <-.
-  by rewrite dotmxE !mxE; apply: eq_bigr => /= k _; rewrite !mxE.
-move=> Mo; apply/matrixP=> i j; rewrite !mxE.
-have := Mo i j; rewrite dotmxE !mxE => <-.
-by apply: eq_bigr => /= k _; rewrite !mxE.
-Qed.
-
-Lemma mul_unitarymx m n p (A : 'M[C]_(m, n)) (B : 'M[C]_(n, p)) :
-  A \is unitarymx -> B \is unitarymx -> A *m B \is unitarymx.
-Proof.
-move=> Aunitary Bunitary; apply/unitarymxP; rewrite trmx_mul map_mxM.
-by rewrite mulmxA -[A *m _ *m _]mulmxA !(unitarymxP _, mulmx1).
-Qed.
-
-Lemma unitarymx_unit n (M : 'M[C]_n) : M \is unitarymx -> M \in unitmx.
-Proof. by move=> /unitarymxP /mulmx1_unit []. Qed.
-
-Lemma invmx_unitary n (M : 'M[C]_n) : M \is unitarymx -> invmx M = M^t*.
-Proof.
-move=> Munitary; apply: (@row_full_inj _ _ _ _ M).
-  by rewrite row_full_unit unitarymx_unit.
-by rewrite mulmxV ?unitarymx_unit ?(unitarymxP _).
-Qed.
-
-Lemma pinvmx_unitary n (M : 'M[C]_n) : M \is unitarymx -> pinvmx M = M^t*.
-Proof. by move=> Munitary; rewrite pinvmxE ?unitarymx_unit// invmx_unitary. Qed.
-
-Lemma conjymx n (P M : 'M[C]_n) : P \is unitarymx -> conjmx P M = P *m M *m P^t*.
-Proof. by move=> Munitary; rewrite conjumx ?invmx_unitary ?unitarymx_unit. Qed.
-
-Lemma trmx_unitary {n} {M : 'M[C]_n} : (M ^T \is unitarymx) = (M \is unitarymx).
-Proof.
-apply/unitarymxP/unitarymxP; rewrite -?map_trmx -trmx_mul.
-  by rewrite -trmx1 => /trmx_inj /mulmx1C->; rewrite trmx1.
-by move=> /mulmx1C->; rewrite trmx1.
-Qed.
-
-Lemma conjC_unitary {m n} {M : 'M[C]_(m, n)} :
-  (M ^ conjC \is unitarymx) = (M \is unitarymx).
-Proof.
-apply/unitarymxP/unitarymxP; rewrite -?map_mxM ?map_trmx; last first.
-  by move=> ->; rewrite map_mx1.
-by rewrite -[1%:M](map_mx1 conjC) => /map_mx_inj ->; rewrite map_mx1.
-Qed.
-
-Lemma trmxC_unitary {n} {M : 'M[C]_n} : (M ^t* \is unitarymx) = (M \is unitarymx).
-Proof. by rewrite conjC_unitary trmx_unitary. Qed.
 
 Lemma schmidt_subproof m n (A : 'M[C]_(m, n)) : (m <= n)%N ->
   exists2 B : 'M_(m, n), B \is unitarymx & [forall i : 'I_m,
@@ -312,7 +450,8 @@ have [v /and4P [vBn v_neq0 dAv_ge0 dAsub]] :
     by rewrite invr_gt0 sqrtC_gt0 lt_def ?dnorm_eq0 ?dnorm_ge0 BoSn_neq0.
   exists BoSn; apply/and4P; split => //.
   - by rewrite orthomx_sym ?proj_ortho_sub // /gtr_eqF.
-  - rewrite -pBE linearDl // [X in X + '[_]](hermmx_eq0P _ _) ?add0r ?dnorm_ge0 //.
+  - rewrite -pBE linearDl //.
+    rewrite [X in X + '[_]](hermmx_eq0P _ _) ?add0r ?dnorm_ge0 //.
     by rewrite orthomx_proj_mx_ortho // orthomx_sym.
   - by rewrite -pBE addmx_sub_adds // proj_ortho_sub.
 wlog nv_eq1 : v vBn v_neq0 dAv_ge0 dAsub / '[v] = 1.
@@ -328,10 +467,12 @@ wlog nv_eq1 : v vBn v_neq0 dAv_ge0 dAsub / '[v] = 1.
     by rewrite exprVn rootCK ?mulVf // dnorm_eq0.
 exists (col_mx B v).
   apply/row_unitarymxP => i j.
-  case: (split_ordP i) (split_ordP j) => [] i' -> [] j' ->; rewrite eq_shift;
-  rewrite ?(rowKu, rowKd, row_id, ord1) -?val_eqE /= ?(row_unitarymxP _) //= ?addn0.
+  case: (split_ordP i) (split_ordP j) => [] i' -> [] j' ->;
+    rewrite eq_shift ?(rowKu, rowKd, row_id, ord1) -?val_eqE /=
+            ?(row_unitarymxP _) //= ?addn0.
     by rewrite ['[_, _]](hermmx_eq0P _ _)//= (submx_trans _ vBn)// row_sub.
-  by rewrite ['[_, _]](hermmx_eq0P _ _)//= orthomx_sym (submx_trans _ vBn) // row_sub.
+  rewrite ['[_, _]](hermmx_eq0P _ _)//= orthomx_sym (submx_trans _ vBn) //.
+  exact: row_sub.
 apply/forallP => i; case: (split_ordP i) => j -> /=.
   have /andP [sABj dot_gt0] := subAB j.
   rewrite rowKu -row_usubmx (submx_trans sABj) //=.
@@ -350,7 +491,7 @@ Qed.
 
 Definition schmidt m n (A : 'M[C]_(m, n)) :=
   if (m <= n)%N =P true is ReflectT le_mn
-  then projT1 (sig2_eqW (schmidt_subproof A (le_mn)))
+  then projT1 (sig2_eqW (schmidt_subproof A le_mn))
   else A.
 
 Lemma schmidt_unitarymx m n (A : 'M[C]_(m, n)) : (m <= n)%N ->
@@ -407,62 +548,9 @@ move=> [:nsV]; rewrite !(orthomx1P _) -?scalar_mx_block //;
 by do 2!rewrite eqmx_schmidt_free ?eq_row_base ?row_base_free // orthomx_sym.
 Qed.
 
-Lemma eigenvalue_closed n (A : 'M[C]_n) : (n > 0)%N ->
-   exists a, eigenvalue A a.
-Proof.
-move=> n_gt0; have /closed_rootP [a rAa] : size (char_poly A) != 1%N.
-  by rewrite size_char_poly; case: (n) n_gt0.
-by exists a; rewrite eigenvalue_root_char.
-Qed.
-
-Lemma common_eigenvector n (As : seq 'M[C]_n) :
-  (n > 0)%N -> {in As &, forall A B, comm_mx A B} ->
-  exists2 v : 'rV_n, v != 0 & all (fun A => stablemx v A) As.
-Proof.
-move=> n_gt0 /all_comm_mxP; have [k sAsk] := ubnP (size As).
-elim: k n n_gt0 As sAsk => [//|k IHk]  n n_gt0 [|A As].
-  exists (const_mx 1) => //; apply/negP => /eqP/rowP/(_ (Ordinal n_gt0)).
-  by rewrite !mxE => /eqP; rewrite oner_eq0.
-rewrite ltnS all_comm_mx_cons => sAsk /andP[].
-move=> /allP/(_ _ _)/eqP/= A_comm /all_comm_mxP As_comm.
-have [a a_eigen] := eigenvalue_closed A n_gt0.
-have [] := IHk _ _ [seq restrictmx (eigenspace A a) B | B <- As].
-- by rewrite lt0n mxrank_eq0.
-- by rewrite size_map.
-- apply/all_comm_mxP; move=> _ _ /= /mapP /= [B B_in ->] /mapP /= [B' B'_in ->].
-  rewrite -?conjmxM ?inE ?stablemx_row_base ?comm_mx_stable_eigenspace//;
-  by [rewrite As_comm | apply: As_comm | apply: A_comm].
-move=> v vN0 /allP /= vP; exists (v *m (row_base (eigenspace A a))).
-  by rewrite mulmx_free_eq0 ?row_base_free.
-apply/andP; split.
-  by apply/eigenvectorP; exists a; rewrite mulmx_sub // eq_row_base.
-apply/allP => B B_in; rewrite -stablemx_restrict ?vP //.
-  by apply/mapP; exists B => //.
-by rewrite comm_mx_stable_eigenspace //; apply: A_comm.
-Qed.
-
-Lemma common_eigenvector2 n (A B : 'M[C]_n) : (n > 0)%N -> A *m B = B *m A ->
-  exists2 v : 'rV_n, v != 0 & (stablemx v A) && (stablemx v B).
-Proof.
-move=> n_gt0 AB_comm; have [] := @common_eigenvector _ [:: A; B] n_gt0.
-  by move=> A' B'; rewrite !inE => /orP [] /eqP-> /orP [] /eqP->.
-by move=> v v_neq0 /allP vP; exists v; rewrite ?vP ?(mem_head, in_cons, orbT).
-Qed.
-
-Lemma mulmxtVK (m1 m2 n : nat) (A : 'M[C]_(m1, n)) (B : 'M[C]_(n, m2)) :
-  B \is unitarymx -> A *m B *m B^t* = A.
-Proof. by move=> B_unitary; rewrite -mulmxA (unitarymxP _) ?mulmx1. Qed.
-
-Lemma mulmxKtV (m1 m2 n : nat) (A : 'M[C]_(m1, n)) (B : 'M[C]_(m2, n)) :
-  B \is unitarymx -> m2 = n -> A *m B^t* *m B = A.
-Proof.
-move=> B_unitary m2E; case: _ / (esym m2E) in B B_unitary *.
-by rewrite -invmx_unitary // mulmxKV //; apply: unitarymx_unit.
-Qed.
-
 Lemma cotrigonalization n (As : seq 'M[C]_n) :
   {in As &, forall A B, comm_mx A B} ->
-  cotrigonalizable_in (@unitarymx n n) As.
+  cotrigonalizable_in (@unitarymx C n n) As.
 Proof.
 elim: n {-2}n (leqnn n) As => [|N IHN] n.
   rewrite leqn0 => /eqP n_eq0.
@@ -500,8 +588,7 @@ have [] := IHN _ _ [seq drsubmx (r A) | A <- As].
 - move=> _ _ /mapP[/= A A_in ->] /mapP[/= B B_in ->].
   have : (r A) *m (r B) = (r B) *m (r A).
     rewrite /r !mulmxA !mulmxKtV // ?schmidt_complete_unitarymx //;
-    rewrite ?add_rank_ortho // -![S *m _ *m _]mulmxA.
-    by rewrite As_comm.
+    by rewrite ?add_rank_ortho // -![S *m _ *m _]mulmxA As_comm.
   rewrite -[r A in X in X -> _]submxK -[r B  in X in X -> _]submxK.
   rewrite 2!mulmx_block => /eq_block_mx [_ _ _].
   suff urr_eq0 X : X \in As -> ursubmx (r X) = 0.
@@ -513,7 +600,7 @@ move=> P' P'_unitary /allP /= P'P.
 exists ((block_mx 1%:M 0 0 P') *m S).
   rewrite mul_unitarymx ?schmidt_complete_unitarymx //.
   apply/unitarymxP; rewrite tr_block_mx map_block_mx mulmx_block.
-  rewrite !trmx0 !map_mx0 !tr_scalar_mx !map_scalar_mx ?conjC1.
+  rewrite !trmx0 !(@map_mx0 _ _ conjC) !tr_scalar_mx !map_scalar_mx ?conjC1.
   rewrite !(mulmx1, mul1mx, mulmx0, mul0mx, addr0, add0r).
   by rewrite (unitarymxP _) -?scalar_mx_block //.
 apply/allP => /= A A_in.
@@ -529,7 +616,7 @@ case: splitP => //= j' j_eq.
 - have /vP /eigenvectorP [a v_in] := A_in.
   by rewrite (vSv _ _ v_in) mxE -val_eqE ltn_eqF //= -i_eq -j_eq.
 - by rewrite vSvo ?mul0mx ?mxE // vP //.
-- move: lt_ij; rewrite i_eq j_eq ltnNge -ltnS (leq_trans (ltn_ord j')) //.
+- move: lt_ij; rewrite i_eq j_eq ltnNge -ltnS (leq_trans (ltn_ord j'))//.
   by rewrite -addnS leq_addr.
 - set A' := _ *m A *m _; rewrite -invmx_unitary // -conjumx ?unitarymx_unit//.
   have /(_ _) /is_trig_mxP -> // := P'P A'; last first.
@@ -537,7 +624,8 @@ case: splitP => //= j' j_eq.
   by apply/mapP; exists A; rewrite //= drrE.
 Qed.
 
-Theorem Schur n (A : 'M[C]_n) : (n > 0)%N -> trigonalizable_in (@unitarymx n n) A.
+Theorem Schur n (A : 'M[C]_n) : (n > 0)%N ->
+  trigonalizable_in (@unitarymx C n n) A.
 Proof.
 case: n => [//|n] in A * => _; have [] := @cotrigonalization _ [:: A].
   by move=> ? ? /=; rewrite !in_cons !orbF => /eqP-> /eqP->.
@@ -554,7 +642,7 @@ move=> P Punitary /allP /= PP; exists P => //.
 by rewrite !PP ?(mem_head, in_cons, orbT).
 Qed.
 
-Theorem orthomx_spectral_subproof {n} {A : 'M[C]_n} : reflect
+Theorem orthomx_spectral_subproof n {A : 'M[C]_n} : reflect
   (exists2 sp : 'M_n * 'rV_n,
                 sp.1 \is unitarymx &
                 A = invmx sp.1 *m diag_mx sp.2 *m sp.1)
@@ -569,7 +657,7 @@ move=> /cotrigonalization2 [P Punitary /andP[]] PA PATC.
 have Punit := unitarymx_unit Punitary.
 suff: similar_diag P A.
   move=> /similar_diagPex[D] PAD; exists (P, D) => //=.
-  by rewrite -conjVmx//; apply/similarLR.
+  by rewrite -conjVmx//; exact/similarLR.
 apply/similar_diagPp => // i j; case: ltngtP => // [lt_ij|lt_ji] _.
   by have /is_trig_mxP-> := PA.
 have /is_trig_mxP -/(_ j i lt_ji)/eqP := PATC.
@@ -592,7 +680,7 @@ rewrite /spectralmx; case: orthomx_spectral_subproof; last first.
 by move=> ?; case: sig2_eqW.
 Qed.
 
-Lemma spectral_unit  n (A : 'M[C]_n) : spectralmx A \in unitmx.
+Lemma spectral_unit n (A : 'M[C]_n) : spectralmx A \in unitmx.
 Proof. exact/unitarymx_unit/spectral_unitarymx. Qed.
 
 Theorem orthomx_spectralP {n} {A : 'M[C]_n}
@@ -604,26 +692,9 @@ case: orthomx_spectral_subproof.
   by move=> Psp; case: sig2_eqW => //=; constructor.
 move=> /orthomx_spectral_subproof Ann; constructor; apply/eqP.
 apply: contra Ann; rewrite invmx1 mul1mx mulmx1 => /eqP->.
-suff -> : diag_mx 0 = 0 by rewrite qualifE trmx0 map_mx0.
-by move=> ??; apply/matrixP=> i j; rewrite !mxE mul0rn.
+suff -> : diag_mx 0 = 0 by rewrite qualifE trmx0 (map_mx0 conjC).
+by move=> ? ?; apply/matrixP=> i j; rewrite !mxE mul0rn.
 Qed.
-
-Lemma hermitian_normalmx n (A : 'M[C]_n) : A \is hermsymmx -> A \is normalmx.
-Proof.
-move=> Ahermi; apply/normalmxP.
-by rewrite (trmx_hermitian (HermitianMx Ahermi)) scale1r map_mxCK.
-Qed.
-
-Lemma realsym_hermsym n (A : 'M[C]_n) :
-  A \is symmetricmx -> A \is a realmx -> A \is hermsymmx.
-Proof.
-move=> Asym Areal; apply/is_hermitianmxP.
-by rewrite (trmx_hermitian (HermitianMx Asym))/= !scale1r ?realmxC ?map_mx_id.
-Qed.
-
-Lemma symmetric_normalmx n (A : 'M[C]_n) : A \is symmetricmx ->
-  A \is a realmx -> A \is normalmx.
-Proof. by move=> Asym Areal; rewrite hermitian_normalmx// realsym_hermsym. Qed.
 
 Lemma hermitian_spectral_diag_real n (A : 'M[C]_n) : A \is hermsymmx ->
   spectral_diag A \is a realmx.
@@ -634,41 +705,13 @@ rewrite invmx_unitary ?spectral_unitarymx //.
 rewrite !trmx_mul !map_mxM map_trmx trmxK -map_mx_comp.
 rewrite tr_diag_mx map_diag_mx (map_mx_id (@conjCK _)).
 rewrite -[in RHS]invmx_unitary ?spectral_unitarymx //.
-have := is_hermitianmxP _ _ _ Ahermi; rewrite expr0 scale1r => <-; rewrite {1}A_eq.
-rewrite mulmxA; move=> /(congr1 (mulmx^~ (invmx (spectralmx A)))).
-rewrite !mulmxK ?spectral_unit //.
-move=> /(congr1 (mulmx (spectralmx A))); rewrite !mulKVmx ?spectral_unit //.
+have := is_hermitianmxP _ _ _ Ahermi; rewrite expr0 scale1r => <-.
+rewrite {1}A_eq mulmxA => /(congr1 (mulmx^~ (invmx (spectralmx A)))).
+rewrite !mulmxK ?spectral_unit//.
+move=> /(congr1 (mulmx (spectralmx A))); rewrite !mulKVmx ?spectral_unit//.
 move=> eq_A_conjA; apply/mxOverP => i j; rewrite ord1 {i}.
 have /matrixP /(_ j j) := eq_A_conjA; rewrite !mxE eqxx !mulr1n.
-by move=> /esym /CrealP.
-Qed.
-
-Lemma real_similar n (A B : 'M[C]_n) : similar_in unitmx A B ->
-  A \is a realmx -> B \is a realmx -> similar_in [predI realmx & unitmx] A B.
-Proof.
-case=> [P /=]; pose Pr := P ^ (@Re _); pose Pi := P ^ (@Im _).
-have Pr_real : Pr \is a realmx by apply/mxOverP=> i j; rewrite !mxE Creal_Re.
-have Pi_real : Pi \is a realmx by apply/mxOverP=> i j; rewrite !mxE Creal_Im.
-pose Q x := P ^ (@Re _) + x *: P ^ (@Im _).
-have -> : P = Q 'i by apply/matrixP=> i j; rewrite !mxE -Crect.
-move=> Qi_unit eq_AP_PB Areal Breal.
-pose p := \det (Pr ^ polyC + 'X *: Pi ^ polyC).
-have horner_evaliC x : horner_eval (x : C) \o polyC =1 id := fun=> hornerC _ _.
-have Qunit x : Q x \in unitmx = (p.[x] != 0).
-  rewrite /p -horner_evalE -det_map_mx map_mxD map_mxZ/= horner_evalE hornerX.
-  by rewrite -![(_ ^ polyC) ^ _]map_mx_comp !map_mx_id// unitmxE unitfE.
-have p_neq0 : p != 0.
-  by move: Qi_unit; rewrite Qunit; apply: contra_neq => ->; rewrite hornerE.
-have [a a_real rootNa] : exists2 a, a \is Num.real &  ~~ root p a.
-  have rs_uniq : uniq [seq (i%:R : C) | i <- iota 0 (size p)].
-    by rewrite map_inj_uniq ?iota_uniq //; apply: mulrIn; rewrite oner_eq0.
-  have := contraNN (fun x => max_poly_roots p_neq0 x rs_uniq).
-  rewrite size_map size_iota ltnn => /(_ isT) /allPn[a a_in rootNpa].
-  by exists a => //; by move: a_in => /mapP [i _ ->]; rewrite realn.
-exists (Q a); first by rewrite ?inE Qunit rootNa rpredD// mxOverZ//.
-apply/similarP; rewrite ?Qunit//; move: eq_AP_PB => /(similarP Qi_unit).
-rewrite !mulmxDl !mulmxDr -!scalemxAr -!scalemxAl => /eqmx_ReiIm.
-by rewrite !mxOverM// => /(_ isT isT isT isT) [-> ->].
+by move=> /esym/CrealP.
 Qed.
 
 End Spectral.

--- a/mathcomp/ssreflect/ssrnotations.v
+++ b/mathcomp/ssreflect/ssrnotations.v
@@ -79,9 +79,9 @@ Reserved Notation "''C_' ( A ) [ x ]" (at level 8).
 Reserved Notation "''C_' ( B ) ( A )" (at level 8).
 
 (* Reserved notation for Euclidean division and divisibility. *)
-Reserved Notation "m %/ d" (at level 40, no associativity). 
-Reserved Notation "m %% d" (at level 40, no associativity). 
-Reserved Notation "m %| d" (at level 70, no associativity). 
+Reserved Notation "m %/ d" (at level 40, no associativity).
+Reserved Notation "m %% d" (at level 40, no associativity).
+Reserved Notation "m %| d" (at level 70, no associativity).
 Reserved Notation "m = n %[mod d ]" (at level 70, n at next level,
   format "'[hv ' m '/'  =  n '/'  %[mod  d ] ']'").
 Reserved Notation "m == n %[mod d ]" (at level 70, n at next level,
@@ -109,3 +109,8 @@ Reserved Notation "x < y :> T" (at level 70, y at next level).
 Reserved Notation "x > y :> T" (at level 70, y at next level).
 Reserved Notation "x <= y ?= 'iff' c :> T" (at level 70, y, c at next level,
   format "x '[hv'  <=  y '/'  ?=  'iff'  c  :> T ']'").
+
+(* Reserved notation for dot product. *)
+Reserved Notation "'[ u , v ]"
+  (at level 2, format "'[hv' ''[' u , '/ '  v ] ']'").
+Reserved Notation "'[ u ]" (at level 2, format "''[' u ]").


### PR DESCRIPTION
Content:
- Adding bilinear, sesquilinear, hermitian (symmetric, skew symmetric and hermitian) and hermitian positive definite forms.
- A proof of the spectral theorem for normal matrices, and some theory of stability wrt a sub(mx)space.
- Several auxiliary lemmas of general purpose.

TODO:
- [x] document,
- [ ] replace ad hoc `cfdot` in classfun (@LaurenceRideau),
- [x] backport several theorems to matrix, vector or mxalgebra,
- [ ] bridge vector and mxalgebra to port results.
- [x] update ChangeLog
- [ ] clear dependencies

TODO update after @LaurenceRideau tried on the odd-order repo (https://github.com/math-comp/odd-order/pull/2)
- [ ] Infer the canonical form on a vector space in notations such as `'[_ ,_]`, `orthogonal`, `isometry`...
- [ ] Make the right `linear_for` on the right and the left for bilinear forms (so that `'[a *: x, b *: y] = a * b^* * '[x ,y]` instead of `'[a *: x, b *: y] = a *: b^* *: '[x ,y]`)
- [x] Have lemmas `linearZl`, `linearZr`, `linearZlr`, `linearZrl` (right now only `linearZl_LR` is only available)