### PR TITLE
do not rely on `elim E: x => i` not clearing `x` if `x` not used in `i`

### DIFF
--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2043,7 +2043,7 @@ Qed.
 Lemma perm_to_subseq s1 s2 :
   subseq s1 s2 -> {s3 | perm_eq s2 (s1 ++ s3)}.
 Proof.
-elim Ds2: s2 s1 => [|y s2' IHs] [|x s1] //=; try by exists s2; rewrite Ds2.
+pose s := s2; elim: s2 s1 => [|y s2 IHs] [|x s1] //= in s *; try by exists s.
 case: eqP => [-> | _] /IHs[s3 perm_s2] {IHs}.
   by exists s3; rewrite perm_cons.
 by exists (rcons s3 y); rewrite -cat_cons -perm_rcons -!cats1 catA perm_cat2r.


### PR DESCRIPTION
I'm not very fond of the new proof script.

I believe that this specific aspect of the equation generation feature was not documented.

With the introduction of new intro patterns it is not so clear what it means to be "not used in `i`" since
`i` may contain `[^ foo ]`. Hence the attempt to simplify the code by removing this special case, that is used only once in the entire library.