### PR TITLE
Merge the order library into ssrnum structures (part of #270)

### DIFF
--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -189,7 +189,9 @@ End Exports.
 End Norm.
 Import Norm.Exports.
 
-Definition norm (R : Type) (T : normedType R) : T -> R := @Norm.class R T.
+Definition norm (R : Type) (T : normedType R) : T -> R :=
+  nosimpl (@Norm.class R T).
+Arguments norm {R T} x.
 Notation "`| x |" := (norm x) : ring_scope.
 
 Import Order.Theory Order.Def Order.Syntax.
@@ -209,8 +211,7 @@ Record mixin_of (R : ringType) (Rorder : Order.POrder.mixin_of R)
   _ : forall x, norm_op x = 0 -> x = 0;
   _ : forall x y, le_op 0 x -> le_op 0 y -> le_op x y || le_op y x;
   _ : {morph norm_op : x y / x * y};
-  _ : forall x y, (le_op x y) = (norm_op (y - x) == y - x);
-  _ : forall x y, (lt_op x y) = (y != x) && (le_op x y)}.
+  _ : forall x y, (le_op x y) = (norm_op (y - x) == y - x)}.
 
 Local Notation ring_for T b := (@GRing.Ring.Pack T b).
 
@@ -236,8 +237,11 @@ Definition class := let: Pack _ c  as cT' := cT return class_of cT' in c.
 Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of xT).
 Definition clone c of phant_id class c := @Pack T c.
-(* TODO Kazuhiko: this is broken, rewrite the pack please *)
-Definition pack c := @Pack T c.
+Definition pack T b0 om0 nb0 (m0 : @mixin_of (ring_for T b0) om0 nb0) :=
+  fun bT b & phant_id (@GRing.IntegralDomain.class bT) b =>
+  fun om   & phant_id om0 om =>
+  fun m    & phant_id m0 m =>
+  @Pack T (@Class T b om nb0 m).
 
 Definition eqType := @Equality.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
@@ -249,14 +253,22 @@ Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
 Definition porderType := @Order.POrder.Pack ring_display cT xclass.
 Definition normedType := @Norm.Pack cT cT xclass.
-
-Definition order_zmodType :=
-  @GRing.Zmodule.Pack (Order.POrder.sort porderType) xclass.
-Definition order_ringType :=
-  @GRing.Ring.Pack (Order.POrder.sort porderType) xclass.
-(* 9 more missing *)
+Definition order_zmodType := @GRing.Zmodule.Pack porderType xclass.
+Definition order_ringType := @GRing.Ring.Pack porderType xclass.
+Definition order_comRingType := @GRing.ComRing.Pack porderType xclass.
+Definition order_unitRingType := @GRing.UnitRing.Pack porderType xclass.
+Definition order_comUnitRingType := @GRing.ComUnitRing.Pack porderType xclass.
+Definition order_idomainType := @GRing.IntegralDomain.Pack porderType xclass.
+Definition order_normedType := @Norm.Pack xT porderType xclass.
+Definition normed_zmodType := @GRing.Zmodule.Pack normedType xclass.
+Definition normed_ringType := @GRing.Ring.Pack normedType xclass.
+Definition normed_comRingType := @GRing.ComRing.Pack normedType xclass.
+Definition normed_unitRingType := @GRing.UnitRing.Pack normedType xclass.
+Definition normed_comUnitRingType := @GRing.ComUnitRing.Pack normedType xclass.
+Definition normed_idomainType := @GRing.IntegralDomain.Pack normedType xclass.
 
 End ClassDef.
+
 Module Exports.
 Coercion sort : type >-> Sortclass.
 Bind Scope ring_scope with sort.
@@ -285,19 +297,27 @@ Coercion normedType : type >-> Norm.type.
 Canonical normedType.
 Canonical order_zmodType.
 Canonical order_ringType.
-(* 9 more missing *)
+Canonical order_comRingType.
+Canonical order_unitRingType.
+Canonical order_comUnitRingType.
+Canonical order_idomainType.
+Canonical order_normedType.
+Canonical normed_zmodType.
+Canonical normed_ringType.
+Canonical normed_comRingType.
+Canonical normed_unitRingType.
+Canonical normed_comUnitRingType.
+Canonical normed_idomainType.
 Notation numDomainType := type.
-Notation NumDomainType T m := (@pack T m).
+Notation NumDomainType T m := (@pack T _ _ _ m _ _ id _ id _ id).
 Notation "[ 'numDomainType' 'of' T 'for' cT ]" := (@clone T cT _ idfun)
   (at level 0, format "[ 'numDomainType'  'of'  T  'for'  cT ]") : form_scope.
 Notation "[ 'numDomainType' 'of' T ]" := (@clone T _ _ id)
   (at level 0, format "[ 'numDomainType'  'of'  T ]") : form_scope.
 End Exports.
+
 End NumDomain.
 Import NumDomain.Exports.
-
-About  NumDomain.order_zmodType.
-Print Canonical Projections.
 
 Module Import Def. Section Def.
 Import NumDomain.
@@ -361,16 +381,112 @@ End ExtensionAxioms.
 
 Local Notation num_for T b := (@NumDomain.Pack T b).
 
+Module NormedModule.
+
+Record mixin_of (R : numDomainType) (T : lmodType R) (norm : Norm.class_of R T)
+  := Mixin {
+  _ : forall (x y : T), norm (x + y) <= norm x + norm y;
+  _ : forall (l : R) (x : T), norm (l *: x) = `|l| * norm x;
+  _ : forall x : T, norm x = 0 -> x = 0}.
+
+Section ClassDef.
+
+Variable R : numDomainType.
+
+Record class_of (T : Type) := Class {
+  base : GRing.Lmodule.class_of R T;
+  norm_base : Norm.class_of R T;
+  mixin : @mixin_of R (@GRing.Lmodule.Pack R (Phant R) T base) norm_base
+}.
+Local Coercion base : class_of >-> GRing.Lmodule.class_of.
+Local Coercion norm_base : class_of >-> Norm.class_of.
+Local Coercion mixin : class_of >-> mixin_of.
+
+Structure type (phR : phant R) :=
+  Pack { sort; _ : class_of sort }.
+Local Coercion sort : type >-> Sortclass.
+
+Variables (phR : phant R) (T : Type) (cT : type phR).
+
+Definition class := let: Pack _ c := cT return class_of cT in c.
+Definition clone c of phant_id class c := @Pack phR T c.
+Let xT := let: Pack T _ := cT in T.
+Notation xclass := (class : class_of xT).
+
+Definition pack
+           b0 n0 (m0 : @mixin_of R (@GRing.Lmodule.Pack R (Phant R) T b0) n0) :=
+  Pack phR (@Class T b0 n0 m0).
+
+Definition eqType := @Equality.Pack cT xclass.
+Definition choiceType := @Choice.Pack cT xclass.
+Definition zmodType := @GRing.Zmodule.Pack cT xclass.
+Definition lmodType := @GRing.Lmodule.Pack R phR cT xclass.
+Definition normedType := @Norm.Pack R cT xclass.
+Definition normed_eqType := @Equality.Pack normedType xclass.
+Definition normed_choiceType := @Choice.Pack normedType xclass.
+Definition normed_lmodType := @GRing.Lmodule.Pack R phR normedType xclass.
+End ClassDef.
+
+Module Exports.
+Coercion base : class_of >-> GRing.Lmodule.class_of.
+Coercion norm_base : class_of >-> Norm.class_of.
+Coercion mixin : class_of >-> mixin_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
+Canonical eqType.
+Coercion choiceType : type >-> Choice.type.
+Canonical choiceType.
+Coercion zmodType : type >-> GRing.Zmodule.type.
+Canonical zmodType.
+Coercion lmodType : type >-> GRing.Lmodule.type.
+Canonical lmodType.
+Coercion normedType : type >-> Norm.type.
+Canonical normedType.
+Canonical normed_eqType.
+Canonical normed_choiceType.
+Canonical normed_lmodType.
+Notation normedModType R := (type (Phant R)).
+Notation NormedModType R T m := (@pack _ (Phant R) T _ _ m).
+Notation NormedModMixin := Mixin.
+Notation "[ 'normedModType' R 'of' T 'for' cT ]" :=
+  (@clone _ (Phant R) T cT _ idfun)
+  (at level 0, format "[ 'normedModType'  R  'of'  T  'for'  cT ]") :
+  form_scope.
+Notation "[ 'normedModType' R 'of' T ]" := (@clone _ (Phant R) T _ _ id)
+  (at level 0, format "[ 'normedModType'  R  'of'  T ]") : form_scope.
+End Exports.
+
+End NormedModule.
+Import NormedModule.Exports.
+
+Coercion numDomain_normedModMixin (R : numDomainType) :
+  @NormedModule.mixin_of R (GRing.regular_lmodType R) (NumDomain.class R) :=
+  @NormedModule.Mixin
+    R
+    (GRing.regular_lmodType R)
+    (NumDomain.norm_base (NumDomain.class R))
+    (let: Num.Mixin a _ _ _ _ _ := NumDomain.mixin (NumDomain.class R) in a)
+    (let: Num.Mixin _ _ _ _ a _ := NumDomain.mixin (NumDomain.class R) in a)
+    (let: Num.Mixin _ _ a _ _ _ := NumDomain.mixin (NumDomain.class R) in a).
+
+Canonical numDomain_normedModType (R : numDomainType) : normedModType R :=
+  NormedModType R R R.
+
+Coercion numDomain_normedModType : numDomainType >-> normedModType.
+
 (* The rest of the numbers interface hierarchy. *)
 Module NumField.
 
 Section ClassDef.
 
-Record class_of R :=
-  Class { base : GRing.Field.class_of R; mixin : mixin_of (ring_for R base) }.
-Definition base2 R (c : class_of R) := NumDomain.Class (mixin c).
+Record class_of R := Class {
+  base        : GRing.Field.class_of R;
+  order_mixin : Order.POrder.mixin_of (ring_for R base);
+  norm_base   : Norm.class_of R R;
+  mixin       : mixin_of order_mixin norm_base
+}.
 Local Coercion base : class_of >-> GRing.Field.class_of.
-Local Coercion base2 : class_of >-> NumDomain.class_of.
+Local Coercion base2 R (c : class_of R) := NumDomain.Class (mixin c).
 
 Structure type := Pack {sort; _ : class_of sort}.
 Local Coercion sort : type >-> Sortclass.
@@ -381,8 +497,8 @@ Notation xclass := (class : class_of xT).
 
 Definition pack :=
   fun bT b & phant_id (GRing.Field.class bT) (b : GRing.Field.class_of T) =>
-  fun mT m & phant_id (NumDomain.class mT) (@NumDomain.Class T b m) =>
-  Pack (@Class T b m).
+  fun mT o n m & phant_id (NumDomain.class mT) (@NumDomain.Class T b o n m) =>
+  Pack (@Class T b o n m).
 
 Definition eqType := @Equality.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
@@ -392,9 +508,16 @@ Definition comRingType := @GRing.ComRing.Pack cT xclass.
 Definition unitRingType := @GRing.UnitRing.Pack cT xclass.
 Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
+Definition porderType := @Order.POrder.Pack ring_display cT xclass.
+Definition normedType := @Norm.Pack cT cT xclass.
 Definition numDomainType := @NumDomain.Pack cT xclass.
 Definition fieldType := @GRing.Field.Pack cT xclass.
-Definition join_numDomainType := @NumDomain.Pack fieldType xclass.
+Definition normedModType :=
+  NormedModType numDomainType cT (numDomain_normedModMixin numDomainType).
+Definition field_porderType :=
+  @Order.POrder.Pack ring_display fieldType xclass.
+Definition field_normedType := @Norm.Pack xT fieldType xclass.
+Definition field_numDomainType := @NumDomain.Pack fieldType xclass.
 
 End ClassDef.
 
@@ -419,12 +542,21 @@ Coercion comUnitRingType : type >-> GRing.ComUnitRing.type.
 Canonical comUnitRingType.
 Coercion idomainType : type >-> GRing.IntegralDomain.type.
 Canonical idomainType.
+Coercion porderType : type >-> Order.POrder.type.
+Canonical porderType.
+Coercion normedType : type >-> Norm.type.
+Canonical normedType.
 Coercion numDomainType : type >-> NumDomain.type.
 Canonical numDomainType.
 Coercion fieldType : type >-> GRing.Field.type.
 Canonical fieldType.
+Coercion normedModType : type >-> NormedModule.type.
+Canonical normedModType.
+Canonical field_porderType.
+Canonical field_normedType.
+Canonical field_numDomainType.
 Notation numFieldType := type.
-Notation "[ 'numFieldType' 'of' T ]" := (@pack T _ _ id _ _ id)
+Notation "[ 'numFieldType' 'of' T ]" := (@pack T _ _ id _ _ _ _ id)
   (at level 0, format "[ 'numFieldType'  'of'  T ]") : form_scope.
 End Exports.
 
@@ -443,13 +575,14 @@ Record imaginary_mixin_of (R : numDomainType) := ImaginaryMixin {
 }.
 
 Record class_of R := Class {
-  base : GRing.ClosedField.class_of R;
-  mixin : mixin_of (ring_for R base);
-  conj_mixin : imaginary_mixin_of (num_for R (NumDomain.Class mixin))
+  base        : GRing.ClosedField.class_of R;
+  order_mixin : Order.POrder.mixin_of (ring_for R base);
+  norm_base   : Norm.class_of R R;
+  mixin       : mixin_of order_mixin norm_base;
+  conj_mixin  : imaginary_mixin_of (num_for R (NumDomain.Class mixin))
 }.
-Definition base2 R (c : class_of R) := NumField.Class (mixin c).
 Local Coercion base : class_of >-> GRing.ClosedField.class_of.
-Local Coercion base2 : class_of >-> NumField.class_of.
+Local Coercion base2 R (c : class_of R) := NumField.Class (mixin c).
 
 Structure type := Pack {sort; _ : class_of sort}.
 Local Coercion sort : type >-> Sortclass.
@@ -461,8 +594,8 @@ Notation xclass := (class : class_of xT).
 Definition pack :=
   fun bT b & phant_id (GRing.ClosedField.class bT)
                       (b : GRing.ClosedField.class_of T) =>
-  fun mT m & phant_id (NumField.class mT) (@NumField.Class T b m) =>
-  fun mc => Pack (@Class T b m mc).
+  fun mT o n m & phant_id (NumField.class mT) (@NumField.Class T b o n m) =>
+  fun mc => Pack (@Class T b o n m mc).
 Definition clone := fun b & phant_id class (b : class_of T) => Pack b.
 
 Definition eqType := @Equality.Pack cT xclass.
@@ -473,15 +606,25 @@ Definition comRingType := @GRing.ComRing.Pack cT xclass.
 Definition unitRingType := @GRing.UnitRing.Pack cT xclass.
 Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
+Definition porderType := @Order.POrder.Pack ring_display cT xclass.
+Definition normedType := @Norm.Pack cT cT xclass.
 Definition numDomainType := @NumDomain.Pack cT xclass.
 Definition fieldType := @GRing.Field.Pack cT xclass.
 Definition numFieldType := @NumField.Pack cT xclass.
 Definition decFieldType := @GRing.DecidableField.Pack cT xclass.
 Definition closedFieldType := @GRing.ClosedField.Pack cT xclass.
-Definition join_dec_numDomainType := @NumDomain.Pack decFieldType xclass.
-Definition join_dec_numFieldType := @NumField.Pack decFieldType xclass.
-Definition join_numDomainType := @NumDomain.Pack closedFieldType xclass.
-Definition join_numFieldType := @NumField.Pack closedFieldType xclass.
+Definition normedModType :=
+  NormedModType numDomainType cT (numDomain_normedModMixin numDomainType).
+Definition dec_porderType :=
+  @Order.POrder.Pack ring_display decFieldType xclass.
+Definition dec_normedType := @Norm.Pack xT decFieldType xclass.
+Definition dec_numDomainType := @NumDomain.Pack decFieldType xclass.
+Definition dec_numFieldType := @NumField.Pack decFieldType xclass.
+Definition closed_porderType :=
+  @Order.POrder.Pack ring_display closedFieldType xclass.
+Definition closed_normedType := @Norm.Pack xT closedFieldType xclass.
+Definition closed_numDomainType := @NumDomain.Pack closedFieldType xclass.
+Definition closed_numFieldType := @NumField.Pack closedFieldType xclass.
 
 End ClassDef.
 
@@ -506,6 +649,10 @@ Coercion comUnitRingType : type >-> GRing.ComUnitRing.type.
 Canonical comUnitRingType.
 Coercion idomainType : type >-> GRing.IntegralDomain.type.
 Canonical idomainType.
+Coercion porderType : type >-> Order.POrder.type.
+Canonical porderType.
+Coercion normedType : type >-> Norm.type.
+Canonical normedType.
 Coercion numDomainType : type >-> NumDomain.type.
 Canonical numDomainType.
 Coercion fieldType : type >-> GRing.Field.type.
@@ -516,12 +663,18 @@ Coercion numFieldType : type >-> NumField.type.
 Canonical numFieldType.
 Coercion closedFieldType : type >-> GRing.ClosedField.type.
 Canonical closedFieldType.
-Canonical join_dec_numDomainType.
-Canonical join_dec_numFieldType.
-Canonical join_numDomainType.
-Canonical join_numFieldType.
+Coercion normedModType : type >-> NormedModule.type.
+Canonical normedModType.
+Canonical dec_porderType.
+Canonical dec_normedType.
+Canonical dec_numDomainType.
+Canonical dec_numFieldType.
+Canonical closed_porderType.
+Canonical closed_normedType.
+Canonical closed_numDomainType.
+Canonical closed_numFieldType.
 Notation numClosedFieldType := type.
-Notation NumClosedFieldType T m := (@pack T _ _ id _ _ id m).
+Notation NumClosedFieldType T m := (@pack T _ _ id _ _ _ _ id m).
 Notation "[ 'numClosedFieldType' 'of' T 'for' cT ]" := (@clone T cT _ id)
   (at level 0, format "[ 'numClosedFieldType'  'of'  T  'for' cT ]") :
                                                          form_scope.
@@ -536,9 +689,24 @@ Module RealDomain.
 
 Section ClassDef.
 
-Record class_of R :=
-  Class {base : NumDomain.class_of R; _ : @real_axiom (num_for R base)}.
+Record class_of R := Class {
+  base  : NumDomain.class_of R;
+  mixin : Order.Total.mixin_of (num_for R base)
+}.
 Local Coercion base : class_of >-> NumDomain.class_of.
+Local Coercion order_base T (c : class_of T) :=
+  @Order.Total.Class _ _
+    (Order.Lattice.Class (Order.TotalLattice.Mixin (@mixin _ c))) (@mixin _ c).
+
+Lemma real_axiom_total (R : numDomainType) :
+  real_axiom R -> Order.Total.mixin_of R.
+Proof.
+move=> H x y; move: {H} (H (x - y)); rewrite unfold_in /le /=.
+case: R x y => T [base order norm [/= ? ? ? ? ? H]] x y.
+by rewrite H subr0 -H orbC; congr orb; rewrite H opprD add0r opprK addrC.
+Qed.
+
+Coercion real_axiom_total : real_axiom >-> total.
 
 Structure type := Pack {sort; _ : class_of sort}.
 Local Coercion sort : type >-> Sortclass.
@@ -548,7 +716,7 @@ Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of xT).
 
 Definition clone c of phant_id class c := @Pack T c.
-Definition pack b0 (m0 : real_axiom (num_for T b0)) :=
+Definition pack b0 (m0 : Order.Total.mixin_of (num_for T b0)) :=
   fun bT b & phant_id (NumDomain.class bT) b =>
   fun    m & phant_id m0 m => Pack (@Class T b m).
 
@@ -560,12 +728,37 @@ Definition comRingType := @GRing.ComRing.Pack cT xclass.
 Definition unitRingType := @GRing.UnitRing.Pack cT xclass.
 Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
+Definition porderType := @Order.POrder.Pack ring_display cT xclass.
+Definition normedType := @Norm.Pack cT cT xclass.
 Definition numDomainType := @NumDomain.Pack cT xclass.
+Definition latticeType := @Order.Lattice.Pack ring_display cT xclass.
+Definition orderType := @Order.Total.Pack ring_display cT xclass.
+Definition normedModType :=
+  NormedModType numDomainType cT (numDomain_normedModMixin numDomainType).
+Definition lattice_zmodType := @GRing.Zmodule.Pack latticeType xclass.
+Definition lattice_ringType := @GRing.Ring.Pack latticeType xclass.
+Definition lattice_comRingType := @GRing.ComRing.Pack latticeType xclass.
+Definition lattice_unitRingType := @GRing.UnitRing.Pack latticeType xclass.
+Definition lattice_comUnitRingType :=
+  @GRing.ComUnitRing.Pack latticeType xclass.
+Definition lattice_iDomainType := @GRing.IntegralDomain.Pack latticeType xclass.
+Definition lattice_normedType := @Norm.Pack xT latticeType xclass.
+Definition lattice_numDomainType := @NumDomain.Pack latticeType xclass.
+Definition order_zmodType := @GRing.Zmodule.Pack orderType xclass.
+Definition order_ringType := @GRing.Ring.Pack orderType xclass.
+Definition order_comRingType := @GRing.ComRing.Pack orderType xclass.
+Definition order_unitRingType := @GRing.UnitRing.Pack orderType xclass.
+Definition order_comUnitRingType :=
+  @GRing.ComUnitRing.Pack orderType xclass.
+Definition order_iDomainType := @GRing.IntegralDomain.Pack orderType xclass.
+Definition order_normedType := @Norm.Pack xT orderType xclass.
+Definition order_numDomainType := @NumDomain.Pack orderType xclass.
 
 End ClassDef.
 
 Module Exports.
 Coercion base : class_of >-> NumDomain.class_of.
+Coercion order_base : class_of >-> Order.Total.class_of.
 Coercion sort : type >-> Sortclass.
 Bind Scope ring_scope with sort.
 Coercion eqType : type >-> Equality.type.
@@ -584,8 +777,34 @@ Coercion comUnitRingType : type >-> GRing.ComUnitRing.type.
 Canonical comUnitRingType.
 Coercion idomainType : type >-> GRing.IntegralDomain.type.
 Canonical idomainType.
+Coercion porderType : type >-> Order.POrder.type.
+Canonical porderType.
+Coercion normedType : type >-> Norm.type.
+Canonical normedType.
 Coercion numDomainType : type >-> NumDomain.type.
 Canonical numDomainType.
+Coercion latticeType : type >-> Order.Lattice.type.
+Canonical latticeType.
+Coercion orderType : type >-> Order.Total.type.
+Canonical orderType.
+Coercion normedModType : type >-> NormedModule.type.
+Canonical normedModType.
+Canonical lattice_zmodType.
+Canonical lattice_ringType.
+Canonical lattice_comRingType.
+Canonical lattice_unitRingType.
+Canonical lattice_comUnitRingType.
+Canonical lattice_iDomainType.
+Canonical lattice_normedType.
+Canonical lattice_numDomainType.
+Canonical order_zmodType.
+Canonical order_ringType.
+Canonical order_comRingType.
+Canonical order_unitRingType.
+Canonical order_comUnitRingType.
+Canonical order_iDomainType.
+Canonical order_normedType.
+Canonical order_numDomainType.
 Notation realDomainType := type.
 Notation RealDomainType T m := (@pack T _ m _ _ id _ id).
 Notation "[ 'realDomainType' 'of' T 'for' cT ]" := (@clone T cT _ idfun)
@@ -601,11 +820,12 @@ Module RealField.
 
 Section ClassDef.
 
-Record class_of R :=
-  Class { base : NumField.class_of R; mixin : real_axiom (num_for R base) }.
-Definition base2 R (c : class_of R) := RealDomain.Class (@mixin R c).
+Record class_of R := Class {
+  base  : NumField.class_of R;
+  mixin : Order.Total.mixin_of (num_for R base)
+}.
 Local Coercion base : class_of >-> NumField.class_of.
-Local Coercion base2 : class_of >-> RealDomain.class_of.
+Local Coercion base2 R (c : class_of R) := RealDomain.Class (@mixin R c).
 
 Structure type := Pack {sort; _ : class_of sort}.
 Local Coercion sort : type >-> Sortclass.
@@ -627,11 +847,25 @@ Definition comRingType := @GRing.ComRing.Pack cT xclass.
 Definition unitRingType := @GRing.UnitRing.Pack cT xclass.
 Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
+Definition porderType := @Order.POrder.Pack ring_display cT xclass.
+Definition normedType := @Norm.Pack cT cT xclass.
 Definition numDomainType := @NumDomain.Pack cT xclass.
+Definition latticeType := @Order.Lattice.Pack ring_display cT xclass.
+Definition orderType := @Order.Total.Pack ring_display cT xclass.
 Definition realDomainType := @RealDomain.Pack cT xclass.
 Definition fieldType := @GRing.Field.Pack cT xclass.
 Definition numFieldType := @NumField.Pack cT xclass.
-Definition join_realDomainType := @RealDomain.Pack numFieldType xclass.
+Definition normedModType :=
+  NormedModType numDomainType cT (numDomain_normedModMixin numDomainType).
+Definition field_latticeType :=
+  @Order.Lattice.Pack ring_display fieldType xclass.
+Definition field_orderType := @Order.Total.Pack ring_display fieldType xclass.
+Definition field_realDomainType := @RealDomain.Pack fieldType xclass.
+Definition numField_latticeType :=
+  @Order.Lattice.Pack ring_display numFieldType xclass.
+Definition numField_orderType :=
+  @Order.Total.Pack ring_display numFieldType xclass.
+Definition numField_realDomainType := @RealDomain.Pack numFieldType xclass.
 
 End ClassDef.
 
@@ -656,15 +890,30 @@ Coercion comUnitRingType : type >-> GRing.ComUnitRing.type.
 Canonical comUnitRingType.
 Coercion idomainType : type >-> GRing.IntegralDomain.type.
 Canonical idomainType.
+Coercion porderType : type >-> Order.POrder.type.
+Canonical porderType.
+Coercion normedType : type >-> Norm.type.
+Canonical normedType.
 Coercion numDomainType : type >-> NumDomain.type.
 Canonical numDomainType.
+Coercion latticeType : type >-> Order.Lattice.type.
+Canonical latticeType.
+Coercion orderType : type >-> Order.Total.type.
+Canonical orderType.
 Coercion realDomainType : type >-> RealDomain.type.
 Canonical realDomainType.
 Coercion fieldType : type >-> GRing.Field.type.
 Canonical fieldType.
 Coercion numFieldType : type >-> NumField.type.
 Canonical numFieldType.
-Canonical join_realDomainType.
+Coercion normedModType : type >-> NormedModule.type.
+Canonical normedModType.
+Canonical field_latticeType.
+Canonical field_orderType.
+Canonical field_realDomainType.
+Canonical numField_latticeType.
+Canonical numField_orderType.
+Canonical numField_realDomainType.
 Notation realFieldType := type.
 Notation "[ 'realFieldType' 'of' T ]" := (@pack T _ _ id _ _ id)
   (at level 0, format "[ 'realFieldType'  'of'  T ]") : form_scope.
@@ -701,11 +950,17 @@ Definition comRingType := @GRing.ComRing.Pack cT xclass.
 Definition unitRingType := @GRing.UnitRing.Pack cT xclass.
 Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
+Definition porderType := @Order.POrder.Pack ring_display cT xclass.
+Definition normedType := @Norm.Pack cT cT xclass.
 Definition numDomainType := @NumDomain.Pack cT xclass.
+Definition latticeType := @Order.Lattice.Pack ring_display cT xclass.
+Definition orderType := @Order.Total.Pack ring_display cT xclass.
 Definition realDomainType := @RealDomain.Pack cT xclass.
 Definition fieldType := @GRing.Field.Pack cT xclass.
 Definition numFieldType := @NumField.Pack cT xclass.
 Definition realFieldType := @RealField.Pack cT xclass.
+Definition normedModType :=
+  NormedModType numDomainType cT (numDomain_normedModMixin numDomainType).
 
 End ClassDef.
 
@@ -729,8 +984,16 @@ Coercion comUnitRingType : type >-> GRing.ComUnitRing.type.
 Canonical comUnitRingType.
 Coercion idomainType : type >-> GRing.IntegralDomain.type.
 Canonical idomainType.
+Coercion porderType : type >-> Order.POrder.type.
+Canonical porderType.
+Coercion normedType : type >-> Norm.type.
+Canonical normedType.
 Coercion numDomainType : type >-> NumDomain.type.
 Canonical numDomainType.
+Coercion latticeType : type >-> Order.Lattice.type.
+Canonical latticeType.
+Coercion orderType : type >-> Order.Total.type.
+Canonical orderType.
 Coercion realDomainType : type >-> RealDomain.type.
 Canonical realDomainType.
 Coercion fieldType : type >-> GRing.Field.type.
@@ -739,6 +1002,8 @@ Coercion numFieldType : type >-> NumField.type.
 Canonical numFieldType.
 Coercion realFieldType : type >-> RealField.type.
 Canonical realFieldType.
+Coercion normedModType : type >-> NormedModule.type.
+Canonical normedModType.
 Notation archiFieldType := type.
 Notation ArchiFieldType T m := (@pack T _ m _ _ id _ id).
 Notation "[ 'archiFieldType' 'of' T 'for' cT ]" := (@clone T cT _ idfun)
@@ -778,11 +1043,17 @@ Definition comRingType := @GRing.ComRing.Pack cT xclass.
 Definition unitRingType := @GRing.UnitRing.Pack cT xclass.
 Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
+Definition porderType := @Order.POrder.Pack ring_display cT xclass.
+Definition normedType := @Norm.Pack cT cT xclass.
 Definition numDomainType := @NumDomain.Pack cT xclass.
+Definition latticeType := @Order.Lattice.Pack ring_display cT xclass.
+Definition orderType := @Order.Total.Pack ring_display cT xclass.
 Definition realDomainType := @RealDomain.Pack cT xclass.
 Definition fieldType := @GRing.Field.Pack cT xclass.
 Definition numFieldType := @NumField.Pack cT xclass.
 Definition realFieldType := @RealField.Pack cT xclass.
+Definition normedModType :=
+  NormedModType numDomainType cT (numDomain_normedModMixin numDomainType).
 
 End ClassDef.
 
@@ -806,16 +1077,26 @@ Coercion comUnitRingType : type >-> GRing.ComUnitRing.type.
 Canonical comUnitRingType.
 Coercion idomainType : type >-> GRing.IntegralDomain.type.
 Canonical idomainType.
+Coercion porderType : type >-> Order.POrder.type.
+Canonical porderType.
+Coercion normedType : type >-> Norm.type.
+Canonical normedType.
 Coercion numDomainType : type >-> NumDomain.type.
 Canonical numDomainType.
 Coercion realDomainType : type >-> RealDomain.type.
 Canonical realDomainType.
+Coercion latticeType : type >-> Order.Lattice.type.
+Canonical latticeType.
+Coercion orderType : type >-> Order.Total.type.
+Canonical orderType.
 Coercion fieldType : type >-> GRing.Field.type.
 Canonical fieldType.
 Coercion numFieldType : type >-> NumField.type.
 Canonical numFieldType.
 Coercion realFieldType : type >-> RealField.type.
 Canonical realFieldType.
+Coercion normedModType : type >-> NormedModule.type.
+Canonical normedModType.
 Notation rcfType := Num.RealClosedField.type.
 Notation RcfType T m := (@pack T _ m _ _ id _ id).
 Notation "[ 'rcfType' 'of' T 'for' cT ]" := (@clone T cT _ idfun)
@@ -831,32 +1112,38 @@ Import RealClosedField.Exports.
 (* operations for the extensions described above.                             *)
 Module Import Internals.
 
+Section NormedModule.
+Variable (R : numDomainType) (V : normedModType R).
+Implicit Types (l : R) (x y : V).
+
+Lemma ler_norm_add x y : `|x + y| <= `|x| + `|y|.
+Proof. by case: V x y => ? [? ? []]. Qed.
+
+Lemma norm_scale l x : `|l *: x| = `|l| * `|x|.
+Proof. by case: V l x => ? [? ? []]. Qed.
+
+Lemma normr0_eq0 x : `|x| = 0 -> x = 0.
+Proof. by case: V x => ? [? ? []]. Qed.
+
+End NormedModule.
+
 Section Domain.
 Variable R : numDomainType.
 Implicit Types x y : R.
 
 (* Lemmas from the signature *)
 
-Lemma normr0_eq0 x : `|x| = 0 -> x = 0.
-Proof. by case: R x => ? [? []]. Qed.
-
-Lemma ler_norm_add x y : `|x + y| <= `|x| + `|y|.
-Proof. by case: R x y => ? [? []]. Qed.
-
 Lemma addr_gt0 x y : 0 < x -> 0 < y -> 0 < x + y.
-Proof. by case: R x y => ? [? []]. Qed.
+Proof. by case: R x y => ? [? ? ? []]. Qed.
 
 Lemma ger_leVge x y : 0 <= x -> 0 <= y -> (x <= y) || (y <= x).
-Proof. by case: R x y => ? [? []]. Qed.
+Proof. by case: R x y => ? [? ? ? []]. Qed.
 
 Lemma normrM : {morph norm : x y / x * y : R}.
-Proof. by case: R => ? [? []]. Qed.
+Proof. by case: R => ? [? ? ? []]. Qed.
 
 Lemma ler_def x y : (x <= y) = (`|y - x| == y - x).
-Proof. by case: R x y => ? [? []]. Qed.
-
-Lemma ltr_def x y : (x < y) = (y != x) && (x <= y).
-Proof. by case: R x y => ? [? []]. Qed.
+Proof. by case: R x y => ? [? ? ? []]. Qed.
 
 (* Basic consequences (just enough to get predicate closure properties). *)
 
@@ -875,29 +1162,29 @@ have n1_nz: `|1| != 0 :> R by apply: contraNneq (@oner_neq0 R) => /normr0_eq0->.
 by rewrite ger0_def -(inj_eq (mulfI n1_nz)) -normrM !mulr1.
 Qed.
 
-Lemma ltr01 : 0 < 1 :> R. Proof. by rewrite ltr_def oner_neq0 ler01. Qed.
+Lemma ltr01 : 0 < 1 :> R.
+Proof. by rewrite lt_def oner_neq0 ler01. Qed.
 
-Lemma ltrW x y : x < y -> x <= y. Proof. by rewrite ltr_def => /andP[]. Qed.
+(* Duplication of ltW
+Lemma ltrW x y : x < y -> x <= y.
+*)
 
+(* Duplication of lexx
 Lemma lerr x : x <= x.
-Proof.
-have n2: `|2%:R| == 2%:R :> R by rewrite -ger0_def ltrW ?addr_gt0 ?ltr01.
-rewrite ler_def subrr -(inj_eq (addrI `|0|)) addr0 -mulr2n -mulr_natr.
-by rewrite -(eqP n2) -normrM mul0r.
-Qed.
+*)
 
 Lemma le0r x : (0 <= x) = (x == 0) || (0 < x).
