### PR TITLE
[RFC] breakage of coq/9341(uniform clear behavior)

### DIFF
--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -650,7 +650,7 @@ apply: (canRL (castmxKV _ _)); apply/matrixP=> i j.
 rewrite castmxE !mxE cast_ord_id; case: splitP => j1 /= def_j.
   have: (j < n1 + n2) && (j < n1) by rewrite def_j lshift_subproof /=.
   by move: def_j; do 2![case: splitP => // ? ->; rewrite ?mxE] => /ord_inj->.
-case: splitP def_j => j2 ->{j} def_j; rewrite !mxE.
+case: splitP def_j => j2 {j}-> def_j; rewrite !mxE.
   have: ~~ (j2 < n1) by rewrite -leqNgt def_j leq_addr.
   have: j1 < n2 by rewrite -(ltn_add2l n1) -def_j.
   by move: def_j; do 2![case: splitP => // ? ->] => /addnI/val_inj->.
@@ -2747,7 +2747,7 @@ apply: (iffP eqP) => [detA0 | [v n0v vA0]]; last first.
   by rewrite scaler0 -mul_mx_scalar -mul_mx_adj mulmxA vA0 mul0mx.
 elim: n => [|n IHn] in A detA0 *.
   by case/idP: (oner_eq0 R); rewrite -detA0 [A]thinmx0 -(thinmx0 1%:M) det1.
-have [{detA0}A'0 | nzA'] := eqVneq (row 0 (\adj A)) 0; last first.
+have [{detA0}-A'0 | nzA'] := eqVneq (row 0 (\adj A)) 0; last first.
   exists (row 0 (\adj A)) => //; rewrite rowE -mulmxA mul_adj_mx detA0.
   by rewrite mul_mx_scalar scale0r.
 pose A' := col' 0 A; pose vA := col 0 A.

--- a/mathcomp/algebra/mxalgebra.v
+++ b/mathcomp/algebra/mxalgebra.v
@@ -2586,7 +2586,7 @@ have anhR i j A B : i != j -> A \in R_ i -> B \in R_ j -> A *m B = 0.
   by rewrite (mulsmx_subP idRiR) // (memmx_subP (sR_R j)).
 apply/eqmxP/andP; split.
   apply/memmx_subP=> Z; rewrite sub_capmx => /andP[].
-  rewrite -{1}defR => /memmx_sumsP[z ->{Z} Rz cRz].
+  rewrite -{1}defR => /memmx_sumsP[z {Z}-> Rz cRz].
   apply/memmx_sumsP; exists z => // i; rewrite sub_capmx Rz.
   apply/cent_mxP=> A RiA; have:= cent_mxP cRz A (memmx_subP (sR_R i) A RiA).
   rewrite (bigD1 i) //= mulmxDl mulmxDr mulmx_suml mulmx_sumr.

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -4032,7 +4032,7 @@ suffices{e f} equal0_equiv e t1 t2:
   + by move=> n f1 IHf1 e; split=> [] [x] /IHf1; exists x.
   + by move=> n f1 IHf1 e; split=> Hx x; apply/IHf1.
 rewrite -(add0r (eval e t2)) -(can2_eq (subrK _) (addrK _)).
-rewrite -/(eval e (t1 - t2)); move: (t1 - t2)%T => {t1 t2} t.
+rewrite -/(eval e (t1 - t2)); move: (t1 - t2)%T => {t1 t2}- t.
 have sub_var_tsubst s t0: s.1 >= ub_var t0 -> tsubst t0 s = t0.
   elim: t0 {t} => //=.
   - by move=> n; case: ltngtP.
@@ -5020,7 +5020,7 @@ have auxP f0 e0 n0: qf_form f0 && rformula f0 ->
   - by case=> x; rewrite qf_to_dnfP //; exists x.
   have: all dnf_rterm bcs by case/andP: cf => _; apply: qf_to_dnf_rterm.
   elim: {f0 cf}bcs => [|bc bcs IHbcs] /=; first by right; case.
-  case/andP=> r_bc /IHbcs {IHbcs}bcsP.
+  case/andP=> r_bc /IHbcs {IHbcs}- bcsP.
   have f_qf := dnf_to_form_qf [:: bc].
   case: ok_proj => //= [ex_x|no_x].
     left; case: ex_x => x /(qf_evalP _ f_qf); rewrite /= orbF => bc_x.

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -2163,7 +2163,7 @@ have [_ <-] := cfBigdprodK nz_Phi1 Pi.
 rewrite Phi1_1 divr1 -/Phi Phi1 rmorph1.
 rewrite prod_cfunE // in Phi1_1; have := Cnat_prod_eq1 _ Phi1_1 Pi.
 rewrite -(cfRes1 (A i)) cfBigdprodiK // => ->; first by rewrite scale1r.
-by move=> {i Pi} j /Nphi Nphi_j; rewrite Cnat_char1 ?cfBigdprodi_char.
+by move=> {i Pi}-j /Nphi Nphi_j; rewrite Cnat_char1 ?cfBigdprodi_char.
 Qed.
 
 Lemma cfBigdprod_Res_lin chi :

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -703,7 +703,7 @@ Lemma rfix_abelem (H : {set gT}) :
 Proof.
 move/subsetP=> sHG; apply/eqmxP/andP; split.
   rewrite -rowgS rowg_mxK -sub_rVabelem_im // subsetI sub_rVabelem /=.
-  apply/centsP=> y /morphimP[v _]; rewrite inE => cGv ->{y} x Gx.
+  apply/centsP=> y /morphimP[v _]; rewrite inE => cGv {y}-> x Gx.
   by apply/commgP/conjg_fixP; rewrite /= -rVabelemJ ?sHG ?(rfix_mxP H _).
 rewrite genmxE; apply/rfix_mxP=> x Hx; apply/row_matrixP=> i.
 rewrite row_mul rowK; case/morphimP: (enum_valP i) => z Ez /setIP[_ cHz] ->.
@@ -871,7 +871,7 @@ have nb_irr: #|sS| = (p ^ n.*2 + p.-1)%N.
     transitivity #|[set [set z] | z in 'Z(S)]|; last first.
       by rewrite card_imset //; apply: set1_inj.
     apply: eq_card => zS; apply/setIdP/imsetP=> [[] | [z]].
-      case/imsetP=> z Sz ->{zS} szSZ.
+      case/imsetP=> z Sz {zS}-> szSZ.
       have Zz: z \in 'Z(S) by rewrite (subsetP szSZ) ?class_refl.
       exists z => //; rewrite inE Sz in Zz.
       apply/eqP; rewrite eq_sym eqEcard sub1set class_refl cards1.
@@ -890,7 +890,7 @@ have nb_irr: #|sS| = (p ^ n.*2 + p.-1)%N.
   have pn_gt0: p ^ n.*2 > 0 by rewrite expn_gt0 p_gt0.
   rewrite card_irr // oSpn expnS -(prednK pn_gt0) mulnS eqn_add2l.
   rewrite (eq_bigr (fun _ => p)) => [|xS]; last first.
-    case/andP=> SxS; rewrite inE SxS; case/imsetP: SxS => x Sx ->{xS} notZxS.
+    case/andP=> SxS; rewrite inE SxS; case/imsetP: SxS => x Sx {xS}-> notZxS.
     have [y Sy ->] := repr_class S x; apply: p_maximal_index => //.
     apply: cent1_extraspecial_maximal => //; first exact: groupJ.
     apply: contra notZxS => Zxy; rewrite -{1}(lcoset_id Sy) class_lcoset.

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -3313,7 +3313,7 @@ Lemma Clifford_componentJ M x :
 Proof.
 set simH := mxsimple rH; set cH := component_mx rH.
 have actG: {in G, forall y M, simH M -> cH M *m rG y <= cH (M *m rG y)}%MS.
-  move=> {M} y Gy /= M simM; have [I [U isoU def_cHM]] := component_mx_def simM.
+  move=> {M} - y Gy /= M simM; have [I [U isoU def_cHM]] := component_mx_def simM.
   rewrite /cH def_cHM sumsmxMr; apply/sumsmx_subP=> i _.
   by apply: mx_iso_component; [apply: Clifford_simple | apply: Clifford_iso2].
 move=> simM Gx; apply/eqmxP; rewrite actG // -/cH.
@@ -4239,7 +4239,7 @@ have [I [W isoW defW]]:= component_mx_def simSi.
 rewrite /'R_i /socle_val /= defW genmxE defE submxMr //.
 apply/sumsmx_subP=> j _.
 have simW := mx_iso_simple (isoW j) simSi; have [modW _ minW] := simW.
-have [{minW}dxWE | nzWE] := eqVneq (W j :&: M)%MS 0; last first.
+have [{minW}-dxWE | nzWE] := eqVneq (W j :&: M)%MS 0; last first.
   by rewrite (sameP capmx_idPl eqmxP) minW ?capmxSl ?capmx_module.
 have [_ Rei ideRi _] := Wedderburn_is_id i.
 have:= nzE; rewrite -submx0 => /memmx_subP[A E_A].

--- a/mathcomp/field/algC.v
+++ b/mathcomp/field/algC.v
@@ -144,7 +144,7 @@ have posP x : reflect (exists y, x = y * conj y) (le 0 x).
   rewrite posE; apply: (iffP eqP) => [Dx | [y {x}->]]; first by exists (sqrt x).
   by rewrite (normE _ _ (normK y)) rmorphM conjK (mulrC (conj _)) -expr2 normK.
 have posJ x : le 0 x -> conj x = x.
-  by case/posP=> {x}u ->; rewrite rmorphM conjK mulrC.
+  by case/posP=> {x} - u ->; rewrite rmorphM conjK mulrC.
 have pos_linear x y : le 0 x -> le 0 y -> le x y || le y x.
   move=> pos_x pos_y; rewrite leB -opprB orbC leB !posE normN -eqf_sqr.
   by rewrite normK rmorphB !posJ ?subrr.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -607,7 +607,7 @@ pose fix xR n : realC :=
   tag (add_Rroot (xR n') p c).
 pose x_ n := tag (xR n).
 have sRle m n: (m <= n)%N -> {subset sQ (x_ m) <= sQ (x_ n)}.
-  move/subnK <-; elim: {n}(n - m)%N => // n IHn x /IHn{IHn}Rx.
+  move/subnK <-; elim: {n}(n - m)%N => // n IHn x /IHn{IHn}-Rx.
   rewrite addSn /x_ /=; case: (unpickle _) => [[p c]|] //=.
   by case: (add_Rroot _ _ _) => yR /= /(sQtrans _ x)->.
 have xRroot n p c: has_Rroot (xR n) p c -> {m | n <= m & root_in (xR m) p}%N.
@@ -738,7 +738,7 @@ have /all_sig[n_ FTA] z: {n | z \in sQ (z_ n)}.
       apply/polyOver_poly=> j _; rewrite -memRn; apply: polyOverP j => /=.
       by rewrite rpredM 1?polyOver_comp ?rpredN ?polyOverX.
     have Rp0: ofQ t pw.[0] \in sQ (x_ n) by rewrite -memRn rpred_horner ?rpred0.
-    have [|{mon_p Rp Rp0 Dp0}m lenm p_Rm_0] := xRroot n p (ofQ t pw.[0]).
+    have [|{mon_p Rp Rp0 Dp0}-m lenm p_Rm_0] := xRroot n p (ofQ t pw.[0]).
       by rewrite /has_Rroot mon_p Rp Rp0 -Dp0 /=.
     have{p_Rm_0} [y Ry pw_y]: {y | y \in sQ (x_ m) & root (pw ^ ofQ t) y}.
       apply/sig2W; have [y Ry] := p_Rm_0.

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -2596,7 +2596,7 @@ Lemma astabQ H Abar : 'C(Abar |'Q) = coset H @*^-1 'C(Abar).
 Proof.
 apply/setP=> x; rewrite inE /= dom_qactJ morphpreE in_setI /=.
 apply: andb_id2l => Nx; rewrite !inE -sub1set centsC cent_set1.
-apply: eq_subset_r => {Abar} Hy; rewrite inE qactJ Nx (sameP eqP conjg_fixP).
+apply: eq_subset_r => {Abar}- Hy; rewrite inE qactJ Nx (sameP eqP conjg_fixP).
 by rewrite (sameP cent1P eqP) (sameP commgP eqP).
 Qed.
 

--- a/mathcomp/fingroup/gproduct.v
+++ b/mathcomp/fingroup/gproduct.v
@@ -1611,7 +1611,7 @@ Proof.
 move=> defG {C D} /dprodP[[C D -> ->] defL cCD trCD].
 case/dprodP: defG (defG) => {A B} [[A B -> ->] defG _ _] dG defC defD.
 case/isogP: defC defL cCD trCD => fA injfA <-{C}.
-case/isogP: defD => fB injfB <-{D} defL cCD trCD.
+case/isogP: defD => fB injfB {D}<- defL cCD trCD.
 apply/isogP; exists (dprodm_morphism dG cCD).
   by rewrite injm_dprodm injfA injfB trCD eqxx.
 by rewrite /= -{2}defG morphim_dprodm.

--- a/mathcomp/fingroup/morphism.v
+++ b/mathcomp/fingroup/morphism.v
@@ -832,7 +832,7 @@ Proof. by move=> Dx; rewrite injm_subnorm ?morphim_set1 ?sub1set. Qed.
 Lemma injm_cent A : A \subset D -> f @* 'C(A) = 'C_(f @* D)(f @* A).
 Proof.
 move=> sAD; apply/eqP; rewrite -morphimIdom eqEsubset morphim_subcent.
-apply/subsetP=> fx; case/setIP; case/morphimP=> x Dx _ ->{fx} cAfx.
+apply/subsetP=> fx; case/setIP; case/morphimP=> x Dx _ {fx}-> cAfx.
 rewrite mem_morphim // inE Dx -sub1set centsC cent_set1 -injmSK //.
 by rewrite injm_cent1 // subsetI morphimS // -cent_set1 centsC sub1set.
 Qed.
@@ -1023,7 +1023,7 @@ Proof.
 apply/setP=> z; apply/morphimP/morphimP=> [[x]|[y Hy fAy ->{z}]].
   rewrite !inE => /andP[Gx Hfx]; exists (f x) => //.
   by apply/morphimP; exists x.
-by case/morphimP: fAy Hy => x Gx Ax ->{y} Hfx; exists x; rewrite ?inE ?Gx.
+by case/morphimP: fAy Hy => x Gx Ax {y}-> Hfx; exists x; rewrite ?inE ?Gx.
 Qed.
 
 Lemma morphpre_comp (C : {set rT}) : gof @*^-1 C = f @*^-1 (g @*^-1 C).
@@ -1304,7 +1304,7 @@ Proof. by case/(restrmP f)=> g [gf _ _ <- //]; rewrite -gf; case/isomP. Qed.
 Lemma sub_isom (A : {set aT}) (C : {set rT}) :
   A \subset G -> f @* A = C -> 'injm f -> isom A C f.
 Proof.
-move=> sAG; case: (restrmP f sAG) => g [_ _ _ img] <-{C} injf.
+move=> sAG; case: (restrmP f sAG) => g [_ _ _ img] {C}<- injf.
 rewrite /isom -morphimEsub ?morphimDG ?morphim1 //.
 by rewrite subDset setUC subsetU ?sAG.
 Qed.

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -272,7 +272,7 @@ rewrite -!sum1dep_card -sum1_card (reindex_onto fA pfT) => [|f].
   by rewrite if_arg ffunE; case: insubP; rewrite // pvalE perm1 if_same eqxx.
 case/andP=> /forallP-onA /injectiveP-f_inj.
 apply/ffunP=> u; rewrite ffunE -pvalE insubdK; first by rewrite ffunE valK.
-apply/injectiveP=> {u} x y; rewrite !ffunE.
+apply/injectiveP=> {u}- x y; rewrite !ffunE.
 case: insubP => [u _ <-|]; case: insubP => [v _ <-|] //=; first by move/f_inj->.
   by move=> Ay' def_y; rewrite -def_y [_ \in A]onA in Ay'.
 by move=> Ax' def_x; rewrite def_x [_ \in A]onA in Ax'.
@@ -419,7 +419,7 @@ rewrite (cardsD1 (pcycle s y)) (cardsD1 (pcycle s x)) !(mem_imset, inE) //.
 rewrite -/(dp s) !addnA !eq_pcycle_mem andbT; congr (_ + _); last first.
   wlog suffices: s / dp s <= dp (t x y s).
     by move=> IHs; apply/eqP; rewrite eqn_leq -{2}(tK x y s) !IHs.
-  apply/subset_leq_card/subsetP=> {dp} C.
+  apply/subset_leq_card/subsetP=> {dp}- C.
   rewrite !inE andbA andbC !(eq_sym C) => /and3P[/imsetP[z _ ->{C}]].
   rewrite 2!eq_pcycle_mem => sxz syz.
   suffices ts_z: pcycle (t x y s) z = pcycle s z.
@@ -490,8 +490,8 @@ Qed.
 
 Lemma odd_permM : {morph odd_perm : s1 s2 / s1 * s2 >-> s1 (+) s2}.
 Proof.
-move=> s1 s2; case: (prod_tpermP s1) => ts1 ->{s1} dts1.
-case: (prod_tpermP s2) => ts2 ->{s2} dts2.
+move=> s1 s2; case: (prod_tpermP s1) => ts1 {s1}-> dts1.
+case: (prod_tpermP s2) => ts2 {s2}-> dts2.
 by rewrite -big_cat !odd_perm_prod ?all_cat ?dts1 // size_cat odd_add.
 Qed.
 

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -584,7 +584,7 @@ Qed.
 Lemma card_p1Elem_pnElem p n A E :
   E \in 'E_p^n(A) -> #|'E_p^1(E)| = (\sum_(i < n) p ^ i)%N.
 Proof.
-case/pnElemP=> _ {A} abelE dimE; have [pE cEE _] := and3P abelE.
+case/pnElemP=> _ {A}- abelE dimE; have [pE cEE _] := and3P abelE.
 have [E1 | ntE] := eqsVneq E 1.
   rewrite -dimE E1 cards1 logn1 big_ord0 eq_card0 // => X.
   by rewrite !inE subG1 trivg_card1; case: eqP => // ->; rewrite logn1 andbF.
@@ -1470,7 +1470,7 @@ Lemma cyclic_pgroup_dprod_trivg p A B C :
     p.-group C -> cyclic C -> A \x B = C ->
   A = 1 /\ B = C \/ B = 1 /\ A = C.
 Proof.
-move=> pC cycC; case/cyclicP: cycC pC => x ->{C} pC defC.
+move=> pC cycC; case/cyclicP: cycC pC => x {C}-> pC defC.
 case/dprodP: defC => [] [G H -> ->{A B}] defC _ tiGH; rewrite -defC.
 case: (eqVneq <[x]> 1) => [|ntC].
   move/trivgP; rewrite -defC mulG_subG => /andP[/trivgP-> _].
@@ -1562,7 +1562,7 @@ have{x_yp} xp_yp: (y ^+ p \in <[x ^+ p]>).
   rewrite cycle_subG orderXdiv // divnA // mulnC ox.
   by rewrite -muln_divA ?dvdn_exponent ?expgM 1?groupX ?cycle_id.
 have: p <= #[y] by rewrite dvdn_leq.
-rewrite leq_eqVlt; case/predU1P=> [{xp_yp m IHm leym}oy | ltpy]; last first.
+rewrite leq_eqVlt; case/predU1P=> [{xp_yp m IHm leym}-oy | ltpy]; last first.
   case/cycleP: xp_yp => k; rewrite -expgM mulnC expgM => def_yp.
   suffices: #[y * x ^- k] < m.
     by move/IHm; apply; rewrite groupMr // groupV groupX ?cycle_id.

--- a/mathcomp/solvable/extremal.v
+++ b/mathcomp/solvable/extremal.v
@@ -554,7 +554,7 @@ have defMho: 'Mho^1(G) = <[x ^+ p]>.
   apply: subsetP (XYp z t Xz Yt); case/cycleP: Xz => i ->.
   by rewrite expgAC mul_subG ?sub1set ?mem_cycle //= -defZ cycle_subG groupX.
 split=> //; try exact: extend_cyclic_Mho.
-- rewrite sdprodE //; split=> // z; case/cycleP=> i ->{z} j.
+- rewrite sdprodE //; split=> // z; case/cycleP=> i {z}-> j.
   rewrite conjXg -expgM mulnC expgM actX; congr (_ ^+ i).
   elim: j {i} => //= j ->; rewrite conjXg xy -!expgM mulnS mulSn addSn.
   rewrite addnA -mulSn -addSn expgD mulnCA (mulnC j).
@@ -1096,7 +1096,7 @@ have isoMt: {in G :\: X, forall t, <<t ^: G>> \isog 'D_q}.
   have [_ <- nX2T _] := sdprodP (defMt t X't); rewrite norm_joinEr //.
   rewrite -/q -/r !xpair_eqE eqxx -expgM def2r -ox -{1}(oX' t X't).
   by rewrite !expg_order !eqxx /= invXX' ?mem_cycle.
-rewrite !isoMt //; split=> // C; case/cyclicP=> z ->{C} sCG iCG.
+rewrite !isoMt //; split=> // C; case/cyclicP=> z {C}-> sCG iCG.
 rewrite [X]defU // defU -?cycle_subG //.
 by apply: double_inj; rewrite -muln2 -iCG Lagrange // oG -mul2n.
 Qed.
@@ -1293,7 +1293,7 @@ have isoMt: {in G :\: X, forall z, <<z ^: G>> \isog 'Q_q}.
   rewrite defMt // -/q -/r !xpair_eqE -!expgM def2r -order_dvdn ox dvdnn.
   rewrite -expnS prednK; last by rewrite -subn2 subn_gt0.
   by rewrite X'2 // def_xr !eqxx /= invXX' ?mem_cycle.
-rewrite !isoMt //; split=> // C; case/cyclicP=> z ->{C} sCG iCG.
+rewrite !isoMt //; split=> // C; case/cyclicP=> z {C}-> sCG iCG.
 rewrite [X]defU // defU -?cycle_subG //.
 by apply: double_inj; rewrite -muln2 -iCG Lagrange // oG -mul2n.
 Qed.
@@ -1492,7 +1492,7 @@ have invX2X': {in G :\: X, forall t, x ^+ 2 ^ t == x ^- 2}.
 - apply/existsP; exists (x ^+ 2, x * y); rewrite /= defMt // !xpair_eqE.
   rewrite -!expgM def2r -order_dvdn ox xy2 dvdnn eqxx invX2X' //=.
   by rewrite andbT /r -(subnKC n_gt3).
-case/cyclicP=> z ->{C} sCG iCG; rewrite [X]defU // defU -?cycle_subG //.
+case/cyclicP=> z {C}-> sCG iCG; rewrite [X]defU // defU -?cycle_subG //.
 by apply: double_inj; rewrite -muln2 -iCG Lagrange // oG -mul2n.
 Qed.
 

--- a/mathcomp/solvable/hall.v
+++ b/mathcomp/solvable/hall.v
@@ -131,7 +131,7 @@ have [xb]: exists2 xb, xb \in H / M & K1 / M = (K / M) :^ xb.
   apply: IHn; try by rewrite (quotient_sol, morphim_norms, oKM K) ?(oKM K1).
     by apply: leq_trans leHn; rewrite ltn_quotient.
   by rewrite -morphimMl ?nMsG // -defG morphimS.
-case/morphimP=> x nMx Hx ->{xb} eqK1Kx; pose K2 := (K :^ x)%G.
+case/morphimP=> x nMx Hx {xb}-> eqK1Kx; pose K2 := (K :^ x)%G.
 have{eqK1Kx} eqK12: K1 / M = K2 / M by rewrite quotientJ.
 suff [y My ->]: exists2 y, y \in M & K1 :=: K2 :^ y.
   by exists (x * y); [rewrite groupMl // (subsetP sMH) | rewrite conjsgM].

--- a/mathcomp/solvable/maximal.v
+++ b/mathcomp/solvable/maximal.v
@@ -241,7 +241,7 @@ Qed.
 
 Lemma Phi_quotient_cyclic G : cyclic (G / 'Phi(G)) -> cyclic G.
 Proof.
-case/cyclicP=> /= Px; case: (cosetP Px) => x nPx ->{Px} defG.
+case/cyclicP=> /= Px; case: (cosetP Px) => x nPx {Px}-> defG.
 apply/cyclicP; exists x; symmetry; apply: Phi_nongen.
 rewrite -joing_idr norm_joinEr -?quotientK ?cycle_subG //.
 by rewrite /quotient morphim_cycle //= -defG quotientGK ?Phi_normal.

--- a/mathcomp/solvable/primitive_action.v
+++ b/mathcomp/solvable/primitive_action.v
@@ -269,7 +269,7 @@ Qed.
 Lemma ntransitive_primitive m :
   1 < m -> [transitive^m G, on S | to] -> [primitive G, on S | to].
 Proof.
-move=> lt1m /(ntransitive_weak lt1m) {m lt1m}tr2G.
+move=> lt1m /(ntransitive_weak lt1m) {m lt1m}-tr2G.
 have trG: [transitive G, on S | to] by apply: ntransitive1 tr2G.
 have [x Sx _]:= imsetP trG; rewrite (trans_prim_astab Sx trG).
 apply/maximal_eqP; split=> [|H]; first exact: subsetIl; rewrite subEproper.

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1560,7 +1560,7 @@ transitivity (\big[+%M/0]_(f in Pf r) \big[*%M/1]_(i <- r) F i (f i)).
 have: uniq r by apply: enum_uniq.
 elim: {P}r => /= [_ | i r IHr].
   rewrite (big_pred1 [ffun => j0]) ?big_nil //= => f.
-  apply/familyP/eqP=> /= [Df |->{f} i]; last by rewrite ffunE !inE.
+  apply/familyP/eqP=> /= [Df | {f}-> i]; last by rewrite ffunE !inE.
   by apply/ffunP=> i; rewrite ffunE; apply/eqP/Df.
 case/andP=> /negbTE nri; rewrite big_cons big_distrl => {IHr}/IHr <-.
 rewrite (partition_big (fun f : fIJ => f i) (Q i)) => [|f]; last first.

--- a/mathcomp/ssreflect/div.v
+++ b/mathcomp/ssreflect/div.v
@@ -126,7 +126,7 @@ Proof. by case: d => // d; rewrite -{1}[d.+1]muln1 mulKn. Qed.
 Lemma divnMl p m d : p > 0 -> p * m %/ (p * d) = m %/ d.
 Proof.
 move=> p_gt0; case: (posnP d) => [-> | d_gt0]; first by rewrite muln0.
-rewrite {2}/divn; case: edivnP; rewrite d_gt0 /= => q r ->{m} lt_rd.
+rewrite {2}/divn; case: edivnP; rewrite d_gt0 /= => q r {m}-> lt_rd.
 rewrite mulnDr mulnCA divnMDl; last by rewrite muln_gt0 p_gt0.
 by rewrite addnC divn_small // ltn_pmul2l.
 Qed.

--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -1979,7 +1979,7 @@ Qed.
 Lemma equivalence_partition_pblock P D :
   partition P D -> equivalence_partition (fun x y => y \in pblock P x) D = P.
 Proof.
-case/and3P=> /eqP <-{D} tiP notP0; apply/setP=> B /=; set D := cover P.
+case/and3P=> /eqP {D}<- tiP notP0; apply/setP=> B /=; set D := cover P.
 have defP x: x \in D -> [set y in D | y \in pblock P x] = pblock P x.
   by move=> Dx; apply/setIidPr; rewrite (bigcup_max (pblock P x)) ?pblock_mem.
 apply/imsetP/idP=> [[x Px ->{B}] | PB]; first by rewrite defP ?pblock_mem.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -539,7 +539,7 @@ elim: {s}_.+1 {-2}s [::] (ltnSn (size s)) => // n IHn s ss.
 have: perm_eq (catss ss ++ s) (merge_sort_pop s ss).
   elim: ss s => //= s2 ss IHss s1; rewrite -{IHss}(perm_eqrP (IHss _)).
   by rewrite perm_catC catA perm_catC perm_cat2l -perm_merge.
-case: s => // x1 [//|x2 s _]; move/ltnW; move/IHn=> {n IHn}IHs.
+case: s => // x1 [//|x2 s _]; move/ltnW; move/IHn=> {n IHn}-IHs.
 rewrite -{IHs}(perm_eqrP (IHs _)) ifE; set s1 := if_expr _ _ _.
 rewrite (catA _ [:: _; _] s) {s}perm_cat2r.
 apply: (@perm_eq_trans _ (catss ss ++ s1)).

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -411,7 +411,7 @@ case: n1 / le_mn1 def_n1 => [|n1 le_mn1] def_n1 [|n2 le_mn2] def_n2.
 - by rewrite [def_n2]eq_axiomK.
 - by move/leP: (le_mn2); rewrite -{1}def_n2 ltnn.
 - by move/leP: (le_mn1); rewrite {1}def_n2 ltnn.
-case: def_n2 (def_n2) => ->{n2} def_n2 in le_mn2 *.
+case: def_n2 (def_n2) => {n2}-> def_n2 in le_mn2 *.
 by rewrite [def_n2]eq_axiomK /=; congr le_S; apply: IHn.
 Qed.
 


### PR DESCRIPTION
coq/coq#9341 makes two breaking changes. This PR is to let @ggonthier evaluate the breakage they would have.

Two kind of breakages:
- `=> ... ->{x} y` is quite frequent and after coq/coq#9341 also clears `y`.  fixed the occurrences by putting the clear *before* the arrow (dunno if it is acceptable)
- `=> ...{x} y` is less frequent, in that case I did put an extra `-` so that the clear does not involve `y` (I was sloppy, sometime I've added an extra space, easy to fix)

I've also added a warning (called duplicate-clear, that triggers quite frequently BTW) where stuff like `{H}/H` could be simply written `{}/H` after the aforementioned PR.

Waiting for feedback