### PR TITLE
Setup Docker-based configuration for GitLab CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+*
+# Begin files referenced by symlinks
+!README.md
+!AUTHORS
+!INSTALL.md
+!CeCILL-B
+# End files referenced by symlinks
+!*.opam
+!plugin
+!mathcomp
+
+**/*.d
+**/*.vo
+**/*.vio
+**/*.cm*
+**/*~
+**/*.glob
+**/*.aux
+**/*.a
+**/*.o
+**/*#
+**/Make*.coq
+**/Make*.coq.bak
+**/Make*.coq.conf
+mathcomp/ssreflect/ssreflect.ml4
+mathcomp/ssreflect/ssrmatching.ml4
+mathcomp/ssreflect/ssrmatching.mli
+# mathcomp/ssreflect/ssrmatching.v
+mathcomp/ssreflect/ssreflect_plugin.mllib
+mathcomp/ssreflect/ssreflect_plugin.mlpack
+mathcomp/ssreflect.ml4
+mathcomp/ssrmatching.ml4
+mathcomp/ssrmatching.mli
+mathcomp/ssrmatching.v
+mathcomp/ssreflect_plugin.mllib
+mathcomp/ssreflect_plugin.mlpack

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,6 +70,28 @@ coq-8.8:
 coq-dev:
   extends: .opam-build
 
+# set var OPAM_SWITCH (if need be) and COQ_VERSION when using
+.make-build:
+  stage: build
+  image: docker:latest
+  services:
+    - docker:dind
+  variables:
+    # This image will be built locally only (not pushed)
+    IMAGE: "mathcomp-dev:make_coq-${COQ_VERSION}"
+    OPAM_SWITCH: "edge"
+  before_script:
+  script:
+    - docker build -f Dockerfile.make --pull --build-arg=coq_image="coqorg/coq:${COQ_VERSION}" --build-arg=compiler="${OPAM_SWITCH}" -t "${IMAGE}" .
+  except:
+    - tags
+    - merge_requests
+
+make-coq-latest:
+  extends: .make-build
+  variables:
+    COQ_VERSION: "latest"
+  
 # set CONTRIB_URL, script, COQ_VERSION, CONTRIB_VERSION when using
 .ci:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,126 @@