-Proof. by rewrite ltr_def; case: eqP => // ->; rewrite lerr. Qed.
+Proof. by rewrite lt_def; case: eqP => // ->; rewrite lexx. Qed.
 
 Lemma addr_ge0 x y : 0 <= x -> 0 <= y -> 0 <= x + y.
 Proof.
 rewrite le0r; case/predU1P=> [-> | x_pos]; rewrite ?add0r // le0r.
-by case/predU1P=> [-> | y_pos]; rewrite ltrW ?addr0 ?addr_gt0.
+by case/predU1P=> [-> | y_pos]; rewrite ltW ?addr0 ?addr_gt0.
 Qed.
 
 Lemma pmulr_rgt0 x y : 0 < x -> (0 < x * y) = (0 < y).
 Proof.
-rewrite !ltr_def !ger0_def normrM mulf_eq0 negb_or => /andP[x_neq0 /eqP->].
+rewrite !lt_def !ger0_def normrM mulf_eq0 negb_or => /andP[x_neq0 /eqP->].
 by rewrite x_neq0 (inj_eq (mulfI x_neq0)).
 Qed.
 
@@ -926,7 +1213,7 @@ Canonical nneg_mulrPred := MulrPred nneg_divr_closed.
 Canonical nneg_divrPred := DivrPred nneg_divr_closed.
 
 Fact nneg_addr_closed : addr_closed (@nneg R).
-Proof. by split; [apply: lerr | apply: addr_ge0]. Qed.
+Proof. by split; [apply: lexx | apply: addr_ge0]. Qed.
 Canonical nneg_addrPred := AddrPred nneg_addr_closed.
 Canonical nneg_semiringPred := SemiringPred nneg_divr_closed.
 
@@ -936,7 +1223,7 @@ Canonical real_opprPred := OpprPred real_oppr_closed.
 
 Fact real_addr_closed : addr_closed (@real R).
 Proof.
-split=> [|x y Rx Ry]; first by rewrite realE lerr.
+split=> [|x y Rx Ry]; first by rewrite realE lexx.
 without loss{Rx} x_ge0: x y Ry / 0 <= x.
   case/orP: Rx => [? | x_le0]; first exact.
   by rewrite -rpredN opprD; apply; rewrite ?rpredN ?oppr_ge0.
@@ -967,7 +1254,7 @@ Canonical real_divringPred := DivringPred real_divr_closed.
 End Domain.
 
 Lemma num_real (R : realDomainType) (x : R) : x \is real.
-Proof. by case: R x => T []. Qed.
+Proof. by rewrite unfold_in; apply: le_total. Qed.
 
 Fact archi_bound_subproof (R : archiFieldType) : archimedean_axiom R.
 Proof. by case: R => ? []. Qed.
@@ -989,12 +1276,6 @@ by rewrite rootE !hornerE subr_eq0; exists y.
 Qed.
 
 End RealClosed.
-
-(* TODO Kazuhiko: Add a normedModType R, with R : numDomainType *)
-(* follow https://github.com/math-comp/analysis/blob/3f8dfbe0e8a963d32003ef7fdcef71823c8484c3/hierarchy.v#L1273-L1279 replacing absRingType by numDomainType,
-parametrize by Norm.class, and remove ax3 *)
-
-(* TODO Kazuhiko: Add that any R : numDomainType is canonically a normedModType R *)
 
 End Internals.
 
@@ -1044,24 +1325,30 @@ Module Theory.
 
 Section NumIntegralDomainTheory.
 
-Variable R : numDomainType.
-Implicit Types x y z t : R.
+Variable (R : numDomainType).
+Implicit Types (V : normedModType R) (x y z t : R).
 
 (* Lemmas from the signature (reexported from internals). *)
 
-Definition ler_norm_add x y : `|x + y| <= `|x| + `|y| := ler_norm_add x y.
+Definition ler_norm_add V (x y : V) : `|x + y| <= `|x| + `|y| :=
+  ler_norm_add x y.
 Definition addr_gt0 x y : 0 < x -> 0 < y -> 0 < x + y := @addr_gt0 R x y.
-Definition normr0_eq0 x : `|x| = 0 -> x = 0 := @normr0_eq0 R x.
+Definition normr0_eq0 V (x : V) : `|x| = 0 -> x = 0 := @normr0_eq0 R V x.
 Definition ger_leVge x y : 0 <= x -> 0 <= y -> (x <= y) || (y <= x) :=
   @ger_leVge R x y.
-Definition normrM : {morph normr : x y / x * y : R} := @normrM R.
+Definition normrM : {morph norm : x y / x * y : R} := @normrM R.
+Definition norm_scale V x (v : V) : `|x *: v| = `|x| * `|v| := norm_scale x v.
 Definition ler_def x y : (x <= y) = (`|y - x| == y - x) := @ler_def R x y.
+(*
 Definition ltr_def x y : (x < y) = (y != x) && (x <= y) := @ltr_def R x y.
+*)
 
-(* Predicate and relation definitions. *)
+(* Predicate definitions. *)
 
+(* Ported to order: geE, gtrE
 Lemma gerE x y : ge x y = (y <= x). Proof. by []. Qed.
 Lemma gtrE x y : gt x y = (y < x). Proof. by []. Qed.
+*)
 Lemma posrE x : (x \is pos) = (0 < x). Proof. by []. Qed.
 Lemma negrE x : (x \is neg) = (x < 0). Proof. by []. Qed.
 Lemma nnegrE x : (x \is nneg) = (0 <= x). Proof. by []. Qed.
@@ -1069,6 +1356,7 @@ Lemma realE x : (x \is real) = (0 <= x) || (x <= 0). Proof. by []. Qed.
 
 (* General properties of <= and < *)
 
+(* Duplication of lexx, ltxx, ltW, lt_neqAle, le_eqVlt
 Lemma lerr x : x <= x. Proof. exact: lerr. Qed.
 Lemma ltrr x : x < x = false. Proof. by rewrite ltr_def eqxx. Qed.
 Lemma ltrW x y : x < y -> x <= y. Proof. exact: ltrW. Qed.
@@ -1079,21 +1367,24 @@ Proof. by rewrite ltr_def eq_sym. Qed.
 
 Lemma ler_eqVlt x y : (x <= y) = (x == y) || (x < y).
 Proof. by rewrite ltr_neqAle; case: eqP => // ->; rewrite lerr. Qed.
+*)
 
-Lemma lt0r x : (0 < x) = (x != 0) && (0 <= x). Proof. by rewrite ltr_def. Qed.
+Lemma lt0r x : (0 < x) = (x != 0) && (0 <= x). Proof. by rewrite lt_def. Qed.
 Lemma le0r x : (0 <= x) = (x == 0) || (0 < x). Proof. exact: le0r. Qed.
 
-Lemma lt0r_neq0 (x : R) : 0 < x  -> x != 0.
+Lemma lt0r_neq0 (x : R) : 0 < x -> x != 0.
 Proof. by rewrite lt0r; case/andP. Qed.
 
-Lemma ltr0_neq0 (x : R) : x < 0  -> x != 0.
-Proof. by rewrite ltr_neqAle; case/andP. Qed.
+Lemma ltr0_neq0 (x : R) : x < 0 -> x != 0.
+Proof. by rewrite lt_neqAle; case/andP. Qed.
 
+(* Duplication of gt_eqF, lt_eqF
 Lemma gtr_eqF x y : y < x -> x == y = false.
 Proof. by rewrite ltr_def; case/andP; move/negPf=> ->. Qed.
 
 Lemma ltr_eqF x y : x < y -> x == y = false.
 Proof. by move=> hyx; rewrite eq_sym gtr_eqF. Qed.
+*)
 
 Lemma pmulr_rgt0 x y : 0 < x -> (0 < x * y) = (0 < y).
 Proof. exact: pmulr_rgt0. Qed.
@@ -1115,7 +1406,7 @@ Proof. by case: n => //= n; apply: ltr0Sn. Qed.
 Hint Resolve ltr0Sn : core.
 
 Lemma pnatr_eq0 n : (n%:R == 0 :> R) = (n == 0)%N.
-Proof. by case: n => [|n]; rewrite ?mulr0n ?eqxx // gtr_eqF. Qed.
+Proof. by case: n => [|n]; rewrite ?mulr0n ?eqxx // gt_eqF. Qed.
 
 Lemma char_num : [char R] =i pred0.
 Proof. by case=> // p /=; rewrite !inE pnatr_eq0 andbF. Qed.
