### PR TITLE
add a link to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ installation instructions in other scenarios.
 ## How to get help
 
 - The [website](http://math-comp.github.io/math-comp/) of the MathComp library
-  contains links to the HTML documentation of each file
+  contains links to the HTML documentation of each file.
 - The [ssreflect mailing
   list](https://sympa.inria.fr/sympa/info/ssreflect) is the primary
   venue for help and questions about the library.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ installation instructions in other scenarios.
 
 ## How to get help
 
+- The [website](http://math-comp.github.io/math-comp/) of the MathComp library
+  contains links to the HTML documentation of each file
 - The [ssreflect mailing
   list](https://sympa.inria.fr/sympa/info/ssreflect) is the primary
   venue for help and questions about the library.


### PR DESCRIPTION
Looks like there is no link from the README to the webpage, and the webpage contains the html doc..