+# Design:
+# - build stage (e.g. docker build -t mathcomp-dev:$IID_$SLUG_coq-8.6 .)
+#   - choice of the OCaml compiler: var OPAM_SWITCH in {base, edge}
+#     (Dockerfile containing: "opam switch set $compiler && eval $(opam env)")
+#   - master (protected branch) => push on GitLab registry and Docker Hub
+#   - other branches (not tags) => push on GitLab registry
+#   - Todo: GitHub PRs => push on GitLab
+# - test stage (image: mathcomp-dev:$IID_$SLUG_coq-8.6)
+#   - script template foreach project (custom CONTRIB_URL, script)
+#   - jobs foreach project and Coq version (custom COQ_VERSION, CONTRIB_VERSION)
+#
+# Config for protected branches:
+# - set vars HUB_REGISTRY, HUB_REGISTRY_USER, HUB_REGISTRY_IMAGE, HUB_TOKEN
+#
+# Remark:
+# - The name chosen for branches should ideally yield different values
+#   of CI_COMMIT_REF_SLUG.
+# - But this is not mandatory as image tags start with "${CI_PIPELINE_IID}_".
+# cf. doc:
+# - CI_COMMIT_REF_NAME: The branch or tag name for which project is built.
+# - CI_COMMIT_REF_SLUG: $CI_COMMIT_REF_NAME lowercased, shortened to 63 bytes,
+#   and with everything except 0-9 and a-z replaced with -.
+#   No leading / trailing -. Use in URLs, host names and domain names.
+# - CI_PIPELINE_IID: The unique id of the current pipeline scoped to project.
+
+stages:
+  - build
+  - test
+
+# set var OPAM_SWITCH (if need be) when using
+.build:
+  stage: build
+  image: docker:latest
+  services:
+    - docker:dind
+  variables:
+    IMAGE: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_IID}_${CI_COMMIT_REF_SLUG}_${CI_JOB_NAME}"
+    HUB_IMAGE: "${HUB_REGISTRY_IMAGE}:${CI_JOB_NAME}"
+    OPAM_SWITCH: "edge"
+  before_script:
+    - echo "${CI_JOB_TOKEN}" | docker login -u "${CI_REGISTRY_USER}" --password-stdin "${CI_REGISTRY}"
+  script:
+    - docker build --pull --build-arg=coq_image="coqorg/${CI_JOB_NAME//-/:}" --build-arg=compiler="${OPAM_SWITCH}" -t "${IMAGE}" .
+    - docker push "${IMAGE}"
+    - docker logout "${CI_REGISTRY}"
+    - |
+      if [ -n "${HUB_REGISTRY_IMAGE}" ]; then
+        set -e
+        echo "${HUB_TOKEN}" | docker login -u "${HUB_REGISTRY_USER}" --password-stdin "${HUB_REGISTRY}"
+        docker tag "${IMAGE}" "${HUB_IMAGE}"
+        docker push "${HUB_IMAGE}"
+        docker logout "${HUB_REGISTRY}"
+        set +e
+      fi
+  except:
+    - tags
+    - merge_requests
+
+coq-8.6:
+  extends: .build
+  variables:
+    OPAM_SWITCH: "base"
+
+coq-8.7:
+  extends: .build
+
+coq-8.8:
+  extends: .build
+
+coq-dev:
+  extends: .build
+
+# set CONTRIB_URL, script, COQ_VERSION, CONTRIB_VERSION when using
+.ci:
+  stage: test
+  image: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_IID}_${CI_COMMIT_REF_SLUG}_coq-${COQ_VERSION}"
+  variables:
+    GIT_STRATEGY: none
+  before_script:
+    - cat /proc/{cpu,mem}info || true
+    # don't printenv if there are private tokens
+    - opam config list
+    - opam repo list
+    - opam list
+    - coqc --version
+    - git clone -b "${CONTRIB_VERSION}" --depth 1 "${CONTRIB_URL}" /home/coq/ci
+    - cd /home/coq/ci
+  except:
+    - tags
+    - merge_requests
+
+# Guidelines to add a library to mathcomp CI:
+# - Add a hidden job (starting with a .) .ci-lib that extends the .ci job,
+#   sets var CONTRIB_URL (library Git URL), and defines a dedicated script
+# - Add 1 job per Coq version to test, that extends the previous hidden job,
+#   and sets vars COQ_VERSION, CONTRIB_VERSION (compatible Git branch/tag)
+
+.ci-fourcolor:
+  extends: .ci
+  variables:
+    CONTRIB_URL: "https://github.com/math-comp/fourcolor.git"
+    CONTRIB_VERSION: master
+  script:
+    - make -j "${NJOBS}"
+    - make install
+
+ci-fourcolor-8.6:
+  extends: .ci-fourcolor
+  variables:
+    COQ_VERSION: "8.6"
+    # CONTRIB_VERSION: "v8.6"
+
+ci-fourcolor-8.7:
+  extends: .ci-fourcolor
+  variables:
+    COQ_VERSION: "8.7"
+
+ci-fourcolor-8.8:
+  extends: .ci-fourcolor
+  variables:
+    COQ_VERSION: "8.8"
+
+ci-fourcolor-dev:
+  extends: .ci-fourcolor
+  variables:
+    COQ_VERSION: "dev"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ stages:
   - test
 
 # set var OPAM_SWITCH (if need be) when using
-.build:
+.opam-build:
   stage: build
   image: docker:latest
   services:
@@ -57,18 +57,18 @@ stages:
     - merge_requests
 
 coq-8.6:
-  extends: .build
+  extends: .opam-build
   variables:
     OPAM_SWITCH: "base"
 
 coq-8.7:
-  extends: .build
+  extends: .opam-build
 
 coq-8.8:
-  extends: .build
+  extends: .opam-build
 
 coq-dev:
-  extends: .build
+  extends: .opam-build
 
 # set CONTRIB_URL, script, COQ_VERSION, CONTRIB_VERSION when using
 .ci:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+ARG coq_image="coqorg/coq:dev"
