### PR TITLE
[opam]: add dev-repo links

### DIFF
--- a/mathcomp/algebra/opam
+++ b/mathcomp/algebra/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-algebra"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/mathcomp/character/opam
+++ b/mathcomp/character/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-character"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/mathcomp/field/opam
+++ b/mathcomp/field/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-field"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/mathcomp/fingroup/opam
+++ b/mathcomp/fingroup/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-fingroup"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/mathcomp/solvable/opam
+++ b/mathcomp/solvable/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-solvable"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/mathcomp/ssreflect/opam
+++ b/mathcomp/ssreflect/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-ssreflect"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]


### PR DESCRIPTION
This commit fixes the following issue:
```shell
$ opam pin add --dev-repo coq-mathcomp-ssreflect
[ERROR] "dev-repo" field missing in coq-mathcomp-ssreflect metadata,
you'll need to specify the pinning location
```
This commit also changes http to https for the homepage links.

Please see also https://github.com/coq/opam-coq-archive/pull/456 for details.