@@ -1127,11 +1418,8 @@ Lemma normr_idP {x} : reflect (`|x| = x) (0 <= x).
 Proof. by rewrite ger0_def; apply: eqP. Qed.
 Lemma ger0_norm x : 0 <= x -> `|x| = x. Proof. exact: normr_idP. Qed.
 
-Lemma normr0 : `|0| = 0 :> R. Proof. exact: ger0_norm. Qed.
 Lemma normr1 : `|1| = 1 :> R. Proof. exact: ger0_norm. Qed.
 Lemma normr_nat n : `|n%:R| = n%:R :> R. Proof. exact: ger0_norm. Qed.
-Lemma normrMn x n : `|x *+ n| = `|x| *+ n.
-Proof. by rewrite -mulr_natl normrM normr_nat mulr_natl. Qed.
 
 Lemma normr_prod I r (P : pred I) (F : I -> R) :
   `|\prod_(i <- r | P i) F i| = \prod_(i <- r | P i) `|F i|.
@@ -1140,60 +1428,85 @@ Proof. exact: (big_morph norm normrM normr1). Qed.
 Lemma normrX n x : `|x ^+ n| = `|x| ^+ n.
 Proof. by rewrite -(card_ord n) -!prodr_const normr_prod. Qed.
 
-Lemma normr_unit : {homo (@norm R) : x / x \is a GRing.unit}.
+Lemma normr_unit : {homo (@norm R R) : x / x \is a GRing.unit}.
 Proof.
 move=> x /= /unitrP [y [yx xy]]; apply/unitrP; exists `|y|.
 by rewrite -!normrM xy yx normr1.
 Qed.
 
-Lemma normrV : {in GRing.unit, {morph (@normr R) : x / x ^-1}}.
+Lemma normrV : {in GRing.unit, {morph (@norm R R) : x / x ^-1}}.
 Proof.
 move=> x ux; apply: (mulrI (normr_unit ux)).
 by rewrite -normrM !divrr ?normr1 ?normr_unit.
 Qed.
 
-Lemma normr0P {x} : reflect (`|x| = 0) (x == 0).
-Proof. by apply: (iffP eqP)=> [->|/normr0_eq0 //]; apply: normr0. Qed.
-
-Definition normr_eq0 x := sameP (`|x| =P 0) normr0P.
-
 Lemma normrN1 : `|-1| = 1 :> R.
 Proof.
 have: `|-1| ^+ 2 == 1 :> R by rewrite -normrX -signr_odd normr1.
 rewrite sqrf_eq1 => /orP[/eqP //|]; rewrite -ger0_def le0r oppr_eq0 oner_eq0.
-by move/(addr_gt0 ltr01); rewrite subrr ltrr.
+by move/(addr_gt0 ltr01); rewrite subrr ltxx.
 Qed.
 
-Lemma normrN x : `|- x| = `|x|.
-Proof. by rewrite -mulN1r normrM normrN1 mul1r. Qed.
+Section NormedModuleTheory.
 
-Lemma distrC x y : `|x - y| = `|y - x|.
+Variable (V : normedModType R).
+Implicit Types (v w : V).
+
+Lemma normr0 : `|0 : V| = 0 :> R.
+Proof. by rewrite -(scale0r 0) norm_scale ger0_norm // mul0r. Qed.
+
+Lemma normr0P v : reflect (`|v| = 0) (v == 0).
+Proof. by apply: (iffP eqP)=> [->|/normr0_eq0 //]; apply: normr0. Qed.
+
+Definition normr_eq0 v := sameP (`|v| =P 0) (normr0P v).
+
+Lemma normrMn v n : `|v *+ n| = `|v| *+ n.
+Proof. by rewrite -scaler_nat norm_scale normr_nat mulr_natl. Qed.
+
+Lemma normrN v : `|- v| = `|v|.
+Proof. by rewrite -scaleN1r norm_scale normrN1 mul1r. Qed.
+
+Lemma distrC v w : `|v - w| = `|w - v|.
 Proof. by rewrite -opprB normrN. Qed.
+
+Lemma normr_id v : `| `|v| | = `|v|.
+Proof.
+have nz2: 2%:R != 0 :> R by rewrite pnatr_eq0.
+apply: (mulfI nz2); rewrite -{1}normr_nat -normrM mulr_natl mulr2n ger0_norm //.
+by rewrite -{2}normrN -normr0 -(subrr v) ler_norm_add.
+Qed.
+
+Lemma normr_ge0 v : 0 <= `|v|. Proof. by rewrite ger0_def normr_id. Qed.
+Hint Resolve normr_ge0 : core.
+
+Lemma normr_le0 v : (`|v| <= 0) = (v == 0).
+Proof. by rewrite -normr_eq0 eq_le normr_ge0 andbT. Qed.
+
+Lemma normr_lt0 v : `|v| < 0 = false.
+Proof. by rewrite lt_neqAle normr_le0 normr_eq0 andNb. Qed.
+
+Lemma normr_gt0 v : (`|v| > 0) = (v != 0).
+Proof. by rewrite lt_def normr_eq0 normr_ge0 andbT. Qed.
+
+Definition normrE := (normr_id, normr0, normr1, normrN1, normr_ge0, normr_eq0,
+  normr_lt0, normr_le0, normr_gt0, normrN).
+
+End NormedModuleTheory.
 
 Lemma ler0_def x : (x <= 0) = (`|x| == - x).
 Proof. by rewrite ler_def sub0r normrN. Qed.
 
-Lemma normr_id x : `|`|x| | = `|x|.
-Proof.
-have nz2: 2%:R != 0 :> R by rewrite pnatr_eq0.
-apply: (mulfI nz2); rewrite -{1}normr_nat -normrM mulr_natl mulr2n ger0_norm //.
-by rewrite -{2}normrN -normr0 -(subrr x) ler_norm_add.
-Qed.
-
-Lemma normr_ge0 x : 0 <= `|x|. Proof. by rewrite ger0_def normr_id. Qed.
-Hint Resolve normr_ge0 : core.
-
 Lemma ler0_norm x : x <= 0 -> `|x| = - x.
 Proof. by move=> x_le0; rewrite -[r in _ = r]ger0_norm ?normrN ?oppr_ge0. Qed.
 
-Definition gtr0_norm x (hx : 0 < x) := ger0_norm (ltrW hx).
-Definition ltr0_norm x (hx : x < 0) := ler0_norm (ltrW hx).
+Definition gtr0_norm x (hx : 0 < x) := ger0_norm (ltW hx).
+Definition ltr0_norm x (hx : x < 0) := ler0_norm (ltW hx).
 
 (* Comparision to 0 of a difference *)
 
 Lemma subr_ge0 x y : (0 <= y - x) = (x <= y). Proof. exact: subr_ge0. Qed.
 Lemma subr_gt0 x y : (0 < y - x) = (x < y).
-Proof. by rewrite !ltr_def subr_eq0 subr_ge0. Qed.
+Proof. by rewrite !lt_def subr_eq0 subr_ge0. Qed.
 Lemma subr_le0  x y : (y - x <= 0) = (y <= x).
 Proof. by rewrite -subr_ge0 opprB add0r subr_ge0. Qed.
 Lemma subr_lt0  x y : (y - x < 0) = (y < x).
@@ -1205,7 +1518,8 @@ Definition subr_cp0 := (subr_lte0, subr_gte0).
 
 (* Ordered ring properties. *)
 
-Lemma ler_asym : antisymmetric (<=%R : rel R).
+(* Duplication of le_anti, eq_le, lt_trans, le_lt_trans, lt_le_trans, le_trans
+Lemma ler_asym : antisymmetric (<=%O : rel R).
 Proof.
 move=> x y; rewrite !ler_def distrC -opprB -addr_eq0 => /andP[/eqP->].
 by rewrite -mulr2n -mulr_natl mulf_eq0 subr_eq0 pnatr_eq0 => /eqP.
@@ -1231,23 +1545,31 @@ Proof.
 move=> y x z; rewrite !ler_eqVlt => /orP [/eqP -> //|lxy].
 by move=> /orP [/eqP <-|/(ltr_trans lxy) ->]; rewrite ?lxy orbT.
 Qed.
+*)
 
 Definition lter01 := (ler01, ltr01).
+(* Ported to order: ltexx
 Definition lterr := (lerr, ltrr).
+*)
 
 Lemma addr_ge0 x y : 0 <= x -> 0 <= y -> 0 <= x + y.
 Proof. exact: addr_ge0. Qed.
 
+(* Duplication of leifP
 Lemma lerifP x y C : reflect (x <= y ?= iff C) (if C then x == y else x < y).
 Proof.
 rewrite /lerif ler_eqVlt; apply: (iffP idP)=> [|[]].
   by case: C => [/eqP->|lxy]; rewrite ?eqxx // lxy ltr_eqF.
 by move=> /orP[/eqP->|lxy] <-; rewrite ?eqxx // ltr_eqF.
 Qed.
+*)
 
+(* Ported to order: lt_asym
 Lemma ltr_asym x y : x < y < x = false.
 Proof. by apply/negP=> /andP [/ltr_trans hyx /hyx]; rewrite ltrr. Qed.
+*)
 
+(* Duplication of le_anti, lt_le_asym, lte_anti, lt_geF, le_gtF, lt_gtF
 Lemma ler_anti : antisymmetric (@ler R).
 Proof. by move=> x y; rewrite -eqr_le=> /eqP. Qed.
 
@@ -1268,298 +1590,15 @@ Lemma ler_gtF x y : x <= y -> (y < x = false).
 Proof. by apply: contraTF=> /ltr_geF->. Qed.
 
 Definition ltr_gtF x y hxy := ler_gtF (@ltrW x y hxy).
-
-(* Norm and order properties. *)
-
-Lemma normr_le0 x : (`|x| <= 0) = (x == 0).
-Proof. by rewrite -normr_eq0 eqr_le normr_ge0 andbT. Qed.
-
-Lemma normr_lt0 x : `|x| < 0 = false.
-Proof. by rewrite ltr_neqAle normr_le0 normr_eq0 andNb. Qed.
-
-Lemma normr_gt0 x : (`|x| > 0) = (x != 0).
-Proof. by rewrite ltr_def normr_eq0 normr_ge0 andbT. Qed.
-
-Definition normrE x := (normr_id, normr0, normr1, normrN1, normr_ge0, normr_eq0,
-  normr_lt0, normr_le0, normr_gt0, normrN).
+*)
 
 End NumIntegralDomainTheory.
 
 Arguments ler01 {R}.
 Arguments ltr01 {R}.
 Arguments normr_idP {R x}.
-Arguments normr0P {R x}.
-Arguments lerifP {R x y C}.
-Hint Resolve @ler01 @ltr01 lerr ltrr ltrW ltr_eqF ltr0Sn ler0n normr_ge0 : core.
-
-Section NumIntegralDomainMonotonyTheory.
-
-Variables R R' : numDomainType.
-Implicit Types m n p : nat.
-Implicit Types x y z : R.
-Implicit Types u v w : R'.
-
-(****************************************************************************)
-(* This listing of "Let"s factor out the required premices for the          *)
-(* subsequent lemmas, putting them in the context so that "done" solves the *)
-(* goals quickly                                                            *)
-(****************************************************************************)
-
-Let leqnn := leqnn.
-Let ltnE := ltn_neqAle.
-Let ltrE := @ltr_neqAle R.
-Let ltr'E := @ltr_neqAle R'.
-Let gtnE (m n : nat) : (m > n)%N = (m != n) && (m >= n)%N.
-Proof. by rewrite ltn_neqAle eq_sym. Qed.
-Let gtrE (x y : R) : (x > y) = (x != y) && (x >= y).
-Proof. by rewrite ltr_neqAle eq_sym. Qed.
-Let gtr'E (x y : R') : (x > y) = (x != y) && (x >= y).
-Proof. by rewrite ltr_neqAle eq_sym. Qed.
-Let leq_anti : antisymmetric leq.
-Proof. by move=> m n; rewrite -eqn_leq => /eqP. Qed.
-Let geq_anti : antisymmetric geq.
-Proof. by move=> m n; rewrite -eqn_leq => /eqP. Qed.
-Let ler_antiR := @ler_anti R.
-Let ler_antiR' := @ler_anti R'.
-Let ger_antiR : antisymmetric (>=%R : rel R).
-Proof. by move=> ??; rewrite andbC; apply: ler_anti. Qed.
-Let ger_antiR' : antisymmetric (>=%R : rel R').
-Proof. by move=> ??; rewrite andbC; apply: ler_anti. Qed.
-Let leq_total := leq_total.
-Let geq_total : total geq.
-Proof. by move=> m n; apply: leq_total. Qed.
-
-Section AcrossTypes.
-
-Variable D D' : pred R.
-Variable (f : R -> R').
-
-Lemma ltrW_homo : {homo f : x y / x < y} -> {homo f : x y / x <= y}.
-Proof. exact: homoW. Qed.
-
-Lemma ltrW_nhomo : {homo f : x y /~ x < y} -> {homo f : x y /~ x <= y}.
-Proof. exact: homoW. Qed.
-
-Lemma inj_homo_ltr :
-  injective f -> {homo f : x y / x <= y} -> {homo f : x y / x < y}.
-Proof. exact: inj_homo. Qed.
-
-Lemma inj_nhomo_ltr :
-  injective f -> {homo f : x y /~ x <= y} -> {homo f : x y /~ x < y}.
-Proof. exact: inj_homo. Qed.
-
-Lemma incr_inj : {mono f : x y / x <= y} -> injective f.
-Proof. exact: mono_inj. Qed.
-
-Lemma decr_inj : {mono f : x y /~ x <= y} -> injective f.
-Proof. exact: mono_inj. Qed.
-
-Lemma lerW_mono : {mono f : x y / x <= y} -> {mono f : x y / x < y}.
-Proof. exact: anti_mono. Qed.
-
-Lemma lerW_nmono : {mono f : x y /~ x <= y} -> {mono f : x y /~ x < y}.
-Proof. exact: anti_mono. Qed.
-
-(* Monotony in D D' *)
-Lemma ltrW_homo_in :
-  {in D & D', {homo f : x y / x < y}} -> {in D & D', {homo f : x y / x <= y}}.
-Proof. exact: homoW_in. Qed.
-
-Lemma ltrW_nhomo_in :
-  {in D & D', {homo f : x y /~ x < y}} -> {in D & D', {homo f : x y /~ x <= y}}.
-Proof. exact: homoW_in. Qed.
-
-Lemma inj_homo_ltr_in :
-    {in D & D', injective f} ->  {in D & D', {homo f : x y / x <= y}} ->
-  {in D & D', {homo f : x y / x < y}}.
-Proof. exact: inj_homo_in. Qed.
-
-Lemma inj_nhomo_ltr_in :
-    {in D & D', injective f} -> {in D & D', {homo f : x y /~ x <= y}} ->
-  {in D & D', {homo f : x y /~ x < y}}.
-Proof. exact: inj_homo_in. Qed.
-
-Lemma incr_inj_in : {in D &, {mono f : x y / x <= y}} ->
-   {in D &, injective f}.
-Proof. exact: mono_inj_in. Qed.
-
-Lemma decr_inj_in :
-  {in D &, {mono f : x y /~ x <= y}} -> {in D &, injective f}.
-Proof. exact: mono_inj_in. Qed.
-
-Lemma lerW_mono_in :
-  {in D &, {mono f : x y / x <= y}} -> {in D &, {mono f : x y / x < y}}.
-Proof. exact: anti_mono_in. Qed.
-
-Lemma lerW_nmono_in :
-  {in D &, {mono f : x y /~ x <= y}} -> {in D &, {mono f : x y /~ x < y}}.
-Proof. exact: anti_mono_in. Qed.
-
-End AcrossTypes.
-
-Section NatToR.
-
-Variable D D' : pred nat.
-Variable (f : nat -> R).
-
-Lemma ltnrW_homo : {homo f : m n / (m < n)%N >-> m < n} ->
-  {homo f : m n / (m <= n)%N >-> m <= n}.
-Proof. exact: homoW. Qed.
-
-Lemma ltnrW_nhomo : {homo f : m n / (n < m)%N >-> m < n} ->
-  {homo f : m n / (n <= m)%N >-> m <= n}.
-Proof. exact: homoW. Qed.
-
-Lemma inj_homo_ltnr : injective f ->
-  {homo f : m n / (m <= n)%N >-> m <= n} ->
-  {homo f : m n / (m < n)%N >-> m < n}.
-Proof. exact: inj_homo. Qed.
-
-Lemma inj_nhomo_ltnr : injective f ->
-  {homo f : m n / (n <= m)%N >-> m <= n} ->
-  {homo f : m n / (n < m)%N >-> m < n}.
-Proof. exact: inj_homo. Qed.
-
-Lemma incnr_inj : {mono f : m n / (m <= n)%N >-> m <= n} -> injective f.
-Proof. exact: mono_inj. Qed.
-
-Lemma decnr_inj_inj : {mono f : m n / (n <= m)%N >-> m <= n} -> injective f.
-Proof. exact: mono_inj. Qed.
-
-Lemma lenrW_mono : {mono f : m n / (m <= n)%N >-> m <= n} ->
-  {mono f : m n / (m < n)%N >-> m < n}.
-Proof. exact: anti_mono. Qed.
-
-Lemma lenrW_nmono : {mono f : m n / (n <= m)%N >-> m <= n} ->
-  {mono f : m n / (n < m)%N >-> m < n}.
-Proof. exact: anti_mono. Qed.
-
-Lemma lenr_mono : {homo f : m n / (m < n)%N >-> m < n} ->
-   {mono f : m n / (m <= n)%N >-> m <= n}.
-Proof. exact: total_homo_mono. Qed.
-
-Lemma lenr_nmono : {homo f : m n / (n < m)%N >-> m < n} ->
-  {mono f : m n / (n <= m)%N >-> m <= n}.
-Proof. exact: total_homo_mono. Qed.
-
-Lemma ltnrW_homo_in : {in D & D', {homo f : m n / (m < n)%N >-> m < n}} ->
-  {in D & D', {homo f : m n / (m <= n)%N >-> m <= n}}.
-Proof. exact: homoW_in. Qed.
-
-Lemma ltnrW_nhomo_in : {in D & D', {homo f : m n / (n < m)%N >-> m < n}} ->
-  {in D & D', {homo f : m n / (n <= m)%N >-> m <= n}}.
-Proof. exact: homoW_in. Qed.
-
-Lemma inj_homo_ltnr_in : {in D & D', injective f} ->
-  {in D & D', {homo f : m n / (m <= n)%N >-> m <= n}} ->
-  {in D & D', {homo f : m n / (m < n)%N >-> m < n}}.
-Proof. exact: inj_homo_in. Qed.
-
-Lemma inj_nhomo_ltnr_in : {in D & D', injective f} ->
-  {in D & D', {homo f : m n / (n <= m)%N >-> m <= n}} ->
-  {in D & D', {homo f : m n / (n < m)%N >-> m < n}}.
-Proof. exact: inj_homo_in. Qed.
-
-Lemma incnr_inj_in : {in D &, {mono f : m n / (m <= n)%N >-> m <= n}} ->
-  {in D &, injective f}.
-Proof. exact: mono_inj_in. Qed.
-
-Lemma decnr_inj_inj_in : {in D &, {mono f : m n / (n <= m)%N >-> m <= n}} ->
-  {in D &, injective f}.
-Proof. exact: mono_inj_in. Qed.
-
-Lemma lenrW_mono_in : {in D &, {mono f : m n / (m <= n)%N >-> m <= n}} ->
-  {in D &, {mono f : m n / (m < n)%N >-> m < n}}.
-Proof. exact: anti_mono_in. Qed.
-
-Lemma lenrW_nmono_in : {in D &, {mono f : m n / (n <= m)%N >-> m <= n}} ->
-  {in D &, {mono f : m n / (n < m)%N >-> m < n}}.
-Proof. exact: anti_mono_in. Qed.
-
-Lemma lenr_mono_in : {in D &, {homo f : m n / (m < n)%N >-> m < n}} ->
-   {in D &, {mono f : m n / (m <= n)%N >-> m <= n}}.
-Proof. exact: total_homo_mono_in. Qed.
-
-Lemma lenr_nmono_in : {in D &, {homo f : m n / (n < m)%N >-> m < n}} ->
-  {in D &, {mono f : m n / (n <= m)%N >-> m <= n}}.
-Proof. exact: total_homo_mono_in. Qed.
-
-End NatToR.
-
-Section RToNat.
-
-Variable D D' : pred R.
-Variable (f : R -> nat).
-
-Lemma ltrnW_homo : {homo f : m n / m < n >-> (m < n)%N} ->
-  {homo f : m n / m <= n >-> (m <= n)%N}.
-Proof. exact: homoW. Qed.
-
-Lemma ltrnW_nhomo : {homo f : m n / n < m >-> (m < n)%N} ->
-  {homo f : m n / n <= m >-> (m <= n)%N}.
-Proof. exact: homoW. Qed.
-
-Lemma inj_homo_ltrn : injective f ->
-  {homo f : m n / m <= n >-> (m <= n)%N} ->
-  {homo f : m n / m < n >-> (m < n)%N}.
-Proof. exact: inj_homo. Qed.
-
-Lemma inj_nhomo_ltrn : injective f ->
-  {homo f : m n / n <= m >-> (m <= n)%N} ->
-  {homo f : m n / n < m >-> (m < n)%N}.
-Proof. exact: inj_homo. Qed.
-
-Lemma incrn_inj : {mono f : m n / m <= n >-> (m <= n)%N} -> injective f.
-Proof. exact: mono_inj. Qed.
-
-Lemma decrn_inj : {mono f : m n / n <= m >-> (m <= n)%N} -> injective f.
-Proof. exact: mono_inj. Qed.
-
-Lemma lernW_mono : {mono f : m n / m <= n >-> (m <= n)%N} ->
-  {mono f : m n / m < n >-> (m < n)%N}.
-Proof. exact: anti_mono. Qed.
-
-Lemma lernW_nmono : {mono f : m n / n <= m >-> (m <= n)%N} ->
-  {mono f : m n / n < m >-> (m < n)%N}.
-Proof. exact: anti_mono. Qed.
-
-Lemma ltrnW_homo_in : {in D & D', {homo f : m n / m < n >-> (m < n)%N}} ->
-  {in D & D', {homo f : m n / m <= n >-> (m <= n)%N}}.
-Proof. exact: homoW_in. Qed.
-
-Lemma ltrnW_nhomo_in : {in D & D', {homo f : m n / n < m >-> (m < n)%N}} ->
-  {in D & D', {homo f : m n / n <= m >-> (m <= n)%N}}.
-Proof. exact: homoW_in. Qed.
-
-Lemma inj_homo_ltrn_in : {in D & D', injective f} ->
-  {in D & D', {homo f : m n / m <= n >-> (m <= n)%N}} ->
-  {in D & D', {homo f : m n / m < n >-> (m < n)%N}}.
-Proof. exact: inj_homo_in. Qed.
-
-Lemma inj_nhomo_ltrn_in : {in D & D', injective f} ->
-  {in D & D', {homo f : m n / n <= m >-> (m <= n)%N}} ->
-  {in D & D', {homo f : m n / n < m >-> (m < n)%N}}.
-Proof. exact: inj_homo_in. Qed.
-
-Lemma incrn_inj_in : {in D &, {mono f : m n / m <= n >-> (m <= n)%N}} ->
-  {in D &, injective f}.
-Proof. exact: mono_inj_in. Qed.
-
-Lemma decrn_inj_in : {in D &, {mono f : m n / n <= m >-> (m <= n)%N}} ->
-  {in D &, injective f}.
-Proof. exact: mono_inj_in. Qed.
-
-Lemma lernW_mono_in : {in D &, {mono f : m n / m <= n >-> (m <= n)%N}} ->
-  {in D &, {mono f : m n / m < n >-> (m < n)%N}}.
-Proof. exact: anti_mono_in. Qed.
-
-Lemma lernW_nmono_in : {in D &, {mono f : m n / n <= m >-> (m <= n)%N}} ->
-  {in D &, {mono f : m n / n < m >-> (m < n)%N}}.
-Proof. exact: anti_mono_in. Qed.
-
-End RToNat.
-
-End NumIntegralDomainMonotonyTheory.
+Arguments normr0P {R V v}.
+Hint Resolve @ler01 @ltr01 ltr0Sn ler0n normr_ge0 : core.
 
 Section NumDomainOperationTheory.
 
@@ -1572,7 +1611,7 @@ Lemma ler_opp2 : {mono -%R : x y /~ x <= y :> R}.
 Proof. by move=> x y /=; rewrite -subr_ge0 opprK addrC subr_ge0. Qed.
 Hint Resolve ler_opp2 : core.
 Lemma ltr_opp2 : {mono -%R : x y /~ x < y :> R}.
-Proof. by move=> x y /=; rewrite lerW_nmono. Qed.
+Proof. by move=> x y /=; rewrite leW_nmono. Qed.
 Hint Resolve ltr_opp2 : core.
 Definition lter_opp2 := (ler_opp2, ltr_opp2).
 
@@ -1580,7 +1619,7 @@ Lemma ler_oppr x y : (x <= - y) = (y <= - x).
 Proof. by rewrite (monoRL opprK ler_opp2). Qed.
 
 Lemma ltr_oppr x y : (x < - y) = (y < - x).
-Proof. by rewrite (monoRL opprK (lerW_nmono _)). Qed.
+Proof. by rewrite (monoRL opprK (leW_nmono _)). Qed.
 
 Definition lter_oppr := (ler_oppr, ltr_oppr).
 
@@ -1588,7 +1627,7 @@ Lemma ler_oppl x y : (- x <= y) = (- y <= x).
 Proof. by rewrite (monoLR opprK ler_opp2). Qed.
 
 Lemma ltr_oppl x y : (- x < y) = (- y < x).
-Proof. by rewrite (monoLR opprK (lerW_nmono _)). Qed.
+Proof. by rewrite (monoLR opprK (leW_nmono _)). Qed.
 
 Definition lter_oppl := (ler_oppl, ltr_oppl).
 
@@ -1611,23 +1650,23 @@ Definition oppr_cp0 := (oppr_gte0, oppr_lte0).
 Definition lter_oppE := (oppr_cp0, lter_opp2).
 
 Lemma ge0_cp x : 0 <= x -> (- x <= 0) * (- x <= x).
-Proof. by move=> hx; rewrite oppr_cp0 hx (@ler_trans _ 0) ?oppr_cp0. Qed.
+Proof. by move=> hx; rewrite oppr_cp0 hx (@le_trans _ _ 0) ?oppr_cp0. Qed.
 
 Lemma gt0_cp x : 0 < x ->
   (0 <= x) * (- x <= 0) * (- x <= x) * (- x < 0) * (- x < x).
 Proof.
-move=> hx; move: (ltrW hx) => hx'; rewrite !ge0_cp hx' //.
-by rewrite oppr_cp0 hx // (@ltr_trans _ 0) ?oppr_cp0.
+move=> hx; move: (ltW hx) => hx'; rewrite !ge0_cp hx' //.
+by rewrite oppr_cp0 hx // (@lt_trans _ _ 0) ?oppr_cp0.
 Qed.
 
 Lemma le0_cp x : x <= 0 -> (0 <= - x) * (x <= - x).
-Proof. by move=> hx; rewrite oppr_cp0 hx (@ler_trans _ 0) ?oppr_cp0. Qed.
+Proof. by move=> hx; rewrite oppr_cp0 hx (@le_trans _ _ 0) ?oppr_cp0. Qed.
 
 Lemma lt0_cp x :
   x < 0 -> (x <= 0) * (0 <= - x) * (x <= - x) * (0 < - x) * (x < - x).
 Proof.
-move=> hx; move: (ltrW hx) => hx'; rewrite !le0_cp // hx'.
-by rewrite oppr_cp0 hx // (@ltr_trans _ 0) ?oppr_cp0.
+move=> hx; move: (ltW hx) => hx'; rewrite !le0_cp // hx'.
+by rewrite oppr_cp0 hx // (@lt_trans _ _ 0) ?oppr_cp0.
 Qed.
 
 (* Properties of the real subset. *)
@@ -1639,10 +1678,10 @@ Lemma ler0_real x : x <= 0 -> x \is real.
 Proof. by rewrite realE orbC => ->. Qed.
 
 Lemma gtr0_real x : 0 < x -> x \is real.
-Proof. by move=> /ltrW/ger0_real. Qed.
+Proof. by move=> /ltW/ger0_real. Qed.
 
 Lemma ltr0_real x : x < 0 -> x \is real.
-Proof. by move=> /ltrW/ler0_real. Qed.
+Proof. by move=> /ltW/ler0_real. Qed.
 
 Lemma real0 : 0 \is @real R. Proof. by rewrite ger0_real. Qed.
 Hint Resolve real0 : core.
@@ -1658,8 +1697,8 @@ Proof. by rewrite -!oppr_ge0 => /(ger_leVge _) h /h; rewrite !ler_opp2. Qed.
 Lemma real_leVge x y : x \is real -> y \is real -> (x <= y) || (y <= x).
 Proof.
 rewrite !realE; have [x_ge0 _|x_nge0 /= x_le0] := boolP (_ <= _); last first.
-  by have [/(ler_trans x_le0)->|_ /(ler_leVge x_le0) //] := boolP (0 <= _).
-by have [/(ger_leVge x_ge0)|_ /ler_trans->] := boolP (0 <= _); rewrite ?orbT.
+  by have [/(le_trans x_le0)->|_ /(ler_leVge x_le0) //] := boolP (0 <= _).
+by have [/(ger_leVge x_ge0)|_ /le_trans->] := boolP (0 <= _); rewrite ?orbT.
 Qed.
 
 Lemma realB : {in real &, forall x y, x - y \is real}.
@@ -1694,39 +1733,39 @@ Variant comparer x y : R -> R ->
   | ComparerEq of x = y : comparer x y 0 0
     true true true true false false.
 
-Lemma real_lerP x y :
+Lemma real_leP x y :
     x \is real -> y \is real ->
   ler_xor_gt x y `|x - y| `|y - x| (x <= y) (y < x).
 Proof.
 move=> xR /(real_leVge xR); have [le_xy _|Nle_xy /= le_yx] := boolP (_ <= _).
-  have [/(ler_lt_trans le_xy)|] := boolP (_ < _); first by rewrite ltrr.
+  have [/(le_lt_trans le_xy)|] := boolP (_ < _); first by rewrite ltxx.
   by rewrite ler0_norm ?ger0_norm ?subr_cp0 ?opprB //; constructor.
 have [lt_yx|] := boolP (_ < _).
   by rewrite ger0_norm ?ler0_norm ?subr_cp0 ?opprB //; constructor.
-by rewrite ltr_def le_yx andbT negbK=> /eqP exy; rewrite exy lerr in Nle_xy.
+by rewrite lt_def le_yx andbT negbK=> /eqP exy; rewrite exy lexx in Nle_xy.
 Qed.
 
-Lemma real_ltrP x y :
+Lemma real_ltP x y :
     x \is real -> y \is real ->
   ltr_xor_ge x y `|x - y| `|y - x| (y <= x) (x < y).
-Proof. by move=> xR yR; case: real_lerP=> //; constructor. Qed.
+Proof. by move=> xR yR; case: real_leP=> //; constructor. Qed.
 
-Lemma real_ltrNge : {in real &, forall x y, (x < y) = ~~ (y <= x)}.
-Proof. by move=> x y xR yR /=; case: real_lerP. Qed.
+Lemma real_ltNge : {in real &, forall x y, (x < y) = ~~ (y <= x)}.
+Proof. by move=> x y xR yR /=; case: real_leP. Qed.
 
-Lemma real_lerNgt : {in real &, forall x y, (x <= y) = ~~ (y < x)}.
-Proof. by move=> x y xR yR /=; case: real_lerP. Qed.
+Lemma real_leNgt : {in real &, forall x y, (x <= y) = ~~ (y < x)}.
+Proof. by move=> x y xR yR /=; case: real_leP. Qed.
 
-Lemma real_ltrgtP x y :
+Lemma real_ltgtP x y :
     x \is real -> y \is real ->
   comparer x y `|x - y| `|y - x|
                 (y == x) (x == y) (x <= y) (y <= x) (x < y) (x > y).
 Proof.
-move=> xR yR; case: real_lerP => // [le_yx|lt_xy]; last first.
-  by rewrite gtr_eqF // ltr_eqF // ler_gtF ?ltrW //; constructor.
-case: real_lerP => // [le_xy|lt_yx]; last first.
-  by rewrite ltr_eqF // gtr_eqF //; constructor.
-have /eqP ->: x == y by rewrite eqr_le le_yx le_xy.
+move=> xR yR; case: real_leP => // [le_yx|lt_xy]; last first.
+  by rewrite gt_eqF // lt_eqF // le_gtF ?ltW //; constructor.
+case: real_leP => // [le_xy|lt_yx]; last first.
+  by rewrite lt_eqF // gt_eqF //; constructor.
+have /eqP ->: x == y by rewrite eq_le le_yx le_xy.
 by rewrite subrr eqxx; constructor.
 Qed.
 
@@ -1744,28 +1783,28 @@ Variant comparer0 x :
   | ComparerLt0 of x < 0 : comparer0 x (- x) false false true false true false
   | ComparerEq0 of x = 0 : comparer0 x 0 true true true true false false.
 
-Lemma real_ger0P x : x \is real -> ger0_xor_lt0 x `|x| (x < 0) (0 <= x).
+Lemma real_ge0P x : x \is real -> ger0_xor_lt0 x `|x| (x < 0) (0 <= x).
 Proof.
-move=> hx; rewrite -{2}[x]subr0; case: real_ltrP;
+move=> hx; rewrite -{2}[x]subr0; case: real_ltP;
 by rewrite ?subr0 ?sub0r //; constructor.
 Qed.
 
-Lemma real_ler0P x : x \is real -> ler0_xor_gt0 x `|x| (0 < x) (x <= 0).
+Lemma real_le0P x : x \is real -> ler0_xor_gt0 x `|x| (0 < x) (x <= 0).
 Proof.
-move=> hx; rewrite -{2}[x]subr0; case: real_ltrP;
+move=> hx; rewrite -{2}[x]subr0; case: real_ltP;
 by rewrite ?subr0 ?sub0r //; constructor.
 Qed.
 
-Lemma real_ltrgt0P x :
+Lemma real_ltgt0P x :
      x \is real ->
   comparer0 x `|x| (0 == x) (x == 0) (x <= 0) (0 <= x) (x < 0) (x > 0).
 Proof.
-move=> hx; rewrite -{2}[x]subr0; case: real_ltrgtP;
+move=> hx; rewrite -{2}[x]subr0; case: real_ltgtP;
 by rewrite ?subr0 ?sub0r //; constructor.
 Qed.
 
 Lemma real_neqr_lt : {in real &, forall x y, (x != y) = (x < y) || (y < x)}.
-Proof. by move=> * /=; case: real_ltrgtP. Qed.
+Proof. by move=> * /=; case: real_ltgtP. Qed.
 
 Lemma ler_sub_real x y : x <= y -> y - x \is real.
 Proof. by move=> le_xy; rewrite ger0_real // subr_ge0. Qed.
@@ -1789,10 +1828,10 @@ Lemma Nreal_geF x y : y \is real -> x \notin real -> (y <= x) = false.
 Proof. by move=> yR; apply: contraNF=> /ger_real->. Qed.
 
 Lemma Nreal_ltF x y : y \is real -> x \notin real -> (x < y) = false.
-Proof. by move=> yR xNR; rewrite ltr_def Nreal_leF ?andbF. Qed.
+Proof. by move=> yR xNR; rewrite lt_def Nreal_leF ?andbF. Qed.
 
 Lemma Nreal_gtF x y : y \is real -> x \notin real -> (y < x) = false.
-Proof. by move=> yR xNR; rewrite ltr_def Nreal_geF ?andbF. Qed.
+Proof. by move=> yR xNR; rewrite lt_def Nreal_geF ?andbF. Qed.
 
 (* real wlog *)
 
@@ -1801,7 +1840,7 @@ Lemma real_wlog_ler P :
   forall a b : R, a \is real -> b \is real -> P a b.
 Proof.
 move=> sP hP a b ha hb; wlog: a b ha hb / a <= b => [hwlog|]; last exact: hP.
-by case: (real_lerP ha hb)=> [/hP //|/ltrW hba]; apply: sP; apply: hP.
+by case: (real_leP ha hb)=> [/hP //|/ltW hba]; apply: sP; apply: hP.
 Qed.
 
 Lemma real_wlog_ltr P :
@@ -1810,7 +1849,7 @@ Lemma real_wlog_ltr P :
   forall a b : R, a \is real -> b \is real -> P a b.
 Proof.
 move=> rP sP hP; apply: real_wlog_ler=> // a b.
-by rewrite ler_eqVlt; case: (altP (_ =P _))=> [->|] //= _ lab; apply: hP.
+by rewrite le_eqVlt; case: (altP (_ =P _))=> [->|] //= _ lab; apply: hP.
 Qed.
 
 (* Monotony of addition *)
@@ -1823,10 +1862,10 @@ Lemma ler_add2r x : {mono +%R^~ x : y z / y <= z}.
 Proof. by move=> y z /=; rewrite ![_ + x]addrC ler_add2l. Qed.
 
 Lemma ltr_add2r z x y : (x + z < y + z) = (x < y).
-Proof. by rewrite (lerW_mono (ler_add2r _)). Qed.
+Proof. by rewrite (leW_mono (ler_add2r _)). Qed.
 
 Lemma ltr_add2l z x y : (z + x < z + y) = (x < y).
-Proof. by rewrite (lerW_mono (ler_add2l _)). Qed.
+Proof. by rewrite (leW_mono (ler_add2l _)). Qed.
 
 Definition ler_add2 := (ler_add2l, ler_add2r).
 Definition ltr_add2 := (ltr_add2l, ltr_add2r).
@@ -1834,16 +1873,16 @@ Definition lter_add2 := (ler_add2, ltr_add2).
 
 (* Addition, subtraction and transitivity *)
 Lemma ler_add x y z t : x <= y -> z <= t -> x + z <= y + t.
-Proof. by move=> lxy lzt; rewrite (@ler_trans _ (y + z)) ?lter_add2. Qed.
+Proof. by move=> lxy lzt; rewrite (@le_trans _ _ (y + z)) ?lter_add2. Qed.
 
 Lemma ler_lt_add x y z t : x <= y -> z < t -> x + z < y + t.
-Proof. by move=> lxy lzt; rewrite (@ler_lt_trans _ (y + z)) ?lter_add2. Qed.
+Proof. by move=> lxy lzt; rewrite (@le_lt_trans _ _ (y + z)) ?lter_add2. Qed.
 
 Lemma ltr_le_add x y z t : x < y -> z <= t -> x + z < y + t.
-Proof. by move=> lxy lzt; rewrite (@ltr_le_trans _ (y + z)) ?lter_add2. Qed.
+Proof. by move=> lxy lzt; rewrite (@lt_le_trans _ _ (y + z)) ?lter_add2. Qed.
 
 Lemma ltr_add x y z t : x < y -> z < t -> x + z < y + t.
-Proof. by move=> lxy lzt; rewrite ltr_le_add // ltrW. Qed.
+Proof. by move=> lxy lzt; rewrite ltr_le_add // ltW. Qed.
 
 Lemma ler_sub x y z t : x <= y -> t <= z -> x - z <= y - t.
 Proof. by move=> lxy ltz; rewrite ler_add // lter_opp2. Qed.
@@ -1971,7 +2010,7 @@ Lemma paddr_eq0 (x y : R) :
   0 <= x -> 0 <= y -> (x + y == 0) = (x == 0) && (y == 0).
 Proof.
 rewrite le0r; case/orP=> [/eqP->|hx]; first by rewrite add0r eqxx.
-by rewrite (gtr_eqF hx) /= => hy; rewrite gtr_eqF // ltr_spaddl.
+by rewrite (gt_eqF hx) /= => hy; rewrite gt_eqF // ltr_spaddl.
 Qed.
 
 Lemma naddr_eq0 (x y : R) :
@@ -1993,7 +2032,7 @@ Proof. exact: (big_ind _ _ (@ler_paddl 0)). Qed.
 Lemma ler_sum I (r : seq I) (P : pred I) (F G : I -> R) :
     (forall i, P i -> F i <= G i) ->
   \sum_(i <- r | P i) F i <= \sum_(i <- r | P i) G i.
-Proof. exact: (big_ind2 _ (lerr _) ler_add). Qed.
+Proof. exact: (big_ind2 _ (lexx _) ler_add). Qed.
 
 Lemma psumr_eq0 (I : eqType) (r : seq I) (P : pred I) (F : I -> R) :
     (forall i, P i -> 0 <= F i) ->
@@ -2020,7 +2059,7 @@ by move=> x_gt0 y z /=; rewrite -subr_ge0 -mulrBr pmulr_rge0 // subr_ge0.
 Qed.
 
 Lemma ltr_pmul2l x : 0 < x -> {mono *%R x : x y / x < y}.
-Proof. by move=> x_gt0; apply: lerW_mono (ler_pmul2l _). Qed.
+Proof. by move=> x_gt0; apply: leW_mono (ler_pmul2l _). Qed.
 
 Definition lter_pmul2l := (ler_pmul2l, ltr_pmul2l).
 
@@ -2028,7 +2067,7 @@ Lemma ler_pmul2r x : 0 < x -> {mono *%R^~ x : x y / x <= y}.
 Proof. by move=> x_gt0 y z /=; rewrite ![_ * x]mulrC ler_pmul2l. Qed.
 
 Lemma ltr_pmul2r x : 0 < x -> {mono *%R^~ x : x y / x < y}.
-Proof. by move=> x_gt0; apply: lerW_mono (ler_pmul2r _). Qed.
+Proof. by move=> x_gt0; apply: leW_mono (ler_pmul2r _). Qed.
 
 Definition lter_pmul2r := (ler_pmul2r, ltr_pmul2r).
 
@@ -2038,7 +2077,7 @@ by move=> x_lt0 y z /=; rewrite -ler_opp2 -!mulNr ler_pmul2l ?oppr_gt0.
 Qed.
 
 Lemma ltr_nmul2l x : x < 0 -> {mono *%R x : x y /~ x < y}.
-Proof. by move=> x_lt0; apply: lerW_nmono (ler_nmul2l _). Qed.
+Proof. by move=> x_lt0; apply: leW_nmono (ler_nmul2l _). Qed.
 
 Definition lter_nmul2l := (ler_nmul2l, ltr_nmul2l).
 
@@ -2046,7 +2085,7 @@ Lemma ler_nmul2r x : x < 0 -> {mono *%R^~ x : x y /~ x <= y}.
 Proof. by move=> x_lt0 y z /=; rewrite ![_ * x]mulrC ler_nmul2l. Qed.
 
 Lemma ltr_nmul2r x : x < 0 -> {mono *%R^~ x : x y /~ x < y}.
-Proof. by move=> x_lt0; apply: lerW_nmono (ler_nmul2r _). Qed.
+Proof. by move=> x_lt0; apply: leW_nmono (ler_nmul2r _). Qed.
 
 Definition lter_nmul2r := (ler_nmul2r, ltr_nmul2r).
 
@@ -2073,15 +2112,15 @@ Qed.
 Lemma ler_pmul x1 y1 x2 y2 :
   0 <= x1 -> 0 <= x2 -> x1 <= y1 -> x2 <= y2 -> x1 * x2 <= y1 * y2.
 Proof.
-move=> x1ge0 x2ge0 le_xy1 le_xy2; have y1ge0 := ler_trans x1ge0 le_xy1.
-exact: ler_trans (ler_wpmul2r x2ge0 le_xy1) (ler_wpmul2l y1ge0 le_xy2).
+move=> x1ge0 x2ge0 le_xy1 le_xy2; have y1ge0 := le_trans x1ge0 le_xy1.
+exact: le_trans (ler_wpmul2r x2ge0 le_xy1) (ler_wpmul2l y1ge0 le_xy2).
 Qed.
 
 Lemma ltr_pmul x1 y1 x2 y2 :
   0 <= x1 -> 0 <= x2 -> x1 < y1 -> x2 < y2 -> x1 * x2 < y1 * y2.
 Proof.
-move=> x1ge0 x2ge0 lt_xy1 lt_xy2; have y1gt0 := ler_lt_trans x1ge0 lt_xy1.
-by rewrite (ler_lt_trans (ler_wpmul2r x2ge0 (ltrW lt_xy1))) ?ltr_pmul2l.
+move=> x1ge0 x2ge0 lt_xy1 lt_xy2; have y1gt0 := le_lt_trans x1ge0 lt_xy1.
+by rewrite (le_lt_trans (ler_wpmul2r x2ge0 (ltW lt_xy1))) ?ltr_pmul2l.
 Qed.
 
 (* complement for x *+ n and <= or < *)
@@ -2092,10 +2131,10 @@ by case: n => // n _ x y /=; rewrite -mulr_natl -[y *+ _]mulr_natl ler_pmul2l.
 Qed.
 
 Lemma ltr_pmuln2r n : (0 < n)%N -> {mono (@GRing.natmul R)^~ n : x y / x < y}.
-Proof. by move/ler_pmuln2r/lerW_mono. Qed.
+Proof. by move/ler_pmuln2r/leW_mono. Qed.
 
 Lemma pmulrnI n : (0 < n)%N -> injective ((@GRing.natmul R)^~ n).
-Proof. by move/ler_pmuln2r/incr_inj. Qed.
+Proof. by move/ler_pmuln2r/inc_inj. Qed.
 
 Lemma eqr_pmuln2r n : (0 < n)%N -> {mono (@GRing.natmul R)^~ n : x y / x == y}.
 Proof. by move/pmulrnI/inj_eq. Qed.
@@ -2128,13 +2167,13 @@ Lemma mulrn_wle0 x n : x <= 0 -> x *+ n <= 0.
 Proof. by move=> /(ler_wmuln2r n); rewrite mul0rn. Qed.
 
 Lemma ler_muln2r n x y : (x *+ n <= y *+ n) = ((n == 0%N) || (x <= y)).
-Proof. by case: n => [|n]; rewrite ?lerr ?eqxx // ler_pmuln2r. Qed.
+Proof. by case: n => [|n]; rewrite ?lexx ?eqxx // ler_pmuln2r. Qed.
 
 Lemma ltr_muln2r n x y : (x *+ n < y *+ n) = ((0 < n)%N && (x < y)).
-Proof. by case: n => [|n]; rewrite ?lerr ?eqxx // ltr_pmuln2r. Qed.
+Proof. by case: n => [|n]; rewrite ?lexx ?eqxx // ltr_pmuln2r. Qed.
 
 Lemma eqr_muln2r n x y : (x *+ n == y *+ n) = (n == 0)%N || (x == y).
-Proof. by rewrite !eqr_le !ler_muln2r -orb_andr. Qed.
+Proof. by rewrite !(@eq_le _ R) !ler_muln2r -orb_andr. Qed.
 
 (* More characteristic zero properties. *)
 
@@ -2167,14 +2206,14 @@ Proof. by case: n => // n hx; rewrite pmulrn_llt0. Qed.
 Lemma ler_pmuln2l x :
   0 < x -> {mono (@GRing.natmul R x) : m n / (m <= n)%N >-> m <= n}.
 Proof.
-move=> x_gt0 m n /=; case: leqP => hmn; first by rewrite ler_wpmuln2l // ltrW.
-rewrite -(subnK (ltnW hmn)) mulrnDr ger_addr ltr_geF //.
+move=> x_gt0 m n /=; case: leqP => hmn; first by rewrite ler_wpmuln2l // ltW.
+rewrite -(subnK (ltnW hmn)) mulrnDr ger_addr lt_geF //.
 by rewrite mulrn_wgt0 // subn_gt0.
 Qed.
 
 Lemma ltr_pmuln2l x :
   0 < x -> {mono (@GRing.natmul R x) : m n / (m < n)%N >-> m < n}.
-Proof. by move=> x_gt0; apply: lenrW_mono (ler_pmuln2l _). Qed.
+Proof. by move=> x_gt0; apply: leW_mono (ler_pmuln2l _). Qed.
 
 Lemma ler_nmuln2l x :
   x < 0 -> {mono (@GRing.natmul R x) : m n / (n <= m)%N >-> m <= n}.
@@ -2184,7 +2223,7 @@ Qed.
 
 Lemma ltr_nmuln2l x :
   x < 0 -> {mono (@GRing.natmul R x) : m n / (n < m)%N >-> m < n}.
-Proof. by move=> x_lt0; apply: lenrW_nmono (ler_nmuln2l _). Qed.
+Proof. by move=> x_lt0; apply: leW_nmono (ler_nmuln2l _). Qed.
 
 Lemma ler_nat m n : (m%:R <= n%:R :> R) = (m <= n)%N.
 Proof. by rewrite ler_pmuln2l. Qed.
@@ -2211,10 +2250,10 @@ Lemma ltrn1 n : n%:R < 1 :> R = (n < 1)%N. Proof. by rewrite -ltr_nat. Qed.
 
 Lemma ltrN10 : -1 < 0 :> R. Proof. by rewrite oppr_lt0. Qed.
 Lemma lerN10 : -1 <= 0 :> R. Proof. by rewrite oppr_le0. Qed.
-Lemma ltr10 : 1 < 0 :> R = false. Proof. by rewrite ler_gtF. Qed.
-Lemma ler10 : 1 <= 0 :> R = false. Proof. by rewrite ltr_geF. Qed.
-Lemma ltr0N1 : 0 < -1 :> R = false. Proof. by rewrite ler_gtF // lerN10. Qed.
-Lemma ler0N1 : 0 <= -1 :> R = false. Proof. by rewrite ltr_geF // ltrN10. Qed.
+Lemma ltr10 : 1 < 0 :> R = false. Proof. by rewrite le_gtF. Qed.
+Lemma ler10 : 1 <= 0 :> R = false. Proof. by rewrite lt_geF. Qed.
+Lemma ltr0N1 : 0 < -1 :> R = false. Proof. by rewrite le_gtF // lerN10. Qed.
+Lemma ler0N1 : 0 <= -1 :> R = false. Proof. by rewrite lt_geF // ltrN10. Qed.
 
 Lemma pmulrn_rgt0 x n : 0 < x -> 0 < x *+ n = (0 < n)%N.
 Proof. by move=> x_gt0; rewrite -(mulr0n x) ltr_pmuln2l. Qed.
@@ -2329,9 +2368,9 @@ Lemma ltr_prod I r (P : pred I) (E1 E2 : I -> R) :
 Proof.
 elim: r => //= i r IHr; rewrite !big_cons; case: ifP => {IHr}// Pi _ ltE12.
 have /andP[le0E1i ltE12i] := ltE12 i Pi; set E2r := \prod_(j <- r | P j) E2 j.
-apply: ler_lt_trans (_ : E1 i * E2r < E2 i * E2r).
-  by rewrite ler_wpmul2l ?ler_prod // => j /ltE12/andP[-> /ltrW].
-by rewrite ltr_pmul2r ?prodr_gt0 // => j /ltE12/andP[le0E1j /ler_lt_trans->].
+apply: le_lt_trans (_ : E1 i * E2r < E2 i * E2r).
+  by rewrite ler_wpmul2l ?ler_prod // => j /ltE12/andP[-> /ltW].
+by rewrite ltr_pmul2r ?prodr_gt0 // => j /ltE12/andP[le0E1j /le_lt_trans->].
 Qed.
 
 Lemma ltr_prod_nat (E1 E2 : nat -> R) (n m : nat) :
@@ -2346,7 +2385,7 @@ Qed.
 
 Lemma realMr x y : x != 0 -> x \is real -> (x * y \is real) = (y \is real).
 Proof.
-move=> x_neq0 xR; case: real_ltrgtP x_neq0 => // hx _; rewrite !realE.
+move=> x_neq0 xR; case: real_ltgtP x_neq0 => // hx _; rewrite !realE.
   by rewrite nmulr_rge0 // nmulr_rle0 // orbC.
 by rewrite pmulr_rge0 // pmulr_rle0 // orbC.
 Qed.
@@ -2438,21 +2477,21 @@ Lemma ler_nimulr x y : y <= 0 -> x <= 1 -> y <= y * x.
 Proof. by move=> hx hy; rewrite -{1}[y]mulr1 ler_wnmul2l. Qed.
 
 Lemma mulr_ile1 x y : 0 <= x -> 0 <= y -> x <= 1 -> y <= 1 -> x * y <= 1.
-Proof. by move=> *; rewrite (@ler_trans _ y) ?ler_pimull. Qed.
+Proof. by move=> *; rewrite (@le_trans _ _ y) ?ler_pimull. Qed.
 
 Lemma mulr_ilt1 x y : 0 <= x -> 0 <= y -> x < 1 -> y < 1 -> x * y < 1.
-Proof. by move=> *; rewrite (@ler_lt_trans _ y) ?ler_pimull // ltrW. Qed.
+Proof. by move=> *; rewrite (@le_lt_trans _ _ y) ?ler_pimull // ltW. Qed.
 
 Definition mulr_ilte1 := (mulr_ile1, mulr_ilt1).
 
 Lemma mulr_ege1 x y : 1 <= x -> 1 <= y -> 1 <= x * y.
 Proof.
-by move=> le1x le1y; rewrite (@ler_trans _ y) ?ler_pemull // (ler_trans ler01).
+by move=> le1x le1y; rewrite (@le_trans _ _ y) ?ler_pemull // (le_trans ler01).
 Qed.
 
 Lemma mulr_egt1 x y : 1 < x -> 1 < y -> 1 < x * y.
 Proof.
-by move=> le1x lt1y; rewrite (@ltr_trans _ y) // ltr_pmull // (ltr_trans ltr01).
+by move=> le1x lt1y; rewrite (@lt_trans _ _ y) // ltr_pmull // (lt_trans ltr01).
 Qed.
 Definition mulr_egte1 := (mulr_ege1, mulr_egt1).
 Definition mulr_cp1 := (mulr_ilte1, mulr_egte1).
@@ -2509,7 +2548,7 @@ Qed.
 Lemma exprn_ilt1 n x : 0 <= x -> x < 1 -> x ^+ n < 1 = (n != 0%N).
 Proof.
 move=> xge0 xlt1.
-case: n; [by rewrite eqxx ltrr | elim=> [|n ihn]; first by rewrite expr1].
+case: n; [by rewrite eqxx ltxx | elim=> [|n ihn]; first by rewrite expr1].
 by rewrite exprS mulr_ilt1 // exprn_ge0.
 Qed.
 
@@ -2522,7 +2561,7 @@ Qed.
 
 Lemma exprn_egt1 n x : 1 < x -> 1 < x ^+ n = (n != 0%N).
 Proof.
-move=> xgt1; case: n; first by rewrite eqxx ltrr.
+move=> xgt1; case: n; first by rewrite eqxx ltxx.
 elim=> [|n ihn]; first by rewrite expr1.
 by rewrite exprS mulr_egt1 // exprn_ge0.
 Qed.
@@ -2535,8 +2574,8 @@ Proof. by case: n => n // *; rewrite exprS ler_pimulr // exprn_ile1. Qed.
 
 Lemma ltr_iexpr x n : 0 < x -> x < 1 -> (x ^+ n < x) = (1 < n)%N.
 Proof.
-case: n=> [|[|n]] //; first by rewrite expr0 => _ /ltr_gtF ->.
-by move=> x0 x1; rewrite exprS gtr_pmulr // ?exprn_ilt1 // ltrW.
+case: n=> [|[|n]] //; first by rewrite expr0 => _ /lt_gtF ->.
+by move=> x0 x1; rewrite exprS gtr_pmulr // ?exprn_ilt1 // ltW.
 Qed.
 
 Definition lter_iexpr := (ler_iexpr, ltr_iexpr).
@@ -2544,13 +2583,13 @@ Definition lter_iexpr := (ler_iexpr, ltr_iexpr).
 Lemma ler_eexpr x n : (0 < n)%N -> 1 <= x -> x <= x ^+ n.
 Proof.
 case: n => // n _ x_ge1.
-by rewrite exprS ler_pemulr ?(ler_trans _ x_ge1) // exprn_ege1.
+by rewrite exprS ler_pemulr ?(le_trans _ x_ge1) // exprn_ege1.
 Qed.
 
 Lemma ltr_eexpr x n : 1 < x -> (x < x ^+ n) = (1 < n)%N.
 Proof.
-move=> x_ge1; case: n=> [|[|n]] //; first by rewrite expr0 ltr_gtF.
-by rewrite exprS ltr_pmulr ?(ltr_trans _ x_ge1) ?exprn_egt1.
+move=> x_ge1; case: n=> [|[|n]] //; first by rewrite expr0 lt_gtF.
+by rewrite exprS ltr_pmulr ?(lt_trans _ x_ge1) ?exprn_egt1.
 Qed.
 
 Definition lter_eexpr := (ler_eexpr, ltr_eexpr).
@@ -2567,15 +2606,15 @@ Lemma ler_weexpn2l x :
   1 <= x -> {homo (GRing.exp x) : m n / (m <= n)%N >-> m <= n}.
 Proof.
 move=> xge1 m n /= hmn; rewrite -(subnK hmn) exprD.
-by rewrite ler_pemull ?(exprn_ge0, exprn_ege1) // (ler_trans _ xge1) ?ler01.
+by rewrite ler_pemull ?(exprn_ge0, exprn_ege1) // (le_trans _ xge1) ?ler01.
 Qed.
 
 Lemma ieexprn_weq1 x n : 0 <= x -> (x ^+ n == 1) = ((n == 0%N) || (x == 1)).
 Proof.
 move=> xle0; case: n => [|n]; first by rewrite expr0 eqxx.
-case: (@real_ltrgtP x 1); do ?by rewrite ?ger0_real.
-+ by move=> x_lt1; rewrite ?ltr_eqF // exprn_ilt1.
-+ by move=> x_lt1; rewrite ?gtr_eqF // exprn_egt1.
+case: (@real_ltgtP x 1); do ?by rewrite ?ger0_real.
++ by move=> x_lt1; rewrite 1?lt_eqF // exprn_ilt1.
++ by move=> x_lt1; rewrite 1?gt_eqF // exprn_egt1.
 by move->; rewrite expr1n eqxx.
 Qed.
 
@@ -2584,50 +2623,50 @@ Proof.
 move=> x_gt0 x_neq1 m n; without loss /subnK <-: m n / (n <= m)%N.
   by move=> IH eq_xmn; case/orP: (leq_total m n) => /IH->.
 case: {m}(m - n)%N => // m /eqP/idPn[]; rewrite -[x ^+ n]mul1r exprD.
-by rewrite (inj_eq (mulIf _)) ?ieexprn_weq1 ?ltrW // expf_neq0 ?gtr_eqF.
+by rewrite (inj_eq (mulIf _)) ?ieexprn_weq1 ?ltW // expf_neq0 ?gt_eqF.
 Qed.
 
 Lemma ler_iexpn2l x :
   0 < x -> x < 1 -> {mono (GRing.exp x) : m n / (n <= m)%N >-> m <= n}.
 Proof.
-move=> xgt0 xlt1; apply: (lenr_nmono (inj_nhomo_ltnr _ _)); last first.
-  by apply: ler_wiexpn2l; rewrite ltrW.
-by apply: ieexprIn; rewrite ?ltr_eqF ?ltr_cpable.
+move=> xgt0 xlt1; apply: (le_nmono (inj_nhomo_lt _ _)); last first.
+  by apply: ler_wiexpn2l; rewrite ltW.
+by apply: ieexprIn; rewrite ?lt_eqF ?ltr_cpable.
 Qed.
 
 Lemma ltr_iexpn2l x :
   0 < x -> x < 1 -> {mono (GRing.exp x) : m n / (n < m)%N >-> m < n}.
-Proof. by move=> xgt0 xlt1; apply: (lenrW_nmono (ler_iexpn2l _ _)). Qed.
+Proof. by move=> xgt0 xlt1; apply: (leW_nmono (ler_iexpn2l _ _)). Qed.
 
 Definition lter_iexpn2l := (ler_iexpn2l, ltr_iexpn2l).
 
 Lemma ler_eexpn2l x :
   1 < x -> {mono (GRing.exp x) : m n / (m <= n)%N >-> m <= n}.
 Proof.
-move=> xgt1; apply: (lenr_mono (inj_homo_ltnr _ _)); last first.
-  by apply: ler_weexpn2l; rewrite ltrW.
-by apply: ieexprIn; rewrite ?gtr_eqF ?gtr_cpable //; apply: ltr_trans xgt1.
+move=> xgt1; apply: (le_mono (inj_homo_lt _ _)); last first.
+  by apply: ler_weexpn2l; rewrite ltW.
+by apply: ieexprIn; rewrite ?gt_eqF ?gtr_cpable //; apply: lt_trans xgt1.
 Qed.
 
 Lemma ltr_eexpn2l x :
   1 < x -> {mono (GRing.exp x) : m n / (m < n)%N >-> m < n}.
-Proof. by move=> xgt1; apply: (lenrW_mono (ler_eexpn2l _)). Qed.
+Proof. by move=> xgt1; apply: (leW_mono (ler_eexpn2l _)). Qed.
 
 Definition lter_eexpn2l := (ler_eexpn2l, ltr_eexpn2l).
 
 Lemma ltr_expn2r n x y : 0 <= x -> x < y ->  x ^+ n < y ^+ n = (n != 0%N).
 Proof.
-move=> xge0 xlty; case: n; first by rewrite ltrr.
+move=> xge0 xlty; case: n; first by rewrite ltxx.
 elim=> [|n IHn]; rewrite ?[_ ^+ _.+2]exprS //.
-rewrite (@ler_lt_trans _ (x * y ^+ n.+1)) ?ler_wpmul2l ?ltr_pmul2r ?IHn //.
-  by rewrite ltrW // ihn.
-by rewrite exprn_gt0 // (ler_lt_trans xge0).
+rewrite (@le_lt_trans _ _ (x * y ^+ n.+1)) ?ler_wpmul2l ?ltr_pmul2r ?IHn //.
+  by rewrite ltW // ihn.
+by rewrite exprn_gt0 // (le_lt_trans xge0).
 Qed.
 
 Lemma ler_expn2r n : {in nneg & , {homo ((@GRing.exp R)^~ n) : x y / x <= y}}.
 Proof.
 move=> x y /= x0 y0 xy; elim: n => [|n IHn]; rewrite !(expr0, exprS) //.
-by rewrite (@ler_trans _ (x * y ^+ n)) ?ler_wpmul2l ?ler_wpmul2r ?exprn_ge0.
+by rewrite (@le_trans _ _ (x * y ^+ n)) ?ler_wpmul2l ?ler_wpmul2r ?exprn_ge0.
 Qed.
 
 Definition lter_expn2r := (ler_expn2r, ltr_expn2r).
@@ -2649,13 +2688,13 @@ Qed.
 Lemma ltr_pexpn2r n :
   (0 < n)%N -> {in nneg & , {mono ((@GRing.exp R)^~ n) : x y / x < y}}.
 Proof.
-by move=> n_gt0 x y x_ge0 y_ge0; rewrite !ltr_neqAle !eqr_le !ler_pexpn2r.
+by move=> n_gt0 x y x_ge0 y_ge0; rewrite !lt_neqAle !eq_le !ler_pexpn2r.
 Qed.
 
 Definition lter_pexpn2r := (ler_pexpn2r, ltr_pexpn2r).
 
 Lemma pexpIrn n : (0 < n)%N -> {in nneg &, injective ((@GRing.exp R)^~ n)}.
-Proof. by move=> n_gt0; apply: incr_inj_in (ler_pexpn2r _). Qed.
+Proof. by move=> n_gt0; apply: inc_inj_in (ler_pexpn2r _). Qed.
 
 (* expr and ler/ltr *)
 Lemma expr_le1 n x : (0 < n)%N -> 0 <= x -> (x ^+ n <= 1) = (x <= 1).
@@ -2683,7 +2722,7 @@ Qed.
 Definition expr_gte1 := (expr_ge1, expr_gt1).
 
 Lemma pexpr_eq1 x n : (0 < n)%N -> 0 <= x -> (x ^+ n == 1) = (x == 1).
-Proof. by move=> ngt0 xge0; rewrite !eqr_le expr_le1 // expr_ge1. Qed.
+Proof. by move=> ngt0 xge0; rewrite !eq_le expr_le1 // expr_ge1. Qed.
 
 Lemma pexprn_eq1 x n : 0 <= x -> (x ^+ n == 1) = (n == 0%N) || (x == 1).
 Proof. by case: n => [|n] xge0; rewrite ?eqxx // pexpr_eq1 ?gtn_eqF. Qed.
@@ -2722,11 +2761,11 @@ Qed.
 
 Lemma ltr_pinv :
   {in [pred x in GRing.unit | 0 < x] &, {mono (@GRing.inv R) : x y /~ x < y}}.
-Proof. exact: lerW_nmono_in ler_pinv. Qed.
+Proof. exact: leW_nmono_in ler_pinv. Qed.
 
 Lemma ltr_ninv :
   {in [pred x in GRing.unit | x < 0] &, {mono (@GRing.inv R) : x y /~ x < y}}.
-Proof. exact: lerW_nmono_in ler_ninv. Qed.
+Proof. exact: leW_nmono_in ler_ninv. Qed.
 
 Lemma invr_gt1 x : x \is a GRing.unit -> 0 < x -> (1 < x^-1) = (x < 1).
 Proof.
@@ -2754,39 +2793,39 @@ Definition invr_cp1 := (invr_gte1, invr_lte1).
 
 Lemma real_ler_norm x : x \is real -> x <= `|x|.
 Proof.
-by case/real_ger0P=> hx //; rewrite (ler_trans (ltrW hx)) // oppr_ge0 ltrW.
+by case/real_ge0P=> hx //; rewrite (le_trans (ltW hx)) // oppr_ge0 ltW.
 Qed.
 
 (* norm + add *)
 
-Lemma normr_real x : `|x| \is real. Proof. by rewrite ger0_real. Qed.
+Lemma normr_real x : `|x| \is real. Proof. apply/ger0_real/normr_ge0. Qed.
 Hint Resolve normr_real : core.
 
 Lemma ler_norm_sum I r (G : I -> R) (P : pred I):
   `|\sum_(i <- r | P i) G i| <= \sum_(i <- r | P i) `|G i|.
 Proof.
 elim/big_rec2: _ => [|i y x _]; first by rewrite normr0.
-by rewrite -(ler_add2l `|G i|); apply: ler_trans; apply: ler_norm_add.
+by rewrite -(ler_add2l `|G i|); apply: le_trans; apply: ler_norm_add.
 Qed.
 
 Lemma ler_norm_sub x y : `|x - y| <= `|x| + `|y|.
-Proof. by rewrite (ler_trans (ler_norm_add _ _)) ?normrN. Qed.
+Proof. by rewrite (le_trans (ler_norm_add _ _)) ?normrN. Qed.
 
 Lemma ler_dist_add z x y : `|x - y| <= `|x - z| + `|z - y|.
-Proof. by rewrite (ler_trans _ (ler_norm_add _ _)) // addrA addrNK. Qed.
+Proof. by rewrite (le_trans _ (ler_norm_add _ _)) // addrA addrNK. Qed.
 
 Lemma ler_sub_norm_add x y : `|x| - `|y| <= `|x + y|.
 Proof.
 rewrite -{1}[x](addrK y) lter_sub_addl.
-by rewrite (ler_trans (ler_norm_add _ _)) // addrC normrN.
+by rewrite (le_trans (ler_norm_add _ _)) // addrC normrN.
 Qed.
 
 Lemma ler_sub_dist x y : `|x| - `|y| <= `|x - y|.
 Proof. by rewrite -[`|y|]normrN ler_sub_norm_add. Qed.
 
-Lemma ler_dist_dist x y : `|`|x| - `|y| | <= `|x - y|.
+Lemma ler_dist_dist x y : `| `|x| - `|y| | <= `|x - y|.
 Proof.
-have [||_|_] // := @real_lerP `|x| `|y|; last by rewrite ler_sub_dist.
+have [||_|_] // := @real_leP `|x| `|y|; last by rewrite ler_sub_dist.
 by rewrite distrC ler_sub_dist.
 Qed.
 
@@ -2799,7 +2838,7 @@ move=> xR; wlog x_ge0 : x xR / 0 <= x => [hwlog|].
   move: (xR) => /(@real_leVge 0) /orP [|/hwlog->|hx] //.
   by rewrite -[x]opprK normrN ler_opp2 andbC ler_oppl hwlog ?realN ?oppr_ge0.
 rewrite ger0_norm //; have [le_xy|] := boolP (x <= y); last by rewrite andbF.
-by rewrite (ler_trans _ x_ge0) // oppr_le0 (ler_trans x_ge0).
+by rewrite (le_trans _ x_ge0) // oppr_le0 (le_trans x_ge0).
 Qed.
 
 Lemma real_ler_normlP x y :
@@ -2814,16 +2853,16 @@ Lemma real_eqr_norml x y :
 Proof.
 move=> Rx.
 apply/idP/idP=> [|/andP[/pred2P[]-> /ger0_norm/eqP]]; rewrite ?normrE //.
-case: real_ler0P => // hx; rewrite 1?eqr_oppLR => /eqP exy.
+case: real_le0P => // hx; rewrite 1?eqr_oppLR => /eqP exy.
   by move: hx; rewrite exy ?oppr_le0 eqxx orbT //.
-by move: hx=> /ltrW; rewrite exy eqxx.
+by move: hx=> /ltW; rewrite exy eqxx.
 Qed.
 
 Lemma real_eqr_norm2 x y :
   x \is real -> y \is real -> (`|x| == `|y|) = (x == y) || (x == -y).
 Proof.
 move=> Rx Ry; rewrite real_eqr_norml // normrE andbT.
-by case: real_ler0P; rewrite // opprK orbC.
+by case: real_le0P; rewrite // opprK orbC.
 Qed.
 
 Lemma real_ltr_norml x y : x \is real -> (`|x| < y) = (- y < x < y).
@@ -2832,7 +2871,7 @@ move=> Rx; wlog x_ge0 : x Rx / 0 <= x => [hwlog|].
   move: (Rx) => /(@real_leVge 0) /orP [|/hwlog->|hx] //.
   by rewrite -[x]opprK normrN ltr_opp2 andbC ltr_oppl hwlog ?realN ?oppr_ge0.
 rewrite ger0_norm //; have [le_xy|] := boolP (x < y); last by rewrite andbF.
-by rewrite (ltr_le_trans _ x_ge0) // oppr_lt0 (ler_lt_trans x_ge0).
+by rewrite (lt_le_trans _ x_ge0) // oppr_lt0 (le_lt_trans x_ge0).
 Qed.
 
 Definition real_lter_norml := (real_ler_norml, real_ltr_norml).
@@ -2849,7 +2888,7 @@ Lemma real_ler_normr x y : y \is real -> (x <= `|y|) = (x <= y) || (x <= - y).
 Proof.
 move=> Ry.
 have [xR|xNR] := boolP (x \is real); last by rewrite ?Nreal_leF ?realN.
-rewrite real_lerNgt ?real_ltr_norml // negb_and -?real_lerNgt ?realN //.
+rewrite real_leNgt ?real_ltr_norml // negb_and -?real_leNgt ?realN //.
 by rewrite orbC ler_oppr.
 Qed.
 
@@ -2857,17 +2896,21 @@ Lemma real_ltr_normr x y : y \is real -> (x < `|y|) = (x < y) || (x < - y).
 Proof.
 move=> Ry.
 have [xR|xNR] := boolP (x \is real); last by rewrite ?Nreal_ltF ?realN.
-rewrite real_ltrNge ?real_ler_norml // negb_and -?real_ltrNge ?realN //.
+rewrite real_ltNge ?real_ler_norml // negb_and -?real_ltNge ?realN //.
 by rewrite orbC ltr_oppr.
 Qed.
 
 Definition real_lter_normr :=  (real_ler_normr, real_ltr_normr).
 
 Lemma ler_nnorml x y : y < 0 -> `|x| <= y = false.
-Proof. by move=> y_lt0; rewrite ltr_geF // (ltr_le_trans y_lt0). Qed.
+Proof.
+by move=> y_lt0; rewrite lt_geF //; apply/(lt_le_trans y_lt0)/normr_ge0.
+Qed.
 
 Lemma ltr_nnorml x y : y <= 0 -> `|x| < y = false.
-Proof. by move=> y_le0; rewrite ler_gtF // (ler_trans y_le0). Qed.
+Proof.
+by move=> y_le0; rewrite le_gtF //; apply/(le_trans y_le0)/normr_ge0.
+Qed.
 
 Definition lter_nnormr := (ler_nnorml, ltr_nnorml).
 
@@ -2888,9 +2931,9 @@ Definition eqr_norm_idVN := =^~ (ger0_def, ler0_def).
 
 Lemma real_exprn_even_ge0 n x : x \is real -> ~~ odd n -> 0 <= x ^+ n.
 Proof.
-move=> xR even_n; have [/exprn_ge0 -> //|x_lt0] := real_ger0P xR.
+move=> xR even_n; have [/exprn_ge0 -> //|x_lt0] := real_ge0P xR.
 rewrite -[x]opprK -mulN1r exprMn -signr_odd (negPf even_n) expr0 mul1r.
-by rewrite exprn_ge0 ?oppr_ge0 ?ltrW.
+by rewrite exprn_ge0 ?oppr_ge0 ?ltW.
 Qed.
 
 Lemma real_exprn_even_gt0 n x :
@@ -2903,21 +2946,21 @@ Qed.
 Lemma real_exprn_even_le0 n x :
   x \is real -> ~~ odd n -> (x ^+ n <= 0) = (n != 0%N) && (x == 0).
 Proof.
-move=> xR n_even; rewrite !real_lerNgt ?rpred0 ?rpredX //.
+move=> xR n_even; rewrite !real_leNgt ?rpred0 ?rpredX //.
 by rewrite real_exprn_even_gt0 // negb_or negbK.
 Qed.
 
 Lemma real_exprn_even_lt0 n x :
   x \is real -> ~~ odd n -> (x ^+ n < 0) = false.
-Proof. by move=> xR n_even; rewrite ler_gtF // real_exprn_even_ge0. Qed.
+Proof. by move=> xR n_even; rewrite le_gtF // real_exprn_even_ge0. Qed.
 
 Lemma real_exprn_odd_ge0 n x :
   x \is real -> odd n -> (0 <= x ^+ n) = (0 <= x).
 Proof.
-case/real_ger0P => [x_ge0|x_lt0] n_odd; first by rewrite exprn_ge0.
-apply: negbTE; rewrite ltr_geF //.
+case/real_ge0P => [x_ge0|x_lt0] n_odd; first by rewrite exprn_ge0.
+apply: negbTE; rewrite lt_geF //.
 case: n n_odd => // n /= n_even; rewrite exprS pmulr_llt0 //.
-by rewrite real_exprn_even_gt0 ?ler0_real ?ltrW // ltr_eqF ?orbT.
+by rewrite real_exprn_even_gt0 ?ler0_real ?ltW // (lt_eqF x_lt0) ?orbT.
 Qed.
 
 Lemma real_exprn_odd_gt0 n x : x \is real -> odd n -> (0 < x ^+ n) = (0 < x).
@@ -2927,12 +2970,12 @@ Qed.
 
 Lemma real_exprn_odd_le0 n x : x \is real -> odd n -> (x ^+ n <= 0) = (x <= 0).
 Proof.
-by move=> xR n_odd; rewrite !real_lerNgt ?rpred0 ?rpredX // real_exprn_odd_gt0.
+by move=> xR n_odd; rewrite !real_leNgt ?rpred0 ?rpredX // real_exprn_odd_gt0.
 Qed.
 
 Lemma real_exprn_odd_lt0 n x : x \is real -> odd n -> (x ^+ n < 0) = (x < 0).
 Proof.
-by move=> xR n_odd; rewrite !real_ltrNge ?rpred0 ?rpredX // real_exprn_odd_ge0.
+by move=> xR n_odd; rewrite !real_ltNge ?rpred0 ?rpredX // real_exprn_odd_ge0.
 Qed.
 
 (* GG: Could this be a better definition of "real" ? *)
@@ -2960,7 +3003,7 @@ Lemma signr_ge0 (b : bool) : (0 <= (-1) ^+ b :> R) = ~~ b.
 Proof. by rewrite le0r signr_eq0 signr_gt0. Qed.
 
 Lemma signr_le0 (b : bool) : ((-1) ^+ b <= 0 :> R) = b.
-Proof. by rewrite ler_eqVlt signr_eq0 signr_lt0. Qed.
+Proof. by rewrite le_eqVlt signr_eq0 signr_lt0. Qed.
 
 (* This actually holds for char R != 2. *)
 Lemma signr_inj : injective (fun b : bool => (-1) ^+ b : R).
@@ -2975,10 +3018,10 @@ Lemma neqr0_sign x : x != 0 -> (-1) ^+ (x < 0)%R = sgr x.
 Proof. by rewrite sgr_def  => ->. Qed.
 
 Lemma gtr0_sg x : 0 < x -> sg x = 1.
-Proof. by move=> x_gt0; rewrite /sg gtr_eqF // ltr_gtF. Qed.
+Proof. by move=> x_gt0; rewrite /sg gt_eqF // lt_gtF. Qed.
 
 Lemma ltr0_sg x : x < 0 -> sg x = -1.
-Proof. by move=> x_lt0; rewrite /sg x_lt0 ltr_eqF. Qed.
+Proof. by move=> x_lt0; rewrite /sg x_lt0 lt_eqF. Qed.
 
 Lemma sgr0 : sg 0 = 0 :> R. Proof. by rewrite /sgr eqxx. Qed.
 Lemma sgr1 : sg 1 = 1 :> R. Proof. by rewrite gtr0_sg // ltr01. Qed.
@@ -3022,16 +3065,16 @@ Proof. by rewrite !(fun_if sg) !sgrE. Qed.
 Lemma sgr_lt0 x : (sg x < 0) = (x < 0).
 Proof.
 rewrite /sg; case: eqP => [-> // | _].
-by case: ifP => _; rewrite ?ltrN10 // ltr_gtF.
+by case: ifP => _; rewrite ?ltrN10 // lt_gtF.
 Qed.
 
 Lemma sgr_le0 x : (sgr x <= 0) = (x <= 0).
-Proof. by rewrite !ler_eqVlt sgr_eq0 sgr_lt0. Qed.
+Proof. by rewrite !le_eqVlt sgr_eq0 sgr_lt0. Qed.
 
 (* sign and norm *)
 
 Lemma realEsign x : x \is real -> x = (-1) ^+ (x < 0)%R * `|x|.
-Proof. by case/real_ger0P; rewrite (mul1r, mulN1r) ?opprK. Qed.
+Proof. by case/real_ge0P; rewrite (mul1r, mulN1r) ?opprK. Qed.
 
 Lemma realNEsign x : x \is real -> - x = (-1) ^+ (0 < x)%R * `|x|.
 Proof. by move=> Rx; rewrite -normrN -oppr_lt0 -realEsign ?rpredN. Qed.
@@ -3056,121 +3099,72 @@ Lemma normr_sg x : `|sg x| = (x != 0)%:R.
 Proof. by rewrite sgr_def -mulr_natr normrMsign normr_nat. Qed.
 
 Lemma sgr_norm x : sg `|x| = (x != 0)%:R.
-Proof. by rewrite /sg ler_gtF ?normr_ge0 // normr_eq0 mulrb if_neg. Qed.
+Proof. by rewrite /sg le_gtF ?normr_ge0 // normr_eq0 mulrb if_neg. Qed.
 
-(* lerif *)
+(* leif *)
 
-Lemma lerif_refl x C : reflect (x <= x ?= iff C) C.
-Proof. by apply: (iffP idP) => [-> | <-] //; split; rewrite ?eqxx. Qed.
+Lemma leif_nat_r m n C : (m%:R <= n%:R ?= iff C :> R) = (m <= n ?= iff C)%N.
+Proof. by rewrite /leif !ler_nat eqr_nat. Qed.
 
-Lemma lerif_trans x1 x2 x3 C12 C23 :
-  x1 <= x2 ?= iff C12 -> x2 <= x3 ?= iff C23 -> x1 <= x3 ?= iff C12 && C23.
-Proof.
-move=> ltx12 ltx23; apply/lerifP; rewrite -ltx12.
-case eqx12: (x1 == x2).
-  by rewrite (eqP eqx12) ltr_neqAle !ltx23 andbT; case C23.
-by rewrite (@ltr_le_trans _ x2) ?ltx23 // ltr_neqAle eqx12 ltx12.
-Qed.
+Lemma leif_subLR x y z C : (x - y <= z ?= iff C) = (x <= z + y ?= iff C).
+Proof. by rewrite /leif !eq_le ler_subr_addr ler_subl_addr. Qed.
 
-Lemma lerif_le x y : x <= y -> x <= y ?= iff (x >= y).
-Proof. by move=> lexy; split=> //; rewrite eqr_le lexy. Qed.
+Lemma leif_subRL x y z C : (x <= y - z ?= iff C) = (x + z <= y ?= iff C).
+Proof. by rewrite -leif_subLR opprK. Qed.
 
-Lemma lerif_eq x y : x <= y -> x <= y ?= iff (x == y).
-Proof. by []. Qed.
-
-Lemma ger_lerif x y C : x <= y ?= iff C -> (y <= x) = C.
-Proof. by case=> le_xy; rewrite eqr_le le_xy. Qed.
-
-Lemma ltr_lerif x y C : x <= y ?= iff C -> (x < y) = ~~ C.
-Proof. by move=> le_xy; rewrite ltr_neqAle !le_xy andbT. Qed.
-
-Lemma lerif_nat m n C : (m%:R <= n%:R ?= iff C :> R) = (m <= n ?= iff C)%N.
-Proof. by rewrite /lerif !ler_nat eqr_nat. Qed.
-
-Lemma mono_in_lerif (A : pred R) (f : R -> R) C :
-   {in A &, {mono f : x y / x <= y}} ->
-  {in A &, forall x y, (f x <= f y ?= iff C) = (x <= y ?= iff C)}.
-Proof.
-by move=> mf x y Ax Ay; rewrite /lerif mf ?(inj_in_eq (incr_inj_in mf)).
-Qed.
-
-Lemma mono_lerif (f : R -> R) C :
-    {mono f : x y / x <= y} ->
-  forall x y, (f x <= f y ?= iff C) = (x <= y ?= iff C).
-Proof. by move=> mf x y; rewrite /lerif mf (inj_eq (incr_inj _)). Qed.
-
-Lemma nmono_in_lerif (A : pred R) (f : R -> R) C :
-    {in A &, {mono f : x y /~ x <= y}} ->
-  {in A &, forall x y, (f x <= f y ?= iff C) = (y <= x ?= iff C)}.
-Proof.
-move=> mf x y Ax Ay; rewrite /lerif eq_sym mf //.
-by rewrite ?(inj_in_eq (decr_inj_in mf)).
-Qed.
-
-Lemma nmono_lerif (f : R -> R) C :
-    {mono f : x y /~ x <= y} ->
-  forall x y, (f x <= f y ?= iff C) = (y <= x ?= iff C).
-Proof. by move=> mf x y; rewrite /lerif eq_sym mf ?(inj_eq (decr_inj mf)). Qed.
-
-Lemma lerif_subLR x y z C : (x - y <= z ?= iff C) = (x <= z + y ?= iff C).
-Proof. by rewrite /lerif !eqr_le ler_subr_addr ler_subl_addr. Qed.
-
-Lemma lerif_subRL x y z C : (x <= y - z ?= iff C) = (x + z <= y ?= iff C).
-Proof. by rewrite -lerif_subLR opprK. Qed.
-
-Lemma lerif_add x1 y1 C1 x2 y2 C2 :
+Lemma leif_add x1 y1 C1 x2 y2 C2 :
     x1 <= y1 ?= iff C1 -> x2 <= y2 ?= iff C2 ->
   x1 + x2 <= y1 + y2 ?= iff C1 && C2.
 Proof.
-rewrite -(mono_lerif _ (ler_add2r x2)) -(mono_lerif C2 (ler_add2l y1)).
-exact: lerif_trans.
+rewrite -(mono_leif (ler_add2r x2)) -(mono_leif (C := C2) (ler_add2l y1)).
+exact: leif_trans.
 Qed.
 
-Lemma lerif_sum (I : finType) (P C : pred I) (E1 E2 : I -> R) :
+Lemma leif_sum (I : finType) (P C : pred I) (E1 E2 : I -> R) :
     (forall i, P i -> E1 i <= E2 i ?= iff C i) ->
   \sum_(i | P i) E1 i <= \sum_(i | P i) E2 i ?= iff [forall (i | P i), C i].
 Proof.
 move=> leE12; rewrite -big_andE.
-elim/big_rec3: _ => [|i Ci m2 m1 /leE12]; first by rewrite /lerif lerr eqxx.
-exact: lerif_add.
+elim/big_rec3: _ => [|i Ci m2 m1 /leE12]; first by rewrite /leif lexx eqxx.
+exact: leif_add.
 Qed.
 
-Lemma lerif_0_sum (I : finType) (P C : pred I) (E : I -> R) :
+Lemma leif_0_sum (I : finType) (P C : pred I) (E : I -> R) :
     (forall i, P i -> 0 <= E i ?= iff C i) ->
   0 <= \sum_(i | P i) E i ?= iff [forall (i | P i), C i].
-Proof. by move/lerif_sum; rewrite big1_eq. Qed.
+Proof. by move/leif_sum; rewrite big1_eq. Qed.
 
-Lemma real_lerif_norm x : x \is real -> x <= `|x| ?= iff (0 <= x).
+Lemma real_leif_norm x : x \is real -> x <= `|x| ?= iff (0 <= x).
 Proof.
-by move=> xR; rewrite ger0_def eq_sym; apply: lerif_eq; rewrite real_ler_norm.
+by move=> xR; rewrite ger0_def eq_sym; apply: leif_eq; rewrite real_ler_norm.
 Qed.
 
-Lemma lerif_pmul x1 x2 y1 y2 C1 C2 :
+Lemma leif_pmul x1 x2 y1 y2 C1 C2 :
     0 <= x1 -> 0 <= x2 -> x1 <= y1 ?= iff C1 -> x2 <= y2 ?= iff C2 ->
   x1 * x2 <= y1 * y2 ?= iff (y1 * y2 == 0) || C1 && C2.
 Proof.
 move=> x1_ge0 x2_ge0 le_xy1 le_xy2; have [y_0 | ] := altP (_ =P 0).
-  apply/lerifP; rewrite y_0 /= mulf_eq0 !eqr_le x1_ge0 x2_ge0 !andbT.
+  apply/leifP; rewrite y_0 /= mulf_eq0 !eq_le x1_ge0 x2_ge0 !andbT.
   move/eqP: y_0; rewrite mulf_eq0.
   by case/pred2P=> <-; rewrite (le_xy1, le_xy2) ?orbT.
 rewrite /= mulf_eq0 => /norP[y1nz y2nz].
-have y1_gt0: 0 < y1 by rewrite ltr_def y1nz (ler_trans _ le_xy1).
+have y1_gt0: 0 < y1 by rewrite lt_def y1nz (le_trans _ le_xy1).
 have [x2_0 | x2nz] := eqVneq x2 0.
-  apply/lerifP; rewrite -le_xy2 x2_0 eq_sym (negPf y2nz) andbF mulr0.
-  by rewrite mulr_gt0 // ltr_def y2nz -x2_0 le_xy2.
-have:= le_xy2; rewrite -(mono_lerif _ (ler_pmul2l y1_gt0)).
-by apply: lerif_trans; rewrite (mono_lerif _ (ler_pmul2r _)) // ltr_def x2nz.
+  apply/leifP; rewrite -le_xy2 x2_0 eq_sym (negPf y2nz) andbF mulr0.
+  by rewrite mulr_gt0 // lt_def y2nz -x2_0 le_xy2.
+have:= le_xy2; rewrite -(mono_leif (ler_pmul2l y1_gt0)).
+by apply: leif_trans; rewrite (mono_leif (ler_pmul2r _)) // lt_def x2nz.
 Qed.
 
-Lemma lerif_nmul x1 x2 y1 y2 C1 C2 :
+Lemma leif_nmul x1 x2 y1 y2 C1 C2 :
     y1 <= 0 -> y2 <= 0 -> x1 <= y1 ?= iff C1 -> x2 <= y2 ?= iff C2 ->
   y1 * y2 <= x1 * x2 ?= iff (x1 * x2 == 0) || C1 && C2.
 Proof.
 rewrite -!oppr_ge0 -mulrNN -[x1 * x2]mulrNN => y1le0 y2le0 le_xy1 le_xy2.
-by apply: lerif_pmul => //; rewrite (nmono_lerif _ ler_opp2).
+by apply: leif_pmul => //; rewrite (nmono_leif ler_opp2).
 Qed.
 
-Lemma lerif_pprod (I : finType) (P C : pred I) (E1 E2 : I -> R) :
+Lemma leif_pprod (I : finType) (P C : pred I) (E1 E2 : I -> R) :
     (forall i, P i -> 0 <= E1 i) ->
     (forall i, P i -> E1 i <= E2 i ?= iff C i) ->
   let pi E := \prod_(i | P i) E i in
@@ -3178,35 +3172,35 @@ Lemma lerif_pprod (I : finType) (P C : pred I) (E1 E2 : I -> R) :
 Proof.
 move=> E1_ge0 leE12 /=; rewrite -big_andE; elim/(big_load (fun x => 0 <= x)): _.
 elim/big_rec3: _ => [|i Ci m2 m1 Pi [m1ge0 le_m12]].
-  by split=> //; apply/lerifP; rewrite orbT.
+  by split=> //; apply/leifP; rewrite orbT.
 have Ei_ge0 := E1_ge0 i Pi; split; first by rewrite mulr_ge0.
-congr (lerif _ _ _): (lerif_pmul Ei_ge0 m1ge0 (leE12 i Pi) le_m12).
+congr (leif _ _ _): (leif_pmul Ei_ge0 m1ge0 (leE12 i Pi) le_m12).
 by rewrite mulf_eq0 -!orbA; congr (_ || _); rewrite !orb_andr orbA orbb.
 Qed.
 
 (* Mean inequalities. *)
 
-Lemma real_lerif_mean_square_scaled x y :
+Lemma real_leif_mean_square_scaled x y :
   x \is real -> y \is real -> x * y *+ 2 <= x ^+ 2 + y ^+ 2 ?= iff (x == y).
 Proof.
-move=> Rx Ry; rewrite -[_ *+ 2]add0r -lerif_subRL addrAC -sqrrB -subr_eq0.
-by rewrite -sqrf_eq0 eq_sym; apply: lerif_eq; rewrite -realEsqr rpredB.
+move=> Rx Ry; rewrite -[_ *+ 2]add0r -leif_subRL addrAC -sqrrB -subr_eq0.
+by rewrite -sqrf_eq0 eq_sym; apply: leif_eq; rewrite -realEsqr rpredB.
 Qed.
 
-Lemma real_lerif_AGM2_scaled x y :
+Lemma real_leif_AGM2_scaled x y :
   x \is real -> y \is real -> x * y *+ 4 <= (x + y) ^+ 2 ?= iff (x == y).
 Proof.
-move=> Rx Ry; rewrite sqrrD addrAC (mulrnDr _ 2) -lerif_subLR addrK.
-exact: real_lerif_mean_square_scaled.
+move=> Rx Ry; rewrite sqrrD addrAC (mulrnDr _ 2) -leif_subLR addrK.
+exact: real_leif_mean_square_scaled.
 Qed.
 
-Lemma lerif_AGM_scaled (I : finType) (A : pred I) (E : I -> R) (n := #|A|) :
+Lemma leif_AGM_scaled (I : finType) (A : pred I) (E : I -> R) (n := #|A|) :
     {in A, forall i, 0 <= E i *+ n} ->
   \prod_(i in A) (E i *+ n) <= (\sum_(i in A) E i) ^+ n
                             ?= iff [forall i in A, forall j in A, E i == E j].
 Proof.
 elim: {A}_.+1 {-2}A (ltnSn #|A|) => // m IHm A leAm in E n * => Ege0.
-apply/lerifP; case: ifPn => [/forall_inP-Econstant | Enonconstant].
+apply/leifP; case: ifPn => [/forall_inP-Econstant | Enonconstant].
   have [i /= Ai | A0] := pickP (mem A); last by rewrite [n]eq_card0 ?big_pred0.
   have /eqfun_inP-E_i := Econstant i Ai; rewrite -(eq_bigr _ E_i) sumr_const.
   by rewrite exprMn_n prodrMn -(eq_bigr _ E_i) prodr_const.
@@ -3217,9 +3211,9 @@ have{Enonconstant} has_cmp_mu e (s := (-1) ^+ e): {i | i \in A & cmp_mu s i}.
   rewrite negb_exists_in => /forall_inP-mu_s_A.
   have n_gt0 i: i \in A -> (0 < n)%N by rewrite [n](cardD1 i) => ->.
   have{mu_s_A} mu_s_A i: i \in A -> s * En i <= s * mu.
-    move=> Ai; rewrite real_lerNgt ?mu_s_A ?rpredMsign ?ger0_real ?Ege0 //.
+    move=> Ai; rewrite real_leNgt ?mu_s_A ?rpredMsign ?ger0_real ?Ege0 //.
     by rewrite -(pmulrn_lge0 _ (n_gt0 i Ai)) -sumrMnl sumr_ge0.
-  have [_ /esym/eqfun_inP] := lerif_sum (fun i Ai => lerif_eq (mu_s_A i Ai)).
+  have [_ /esym/eqfun_inP] := leif_sum (fun i Ai => leif_eq (mu_s_A i Ai)).
   rewrite sumr_const -/n -mulr_sumr sumrMnl -/mu mulrnAr eqxx => A_mu.
   apply/forall_inP=> i Ai; apply/eqfun_inP=> j Aj.
   by apply: (pmulrnI (n_gt0 i Ai)); apply: (can_inj (signrMK e)); rewrite !A_mu.
@@ -3227,17 +3221,17 @@ have [[i Ai Ei_lt_mu] [j Aj Ej_gt_mu]] := (has_cmp_mu 1, has_cmp_mu 0)%N.
 rewrite {cmp_mu has_cmp_mu}/= !mul1r !mulN1r ltr_opp2 in Ei_lt_mu Ej_gt_mu.
 pose A' := [predD1 A & i]; pose n' := #|A'|.
 have [Dn n_gt0]: n = n'.+1 /\ (n > 0)%N  by rewrite [n](cardD1 i) Ai.
-have i'j: j != i by apply: contraTneq Ej_gt_mu => ->; rewrite ltr_gtF.
+have i'j: j != i by apply: contraTneq Ej_gt_mu => ->; rewrite lt_gtF.
 have{i'j} A'j: j \in A' by rewrite !inE Aj i'j.
-have mu_gt0: 0 < mu := ler_lt_trans (Ege0 i Ai) Ei_lt_mu.
+have mu_gt0: 0 < mu := le_lt_trans (Ege0 i Ai) Ei_lt_mu.
 rewrite (bigD1 i) // big_andbC (bigD1 j) //= mulrA; set pi := \prod_(k | _) _.
 have [-> | nz_pi] := eqVneq pi 0; first by rewrite !mulr0 exprn_gt0.
 have{nz_pi} pi_gt0: 0 < pi.
-  by rewrite ltr_def nz_pi prodr_ge0 // => k /andP[/andP[_ /Ege0]].
+  by rewrite lt_def nz_pi prodr_ge0 // => k /andP[/andP[_ /Ege0]].
 rewrite -/(En i) -/(En j); pose E' := [eta En with j |-> En i + En j - mu].
 have E'ge0 k: k \in A' -> E' k *+ n' >= 0.
   case/andP=> /= _ Ak; apply: mulrn_wge0; case: ifP => _; last exact: Ege0.
-  by rewrite subr_ge0 ler_paddl ?Ege0 // ltrW.
+  by rewrite subr_ge0 ler_paddl ?Ege0 // ltW.
 rewrite -/n Dn in leAm; have{leAm IHm E'ge0}: _ <= _ := IHm _ leAm _ E'ge0.
 have ->: \sum_(k in A') E' k = mu *+ n'.
   apply: (addrI mu); rewrite -mulrS -Dn -sumrMnl (bigD1 i Ai) big_andbC /=.
@@ -3246,7 +3240,7 @@ have ->: \sum_(k in A') E' k = mu *+ n'.
 rewrite prodrMn exprMn_n -/n' ler_pmuln2r ?expn_gt0; last by case: (n').
 have ->: \prod_(k in A') E' k = E' j * pi.
   by rewrite (bigD1 j) //=; congr *%R; apply: eq_bigr => k /andP[_ /negPf->].
-rewrite -(ler_pmul2l mu_gt0) -exprS -Dn mulrA; apply: ltr_le_trans.
+rewrite -(ler_pmul2l mu_gt0) -exprS -Dn mulrA; apply: lt_le_trans.
 rewrite ltr_pmul2r //= eqxx -addrA mulrDr mulrC -ltr_subl_addl -mulrBl.
 by rewrite mulrC ltr_pmul2r ?subr_gt0.
 Qed.
@@ -3258,9 +3252,9 @@ Implicit Type p : {poly R}.
 Lemma poly_disk_bound p b : {ub | forall x, `|x| <= b -> `|p.[x]| <= ub}.
 Proof.
 exists (\sum_(j < size p) `|p`_j| * b ^+ j) => x le_x_b.
-rewrite horner_coef (ler_trans (ler_norm_sum _ _ _)) ?ler_sum // => j _.
+rewrite horner_coef (le_trans (ler_norm_sum _ _ _)) ?ler_sum // => j _.
 rewrite normrM normrX ler_wpmul2l ?ler_expn2r ?unfold_in ?normr_ge0 //.
-exact: ler_trans (normr_ge0 x) le_x_b.
+exact: le_trans (normr_ge0 x) le_x_b.
 Qed.
 
 End NumDomainOperationTheory.
@@ -3271,11 +3265,6 @@ Arguments ltr_sqr {R} [x y].
 Arguments signr_inj {R} [x1 x2].
 Arguments real_ler_normlP {R x y}.
 Arguments real_ltr_normlP {R x y}.
-Arguments lerif_refl {R x C}.
-Arguments mono_in_lerif [R A f C].
-Arguments nmono_in_lerif [R A f C].
-Arguments mono_lerif [R f C].
-Arguments nmono_lerif [R f C].
 
 Section NumDomainMonotonyTheoryForReals.
 
@@ -3285,17 +3274,17 @@ Implicit Types (m n p : nat) (x y z : R) (u v w : R').
 Lemma real_mono :
   {homo f : x y / x < y} -> {in real &, {mono f : x y / x <= y}}.
 Proof.
-move=> mf x y xR yR /=; have [lt_xy | le_yx] := real_lerP xR yR.
-  by rewrite ltrW_homo.
-by rewrite ltr_geF ?mf.
+move=> mf x y xR yR /=; have [lt_xy | le_yx] := real_leP xR yR.
+  by rewrite ltW_homo.
+by rewrite lt_geF ?mf.
 Qed.
 
 Lemma real_nmono :
   {homo f : x y /~ x < y} -> {in real &, {mono f : x y /~ x <= y}}.
 Proof.
-move=> mf x y xR yR /=; have [lt_xy|le_yx] := real_ltrP xR yR.
-  by rewrite ltr_geF ?mf.
-by rewrite ltrW_nhomo.
+move=> mf x y xR yR /=; have [lt_xy|le_yx] := real_ltP xR yR.
+  by rewrite lt_geF ?mf.
+by rewrite ltW_nhomo.
 Qed.
 
 Lemma real_mono_in :
@@ -3303,8 +3292,8 @@ Lemma real_mono_in :
   {in [pred x in D | x \is real] &, {mono f : x y / x <= y}}.
 Proof.
 move=> Dmf x y /andP[hx xR] /andP[hy yR] /=.
-have [lt_xy|le_yx] := real_lerP xR yR; first by rewrite (ltrW_homo_in Dmf).
-by rewrite ltr_geF ?Dmf.
+have [lt_xy|le_yx] := real_leP xR yR; first by rewrite (ltW_homo_in Dmf).
+by rewrite lt_geF ?Dmf.
 Qed.
 
 Lemma real_nmono_in :
@@ -3312,40 +3301,40 @@ Lemma real_nmono_in :
   {in [pred x in D | x \is real] &, {mono f : x y /~ x <= y}}.
 Proof.
 move=> Dmf x y /andP[hx xR] /andP[hy yR] /=.
-have [lt_xy|le_yx] := real_ltrP xR yR; last by rewrite (ltrW_nhomo_in Dmf).
-by rewrite ltr_geF ?Dmf.
+have [lt_xy|le_yx] := real_ltP xR yR; last by rewrite (ltW_nhomo_in Dmf).
+by rewrite lt_geF ?Dmf.
 Qed.
 
-Lemma realn_mono : {homo f' : x y / x < y >-> (x < y)%N} ->
-  {in real &, {mono f' : x y / x <= y >-> (x <= y)%N}}.
+Lemma realn_mono : {homo f' : x y / x < y >-> (x < y)} ->
+  {in real &, {mono f' : x y / x <= y >-> (x <= y)}}.
 Proof.
-move=> mf x y xR yR /=; have [lt_xy | le_yx] := real_lerP xR yR.
-  by rewrite ltrnW_homo.
-by rewrite ltn_geF ?mf.
+move=> mf x y xR yR /=; have [lt_xy | le_yx] := real_leP xR yR.
+  by rewrite ltW_homo.
+by rewrite lt_geF ?mf.
 Qed.
 
-Lemma realn_nmono : {homo f' : x y / y < x >-> (x < y)%N} ->
-  {in real &, {mono f' : x y / y <= x >-> (x <= y)%N}}.
+Lemma realn_nmono : {homo f' : x y / y < x >-> (x < y)} ->
+  {in real &, {mono f' : x y / y <= x >-> (x <= y)}}.
 Proof.
-move=> mf x y xR yR /=; have [lt_xy|le_yx] := real_ltrP xR yR.
-  by rewrite ltn_geF ?mf.
-by rewrite ltrnW_nhomo.
+move=> mf x y xR yR /=; have [lt_xy|le_yx] := real_ltP xR yR.
+  by rewrite lt_geF ?mf.
+by rewrite ltW_nhomo.
 Qed.
 
-Lemma realn_mono_in : {in D &, {homo f' : x y / x < y >-> (x < y)%N}} ->
-  {in [pred x in D | x \is real] &, {mono f' : x y / x <= y >-> (x <= y)%N}}.
-Proof.
-move=> Dmf x y /andP[hx xR] /andP[hy yR] /=.
-have [lt_xy|le_yx] := real_lerP xR yR; first by rewrite (ltrnW_homo_in Dmf).
-by rewrite ltn_geF ?Dmf.
-Qed.
-
-Lemma realn_nmono_in : {in D &, {homo f' : x y / y < x >-> (x < y)%N}} ->
-  {in [pred x in D | x \is real] &, {mono f' : x y / y <= x >-> (x <= y)%N}}.
+Lemma realn_mono_in : {in D &, {homo f' : x y / x < y >-> (x < y)}} ->
+  {in [pred x in D | x \is real] &, {mono f' : x y / x <= y >-> (x <= y)}}.
 Proof.
 move=> Dmf x y /andP[hx xR] /andP[hy yR] /=.
-have [lt_xy|le_yx] := real_ltrP xR yR; last by rewrite (ltrnW_nhomo_in Dmf).
-by rewrite ltn_geF ?Dmf.
+have [lt_xy|le_yx] := real_leP xR yR; first by rewrite (ltW_homo_in Dmf).
+by rewrite lt_geF ?Dmf.
+Qed.
+
+Lemma realn_nmono_in : {in D &, {homo f' : x y / y < x >-> (x < y)}} ->
+  {in [pred x in D | x \is real] &, {mono f' : x y / y <= x >-> (x <= y)}}.
+Proof.
+move=> Dmf x y /andP[hx xR] /andP[hy yR] /=.
+have [lt_xy|le_yx] := real_ltP xR yR; last by rewrite (ltW_nhomo_in Dmf).
+by rewrite lt_geF ?Dmf.
 Qed.
 
 End NumDomainMonotonyTheoryForReals.
@@ -3361,13 +3350,13 @@ Lemma natrG_gt0 G : #|G|%:R > 0 :> R.
 Proof. by rewrite ltr0n cardG_gt0. Qed.
 
 Lemma natrG_neq0 G : #|G|%:R != 0 :> R.
-Proof. by rewrite gtr_eqF // natrG_gt0. Qed.
+Proof. by rewrite gt_eqF // natrG_gt0. Qed.
 
 Lemma natr_indexg_gt0 G B : #|G : B|%:R > 0 :> R.
 Proof. by rewrite ltr0n indexg_gt0. Qed.
 
 Lemma natr_indexg_neq0 G B : #|G : B|%:R != 0 :> R.
-Proof. by rewrite gtr_eqF // natr_indexg_gt0. Qed.
+Proof. by rewrite gt_eqF // natr_indexg_gt0. Qed.
 
 End FinGroup.
 
@@ -3377,10 +3366,10 @@ Variable F : numFieldType.
 Implicit Types x y z t : F.
 
 Lemma unitf_gt0 x : 0 < x -> x \is a GRing.unit.
-Proof. by move=> hx; rewrite unitfE eq_sym ltr_eqF. Qed.
+Proof. by move=> hx; rewrite unitfE eq_sym lt_eqF. Qed.
 
 Lemma unitf_lt0 x : x < 0 -> x \is a GRing.unit.
-Proof. by move=> hx; rewrite unitfE ltr_eqF. Qed.
+Proof. by move=> hx; rewrite unitfE lt_eqF. Qed.
 
 Lemma lef_pinv : {in pos &, {mono (@GRing.inv F) : x y /~ x <= y}}.
 Proof. by move=> x y hx hy /=; rewrite ler_pinv ?inE ?unitf_gt0. Qed.
@@ -3389,10 +3378,10 @@ Lemma lef_ninv : {in neg &, {mono (@GRing.inv F) : x y /~ x <= y}}.
 Proof. by move=> x y hx hy /=; rewrite ler_ninv ?inE ?unitf_lt0. Qed.
 
 Lemma ltf_pinv : {in pos &, {mono (@GRing.inv F) : x y /~ x < y}}.
-Proof. exact: lerW_nmono_in lef_pinv. Qed.
+Proof. exact: leW_nmono_in lef_pinv. Qed.
 
 Lemma ltf_ninv: {in neg &, {mono (@GRing.inv F) : x y /~ x < y}}.
-Proof. exact: lerW_nmono_in lef_ninv. Qed.
+Proof. exact: leW_nmono_in lef_ninv. Qed.
 
 Definition ltef_pinv := (lef_pinv, ltf_pinv).
 Definition ltef_ninv := (lef_ninv, ltf_ninv).
@@ -3416,18 +3405,18 @@ Definition invf_cp1 := (invf_gte1, invf_lte1).
 
 (* These lemma are all combinations of mono(LR|RL) with ler_[pn]mul2[rl]. *)
 Lemma ler_pdivl_mulr z x y : 0 < z -> (x <= y / z) = (x * z <= y).
-Proof. by move=> z_gt0; rewrite -(@ler_pmul2r _ z) ?mulfVK ?gtr_eqF. Qed.
+Proof. by move=> z_gt0; rewrite -(@ler_pmul2r _ z _ x) ?mulfVK ?gt_eqF. Qed.
 
 Lemma ltr_pdivl_mulr z x y : 0 < z -> (x < y / z) = (x * z < y).
-Proof. by move=> z_gt0; rewrite -(@ltr_pmul2r _ z) ?mulfVK ?gtr_eqF. Qed.
+Proof. by move=> z_gt0; rewrite -(@ltr_pmul2r _ z _ x) ?mulfVK ?gt_eqF. Qed.
 
 Definition lter_pdivl_mulr := (ler_pdivl_mulr, ltr_pdivl_mulr).
 
 Lemma ler_pdivr_mulr z x y : 0 < z -> (y / z <= x) = (y <= x * z).
-Proof. by move=> z_gt0; rewrite -(@ler_pmul2r _ z) ?mulfVK ?gtr_eqF. Qed.
+Proof. by move=> z_gt0; rewrite -(@ler_pmul2r _ z) ?mulfVK ?gt_eqF. Qed.
 
 Lemma ltr_pdivr_mulr z x y : 0 < z -> (y / z < x) = (y < x * z).
-Proof. by move=> z_gt0; rewrite -(@ltr_pmul2r _ z) ?mulfVK ?gtr_eqF. Qed.
+Proof. by move=> z_gt0; rewrite -(@ltr_pmul2r _ z) ?mulfVK ?gt_eqF. Qed.
 
 Definition lter_pdivr_mulr := (ler_pdivr_mulr, ltr_pdivr_mulr).
 
@@ -3448,18 +3437,18 @@ Proof. by move=> z_gt0; rewrite mulrC ltr_pdivr_mulr ?[z * _]mulrC. Qed.
 Definition lter_pdivr_mull := (ler_pdivr_mull, ltr_pdivr_mull).
 
 Lemma ler_ndivl_mulr z x y : z < 0 -> (x <= y / z) = (y <= x * z).
-Proof. by move=> z_lt0; rewrite -(@ler_nmul2r _ z) ?mulfVK  ?ltr_eqF. Qed.
+Proof. by move=> z_lt0; rewrite -(@ler_nmul2r _ z) ?mulfVK  ?lt_eqF. Qed.
 
 Lemma ltr_ndivl_mulr z x y : z < 0 -> (x < y / z) = (y < x * z).
-Proof. by move=> z_lt0; rewrite -(@ltr_nmul2r _ z) ?mulfVK ?ltr_eqF. Qed.
+Proof. by move=> z_lt0; rewrite -(@ltr_nmul2r _ z) ?mulfVK ?lt_eqF. Qed.
 
 Definition lter_ndivl_mulr := (ler_ndivl_mulr, ltr_ndivl_mulr).
 
 Lemma ler_ndivr_mulr z x y : z < 0 -> (y / z <= x) = (x * z <= y).
-Proof. by move=> z_lt0; rewrite -(@ler_nmul2r _ z) ?mulfVK ?ltr_eqF. Qed.
+Proof. by move=> z_lt0; rewrite -(@ler_nmul2r _ z) ?mulfVK ?lt_eqF. Qed.
 
 Lemma ltr_ndivr_mulr z x y : z < 0 -> (y / z < x) = (x * z < y).
-Proof. by move=> z_lt0; rewrite -(@ltr_nmul2r _ z) ?mulfVK ?ltr_eqF. Qed.
+Proof. by move=> z_lt0; rewrite -(@ltr_nmul2r _ z) ?mulfVK ?lt_eqF. Qed.
 
 Definition lter_ndivr_mulr := (ler_ndivr_mulr, ltr_ndivr_mulr).
 
@@ -3482,13 +3471,13 @@ Definition lter_ndivr_mull := (ler_ndivr_mull, ltr_ndivr_mull).
 Lemma natf_div m d : (d %| m)%N -> (m %/ d)%:R = m%:R / d%:R :> F.
 Proof. by apply: char0_natf_div; apply: (@char_num F). Qed.
 
-Lemma normfV : {morph (@norm F) : x / x ^-1}.
+Lemma normfV : {morph (@norm F F) : x / x ^-1}.
 Proof.
 move=> x /=; have [/normrV //|Nux] := boolP (x \is a GRing.unit).
 by rewrite !invr_out // unitfE normr_eq0 -unitfE.
 Qed.
 
-Lemma normf_div : {morph (@norm F) : x y / x / y}.
+Lemma normf_div : {morph (@norm F F) : x y / x / y}.
 Proof. by move=> x y /=; rewrite normrM normfV. Qed.
 
 Lemma invr_sg x : (sg x)^-1 = sgr x.
@@ -3517,32 +3506,32 @@ Definition midf_lte := (midf_le, midf_lt).
 
 (* The AGM, unscaled but without the nth root. *)
 
-Lemma real_lerif_mean_square x y :
+Lemma real_leif_mean_square x y :
   x \is real -> y \is real -> x * y <= mid (x ^+ 2) (y ^+ 2) ?= iff (x == y).
 Proof.
-move=> Rx Ry; rewrite -(mono_lerif (ler_pmul2r (ltr_nat F 0 2))).
-by rewrite divfK ?pnatr_eq0 // mulr_natr; apply: real_lerif_mean_square_scaled.
+move=> Rx Ry; rewrite -(mono_leif (ler_pmul2r (ltr_nat F 0 2))).
+by rewrite divfK ?pnatr_eq0 // mulr_natr; apply: real_leif_mean_square_scaled.
 Qed.
 
-Lemma real_lerif_AGM2 x y :
+Lemma real_leif_AGM2 x y :
   x \is real -> y \is real -> x * y <= mid x y ^+ 2 ?= iff (x == y).
 Proof.
-move=> Rx Ry; rewrite -(mono_lerif (ler_pmul2r (ltr_nat F 0 4))).
+move=> Rx Ry; rewrite -(mono_leif (ler_pmul2r (ltr_nat F 0 4))).
 rewrite mulr_natr (natrX F 2 2) -exprMn divfK ?pnatr_eq0 //.
-exact: real_lerif_AGM2_scaled.
+exact: real_leif_AGM2_scaled.
 Qed.
 
-Lemma lerif_AGM (I : finType) (A : pred I) (E : I -> F) :
+Lemma leif_AGM (I : finType) (A : pred I) (E : I -> F) :
     let n := #|A| in let mu := (\sum_(i in A) E i) / n%:R in
     {in A, forall i, 0 <= E i} ->
   \prod_(i in A) E i <= mu ^+ n
                      ?= iff [forall i in A, forall j in A, E i == E j].
 Proof.
 move=> n mu Ege0; have [n0 | n_gt0] := posnP n.
-  by rewrite n0 -big_andE !(big_pred0 _ _ _ _ (card0_eq n0)); apply/lerifP.
+  by rewrite n0 -big_andE !(big_pred0 _ _ _ _ (card0_eq n0)); apply/leifP.
 pose E' i := E i / n%:R.
 have defE' i: E' i *+ n = E i by rewrite -mulr_natr divfK ?pnatr_eq0 -?lt0n.
-have /lerif_AGM_scaled (i): i \in A -> 0 <= E' i *+ n by rewrite defE' => /Ege0.
+have /leif_AGM_scaled (i): i \in A -> 0 <= E' i *+ n by rewrite defE' => /Ege0.
 rewrite -/n -mulr_suml (eq_bigr _ (in1W defE')); congr (_ <= _ ?= iff _).
 by do 2![apply: eq_forallb_in => ? _]; rewrite -(eqr_pmuln2r n_gt0) !defE'.
 Qed.
@@ -3558,17 +3547,17 @@ have [q Dp]: {q | forall x, x != 0 -> p.[x] = (a - q.[x^-1] / x) * x ^+ n}.
   rewrite -/n -lead_coefE; congr (_ + _); apply: eq_bigr=> i _.
   by rewrite exprB ?unitfE // -exprVn mulrA mulrAC exprSr mulrA.
 have [b ub_q] := poly_disk_bound q 1; exists (b / `|a| + 1) => x px0.
-have b_ge0: 0 <= b by rewrite (ler_trans (normr_ge0 q.[1])) ?ub_q ?normr1.
+have b_ge0: 0 <= b by rewrite (le_trans (normr_ge0 q.[1])) ?ub_q ?normr1.
 have{b_ge0} ba_ge0: 0 <= b / `|a| by rewrite divr_ge0 ?normr_ge0.
-rewrite real_lerNgt ?rpredD ?rpred1 ?ger0_real ?normr_ge0 //.
+rewrite real_leNgt ?rpredD ?rpred1 ?ger0_real ?normr_ge0 //.
 apply: contraL px0 => lb_x; rewrite rootE.
-have x_ge1: 1 <= `|x| by rewrite (ler_trans _ (ltrW lb_x)) // ler_paddl.
-have nz_x: x != 0 by rewrite -normr_gt0 (ltr_le_trans ltr01).
+have x_ge1: 1 <= `|x| by rewrite (le_trans _ (ltW lb_x)) // ler_paddl.
+have nz_x: x != 0 by rewrite -normr_gt0 (lt_le_trans ltr01).
 rewrite {}Dp // mulf_neq0 ?expf_neq0 // subr_eq0 eq_sym.
-have: (b / `|a|) < `|x| by rewrite (ltr_trans _ lb_x) // ltr_spaddr ?ltr01.
+have: (b / `|a|) < `|x| by rewrite (lt_trans _ lb_x) // ltr_spaddr ?ltr01.
 apply: contraTneq => /(canRL (divfK nz_x))Dax.
 rewrite ltr_pdivr_mulr ?normr_gt0 ?lead_coef_eq0 // mulrC -normrM -{}Dax.
-by rewrite ler_gtF // ub_q // normfV invf_le1 ?normr_gt0.
+by rewrite le_gtF // ub_q // normfV invf_le1 ?normr_gt0.
 Qed.
 
 Import GroupScope.
@@ -3581,16 +3570,17 @@ End NumFieldTheory.
 
 Section RealDomainTheory.
 
-Hint Resolve lerr : core.
-
 Variable R : realDomainType.
 Implicit Types x y z t : R.
 
 Lemma num_real x : x \is real. Proof. exact: num_real. Qed.
 Hint Resolve num_real : core.
 
+(* Duplication of le_total
 Lemma ler_total : total (@le R). Proof. by move=> x y; apply: real_leVge. Qed.
+*)
 
+(* Ported to order: lt_total, wlog_le, wlog_lt
 Lemma ltr_total x y : x != y -> (x < y) || (y < x).
 Proof. by rewrite !ltr_def [_ == y]eq_sym => ->; apply: ler_total. Qed.
 
@@ -3604,32 +3594,36 @@ Lemma wlog_ltr P :
     (forall a b, (P b a -> P a b)) -> (forall a b, a < b -> P a b) ->
   forall a b : R, P a b.
 Proof. by move=> rP sP hP a b; apply: real_wlog_ltr. Qed.
+*)
 
+(* Duplication of
 Lemma ltrNge x y : (x < y) = ~~ (y <= x). Proof. exact: real_ltrNge. Qed.
 
 Lemma lerNgt x y : (x <= y) = ~~ (y < x). Proof. exact: real_lerNgt. Qed.
+*)
 
 Lemma lerP x y : ler_xor_gt x y `|x - y| `|y - x| (x <= y) (y < x).
-Proof. exact: real_lerP. Qed.
+Proof. exact: real_leP. Qed.
 
 Lemma ltrP x y : ltr_xor_ge x y `|x - y| `|y - x| (y <= x) (x < y).
-Proof. exact: real_ltrP. Qed.
+Proof. exact: real_ltP. Qed.
 
 Lemma ltrgtP x y :
    comparer x y `|x - y| `|y - x| (y == x) (x == y)
                  (x <= y) (y <= x) (x < y) (x > y) .
-Proof. exact: real_ltrgtP. Qed.
+Proof. exact: real_ltgtP. Qed.
 
 Lemma ger0P x : ger0_xor_lt0 x `|x| (x < 0) (0 <= x).
-Proof. exact: real_ger0P. Qed.
+Proof. exact: real_ge0P. Qed.
 
 Lemma ler0P x : ler0_xor_gt0 x `|x| (0 < x) (x <= 0).
-Proof. exact: real_ler0P. Qed.
+Proof. exact: real_le0P. Qed.
 
 Lemma ltrgt0P x :
   comparer0 x `|x| (0 == x) (x == 0) (x <= 0) (0 <= x) (x < 0) (x > 0).
-Proof. exact: real_ltrgt0P. Qed.
+Proof. exact: real_ltgt0P. Qed.
 
+(* Ported to order: neq_lt, eq_leLR, eq_leRL, eq_ltLR, eq_ltRL
 Lemma neqr_lt x y : (x != y) = (x < y) || (y < x).
 Proof. exact: real_neqr_lt. Qed.
 
@@ -3648,6 +3642,7 @@ Proof. by move=> *; rewrite !ltrNge; congr negb; apply: eqr_leLR. Qed.
 Lemma eqr_ltRL x y z t :
   (x < y -> z < t) -> (y <= x -> t <= z) -> (z < t) = (x < y).
 Proof. by move=> *; symmetry; apply: eqr_ltLR. Qed.
+*)
 
 (* sign *)
 
@@ -3667,7 +3662,7 @@ Lemma mulr_sign_lt0 (b : bool) x :
   ((-1) ^+ b * x < 0) = (x != 0) && (b (+) (x < 0)%R).
 Proof. by rewrite mulr_lt0 signr_lt0 signr_eq0. Qed.
 
-(* sign & norm*)
+(* sign & norm *)
 
 Lemma mulr_sign_norm x : (-1) ^+ (x < 0)%R * `|x| = x.
 Proof. by rewrite real_mulr_sign_norm. Qed.
@@ -3688,70 +3683,22 @@ End RealDomainTheory.
 
 Hint Resolve num_real : core.
 
-Section RealDomainMonotony.
-
-Variables (R : realDomainType) (R' : numDomainType) (D : pred R).
-Variables (f : R -> R') (f' : R -> nat).
-Implicit Types (m n p : nat) (x y z : R) (u v w : R').
-
-Hint Resolve (@num_real R) : core.
-
-Lemma ler_mono : {homo f : x y / x < y} -> {mono f : x y / x <= y}.
-Proof. by move=> mf x y; apply: real_mono. Qed.
-
-Lemma ler_nmono : {homo f : x y /~ x < y} -> {mono f : x y /~ x <= y}.
-Proof. by move=> mf x y; apply: real_nmono. Qed.
-
-Lemma ler_mono_in :
-  {in D &, {homo f : x y / x < y}} -> {in D &, {mono f : x y / x <= y}}.
-Proof.
-by move=> mf x y Dx Dy; apply: (real_mono_in mf); rewrite ?inE ?Dx ?Dy /=.
-Qed.
-
-Lemma ler_nmono_in :
-  {in D &, {homo f : x y /~ x < y}} -> {in D &, {mono f : x y /~ x <= y}}.
-Proof.
-by move=> mf x y Dx Dy; apply: (real_nmono_in mf); rewrite ?inE ?Dx ?Dy /=.
-Qed.
-
-Lemma lern_mono : {homo f' : m n / m < n >-> (m < n)%N} ->
-   {mono f' : m n / m <= n >-> (m <= n)%N}.
-Proof. by move=> mf x y; apply: realn_mono. Qed.
-
-Lemma lern_nmono : {homo f' : m n / n < m >-> (m < n)%N} ->
-  {mono f' : m n / n <= m >-> (m <= n)%N}.
-Proof. by move=> mf x y; apply: realn_nmono. Qed.
-
-Lemma lern_mono_in : {in D &, {homo f' : m n / m < n >-> (m < n)%N}} ->
-   {in D &, {mono f' : m n / m <= n >-> (m <= n)%N}}.
-Proof.
-by move=> mf x y Dx Dy; apply: (realn_mono_in mf); rewrite ?inE ?Dx ?Dy /=.
-Qed.
-
-Lemma lern_nmono_in : {in D &, {homo f' : m n / n < m >-> (m < n)%N}} ->
-  {in D &, {mono f' : m n / n <= m >-> (m <= n)%N}}.
-Proof.
-by move=> mf x y Dx Dy; apply: (realn_nmono_in mf); rewrite ?inE ?Dx ?Dy /=.
-Qed.
-
-End RealDomainMonotony.
-
 Section RealDomainArgExtremum.
 
 Context {R : realDomainType} {I : finType} (i0 : I).
 Context (P : pred I) (F : I -> R) (Pi0 : P i0).
 
-Definition arg_minr := extremum <=%R i0 P F.
-Definition arg_maxr := extremum >=%R i0 P F.
+Definition arg_minr := extremum <=%O i0 P F.
+Definition arg_maxr := extremum >=%O i0 P F.
 
-Lemma arg_minrP: extremum_spec <=%R P F arg_minr.
-Proof. by apply: extremumP => //; [apply: ler_trans|apply: ler_total]. Qed.
+Lemma arg_minrP: extremum_spec <=%O P F arg_minr.
+Proof. by apply: extremumP => //; [apply: le_trans|apply: le_total]. Qed.
 
-Lemma arg_maxrP: extremum_spec >=%R P F arg_maxr.
+Lemma arg_maxrP: extremum_spec >=%O P F arg_maxr.
 Proof.
-apply: extremumP => //; first exact: lerr.
-  by move=> ??? /(ler_trans _) le /le.
-by move=> ??; apply: ler_total.
+apply: extremumP => //; first exact: lexx.
+  by move=> ??? /(le_trans _) le /le.
+by move=> ??; apply: le_total.
 Qed.
 
 End RealDomainArgExtremum.
@@ -3797,8 +3744,8 @@ Lemma sgr_cp0 x :
   ((sg x == -1) = (x < 0)) *
   ((sg x == 0) = (x == 0)).
 Proof.
-rewrite -[1]/((-1) ^+ false) -signrN lt0r lerNgt sgr_def.
-case: (x =P 0) => [-> | _]; first by rewrite !(eq_sym 0) !signr_eq0 ltrr eqxx.
+rewrite -[1]/((-1) ^+ false) -signrN lt0r leNgt sgr_def.
+case: (x =P 0) => [-> | _]; first by rewrite !(eq_sym 0) !signr_eq0 ltxx eqxx.
 by rewrite !(inj_eq signr_inj) eqb_id eqbF_neg signr_eq0 //.
 Qed.
 
@@ -3847,7 +3794,7 @@ Lemma sgr_gt0 x : (sg x > 0) = (x > 0).
 Proof. by rewrite -sgr_cp0 sgr_id sgr_cp0. Qed.
 
 Lemma sgr_ge0 x : (sgr x >= 0) = (x >= 0).
-Proof. by rewrite !lerNgt sgr_lt0. Qed.
+Proof. by rewrite !leNgt sgr_lt0. Qed.
 
 (* norm section *)
 
@@ -3877,10 +3824,10 @@ Proof. exact: real_ltr_normlP. Qed.
 Arguments ltr_normlP {x y}.
 
 Lemma ler_normr x y : (x <= `|y|) = (x <= y) || (x <= - y).
-Proof. by rewrite lerNgt ltr_norml negb_and -!lerNgt orbC ler_oppr. Qed.
+Proof. by rewrite leNgt ltr_norml negb_and -!leNgt orbC ler_oppr. Qed.
 
 Lemma ltr_normr x y : (x < `|y|) = (x < y) || (x < - y).
-Proof. by rewrite ltrNge ler_norml negb_and -!ltrNge orbC ltr_oppr. Qed.
+Proof. by rewrite ltNge ler_norml negb_and -!ltNge orbC ltr_oppr. Qed.
 
 Definition lter_normr := (ler_normr, ltr_normr).
 
@@ -3923,17 +3870,23 @@ Lemma sqr_ge0 x : 0 <= x ^+ 2. Proof. by rewrite exprn_even_ge0. Qed.
 Lemma sqr_norm_eq1 x : (x ^+ 2 == 1) = (`|x| == 1).
 Proof. by rewrite sqrf_eq1 eqr_norml ler01 andbT. Qed.
 
-Lemma lerif_mean_square_scaled x y :
+Lemma leif_mean_square_scaled x y :
   x * y *+ 2 <= x ^+ 2 + y ^+ 2 ?= iff (x == y).
-Proof. exact: real_lerif_mean_square_scaled. Qed.
+Proof. exact: real_leif_mean_square_scaled. Qed.
 
-Lemma lerif_AGM2_scaled x y : x * y *+ 4 <= (x + y) ^+ 2 ?= iff (x == y).
-Proof. exact: real_lerif_AGM2_scaled. Qed.
+Lemma leif_AGM2_scaled x y : x * y *+ 4 <= (x + y) ^+ 2 ?= iff (x == y).
+Proof. exact: real_leif_AGM2_scaled. Qed.
 
 Section MinMax.
 
 (* GG: Many of the first lemmas hold unconditionally, and others hold for    *)
 (* the real subset of a general domain.                                      *)
+
+Local Notation min := meet (only parsing).
+Local Notation max := join (only parsing).
+
+(* Duplication of meetC, meetxx, meet_idPl, meet_idPr,
+                  joinC, joinxx, join_idPr, join_idPl
 Lemma minrC : @commutative R R min.
 Proof. by move=> x y; rewrite /min; case: ltrgtP. Qed.
 
@@ -3957,11 +3910,13 @@ Proof. by move=> hxy; rewrite /max hxy. Qed.
 
 Lemma maxr_r x y : x <= y -> max x y = y.
 Proof. by move=> hxy; rewrite maxrC maxr_l. Qed.
+*)
 
 Lemma addr_min_max x y : min x y + max x y = x + y.
 Proof.
-case: (lerP x y)=> hxy; first by rewrite maxr_r ?minr_l.
-by rewrite maxr_l ?minr_r ?ltrW // addrC.
+case: (lerP x y)=> [| /ltW] hxy;
+  first by rewrite (meet_idPl hxy) (join_idPl hxy).
+by rewrite (meet_idPr hxy) (join_idPr hxy) addrC.
 Qed.
 
 Lemma addr_max_min x y : max x y + min x y = x + y.
@@ -3973,6 +3928,7 @@ Proof. by rewrite -[x + y]addr_min_max addrK. Qed.
 Lemma maxr_to_min x y : max x y = x + y - min x y.
 Proof. by rewrite -[x + y]addr_max_min addrK. Qed.
 
+(* Duplication of meetA, meetCA, meetAC
 Lemma minrA x y z : min x (min y z) = min (min x y) z.
 Proof.
 rewrite /min; case: (lerP y z) => [hyz | /ltrW hyz].
@@ -3987,26 +3943,30 @@ Proof. by move=> x y z; rewrite !minrA [minr x y]minrC. Qed.
 
 Lemma minrAC : @right_commutative R R min.
 Proof. by move=> x y z; rewrite -!minrA [minr y z]minrC. Qed.
+*)
 
+(* Ported to order: leP, ltP
 Variant minr_spec x y : bool -> bool -> R -> Type :=
 | Minr_r of x <= y : minr_spec x y true false x
 | Minr_l of y < x : minr_spec x y false true y.
 
 Lemma minrP x y : minr_spec x y (x <= y) (y < x) (min x y).
 Proof.
-case: lerP=> hxy; first by rewrite minr_l //; constructor.
-by rewrite minr_r 1?ltrW //; constructor.
+by case: lerP => hxy;
+  rewrite ?(meet_idPl hxy) ?(meet_idPr (ltW hxy)); constructor.
 Qed.
+*)
 
-Lemma oppr_max x y : - max x y = min (- x) (- y).
+Lemma oppr_max : {morph -%R : x y / max x y >-> min x y : R}.
 Proof.
-case: minrP; rewrite lter_opp2 => hxy; first by rewrite maxr_l.
-by rewrite maxr_r // ltrW.
+by move=> x y; case: leP; rewrite -lter_opp2 => hxy;
+  rewrite ?(meet_idPr hxy) ?(meet_idPl (ltW hxy)).
 Qed.
 
-Lemma oppr_min x y : - min x y = max (- x) (- y).
-Proof. by rewrite -[maxr _ _]opprK oppr_max !opprK. Qed.
+Lemma oppr_min : {morph -%R : x y / min x y >-> max x y : R}.
+Proof. by move=> x y; rewrite -[max _ _]opprK oppr_max !opprK. Qed.
 
+(* Duplication of joinA, joinCA, joinAC
 Lemma maxrA x y z : max x (max y z) = max (max x y) z.
 Proof. by apply/eqP; rewrite -eqr_opp !oppr_max minrA. Qed.
 
@@ -4015,15 +3975,17 @@ Proof. by move=> x y z; rewrite !maxrA [maxr x y]maxrC. Qed.
 
 Lemma maxrAC : @right_commutative R R max.
 Proof. by move=> x y z; rewrite -!maxrA [maxr y z]maxrC. Qed.
+*)
 
+(* Ported to order: leP, ltP, eq_meetl, eq_meetr, eq_joinl, eq_joinr
 Variant maxr_spec x y : bool -> bool -> R -> Type :=
 | Maxr_r of y <= x : maxr_spec x y true false x
 | Maxr_l of x < y : maxr_spec x y false true y.
 
-Lemma maxrP x y : maxr_spec x y (y <= x) (x < y) (maxr x y).
+Lemma maxrP x y : maxr_spec x y (y <= x) (x < y) (max x y).
 Proof.
-case: lerP => hxy; first by rewrite maxr_l //; constructor.
-by rewrite maxr_r 1?ltrW //; constructor.
+by case: lerP => hxy;
+  rewrite ?(join_idPr hxy) ?(join_idPl (ltW hxy)); constructor.
 Qed.
 
 Lemma eqr_minl x y : (min x y == x) = (x <= y).
@@ -4037,31 +3999,37 @@ Proof. by case: maxrP=> hxy; rewrite ?eqxx // eq_sym ltr_eqF. Qed.
 
 Lemma eqr_maxr x y : (max x y == y) = (x <= y).
 Proof. by rewrite maxrC eqr_maxl. Qed.
+*)
 
+(* Duplication of lexI
 Lemma ler_minr x y z : (x <= min y z) = (x <= y) && (x <= z).
 Proof.
 case: minrP=> hyz.
   by case: lerP=> hxy //; rewrite (ler_trans _ hyz).
 by case: lerP=> hxz; rewrite andbC // (ler_trans hxz) // ltrW.
 Qed.
+*)
 
+(* Ported to order: leIx_total, lexU_total
 Lemma ler_minl x y z : (min y z <= x) = (y <= x) || (z <= x).
 Proof.
-case: minrP => hyz.
-  case: lerP => hyx //=; symmetry; apply: negbTE.
-  by rewrite -ltrNge (@ltr_le_trans _ y).
-case: lerP => hzx; rewrite orbC //=; symmetry; apply: negbTE.
-by rewrite -ltrNge (@ltr_trans _ z).
+by case: (leP y z) => hyz; case: leP => ?; rewrite /= ?(orbT, orbF) //;
+  apply/esym/negbTE; rewrite -ltNge;
+  [rewrite (@lt_le_trans _ _ y) | rewrite (@lt_trans _ _ z)].
 Qed.
 
 Lemma ler_maxr x y z : (x <= max y z) = (x <= y) || (x <= z).
 Proof. by rewrite -lter_opp2 oppr_max ler_minl !ler_opp2. Qed.
+*)
 
+(* Duplication of lexU
 Lemma ler_maxl x y z : (max y z <= x) = (y <= x) && (z <= x).
 Proof. by rewrite -lter_opp2 oppr_max ler_minr !ler_opp2. Qed.
+*)
 
+(* Ported to order: ltxI, ltIx, ltxU, ltUx, ltexI, lteIx, ltexU, lteUx
 Lemma ltr_minr x y z : (x < min y z) = (x < y) && (x < z).
-Proof. by rewrite !ltrNge ler_minl negb_or. Qed.
+Proof. by rewrite !ltNge ler_minl negb_or. Qed.
 
 Lemma ltr_minl x y z : (min y z < x) = (y < x) || (z < x).
 Proof. by rewrite !ltrNge ler_minr negb_and. Qed.
@@ -4076,31 +4044,25 @@ Definition lter_minr := (ler_minr, ltr_minr).
 Definition lter_minl := (ler_minl, ltr_minl).
 Definition lter_maxr := (ler_maxr, ltr_maxr).
 Definition lter_maxl := (ler_maxl, ltr_maxl).
+*)
 
 Lemma addr_minl : @left_distributive R R +%R min.
 Proof.
-move=> x y z; case: minrP=> hxy; first by rewrite minr_l // ler_add2r.
-by rewrite minr_r // ltrW // ltr_add2r.
+by move=> x y z; case: leP; case: leP => //; rewrite lter_add2; case: leP.
 Qed.
 
 Lemma addr_minr : @right_distributive R R +%R min.
-Proof.
-move=> x y z; case: minrP=> hxy; first by rewrite minr_l // ler_add2l.
-by rewrite minr_r // ltrW // ltr_add2l.
-Qed.
+Proof. by move=> x y z; rewrite !(addrC x) addr_minl. Qed.
 
 Lemma addr_maxl : @left_distributive R R +%R max.
 Proof.
-move=> x y z; rewrite -[_ + _]opprK opprD oppr_max.
-by rewrite addr_minl -!opprD oppr_min !opprK.
+by move=> x y z; case: leP; case: leP => //; rewrite lter_add2; case: leP.
 Qed.
 
 Lemma addr_maxr : @right_distributive R R +%R max.
-Proof.
-move=> x y z; rewrite -[_ + _]opprK opprD oppr_max.
-by rewrite addr_minr -!opprD oppr_min !opprK.
-Qed.
+Proof. by move=> x y z; rewrite !(addrC x) addr_maxl. Qed.
 
+(* Duplication of meetUKC, joinKIC, joinIl, joinIr, meetUl, meetUr
 Lemma minrK x y : max (min x y) x = x.
 Proof. by case: minrP => hxy; rewrite ?maxrr ?maxr_r // ltrW. Qed.
 
@@ -4125,12 +4087,12 @@ Qed.
 
 Lemma minr_maxr : @right_distributive R R min max.
 Proof. by move=> x y z; rewrite minrC minr_maxl ![_ _ x]minrC. Qed.
+*)
 
 Lemma minr_pmulr x y z : 0 <= x -> x * min y z = min (x * y) (x * z).
 Proof.
-case: sgrP=> // hx _; first by rewrite hx !mul0r minrr.
-case: minrP=> hyz; first by rewrite minr_l // ler_pmul2l.
-by rewrite minr_r // ltrW // ltr_pmul2l.
+case: sgrP=> // hx _; first by rewrite hx !mul0r meetxx.
+by case: leP; case: leP => //; rewrite lter_pmul2l //; case: leP.
 Qed.
 
 Lemma minr_nmulr x y z : x <= 0 -> x * min y z = max (x * y) (x * z).
@@ -4164,19 +4126,16 @@ Lemma maxr_nmull x y z : x <= 0 -> max y z * x = min (y * x) (z * x).
 Proof. by move=> *; rewrite mulrC maxr_nmulr // ![_ * x]mulrC. Qed.
 
 Lemma maxrN x : max x (- x) = `|x|.
-Proof.
-case: ger0P=> hx; first by rewrite maxr_l // ge0_cp //.
-by rewrite maxr_r // le0_cp // ltrW.
-Qed.
+Proof. by case: ger0P=> [/ge0_cp [] | /lt0_cp []]; case: (leP (- x) x). Qed.
 
 Lemma maxNr x : max (- x) x = `|x|.
-Proof. by rewrite maxrC maxrN. Qed.
+Proof. by rewrite joinC maxrN. Qed.
 
 Lemma minrN x : min x (- x) = - `|x|.
-Proof. by rewrite -[minr _ _]opprK oppr_min opprK maxNr. Qed.
+Proof. by rewrite -[min _ _]opprK oppr_min opprK maxNr. Qed.
 
 Lemma minNr x : min (- x) x = - `|x|.
-Proof. by rewrite -[minr _ _]opprK oppr_min opprK maxrN. Qed.
+Proof. by rewrite -[min _ _]opprK oppr_min opprK maxrN. Qed.
 
 End MinMax.
 
@@ -4186,8 +4145,8 @@ Variable p : {poly R}.
 
 Lemma poly_itv_bound a b : {ub | forall x, a <= x <= b -> `|p.[x]| <= ub}.
 Proof.
-have [ub le_p_ub] := poly_disk_bound p (Num.max `|a| `|b|).
-exists ub => x /andP[le_a_x le_x_b]; rewrite le_p_ub // ler_maxr !ler_normr.
+have [ub le_p_ub] := poly_disk_bound p (`|a| `|` `|b|).
+exists ub => x /andP[le_a_x le_x_b]; rewrite le_p_ub // lexU_total !ler_normr.
 by have [_|_] := ler0P x; rewrite ?ler_opp2 ?le_a_x ?le_x_b orbT.
 Qed.
 
@@ -4198,16 +4157,16 @@ have [p_le1 | p_gt1] := leqP (size p) 1.
   exists 0 => x _; rewrite (size1_polyC p_le1) hornerC.
   by rewrite -[p`_0]lead_coefC -size1_polyC // mon_p ltr01.
 pose lb := \sum_(j < n.+1) `|p`_j|; exists (lb + 1) => x le_ub_x.
-have x_ge1: 1 <= x; last have x_gt0 := ltr_le_trans ltr01 x_ge1.
+have x_ge1: 1 <= x; last have x_gt0 := lt_le_trans ltr01 x_ge1.
   by rewrite -(ler_add2l lb) ler_paddl ?sumr_ge0 // => j _; apply: normr_ge0.
 rewrite horner_coef -(subnK p_gt1) -/n addnS big_ord_recr /= addn1.
 rewrite [in p`__]subnSK // subn1 -lead_coefE mon_p mul1r -ltr_subl_addl sub0r.
-apply: ler_lt_trans (_ : lb * x ^+ n < _); last first.
+apply: le_lt_trans (_ : lb * x ^+ n < _); last first.
   rewrite exprS ltr_pmul2r ?exprn_gt0 ?(ltr_le_trans ltr01) //.
   by rewrite -(ltr_add2r 1) ltr_spaddr ?ltr01.
-rewrite -sumrN mulr_suml ler_sum // => j _; apply: ler_trans (ler_norm _) _.
+rewrite -sumrN mulr_suml ler_sum // => j _; apply: le_trans (ler_norm _) _.
 rewrite normrN normrM ler_wpmul2l ?normr_ge0 // normrX.
-by rewrite ger0_norm ?(ltrW x_gt0) // ler_weexpn2l ?leq_ord.
+by rewrite ger0_norm ?(ltW x_gt0) // ler_weexpn2l ?leq_ord.
 Qed.
 
 End PolyBounds.
@@ -4218,11 +4177,11 @@ Section RealField.
 
 Variables (F : realFieldType) (x y : F).
 
-Lemma lerif_mean_square : x * y <= (x ^+ 2 + y ^+ 2) / 2%:R ?= iff (x == y).
-Proof. by apply: real_lerif_mean_square; apply: num_real. Qed.
+Lemma leif_mean_square : x * y <= (x ^+ 2 + y ^+ 2) / 2%:R ?= iff (x == y).
+Proof. by apply: real_leif_mean_square; apply: num_real. Qed.
 
-Lemma lerif_AGM2 : x * y <= ((x + y) / 2%:R)^+ 2 ?= iff (x == y).
-Proof. by apply: real_lerif_AGM2; apply: num_real. Qed.
+Lemma leif_AGM2 : x * y <= ((x + y) / 2%:R)^+ 2 ?= iff (x == y).
+Proof. by apply: real_leif_AGM2; apply: num_real. Qed.
 
 End RealField.
 
@@ -4236,7 +4195,7 @@ Proof. by move/ger0_norm=> {1}<-; rewrite /bound; case: (sigW _). Qed.
 Lemma upper_nthrootP i : (bound x <= i)%N -> x < 2%:R ^+ i.
 Proof.
 rewrite /bound; case: (sigW _) => /= b le_x_b le_b_i.
-apply: ler_lt_trans (ler_norm x) (ltr_trans le_x_b _ ).
+apply: le_lt_trans (ler_norm x) (lt_trans le_x_b _ ).
 by rewrite -natrX ltr_nat (leq_ltn_trans le_b_i) // ltn_expl.
 Qed.
 
@@ -4267,7 +4226,7 @@ by have [//|_ /eqP//|->] := ltrgt0P a; rewrite mulf_eq0 orbb => /eqP.
 Qed.
 
 Lemma ltr0_sqrtr a : a < 0 -> sqrt a = 0.
-Proof. by move=> /ltrW; apply: ler0_sqrtr. Qed.
+Proof. by move=> /ltW; apply: ler0_sqrtr. Qed.
 
 Variant sqrtr_spec a : R -> bool -> bool -> R -> Type :=
 | IsNoSqrtr of a < 0 : sqrtr_spec a a false true 0
@@ -4304,13 +4263,13 @@ Proof. by move: (sqrtr_sqr 1); rewrite expr1n => ->; rewrite normr1. Qed.
 
 Lemma sqrtr_eq0 a : (sqrt a == 0) = (a <= 0).
 Proof.
-case: sqrtrP => [/ltrW ->|b]; first by rewrite eqxx.
-case: ltrgt0P => [b_gt0|//|->]; last by rewrite exprS mul0r lerr.
-by rewrite ltr_geF ?pmulr_rgt0.
+case: sqrtrP => [/ltW ->|b]; first by rewrite eqxx.
+case: ltrgt0P => [b_gt0|//|->]; last by rewrite exprS mul0r lexx.
+by rewrite lt_geF ?pmulr_rgt0.
 Qed.
 
 Lemma sqrtr_gt0 a : (0 < sqrt a) = (0 < a).
-Proof. by rewrite lt0r sqrtr_ge0 sqrtr_eq0 -ltrNge andbT. Qed.
+Proof. by rewrite lt0r sqrtr_ge0 sqrtr_eq0 -ltNge andbT. Qed.
 
 Lemma eqr_sqrt a b : 0 <= a -> 0 <= b -> (sqrt a == sqrt b) = (a == b).
 Proof.
@@ -4321,29 +4280,29 @@ Qed.
 Lemma ler_wsqrtr : {homo @sqrt R : a b / a <= b}.
 Proof.
 move=> a b /= le_ab; case: (boolP (0 <= a))=> [pa|]; last first.
-  by rewrite -ltrNge; move/ltrW; rewrite -sqrtr_eq0; move/eqP->.
+  by rewrite -ltNge; move/ltW; rewrite -sqrtr_eq0; move/eqP->.
 rewrite -(@ler_pexpn2r R 2) ?nnegrE ?sqrtr_ge0 //.
-by rewrite !sqr_sqrtr // (ler_trans pa).
+by rewrite !sqr_sqrtr // (le_trans pa).
 Qed.
 
 Lemma ler_psqrt : {in @pos R &, {mono sqrt : a b / a <= b}}.
 Proof.
-apply: ler_mono_in => x y x_gt0 y_gt0.
-rewrite !ltr_neqAle => /andP[neq_xy le_xy].
-by rewrite ler_wsqrtr // eqr_sqrt ?ltrW // neq_xy.
+apply: le_mono_in => x y x_gt0 y_gt0.
+rewrite !lt_neqAle => /andP[neq_xy le_xy].
+by rewrite ler_wsqrtr // eqr_sqrt ?ltW // neq_xy.
 Qed.
 
 Lemma ler_sqrt a b : 0 < b -> (sqrt a <= sqrt b) = (a <= b).
 Proof.
 move=> b_gt0; have [a_le0|a_gt0] := ler0P a; last by rewrite ler_psqrt.
-by rewrite ler0_sqrtr // sqrtr_ge0 (ler_trans a_le0) ?ltrW.
+by rewrite ler0_sqrtr // sqrtr_ge0 (le_trans a_le0) ?ltW.
 Qed.
 
 Lemma ltr_sqrt a b : 0 < b -> (sqrt a < sqrt b) = (a < b).
 Proof.
 move=> b_gt0; have [a_le0|a_gt0] := ler0P a; last first.
-  by rewrite (lerW_mono_in ler_psqrt).
-by rewrite ler0_sqrtr // sqrtr_gt0 b_gt0 (ler_lt_trans a_le0).
+  by rewrite (leW_mono_in ler_psqrt).
+by rewrite ler0_sqrtr // sqrtr_gt0 b_gt0 (le_lt_trans a_le0).
 Qed.
 
 End RealClosedFieldTheory.
@@ -4362,10 +4321,10 @@ Variable C : numClosedFieldType.
 Implicit Types a x y z : C.
 
 Definition normCK x : `|x| ^+ 2 = x * x^*.
-Proof. by case: C x => ? [? ? []]. Qed.
+Proof. by case: C x => ? [? ? ? ? []]. Qed.
 
 Lemma sqrCi : 'i ^+ 2 = -1 :> C.
-Proof. by case: C => ? [? ? []]. Qed.
+Proof. by case: C => ? [? ? ? ? []]. Qed.
 
 Lemma conjCK : involutive (@conjC C).
 Proof.
@@ -4396,7 +4355,7 @@ have argCle_total : total argCle.
   by do 2!case: (nnegIm _) => //; rewrite ?orbT //= real_leVge.
 have argCle_trans : transitive argCle.
   move=> u v w /implyP geZuv /implyP geZvw; apply/implyP.
-  by case/geZvw/andP=> /geZuv/andP[-> geRuv] /ler_trans->.
+  by case/geZvw/andP=> /geZuv/andP[-> geRuv] /le_trans->.
 pose p := 'X^n - (x *+ (n > 0))%:P; have [r0 Dp] := closed_field_poly_normal p.
 have sz_p: size p = n.+1.
   rewrite size_addl ?size_polyXn // ltnS size_opp size_polyC mulrn_eq0.
@@ -4414,7 +4373,7 @@ exists r`_0 => [|z n_gt0 /(mem_rP z n_gt0) r_z].
   case: posnP => [n0 | n_gt0]; first by rewrite nth_default // sz_r n0.
   by apply/mem_rP=> //; rewrite mem_nth ?sz_r.
 case: {Dp mem_rP}r r_z r_arg => // y r1; rewrite inE => /predU1P[-> _|r1z].
-  by apply/implyP=> ->; rewrite lerr.
+  by apply/implyP=> ->; rewrite lexx.
 by move/(order_path_min argCle_trans)/allP->.
 Qed.
 
@@ -4515,7 +4474,7 @@ Proof. by move=> n_gt0; rewrite -{1}(rootC0 n) eqr_rootC. Qed.
 (* Rectangular coordinates. *)
 
 Lemma nonRealCi : ('i : C) \isn't real.
-Proof. by rewrite realEsqr sqrCi oppr_ge0 ltr_geF ?ltr01. Qed.
+Proof. by rewrite realEsqr sqrCi oppr_ge0 lt_geF ?ltr01. Qed.
 
 Lemma neq0Ci : 'i != 0 :> C.
 Proof. by apply: contraNneq nonRealCi => ->; apply: real0. Qed.
@@ -4652,19 +4611,19 @@ Proof.
 by move=> x y Rx Ry; rewrite /= invC_norm conjC_rect // mulrC normC2_rect.
 Qed.
 
-Lemma lerif_normC_Re_Creal z : `|'Re z| <= `|z| ?= iff (z \is real).
+Lemma leif_normC_Re_Creal z : `|'Re z| <= `|z| ?= iff (z \is real).
 Proof.
-rewrite -(mono_in_lerif ler_sqr); try by rewrite qualifE normr_ge0.
+rewrite -(mono_in_leif ler_sqr); try by rewrite qualifE normr_ge0.
 rewrite normCK conj_Creal // normC2_Re_Im -expr2.
-rewrite addrC -lerif_subLR subrr (sameP (Creal_ImP _) eqP) -sqrf_eq0 eq_sym.
-by apply: lerif_eq; rewrite -realEsqr.
+rewrite addrC -leif_subLR subrr (sameP (Creal_ImP _) eqP) -sqrf_eq0 eq_sym.
+by apply: leif_eq; rewrite -realEsqr.
 Qed.
 
-Lemma lerif_Re_Creal z : 'Re z <= `|z| ?= iff (0 <= z).
+Lemma leif_Re_Creal z : 'Re z <= `|z| ?= iff (0 <= z).
 Proof.
 have ubRe: 'Re z <= `|'Re z| ?= iff (0 <= 'Re z).
-  by rewrite ger0_def eq_sym; apply/lerif_eq/real_ler_norm.
-congr (_ <= _ ?= iff _): (lerif_trans ubRe (lerif_normC_Re_Creal z)).
+  by rewrite ger0_def eq_sym; apply/leif_eq/real_ler_norm.
+congr (_ <= _ ?= iff _): (leif_trans ubRe (leif_normC_Re_Creal z)).
 apply/andP/idP=> [[zRge0 /Creal_ReP <- //] | z_ge0].
 by have Rz := ger0_real z_ge0; rewrite (Creal_ReP _ _).
 Qed.
@@ -4715,50 +4674,50 @@ suffices /existsP[i ltRwi0]: [exists i : 'I_n, 'Re (w ^+ i) < 0].
   by exists (w ^+ i) => //; rewrite exprAC wn1 expr1n.
 apply: contra_eqT (congr1 Re pw_0); rewrite negb_exists => /forallP geRw0.
 rewrite raddf_sum raddf0 /= (bigD1 (Ordinal (ltnW n_gt1))) //=.
-rewrite (Creal_ReP _ _) ?rpred1 // gtr_eqF ?ltr_paddr ?ltr01 //=.
-by apply: sumr_ge0 => i _; rewrite real_lerNgt ?rpred0.
+rewrite (Creal_ReP _ _) ?rpred1 // gt_eqF ?ltr_paddr ?ltr01 //=.
+by apply: sumr_ge0 => i _; rewrite real_leNgt ?rpred0.
 Qed.
 
 Lemma Im_rootC_ge0 n x : (n > 1)%N -> 0 <= 'Im (n.-root x).
 Proof.
 set y := n.-root x => n_gt1; have n_gt0 := ltnW n_gt1.
-apply: wlog_neg; rewrite -real_ltrNge ?rpred0 // => ltIy0.
+apply: wlog_neg; rewrite -real_ltNge ?rpred0 // => ltIy0.
 suffices [z zn_x leI0z]: exists2 z, z ^+ n = x & 'Im z >= 0.
   by rewrite /y; case_rootC => /= y1 _ /(_ z n_gt0 zn_x)/argCleP[].
 have [w wn1 ltRw0] := neg_unity_root n_gt1.
 wlog leRI0yw: w wn1 ltRw0 / 0 <= 'Re y * 'Im w.
   move=> IHw; have: 'Re y * 'Im w \is real by rewrite rpredM.
-  case/real_ger0P=> [|/ltrW leRIyw0]; first exact: IHw.
+  case/real_ge0P=> [|/ltW leRIyw0]; first exact: IHw.
   apply: (IHw w^*); rewrite ?Re_conj ?Im_conj ?mulrN ?oppr_ge0 //.
   by rewrite -rmorphX wn1 rmorph1.
 exists (w * y); first by rewrite exprMn wn1 mul1r rootCK.
 rewrite [w]Crect [y]Crect mulC_rect.
-by rewrite Im_rect ?rpredD ?rpredN 1?rpredM // addr_ge0 // ltrW ?nmulr_rgt0.
+by rewrite Im_rect ?rpredD ?rpredN 1?rpredM // addr_ge0 // ltW ?nmulr_rgt0.
 Qed.
 
 Lemma rootC_lt0 n x : (1 < n)%N -> (n.-root x < 0) = false.
 Proof.
 set y := n.-root x => n_gt1; have n_gt0 := ltnW n_gt1.
-apply: negbTE; apply: wlog_neg => /negbNE lt0y; rewrite ler_gtF //.
+apply: negbTE; apply: wlog_neg => /negbNE lt0y; rewrite le_gtF //.
 have Rx: x \is real by rewrite -[x](rootCK n_gt0) rpredX // ltr0_real.
 have Re_y: 'Re y = y by apply/Creal_ReP; rewrite ltr0_real.
 have [z zn_x leR0z]: exists2 z, z ^+ n = x & 'Re z >= 0.
   have [w wn1 ltRw0] := neg_unity_root n_gt1.
   exists (w * y); first by rewrite exprMn wn1 mul1r rootCK.
-  by rewrite ReMr ?ltr0_real // ltrW // nmulr_lgt0.
+  by rewrite ReMr ?ltr0_real // ltW // nmulr_lgt0.
 without loss leI0z: z zn_x leR0z / 'Im z >= 0.
   move=> IHz; have: 'Im z \is real by [].
-  case/real_ger0P=> [|/ltrW leIz0]; first exact: IHz.
+  case/real_ge0P=> [|/ltW leIz0]; first exact: IHz.
   apply: (IHz z^*); rewrite ?Re_conj ?Im_conj ?oppr_ge0 //.
   by rewrite -rmorphX zn_x conj_Creal.
-by apply: ler_trans leR0z _; rewrite -Re_y ?rootC_Re_max ?ltr0_real.
+by apply: le_trans leR0z _; rewrite -Re_y ?rootC_Re_max ?ltr0_real.
 Qed.
 
 Lemma rootC_ge0 n x : (n > 0)%N -> (0 <= n.-root x) = (0 <= x).
 Proof.
 set y := n.-root x => n_gt0.
 apply/idP/idP=> [/(exprn_ge0 n) | x_ge0]; first by rewrite rootCK.
-rewrite -(ger_lerif (lerif_Re_Creal y)).
+rewrite -(ger_leif (leif_Re_Creal y)).
 have Ray: `|y| \is real by apply: normr_real.
 rewrite -(Creal_ReP _ Ray) rootC_Re_max ?(Creal_ImP _ Ray) //.
 by rewrite -normrX rootCK // ger0_norm.
@@ -4769,25 +4728,25 @@ Proof. by move=> n_gt0; rewrite !lt0r rootC_ge0 ?rootC_eq0. Qed.
 
 Lemma rootC_le0 n x : (1 < n)%N -> (n.-root x <= 0) = (x == 0).
 Proof.
-by move=> n_gt1; rewrite ler_eqVlt rootC_lt0 // orbF rootC_eq0 1?ltnW.
+by move=> n_gt1; rewrite le_eqVlt rootC_lt0 // orbF rootC_eq0 1?ltnW.
 Qed.
 
 Lemma ler_rootCl n : (n > 0)%N -> {in Num.nneg, {mono n.-root : x y / x <= y}}.
 Proof.
 move=> n_gt0 x x_ge0 y; have [y_ge0 | not_y_ge0] := boolP (0 <= y).
   by rewrite -(ler_pexpn2r n_gt0) ?qualifE ?rootC_ge0 ?rootCK.
-rewrite (contraNF (@ler_trans _ _ 0 _ _)) ?rootC_ge0 //.
-by rewrite (contraNF (ler_trans x_ge0)).
+rewrite (contraNF (@le_trans _ _ _ 0 _ _)) ?rootC_ge0 //.
+by rewrite (contraNF (le_trans x_ge0)).
 Qed.
 
 Lemma ler_rootC n : (n > 0)%N -> {in Num.nneg &, {mono n.-root : x y / x <= y}}.
 Proof. by move=> n_gt0 x y x_ge0 _; apply: ler_rootCl. Qed.
 
 Lemma ltr_rootCl n : (n > 0)%N -> {in Num.nneg, {mono n.-root : x y / x < y}}.
-Proof. by move=> n_gt0 x x_ge0 y; rewrite !ltr_def ler_rootCl ?eqr_rootC. Qed.
+Proof. by move=> n_gt0 x x_ge0 y; rewrite !lt_def ler_rootCl ?eqr_rootC. Qed.
 
 Lemma ltr_rootC n : (n > 0)%N -> {in Num.nneg &, {mono n.-root : x y / x < y}}.
-Proof. by move/ler_rootC/lerW_mono_in. Qed.
+Proof. by move/ler_rootC/leW_mono_in. Qed.
 
 Lemma exprCK n x : (0 < n)%N -> 0 <= x -> n.-root (x ^+ n) = x.
 Proof.
@@ -4831,31 +4790,31 @@ by move=> n_gt0; rewrite -{1}(rootC1 n_gt0) ler_rootCl // qualifE ler01.
 Qed.
 
 Lemma rootC_gt1 n x : (n > 0)%N -> (n.-root x > 1) = (x > 1).
-Proof. by move=> n_gt0; rewrite !ltr_def rootC_eq1 ?rootC_ge1. Qed.
+Proof. by move=> n_gt0; rewrite !lt_def rootC_eq1 ?rootC_ge1. Qed.
 
 Lemma rootC_le1 n x : (n > 0)%N -> 0 <= x -> (n.-root x <= 1) = (x <= 1).
 Proof. by move=> n_gt0 x_ge0; rewrite -{1}(rootC1 n_gt0) ler_rootCl. Qed.
 
 Lemma rootC_lt1 n x : (n > 0)%N -> 0 <= x -> (n.-root x < 1) = (x < 1).
-Proof. by move=> n_gt0 x_ge0; rewrite !ltr_neqAle rootC_eq1 ?rootC_le1. Qed.
+Proof. by move=> n_gt0 x_ge0; rewrite !lt_neqAle rootC_eq1 ?rootC_le1. Qed.
 
 Lemma rootCMl n x z : 0 <= x -> n.-root (x * z) = n.-root x * n.-root z.
 Proof.
 rewrite le0r => /predU1P[-> | x_gt0]; first by rewrite !(mul0r, rootC0).
 have [| n_gt1 | ->] := ltngtP n 1; last by rewrite !root1C.
   by case: n => //; rewrite !root0C mul0r.
-have [x_ge0 n_gt0] := (ltrW x_gt0, ltnW n_gt1).
+have [x_ge0 n_gt0] := (ltW x_gt0, ltnW n_gt1).
 have nx_gt0: 0 < n.-root x by rewrite rootC_gt0.
-have Rnx: n.-root x \is real by rewrite ger0_real ?ltrW.
+have Rnx: n.-root x \is real by rewrite ger0_real ?ltW.
 apply: eqC_semipolar; last 1 first; try apply/eqP.
 - by rewrite ImMl // !(Im_rootC_ge0, mulr_ge0, rootC_ge0).
 - by rewrite -(eqr_expn2 n_gt0) ?normr_ge0 // -!normrX exprMn !rootCK.
-rewrite eqr_le; apply/andP; split; last first.
+rewrite eq_le; apply/andP; split; last first.
   rewrite rootC_Re_max ?exprMn ?rootCK ?ImMl //.
-  by rewrite mulr_ge0 ?Im_rootC_ge0 ?ltrW.
-rewrite -[n.-root _](mulVKf (negbT (gtr_eqF nx_gt0))) !(ReMl Rnx) //.
-rewrite ler_pmul2l // rootC_Re_max ?exprMn ?exprVn ?rootCK ?mulKf ?gtr_eqF //.
-by rewrite ImMl ?rpredV // mulr_ge0 ?invr_ge0 ?Im_rootC_ge0 ?ltrW.
+  by rewrite mulr_ge0 ?Im_rootC_ge0 ?ltW.
+rewrite -[n.-root _](mulVKf (negbT (gt_eqF nx_gt0))) !(ReMl Rnx) //.
+rewrite ler_pmul2l // rootC_Re_max ?exprMn ?exprVn ?rootCK ?mulKf ?gt_eqF //.
+by rewrite ImMl ?rpredV // mulr_ge0 ?invr_ge0 ?Im_rootC_ge0 ?ltW.
 Qed.
 
 Lemma rootCMr n x z : 0 <= x -> n.-root (z * x) = n.-root z * n.-root x.
@@ -4872,18 +4831,18 @@ Qed.
 
 (* The proper form of the Arithmetic - Geometric Mean inequality. *)
 
-Lemma lerif_rootC_AGM (I : finType) (A : pred I) (n := #|A|) E :
+Lemma leif_rootC_AGM (I : finType) (A : pred I) (n := #|A|) E :
     {in A, forall i, 0 <= E i} ->
   n.-root (\prod_(i in A) E i) <= (\sum_(i in A) E i) / n%:R
                              ?= iff [forall i in A, forall j in A, E i == E j].
 Proof.
 move=> Ege0; have [n0 | n_gt0] := posnP n.
-  rewrite n0 root0C invr0 mulr0; apply/lerif_refl/forall_inP=> i.
+  rewrite n0 root0C invr0 mulr0; apply/leif_refl/forall_inP=> i.
   by rewrite (card0_eq n0).
-rewrite -(mono_in_lerif (ler_pexpn2r n_gt0)) ?rootCK //=; first 1 last.
+rewrite -(mono_in_leif (ler_pexpn2r n_gt0)) ?rootCK //=; first 1 last.
 - by rewrite qualifE rootC_ge0 // prodr_ge0.
 - by rewrite rpred_div ?rpred_nat ?rpred_sum.
-exact: lerif_AGM.
+exact: leif_AGM.
 Qed.
 
 (* Square root. *)
@@ -4915,8 +4874,8 @@ Proof.
 apply: (iffP andP) => [[leI0x not_gt0x] | <-]; last first.
   by rewrite sqrtC_lt0 Im_rootC_ge0.
 have /eqP := sqrtCK (x ^+ 2); rewrite eqf_sqr => /pred2P[] // defNx.
-apply: sqrCK; rewrite -real_lerNgt ?rpred0 // in not_gt0x;
-apply/Creal_ImP/ler_anti;
+apply: sqrCK; rewrite -real_leNgt ?rpred0 // in not_gt0x;
+apply/Creal_ImP/le_anti;
 by rewrite leI0x -oppr_ge0 -raddfN -defNx Im_rootC_ge0.
 Qed.
 
@@ -4954,7 +4913,7 @@ have def_xy: x * y^* = y * x^*.
   by rewrite mulrN mulrAC mulrA -mulrA mulrACA -!normCK mulNrn addNr.
 have{def_xy def2xy} def_yx: `|y * x| = y * x^*.
   by apply: (mulIf nz2); rewrite !mulr_natr mulrC normrM def2xy def_xy.
-rewrite -{1}(divfK nz_x y) invC_norm mulrCA -{}def_yx !normrM invfM.
+rewrite -{1}(divfK nz_x y) (invC_norm x) mulrCA -{}def_yx !normrM invfM.
 by rewrite mulrCA divfK ?normr_eq0 // mulrAC mulrA.
 Qed.
 
@@ -4972,8 +4931,8 @@ have [Qj | /nandP[/negP[]// | /negbNE/eqP->]] := boolP (Q j); last first.
   by rewrite mulrC divfK.
 have: `|F i + F j| = `|F i| + `|F j|.
   do [rewrite !(bigD1 j Qj) /=; set z := \sum_(k | _) `|_|] in norm_sumF.
-  apply/eqP; rewrite eqr_le ler_norm_add -(ler_add2r z) -addrA -norm_sumF addrA.
-  by rewrite (ler_trans (ler_norm_add _ _)) // ler_add2l ler_norm_sum.
+  apply/eqP; rewrite eq_le ler_norm_add -(ler_add2r z) -addrA -norm_sumF addrA.
+  by rewrite (le_trans (ler_norm_add _ _)) // ler_add2l ler_norm_sum.
 by case/normC_add_eq=> k _ [/(canLR (mulKf nzFi)) <-]; rewrite -(mulrC (F i)).
 Qed.
 
@@ -4992,14 +4951,14 @@ Lemma normC_sum_upper (I : finType) (P : pred I) (F G : I -> C) :
    forall i, P i -> F i = G i.
 Proof.
 set sumF := \sum_(i | _) _; set sumG := \sum_(i | _) _ => leFG eq_sumFG.
-have posG i: P i -> 0 <= G i by move/leFG; apply: ler_trans; apply: normr_ge0.
+have posG i: P i -> 0 <= G i by move/leFG; apply: le_trans; apply: normr_ge0.
 have norm_sumG: `|sumG| = sumG by rewrite ger0_norm ?sumr_ge0.
 have norm_sumF: `|sumF| = \sum_(i | P i) `|F i|.
-  apply/eqP; rewrite eqr_le ler_norm_sum eq_sumFG norm_sumG -subr_ge0 -sumrB.
+  apply/eqP; rewrite eq_le ler_norm_sum eq_sumFG norm_sumG -subr_ge0 -sumrB.
   by rewrite sumr_ge0 // => i Pi; rewrite subr_ge0 ?leFG.
 have [t _ defF] := normC_sum_eq norm_sumF.
 have [/(psumr_eq0P posG) G0 i Pi | nz_sumG] := eqVneq sumG 0.
-  by apply/eqP; rewrite G0 // -normr_eq0 eqr_le normr_ge0 -(G0 i Pi) leFG.
+  by apply/eqP; rewrite G0 // -normr_eq0 eq_le normr_ge0 -(G0 i Pi) leFG.
 have t1: t = 1.
   apply: (mulfI nz_sumG); rewrite mulr1 -{1}norm_sumG -eq_sumFG norm_sumF.
   by rewrite mulr_suml -(eq_bigr _ defF).
@@ -5063,6 +5022,9 @@ Proof.
 by case/orP: (le0_total 1)=> // ?; rewrite -[1]mul1r -mulrNN le0_mul ?le0N.
 Qed.
 
+Fact lt_neqAle x y : (x < y) = (x != y) && (x <= y).
+Proof. by rewrite lt_def eq_sym. Qed.
+
 Fact lt0_add x y : 0 < x -> 0 < y -> 0 < x + y.
 Proof.
 rewrite !lt_def => /andP[x_neq0 l0x] /andP[y_neq0 l0y]; rewrite le0_add //.
@@ -5102,11 +5064,27 @@ rewrite -normN ge0_norm //; have [hxy|hxy] := leN_total (x + y).
 by rewrite -normN ge0_norm // opprK addrCA addrNK le0_add.
 Qed.
 
-Lemma le_total x y : (x <= y) || (y <= x).
-Proof. by rewrite -sub_ge0 -opprB le0N orbC -sub_ge0 le0_total. Qed.
+Fact le_total : total le.
+Proof. by move=> x y; rewrite -sub_ge0 -opprB le0N orbC -sub_ge0 le0_total. Qed.
+
+Fact le_refl : reflexive le.
+Proof. by move=> x; move: (le_total x x); rewrite orbb. Qed.
+
+Fact le_anti : antisymmetric le.
+Proof.
+move=> x y /andP [].
+rewrite -sub_ge0 -(sub_ge0 y) -opprB le0N => hxy hxy'.
+by move/eqP: (le0_anti hxy' hxy); rewrite subr_eq0 => /eqP.
+Qed.
+
+Fact le_trans : transitive le.
+Proof.
+by move=> x y z hyx hxz; rewrite -sub_ge0 -(subrK x z) -addrA le0_add ?sub_ge0.
+Qed.
 
 Definition Le :=
-  Mixin le_normD lt0_add eq0_norm (in2W le_total) normM le_def lt_def.
+  Mixin (Rorder := @POrderMixin R le lt lt_neqAle le_refl le_anti le_trans)
+        le_normD lt0_add eq0_norm (in2W le_total) normM le_def.
 
 Lemma Real (R' : numDomainType) & phant R' :
   R' = NumDomainType R Le -> real_axiom R'.


### PR DESCRIPTION
I finished fixing the ssrnum library and integrating the order library. Many ssrnum lemmas are moved to order.v, removed because of duplication, and renamed. Many libraries using ssrnum are still broken.

TODO (as separate PR?):
- [ ] Compatibility module
- [ ] Documentation
- [ ] ChangeLog