+FROM ${coq_image}
+
+ENV MATHCOMP_VERSION="dev"
+ENV MATHCOMP_PACKAGE="coq-mathcomp-character"
+
+WORKDIR /home/coq/mathcomp
+
+COPY . .
+
+ARG compiler="base"
+# other possible value: "edge"
+
+RUN ["/bin/bash", "--login", "-c", "set -x \
+  && declare -A switch_table \
+  && switch_table=( [\"base\"]=\"${COMPILER}\" [\"edge\"]=\"${COMPILER_EDGE}\" ) \
+  && compiler=\"${switch_table[${compiler}]}\" \
+  && [ -n \"$compiler\" ] \
+  && opam switch set ${compiler} \
+  && eval $(opam env) \
+  && opam repository add --all-switches --set-default coq-extra-dev https://coq.inria.fr/opam/extra-dev \
+  && opam repository add --all-switches --set-default coq-core-dev https://coq.inria.fr/opam/core-dev \
+  && opam update -y \
+  && opam config list && opam repo list && opam list && coqc --version \
+  && sudo chown -R coq:coq /home/coq/mathcomp \
+  && opam pin add -n -k path coq-mathcomp-ssreflect . \
+  && opam pin add -n -k path coq-mathcomp-fingroup . \
+  && opam pin add -n -k path coq-mathcomp-algebra . \
+  && opam pin add -n -k path coq-mathcomp-solvable . \
+  && opam pin add -n -k path coq-mathcomp-field . \
+  && opam pin add -n -k path coq-mathcomp-character . \
+  && opam install -y -v -j ${NJOBS} coq-mathcomp-character \
+  && opam clean -a -c -s --logs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 ARG coq_image="coqorg/coq:dev"
-FROM ${coq_image}
-
-ENV MATHCOMP_VERSION="dev"
-ENV MATHCOMP_PACKAGE="coq-mathcomp-character"
+FROM ${coq_image} as builder
 
 WORKDIR /home/coq/mathcomp
 
@@ -14,10 +11,12 @@ ARG compiler="base"
 RUN ["/bin/bash", "--login", "-c", "set -x \
   && declare -A switch_table \
   && switch_table=( [\"base\"]=\"${COMPILER}\" [\"edge\"]=\"${COMPILER_EDGE}\" ) \
-  && compiler=\"${switch_table[${compiler}]}\" \
-  && [ -n \"$compiler\" ] \
-  && opam switch set ${compiler} \
+  && opam_switch=\"${switch_table[${compiler}]}\" \
+  && [ -n \"opam_switch\" ] \
+  && opam switch set ${opam_switch} \
   && eval $(opam env) \
+  && unset \"switch_table[${compiler}]\" \
+  && for sw in \"${switch_table[@]}\"; do if [ -n \"$sw\" ]; then opam switch remove -y \"${sw}\"; fi; done \
   && opam repository add --all-switches --set-default coq-extra-dev https://coq.inria.fr/opam/extra-dev \
   && opam repository add --all-switches --set-default coq-core-dev https://coq.inria.fr/opam/core-dev \
   && opam update -y \
@@ -31,3 +30,11 @@ RUN ["/bin/bash", "--login", "-c", "set -x \
   && opam pin add -n -k path coq-mathcomp-character . \
   && opam install -y -v -j ${NJOBS} coq-mathcomp-character \
   && opam clean -a -c -s --logs"]
+
+FROM coqorg/base:bare
+
+ENV MATHCOMP_VERSION="dev"
+ENV MATHCOMP_PACKAGE="coq-mathcomp-character"
+
+COPY --from=builder --chown=coq:coq /home/coq/.opam /home/coq/.opam
+COPY --from=builder --chown=coq:coq /home/coq/.profile /home/coq/.profile

--- a/Dockerfile.make
+++ b/Dockerfile.make
@@ -1,0 +1,29 @@
+ARG coq_image="coqorg/coq:dev"
+FROM ${coq_image}
+
+WORKDIR /home/coq/mathcomp
+
+COPY . .
+
+ARG compiler="base"
+# other possible value: "edge"
+
+RUN ["/bin/bash", "--login", "-c", "set -x \
+  && declare -A switch_table \
+  && switch_table=( [\"base\"]=\"${COMPILER}\" [\"edge\"]=\"${COMPILER_EDGE}\" ) \
+  && opam_switch=\"${switch_table[${compiler}]}\" \
+  && [ -n \"opam_switch\" ] \
+  && opam switch set ${opam_switch} \
+  && eval $(opam env) \
+  && unset \"switch_table[${compiler}]\" \
+  && for sw in \"${switch_table[@]}\"; do [ -n \"$sw\" ] && opam switch remove -y \"${sw}\"; done \
+  && opam repository add --all-switches --set-default coq-extra-dev https://coq.inria.fr/opam/extra-dev \
+  && opam repository add --all-switches --set-default coq-core-dev https://coq.inria.fr/opam/core-dev \
+  && opam update -y \
+  && opam config list && opam repo list && opam list && coqc --version \
+  && opam clean -a -c -s --logs \
+  && sudo chown -R coq:coq /home/coq/mathcomp \
+  && cd mathcomp \
+  && make Makefile.coq \
+  && make -f Makefile.coq -j ${NJOBS} all \
+  && make -f Makefile.coq install"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![pipeline status](https://gitlab.com/math-comp/math-comp/badges/master/pipeline.svg)](https://gitlab.com/math-comp/math-comp/commits/master)
 [![Build Status](https://travis-ci.org/math-comp/math-comp.svg?branch=master)](https://travis-ci.org/math-comp/math-comp)
 [![Join the chat at https://gitter.im/math-comp/](https://badges.gitter.im/math-comp.svg)](https://gitter.im/math-comp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/coq-mathcomp-algebra.opam
+++ b/coq-mathcomp-algebra.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "coq-mathcomp-ssreflect"
+name: "coq-mathcomp-algebra"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
@@ -8,10 +8,10 @@ bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
-build: [ make "-j" "%{jobs}%" ]
-install: [ make "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp'" ]
-depends: [ "coq" { ((>= "8.6" & < "8.9~") | (= "dev"))} ]
+build: [ make "-C" "mathcomp/algebra" "-j" "%{jobs}%" ]
+install: [ make "-C" "mathcomp/algebra" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/algebra'" ]
+depends: [ "coq-mathcomp-fingroup" { = "dev" } ]
 
-tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:algebra" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-algebra.opam
+++ b/coq-mathcomp-algebra.opam
@@ -2,6 +2,7 @@ opam-version: "1.2"
 name: "coq-mathcomp-algebra"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+synopsis: "The Mathematical Components library"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"

--- a/coq-mathcomp-character.opam
+++ b/coq-mathcomp-character.opam
@@ -2,6 +2,7 @@ opam-version: "1.2"
 name: "coq-mathcomp-character"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+synopsis: "The Mathematical Components library"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"

--- a/coq-mathcomp-character.opam
+++ b/coq-mathcomp-character.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "coq-mathcomp-solvable"
+name: "coq-mathcomp-character"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
@@ -8,10 +8,10 @@ bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
-build: [ make "-j" "%{jobs}%" ]
-install: [ make "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/solvable'" ]
-depends: [ "coq-mathcomp-algebra" { = "dev" } ]
+build: [ make "-C" "mathcomp/character" "-j" "%{jobs}%" ]
+install: [ make "-C" "mathcomp/character" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/character'" ]
+depends: [ "coq-mathcomp-field" { = "dev" } ]
 
-tags: [ "keyword:finite groups" "keyword:Feit Thompson theorem" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:algebra" "keyword:character" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-field.opam
+++ b/coq-mathcomp-field.opam
@@ -8,8 +8,8 @@ bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
-build: [ make "-j" "%{jobs}%" ]
-install: [ make "install" ]
+build: [ make "-C" "mathcomp/field" "-j" "%{jobs}%" ]
+install: [ make "-C" "mathcomp/field" "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/field'" ]
 depends: [ "coq-mathcomp-solvable" { = "dev" } ]
 

--- a/coq-mathcomp-field.opam
+++ b/coq-mathcomp-field.opam
@@ -2,6 +2,7 @@ opam-version: "1.2"
 name: "coq-mathcomp-field"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+synopsis: "The Mathematical Components library"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"

--- a/coq-mathcomp-fingroup.opam
+++ b/coq-mathcomp-fingroup.opam
@@ -2,6 +2,7 @@ opam-version: "1.2"
 name: "coq-mathcomp-fingroup"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+synopsis: "The Mathematical Components library"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"

--- a/coq-mathcomp-fingroup.opam
+++ b/coq-mathcomp-fingroup.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "coq-mathcomp-character"
+name: "coq-mathcomp-fingroup"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
@@ -8,10 +8,10 @@ bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
-build: [ make "-j" "%{jobs}%" ]
-install: [ make "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/character'" ]
-depends: [ "coq-mathcomp-field" { = "dev" } ]
+build: [ make "-C" "mathcomp/fingroup" "-j" "%{jobs}%" ]
+install: [ make "-C" "mathcomp/fingroup" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/fingroup'" ]
+depends: [ "coq-mathcomp-ssreflect" { = "dev" } ]
 
-tags: [ "keyword:algebra" "keyword:character" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:finite groups" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-solvable.opam
+++ b/coq-mathcomp-solvable.opam
@@ -2,6 +2,7 @@ opam-version: "1.2"
 name: "coq-mathcomp-solvable"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+synopsis: "The Mathematical Components library"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"

--- a/coq-mathcomp-solvable.opam
+++ b/coq-mathcomp-solvable.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "coq-mathcomp-fingroup"
+name: "coq-mathcomp-solvable"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
@@ -8,10 +8,10 @@ bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
-build: [ make "-j" "%{jobs}%" ]
-install: [ make "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/fingroup'" ]
-depends: [ "coq-mathcomp-ssreflect" { = "dev" } ]
+build: [ make "-C" "mathcomp/solvable" "-j" "%{jobs}%" ]
+install: [ make "-C" "mathcomp/solvable"  "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/solvable'" ]
+depends: [ "coq-mathcomp-algebra" { = "dev" } ]
 
-tags: [ "keyword:finite groups" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:finite groups" "keyword:Feit Thompson theorem" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "coq-mathcomp-algebra"
+name: "coq-mathcomp-ssreflect"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
@@ -8,10 +8,10 @@ bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
-build: [ make "-j" "%{jobs}%" ]
-install: [ make "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/algebra'" ]
-depends: [ "coq-mathcomp-fingroup" { = "dev" } ]
+build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
+install: [ make "-C" "mathcomp/ssreflect" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp'" ]
+depends: [ "coq" { ((>= "8.6" & < "8.9~") | (= "dev"))} ]
 
-tags: [ "keyword:algebra" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -2,6 +2,7 @@ opam-version: "1.2"
 name: "coq-mathcomp-ssreflect"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+synopsis: "The Mathematical Components library"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"


### PR DESCRIPTION
Closes #243 
Closes #256  
Related: #159, #245

Dear MathComp developers,

I've just finished to polish the configuration mentioned in https://github.com/math-comp/math-comp/issues/243#issuecomment-447613466.

Beyond what was already mentioned in this comment, this PR provides several other features:

* **opam-based build:** unlike the current Travis CI config that relies on make, the main `Dockerfile` in this PR relies on opam path pinning so (1) the opam specifications are tested, and (2) the mathcomp-dev Docker images obtained in the end allow installing other opam packages based on `coq-mathcomp-character:dev`. To implement this approach, it proved necessary to move the opam files in the parent folder, as opam 2.0 fails when a path-pinned package refers to files in the parent folders (e.g. `../Makefile.common`)

    * lightweight images: the main `Dockefile` in this PR only builds mathcomp with one switch (4.07.0+flambda if applicable), and relies on the so-called *multi-stage build* feature of Docker to significantly reduce the size of the images for Coq ≥ 8.7, given that many such images will be pushed to Docker Hub and/or the GitLab registry. Indeed without this feature, a Docker image that "inherits" from another image and just removes many files won't be smaller.  
    (Thus, the uncompressed size of coqorg/coq:dev (containing two switches) is around 2.86GB on my machine, while the size of a mathcomp-dev image built this way from coqorg/coq:dev and coqorg/base:bare is around 1.57GB.)

    * all branch builds of MathComp will pushed to the GitLab registry with a naming convention like this     (where 1 is the value of CI_PIPELINE_IID = unique id of the current pipeline scoped to the project):
        * `registry.gitlab.com/math-comp/math-comp:1_master_coq-8.6`
        * `registry.gitlab.com/math-comp/math-comp:1_master_coq-8.7`
        * `registry.gitlab.com/math-comp/math-comp:1_master_coq-8.8`
        * `registry.gitlab.com/math-comp/math-comp:1_master_coq-dev`

    * additionally, the master branch builds will be pushed to Docker Hub with the following naming convention:
        * `mathcomp/mathcomp-dev:coq-8.6`
        * `mathcomp/mathcomp-dev:coq-8.7`
        * `mathcomp/mathcomp-dev:coq-8.8`
        * `mathcomp/mathcomp-dev:coq-dev`

* **make-based build:** an extra job also builds MathComp using make with `coqorg/coq:latest` (latest stable version), essentially to test the "Makefile build specification".

### ToDo
~To fully test this configuration before merging to master, could a math-comp commiter **create and push a `setup-gitlab-ci` branch from master**? Then you could change the target branch of this PR to this new branch and merge the PR to trigger the GitLab CI branch build…~  

**Edit:** To fully test this configuration before merging to master, could a math-comp commiter do the steps below to trigger a GitLab CI branch build? (so no need to change the target branch of the PR that could be later directly merged to master)
```
$ git fetch -fv upstream pull/266/head:gitlab-ci
$ git checkout gitlab-ci
$ git push -u upstream gitlab-ci
```

### Later on
The two other tasks mentioned in https://github.com/math-comp/math-comp/issues/243#issuecomment-447613466 (add support for GitHub PR builds and add other libs to the CI) could be addressed in another PR.

Finally, a very last task to implement will be a periodic cleaning of all images from GitLab registry if we don't want/can't keep all built images forever. I've seen in the doc that this can be achieved using a scheduled pipeline against a protected branch. Likewise, this could be implemented in a later PR.