### PR TITLE
WIP: Docker-based CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,45 @@
 dist: trusty
 sudo: required
-language: c
+language: generic
+services:
+  - docker
 cache:
   apt: true
-  directories:
-  - $HOME/.opam
-addons:
-  apt:
-    sources:
-    - avsm
-    packages:
-    - opam
-    - aspcud
 env:
   global:
   - NJOBS=2
-  - COMPILER="4.05.0"
+  - CONTRIB_NAME="Mathcomp"
   # Main test targets
   matrix:
-  - TEST_TARGET="v8.6"
-  - TEST_TARGET="v8.7"
-  - TEST_TARGET="v8.8"
-  - TEST_TARGET="master"
+  - COQ_IMAGE="coqorg/coq:8.6"
+  - COQ_IMAGE="coqorg/coq:8.7"
+  - COQ_IMAGE="coqorg/coq:8.8"
+  - COQ_IMAGE="coqorg/coq:dev"
 
-install:
-- opam init -j ${NJOBS} --compiler=${COMPILER} -n -y
-- eval $(opam config env)
-- opam config var root
-- opam install -j ${NJOBS} -y ocamlfind camlp5 ${EXTRA_OPAM}
-- opam list
-- git clone --depth 1 -b ${TEST_TARGET} https://github.com/coq/coq.git coq-${TEST_TARGET}
-- cd coq-${TEST_TARGET}
-- ./configure -native-compiler no -local -coqide no
-- make -j ${NJOBS}
-- cd -
+install: |
+  # Prepare the Coq container
+  docker pull ${COQ_IMAGE}
+  docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
+  docker exec COQ /bin/bash --login -c "
+    # This bash script is double-quoted to interpolate Travis CI env vars:
+    echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
+    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+    set -ex  # -e = exit on failure; -x = trace for debug
+    opam config list
+    opam repo list
+    opam list
+    "
 
 script:
-- echo 'Building Mathcomp...' && echo -en 'travis_fold:start:mathcomp.build\\r'
-- export PATH=`pwd`/coq-${TEST_TARGET}/bin:$PATH
-- cd mathcomp
-- make Makefile.coq
-- make -f Makefile.coq -j ${NJOBS} all
-- echo -en 'travis_fold:end:mathcomp.build\\r'
+- echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+- |
+  docker exec COQ /bin/bash --login -c "
+    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+    set -ex
+    sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
+    cd mathcomp
+    make Makefile.coq
+    make -f Makefile.coq -j ${NJOBS} all
+    "
+- docker stop COQ  # optional
+- echo -en 'travis_fold:end:script\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,12 @@ script:
     cd mathcomp
     make Makefile.coq
     make -f Makefile.coq -j ${NJOBS} all
+    make install
+    # Testing odd-order
+    cd ../..
+    git clone https://github.com/math-comp/odd-order
+    cd odd-order
+    make -j ${NJOBS}
     "
 - docker stop COQ  # optional
 - echo -en 'travis_fold:end:script\\r'


### PR DESCRIPTION
Trying to fix #245. I added https://github.com/math-comp/odd-order to CI. I did a quick hack, so I'd appreciate if someone reviewed this PR.

- In particular, I'd love to learn a good way of finding the source of failure if a library stops compiling with an updated mathcomp version. Right now one would have to scroll back through the log.
- What other libraries should be added to CI? I'd like to have at least https://github.com/imdea-software/fcsl-pcm and https://github.com/coq-community/lemma-overloading, as I'm a maintainer for those (and these are covered by Coq's or coq-community's CI). Also, quickchick, coquelicot, and iris-lambda-rust seem to be good candidates, as those are covered by Coq's CI.

CC @erikmd @ejgallego (and just in case, @Zimmi48).

TODO:
- [ ] introduce build stages
- [ ] add https://github.com/math-comp/odd-order
- [ ] add https://github.com/math-comp/fourcolor
- [ ] add https://github.com/imdea-software/fcsl-pcm
- [ ] add https://github.com/coq-community/lemma-overloading
- [ ] add https://github.com/math-comp/analysis