### PR TITLE
we silence warnings that just pollute our logs so that we can see the relevant warnings

### DIFF
--- a/mathcomp/Make
+++ b/mathcomp/Make
@@ -90,3 +90,7 @@ ssreflect/tuple.v
 
 -I .
 -R . mathcomp
+
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -redundant-canonical-projection
+-arg -w -arg -notation-overridden

--- a/mathcomp/_CoqProject
+++ b/mathcomp/_CoqProject
@@ -1,1 +1,6 @@
+-I .
 -R . mathcomp
+
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -redundant-canonical-projection
+-arg -w -arg -notation-overridden


### PR DESCRIPTION
Namely:
-projection-no-head-constant
-redundant-canonical-projection
-notation-overridden