### PR TITLE
Some progress on #270

### DIFF
--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -567,29 +567,24 @@ rewrite ge_rat0; case: ratP=> [] // n d cnd n_ge0.
 by rewrite /normq /= normr_num_div ?ger0_norm // divq_num_den.
 Qed.
 
-Fact lt_rat_def x y : (lt_rat x y) = (y != x) && (le_rat x y).
-Proof. by rewrite /lt_rat lt_def rat_eq. Qed.
+Fact lt_rat_def x y : (lt_rat x y) = (x != y) && (le_rat x y).
+Proof. by rewrite /lt_rat lt_def rat_eq eq_sym. Qed.
 
 Canonical rat_normedType := NormedType rat rat normq.
 
-Definition ratPoMixin :=
-  RealLePoMixin le_rat0D le_rat0_anti subq_ge0 (@le_rat_total 0) lt_rat_def.
-
-Definition ratLeMixin : Num.mixin_of ratPoMixin norm :=
+Definition ratLeMixin : realLeMixin rat_iDomain :=
   RealLeMixin le_rat0D le_rat0M le_rat0_anti subq_ge0
               (@le_rat_total 0) norm_ratN ge_rat0_norm lt_rat_def.
 
-Canonical rat_porderType := POrderType ring_display rat ratPoMixin.
-Canonical rat_latticeType :=
-  LatticeType rat (Order.TotalLattice.Mixin le_rat_total).
+Canonical rat_porderType := POrderType ring_display rat ratLeMixin.
+Canonical rat_latticeType := LatticeType rat ratLeMixin.
 Canonical rat_orderType := OrderType rat le_rat_total.
 Canonical rat_numDomainType := NumDomainType rat ratLeMixin.
 Canonical rat_numFieldType := [numFieldType of rat].
 Canonical rat_realDomainType := RealDomainType rat le_rat_total.
 Canonical rat_realFieldType := [realFieldType of rat].
 Canonical rat_lmodType := LmodType rat rat (GRing.regular_lmodMixin _).
-Canonical rat_normedModType :=
-  NormedModType rat rat rat_numDomainType.
+Canonical rat_normedModType := NormedModType rat rat rat_numDomainType.
 
 Lemma numq_ge0 x : (0 <= numq x) = (0 <= x).
 Proof.

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -1674,7 +1674,7 @@ Definition clone c of phant_id class c := @Pack phR T c.
 Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of xT).
 
-Definition pack T b0 mul0 (axT : @axiom R (@Lmodule.Pack R _ T b0) mul0) :=
+Definition pack b0 mul0 (axT : @axiom R (@Lmodule.Pack R _ T b0) mul0) :=
   fun bT b & phant_id (Ring.class bT) (b : Ring.class_of T) =>
   fun mT m & phant_id (@Lmodule.class R phR mT) (@Lmodule.Class R T b m) =>
   fun ax & phant_id axT ax =>

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -421,24 +421,20 @@ Proof. by case: m => // -[]. Qed.
 Fact gez0_norm m : lez 0 m -> norm m = m.
 Proof. by case: m. Qed.
 
-Fact ltz_def m n : (ltz m n) = (n != m) && (lez m n).
+Fact ltz_def m n : (ltz m n) = (m != n) && (lez m n).
 Proof.
 by move: m n => [] m [] n //=; rewrite (ltn_neqAle, leq_eqVlt) // eq_sym.
 Qed.
 
-Definition PoMixin :=
-  RealLePoMixin lez_add lez_anti subz_ge0 (lez_total 0) ltz_def.
-
-Definition Mixin : Num.mixin_of PoMixin norm :=
+Definition Mixin : realLeMixin int_iDomain :=
   RealLeMixin
     lez_add lez_mul lez_anti subz_ge0 (lez_total 0) normzN gez0_norm ltz_def.
 
 End intOrdered.
 End intOrdered.
 
-Canonical int_porderType := POrderType ring_display int intOrdered.PoMixin.
-Canonical int_latticeType :=
-  LatticeType int (Order.TotalLattice.Mixin intOrdered.lez_total).
+Canonical int_porderType := POrderType ring_display int intOrdered.Mixin.
+Canonical int_latticeType := LatticeType int intOrdered.Mixin.
 Canonical int_orderType := OrderType int intOrdered.lez_total.
 Canonical int_numDomainType := NumDomainType int intOrdered.Mixin.
 Canonical int_realDomainType := RealDomainType int intOrdered.lez_total.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -4701,46 +4701,49 @@ Arguments sqrCK_P {C x}.
 
 End Theory.
 
-(* TODO Kazuhiko: divide those Mixin builders into order.v and here *)
+(*************)
+(* FACTORIES *)
+(*************)
 
-Module RealMixin.
+Module RealLeMixin.
+Section RealLeMixin.
+Variables (R : idomainType).
 
-Section RealMixins.
+Record of_ := Mixin {
+  le : rel R;
+  lt : rel R;
+  norm : R -> R;
+  le0_add   : forall x y, le 0 x -> le 0 y -> le 0 (x + y);
+  le0_mul   : forall x y, le 0 x -> le 0 y -> le 0 (x * y);
+  le0_anti  : forall x, le 0 x -> le x 0 -> x = 0;
+  sub_ge0   : forall x y, le 0 (y - x) = le x y;
+  le0_total : forall x, le 0 x || le x 0;
+  normN     : forall x, norm (- x) = norm x;
+  ge0_norm  : forall x, le 0 x -> norm x = x;
+  lt_def    : forall x y, lt x y = (x != y) && le x y;
+}.
 
-Variables (R : idomainType) (le : rel R) (lt : rel R) (norm : R -> R).
-Local Infix "<=" := le.
-Local Infix "<" := lt.
-Local Notation "`| x |" := (norm x) : ring_scope.
+Variable (m : of_).
 
-Section LeMixin.
-
-Hypothesis le0_add : forall x y, 0 <= x -> 0 <= y -> 0 <= x + y.
-Hypothesis le0_mul : forall x y, 0 <= x -> 0 <= y -> 0 <= x * y.
-Hypothesis le0_anti : forall x, 0 <= x -> x <= 0 -> x = 0.
-Hypothesis sub_ge0  : forall x y, (0 <= y - x) = (x <= y).
-Hypothesis le0_total : forall x, (0 <= x) || (x <= 0).
-Hypothesis normN: forall x, `|- x| = `|x|.
-Hypothesis ge0_norm : forall x, 0 <= x -> `|x| = x.
-Hypothesis lt_def : forall x y, (x < y) = (y != x) && (x <= y).
+Local Notation "x <= y" := (le m x y).
+Local Notation "x < y" := (lt m x y).
+Local Notation "`| x |" := (norm m x) : ring_scope.
 
 Let le0N x : (0 <= - x) = (x <= 0). Proof. by rewrite -sub0r sub_ge0. Qed.
 Let leN_total x : 0 <= x \/ 0 <= - x.
 Proof. by apply/orP; rewrite le0N le0_total. Qed.
 
-Let le00 : (0 <= 0). Proof. by have:= le0_total 0; rewrite orbb. Qed.
+Let le00 : (0 <= 0). Proof. by have:= le0_total m 0; rewrite orbb. Qed.
 Let le01 : (0 <= 1).
 Proof.
-by case/orP: (le0_total 1)=> // ?; rewrite -[1]mul1r -mulrNN le0_mul ?le0N.
+by case/orP: (le0_total m 1)=> // ?; rewrite -[1]mul1r -mulrNN le0_mul ?le0N.
 Qed.
-
-Fact lt_neqAle x y : (x < y) = (x != y) && (x <= y).
-Proof. by rewrite lt_def eq_sym. Qed.
 
 Fact lt0_add x y : 0 < x -> 0 < y -> 0 < x + y.
 Proof.
-rewrite !lt_def => /andP[x_neq0 l0x] /andP[y_neq0 l0y]; rewrite le0_add //.
-rewrite andbT addr_eq0; apply: contraNneq x_neq0 => hxy.
-by rewrite [x]le0_anti // hxy -le0N opprK.
+rewrite !lt_def => /andP [x_neq0 l0x] /andP [y_neq0 l0y]; rewrite le0_add //.
+rewrite andbT eq_sym addr_eq0; apply: contraNneq x_neq0 => hxy.
+by rewrite [x](@le0_anti m) // hxy -le0N opprK.
 Qed.
 
 Fact eq0_norm x : `|x| = 0 -> x = 0.
@@ -4756,7 +4759,7 @@ rewrite {x}subr0; apply/idP/eqP=> [/ge0_norm// | Dy].
 by have [//| ny_ge0] := leN_total y; rewrite -Dy -normN ge0_norm.
 Qed.
 
-Fact normM : {morph norm : x y / x * y}.
+Fact normM : {morph norm m : x y / x * y}.
 Proof.
 move=> x y /=; wlog x_ge0 : x / 0 <= x.
   by move=> IHx; case: (leN_total x) => /IHx//; rewrite mulNr !normN.
@@ -4775,89 +4778,190 @@ rewrite -normN ge0_norm //; have [hxy|hxy] := leN_total (x + y).
 by rewrite -normN ge0_norm // opprK addrCA addrNK le0_add.
 Qed.
 
-Fact le_total : total le.
+Fact le_total : total (le m).
 Proof. by move=> x y; rewrite -sub_ge0 -opprB le0N orbC -sub_ge0 le0_total. Qed.
 
-Fact le_refl : reflexive le.
+Fact le_refl : reflexive (le m).
 Proof. by move=> x; move: (le_total x x); rewrite orbb. Qed.
 
-Fact le_anti : antisymmetric le.
+Fact le_anti : antisymmetric (le m).
 Proof.
 move=> x y /andP [].
-rewrite -sub_ge0 -(sub_ge0 y) -opprB le0N => hxy hxy'.
+rewrite -sub_ge0 -(sub_ge0 _ y) -opprB le0N => hxy hxy'.
 by move/eqP: (le0_anti hxy' hxy); rewrite subr_eq0 => /eqP.
 Qed.
 
-Fact le_trans : transitive le.
+Fact le_trans : transitive (le m).
 Proof.
 by move=> x y z hyx hxz; rewrite -sub_ge0 -(subrK x z) -addrA le0_add ?sub_ge0.
 Qed.
 
-Definition LePo : porderMixin R :=
-  POrderMixin lt_neqAle le_refl le_anti le_trans.
+Definition orderMixin : leOrderMixin ring_display R :=
+  LeOrderMixin ring_display
+               le_anti le_trans le_total (lt_def _) (rrefl _) (rrefl _).
 
-Definition Le : mixin_of LePo norm :=
-  Mixin (Rorder := LePo) le_normD lt0_add eq0_norm (in2W le_total) normM le_def.
-
-Lemma Real (R' : numDomainType) & phant R' :
-  R' = NumDomainType R Le -> real_axiom R'.
-Proof. by move->. Qed.
+Definition numMixin : mixin_of orderMixin (norm m) :=
+  Num.Mixin (Rorder := orderMixin)
+            le_normD lt0_add eq0_norm (in2W le_total) normM le_def.
 
 Lemma Total (R' : numDomainType) & phant R' :
-  R' = NumDomainType R Le -> total (<=%R : rel R').
+  R' = NumDomainType R numMixin -> total (<=%R : rel R').
 Proof. move->; exact: le_total. Qed.
 
-End LeMixin.
+End RealLeMixin.
 
-Section LtMixin.
+Module Exports.
+Notation realLeMixin := of_.
+Notation RealLeMixin := Mixin.
+Notation realLeMixin_total R := (Total (Phant R) (erefl _)).
+Coercion orderMixin : realLeMixin >-> leOrderMixin.
+Coercion numMixin : realLeMixin >-> mixin_of.
+End Exports.
 
-Hypothesis lt0_add : forall x y, 0 < x -> 0 < y -> 0 < x + y.
-Hypothesis lt0_mul : forall x y, 0 < x -> 0 < y -> 0 < x * y.
-Hypothesis lt0_ngt0  : forall x,  0 < x -> ~~ (x < 0).
-Hypothesis sub_gt0  : forall x y, (0 < y - x) = (x < y).
-Hypothesis lt0_total : forall x, x != 0 -> (0 < x) || (x < 0).
-Hypothesis normN : forall x, `|- x| = `|x|.
-Hypothesis ge0_norm : forall x, 0 <= x -> `|x| = x.
-Hypothesis le_def : forall x y, (x <= y) = (y == x) || (x < y).
+End RealLeMixin.
+
+Module RealLtMixin.
+Section RealLtMixin.
+Variables (R : idomainType).
+
+Record of_ := Mixin {
+  lt : rel R;
+  le : rel R;
+  norm : R -> R;
+  lt0_add   : forall x y, lt 0 x -> lt 0 y -> lt 0 (x + y);
+  lt0_mul   : forall x y, lt 0 x -> lt 0 y -> lt 0 (x * y);
+  lt0_ngt0  : forall x,  lt 0 x -> ~~ (lt x 0);
+  sub_gt0   : forall x y, lt 0 (y - x) = lt x y;
+  lt0_total : forall x, x != 0 -> lt 0 x || lt x 0;
+  normN     : forall x, norm (- x) = norm x;
+  ge0_norm  : forall x, le 0 x -> norm x = x;
+  le_def    : forall x y, le x y = (x == y) || lt x y;
+}.
+
+Variable (m : of_).
+
+Local Notation "x < y" := (lt m x y).
+Local Notation "x <= y" := (le m x y).
+Local Notation "`| x |" := (norm m x) : ring_scope.
+
+Fact lt0N x : (- x < 0) = (0 < x).
+Proof. by rewrite -sub_gt0 add0r opprK. Qed.
+Let leN_total x : 0 <= x \/ 0 <= - x.
+Proof.
+rewrite !le_def [_ == - x]eq_sym oppr_eq0 eq_sym -[0 < - x]lt0N opprK.
+apply/orP; case: (altP eqP) => //=; exact: lt0_total.
+Qed.
+
+Let le00 : (0 <= 0). Proof. by rewrite le_def eqxx. Qed.
+Let le01 : (0 <= 1).
+Proof.
+rewrite le_def eq_sym; case: (altP eqP) => // /(lt0_total m) /orP [] //= ?.
+by rewrite -[1]mul1r -mulrNN lt0_mul -?lt0N ?opprK.
+Qed.
+
+Fact sub_ge0 x y : (0 <= y - x) = (x <= y).
+Proof. by rewrite !le_def eq_sym subr_eq0 eq_sym sub_gt0. Qed.
 
 Fact le0_add x y : 0 <= x -> 0 <= y -> 0 <= x + y.
 Proof.
-rewrite !le_def => /predU1P[->|x_gt0]; first by rewrite add0r.
-by case/predU1P=> [->|y_gt0]; rewrite ?addr0 ?x_gt0 ?lt0_add // orbT.
+rewrite !le_def => /predU1P [<-|x_gt0]; first by rewrite add0r.
+by case/predU1P=> [<-|y_gt0]; rewrite ?addr0 ?x_gt0 ?lt0_add // orbT.
 Qed.
 
 Fact le0_mul x y : 0 <= x -> 0 <= y -> 0 <= x * y.
 Proof.
-rewrite !le_def => /predU1P[->|x_gt0]; first by rewrite mul0r eqxx.
-by case/predU1P=> [->|y_gt0]; rewrite ?mulr0 ?eqxx // orbC lt0_mul.
+rewrite !le_def => /predU1P [<-|x_gt0]; first by rewrite mul0r eqxx.
+by case/predU1P=> [<-|y_gt0]; rewrite ?mulr0 ?eqxx ?lt0_mul // orbT.
 Qed.
 
-Fact le0_anti x : 0 <= x -> x <= 0 -> x = 0.
-Proof. by rewrite !le_def => /predU1P[] // /lt0_ngt0/negPf-> /predU1P[]. Qed.
+Fact normM : {morph norm m : x y / x * y}.
+Proof.
+move=> x y /=; wlog x_ge0 : x / 0 <= x.
+  by move=> IHx; case: (leN_total x) => /IHx//; rewrite mulNr !normN.
+wlog y_ge0 : y / 0 <= y; last by rewrite ?ge0_norm ?le0_mul.
+by move=> IHy; case: (leN_total y) => /IHy//; rewrite mulrN !normN.
+Qed.
 
-Fact sub_ge0  x y : (0 <= y - x) = (x <= y).
-Proof. by rewrite !le_def subr_eq0 sub_gt0. Qed.
+Fact le_normD x y : `|x + y| <= `|x| + `|y|.
+Proof.
+wlog x_ge0 : x y / 0 <= x.
+  by move=> IH; case: (leN_total x) => /IH// /(_ (- y)); rewrite -opprD !normN.
+rewrite -sub_ge0 ge0_norm //; have [y_ge0 | ny_ge0] := leN_total y.
+  by rewrite !ge0_norm ?subrr ?le0_add.
+rewrite -normN ge0_norm //; have [hxy|hxy] := leN_total (x + y).
+  by rewrite ge0_norm // opprD addrCA -addrA addKr le0_add.
+by rewrite -normN ge0_norm // opprK addrCA addrNK le0_add.
+Qed.
+
+Fact eq0_norm x : `|x| = 0 -> x = 0.
+Proof.
+case: (leN_total x) => /ge0_norm => [-> // | Dnx nx0].
+by rewrite -[x]opprK -Dnx normN nx0 oppr0.
+Qed.
+
+Fact le_def' x y : (x <= y) = (`|y - x| == y - x).
+Proof.
+wlog ->: x y / x = 0 by move/(_ 0 (y - x)); rewrite subr0 sub_ge0 => ->.
+rewrite {x}subr0; apply/idP/eqP=> [/ge0_norm// | Dy].
+by have [//| ny_ge0] := leN_total y; rewrite -Dy -normN ge0_norm.
+Qed.
 
 Fact lt_def x y : (x < y) = (y != x) && (x <= y).
 Proof.
-rewrite le_def; case: eqP => //= ->; rewrite -sub_gt0 subrr.
+rewrite le_def eq_sym; case: eqP => //= ->; rewrite -sub_gt0 subrr.
 by apply/idP=> lt00; case/negP: (lt0_ngt0 lt00).
 Qed.
 
-Fact le0_total x : (0 <= x) || (x <= 0).
-Proof. by rewrite !le_def [0 == _]eq_sym; have [|/lt0_total] := altP eqP. Qed.
+Fact lt_irr : irreflexive (lt m).
+Proof. by move=> x; rewrite lt_def eqxx. Qed.
 
-Definition LtPo : porderMixin R :=
-  LePo le0_add le0_anti sub_ge0 le0_total lt_def.
+Fact lt_asym x y : ~~ ((x < y) && (y < x)).
+Proof.
+rewrite -[x < _]sub_gt0 -[y < _]sub_gt0 -lt0N opprB andbC.
+by apply/negP => /andP [] /lt0_ngt0; case: (_ < _).
+Qed.
 
-Definition Lt : mixin_of LtPo norm :=
-  Le le0_add le0_mul le0_anti sub_ge0 le0_total normN ge0_norm lt_def.
+Fact lt_trans : transitive (lt m).
+Proof.
+move=> y x z.
+rewrite -![x < _]sub_gt0 -[y < _]sub_gt0 -[z - x](GRing.addrKA (- y)).
+rewrite opprD opprK [_ - _ + _]addrC; exact: lt0_add.
+Qed.
 
-End LtMixin.
+Fact lt_total x y : x != y -> (x < y) || (y < x).
+Proof.
+rewrite -subr_eq0 => /(lt0_total m).
+by rewrite -(sub_gt0 _ (x - y)) sub0r opprB !sub_gt0 orbC.
+Qed.
 
-End RealMixins.
+Fact le_total : total (le m).
+Proof.
+by move=> x y; rewrite !le_def [y == x]eq_sym; case: (altP eqP) => [|/lt_total].
+Qed.
 
-End RealMixin.
+Definition orderMixin : ltOrderMixin ring_display R :=
+  LtOrderMixin ring_display
+               lt_irr lt_trans lt_total (le_def m) (rrefl _) (rrefl _).
+
+Definition numMixin : mixin_of orderMixin (norm m) :=
+  Num.Mixin (Rorder := orderMixin)
+            le_normD (@lt0_add m) eq0_norm (in2W le_total) normM le_def'.
+
+Lemma Total (R' : numDomainType) & phant R' :
+  R' = NumDomainType R numMixin -> total (<=%R : rel R').
+Proof. move->; exact: le_total. Qed.
+
+End RealLtMixin.
+
+Module Exports.
+Notation realLtMixin := of_.
+Notation RealLtMixin := Mixin.
+Notation realLtMixin_total R := (Total (Phant R) (erefl _)).
+Coercion orderMixin : realLtMixin >-> ltOrderMixin.
+Coercion numMixin : realLtMixin >-> mixin_of.
+End Exports.
+
+End RealLtMixin.
 
 End Num.
 
@@ -4867,13 +4971,8 @@ Export Num.NumField.Exports Num.ClosedField.Exports.
 Export Num.RealDomain.Exports Num.RealField.Exports.
 Export Num.ArchimedeanField.Exports Num.RealClosedField.Exports.
 Export Num.Syntax Num.PredInstances.
+Export Num.RealLeMixin.Exports Num.RealLtMixin.Exports.
 
-Notation RealLePoMixin := Num.RealMixin.LePo.
-Notation RealLtPoMixin := Num.RealMixin.LtPo.
-Notation RealLeMixin := Num.RealMixin.Le.
-Notation RealLtMixin := Num.RealMixin.Lt.
-Notation RealLeAxiom R := (Num.RealMixin.Real (Phant R) (erefl _)).
-Notation RealLeTotal R := (Num.RealMixin.Total (Phant R) (erefl _)).
 Notation ImaginaryMixin := Num.ClosedField.ImaginaryMixin.
 
 (* compatibility module *)

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -346,7 +346,6 @@ Fact Rnneg_key : pred_key (@nneg R). Proof. by []. Qed.
 Definition Rnneg_keyed := KeyedQualifier Rnneg_key.
 Fact Rreal_key : pred_key (@real R). Proof. by []. Qed.
 Definition Rreal_keyed := KeyedQualifier Rreal_key.
-Definition le_of_leif' := le_of_leif.
 End Keys. End Keys.
 
 (* (Exported) symbolic syntax. *)
@@ -409,7 +408,7 @@ Canonical Rneg_keyed.
 Canonical Rnneg_keyed.
 Canonical Rreal_keyed.
 
-Coercion le_of_leif' : leif >-> is_true.
+Export Order.POCoercions.
 
 End Syntax.
 
@@ -3863,7 +3862,7 @@ Variable p : {poly R}.
 Lemma poly_itv_bound a b : {ub | forall x, a <= x <= b -> `|p.[x]| <= ub}.
 Proof.
 have [ub le_p_ub] := poly_disk_bound p (`|a| `|` `|b|).
-exists ub => x /andP[le_a_x le_x_b]; rewrite le_p_ub // lexU_total !ler_normr.
+exists ub => x /andP[le_a_x le_x_b]; rewrite le_p_ub // lexU !ler_normr.
 by have [_|_] := ler0P x; rewrite ?ler_opp2 ?le_a_x ?le_x_b orbT.
 Qed.
 
@@ -5304,10 +5303,8 @@ Definition eqr_minr x y : (min x y == y) = (y <= x) := eq_meetr x y.
 Definition eqr_maxl x y : (max x y == x) = (y <= x) := eq_joinl x y.
 Definition eqr_maxr x y : (max x y == y) = (x <= y) := eq_joinr x y.
 Definition ler_minr x y z : (x <= min y z) = (x <= y) && (x <= z) := lexI x y z.
-Definition ler_minl x y z : (min y z <= x) = (y <= x) || (z <= x) :=
-  leIx_total x y z.
-Definition ler_maxr x y z : (x <= max y z) = (x <= y) || (x <= z) :=
-  lexU_total x y z.
+Definition ler_minl x y z : (min y z <= x) = (y <= x) || (z <= x) := leIx x y z.
+Definition ler_maxr x y z : (x <= max y z) = (x <= y) || (x <= z) := lexU x y z.
 Definition ler_maxl x y z : (max y z <= x) = (y <= x) && (z <= x) := leUx y z x.
 Definition ltr_minr x y z : (x < min y z) = (x < y) && (x < z) := ltxI x y z.
 Definition ltr_minl x y z : (min y z < x) = (y < x) || (z < x) := ltIx x y z.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -2735,39 +2735,56 @@ Qed.
 
 (* norm + add *)
 
-Lemma normr_real x : `|x| \is real. Proof. by apply/ger0_real. Qed.
+Section NormedModuleTheory.
+
+Variable V : normedModType R.
+Implicit Types (u v w : V).
+
+Lemma normr_real v : `|v| \is real. Proof. by apply/ger0_real. Qed.
 Hint Resolve normr_real : core.
 
-Lemma ler_norm_sum I r (G : I -> R) (P : pred I):
+Lemma ler_norm_sum I r (G : I -> V) (P : pred I):
   `|\sum_(i <- r | P i) G i| <= \sum_(i <- r | P i) `|G i|.
 Proof.
 elim/big_rec2: _ => [|i y x _]; first by rewrite normr0.
 by rewrite -(ler_add2l `|G i|); apply: le_trans; apply: ler_norm_add.
 Qed.
 
-Lemma ler_norm_sub x y : `|x - y| <= `|x| + `|y|.
+Lemma ler_norm_sub v w : `|v - w| <= `|v| + `|w|.
 Proof. by rewrite (le_trans (ler_norm_add _ _)) ?normrN. Qed.
 
-Lemma ler_dist_add z x y : `|x - y| <= `|x - z| + `|z - y|.
+Lemma ler_dist_add u v w : `|v - w| <= `|v - u| + `|u - w|.
 Proof. by rewrite (le_trans _ (ler_norm_add _ _)) // addrA addrNK. Qed.
 
-Lemma ler_sub_norm_add x y : `|x| - `|y| <= `|x + y|.
+Lemma ler_sub_norm_add v w : `|v| - `|w| <= `|v + w|.
 Proof.
-rewrite -{1}[x](addrK y) lter_sub_addl.
+rewrite -{1}[v](addrK w) lter_sub_addl.
 by rewrite (le_trans (ler_norm_add _ _)) // addrC normrN.
 Qed.
 
-Lemma ler_sub_dist x y : `|x| - `|y| <= `|x - y|.
-Proof. by rewrite -[`|y|]normrN ler_sub_norm_add. Qed.
+Lemma ler_sub_dist v w : `|v| - `|w| <= `|v - w|.
+Proof. by rewrite -[`|w|]normrN ler_sub_norm_add. Qed.
 
-Lemma ler_dist_dist x y : `| `|x| - `|y| | <= `|x - y|.
+Lemma ler_dist_dist v w : `| `|v| - `|w| | <= `|v - w|.
 Proof.
-have [||_|_] // := @real_leP `|x| `|y|; last by rewrite ler_sub_dist.
+have [||_|_] // := @real_leP `|v| `|w|; last by rewrite ler_sub_dist.
 by rewrite distrC ler_sub_dist.
 Qed.
 
-Lemma ler_dist_norm_add x y : `| `|x| - `|y| | <= `| x + y |.
-Proof. by rewrite -[y]opprK normrN ler_dist_dist. Qed.
+Lemma ler_dist_norm_add v w : `| `|v| - `|w| | <= `|v + w|.
+Proof. by rewrite -[w]opprK normrN ler_dist_dist. Qed.
+
+Lemma ler_nnorml v x : x < 0 -> `|v| <= x = false.
+Proof. by move=> h; rewrite lt_geF //; apply/(lt_le_trans h). Qed.
+
+Lemma ltr_nnorml v x : x <= 0 -> `|v| < x = false.
+Proof. by move=> h; rewrite le_gtF //; apply/(le_trans h). Qed.
+
+Definition lter_nnormr := (ler_nnorml, ltr_nnorml).
+
+End NormedModuleTheory.
+
+Hint Extern 0 (is_true (norm _ \is real)) => exact: normr_real : core.
 
 Lemma real_ler_norml x y : x \is real -> (`|x| <= y) = (- y <= x <= y).
 Proof.
@@ -2838,14 +2855,6 @@ by rewrite orbC ltr_oppr.
 Qed.
 
 Definition real_lter_normr :=  (real_ler_normr, real_ltr_normr).
-
-Lemma ler_nnorml x y : y < 0 -> `|x| <= y = false.
-Proof. by move=> h; rewrite lt_geF //; apply/(lt_le_trans h). Qed.
-
-Lemma ltr_nnorml x y : y <= 0 -> `|x| < y = false.
-Proof. by move=> h; rewrite le_gtF //; apply/(le_trans h). Qed.
-
-Definition lter_nnormr := (ler_nnorml, ltr_nnorml).
 
 Lemma real_ler_distl x y e :
   x - y \is real -> (`|x - y| <= e) = (y - e <= x <= y + e).
@@ -5041,6 +5050,19 @@ Definition lter_anti := (=^~ eqr_le, ltr_asym, ltr_le_asym, ler_lt_asym).
 Definition ltr_geF x y : x < y -> y <= x = false := @lt_geF _ _ x y.
 Definition ler_gtF x y : x <= y -> y < x = false := @le_gtF _ _ x y.
 Definition ltr_gtF x y : x < y -> y < x = false := @lt_gtF _ _ x y.
+Definition normr0 : `|0| = 0 :> R := normr0 _.
+Definition normrMn x n : `|x *+ n| = `|x| *+ n := normrMn x n.
+Definition normr0P {x} : reflect (`|x| = 0) (x == 0) := normr0P.
+Definition normr_eq0 x : (`|x| == 0) = (x == 0) := normr_eq0 x.
+Definition normrN x : `|- x| = `|x| := normrN x.
+Definition distrC x y : `|x - y| = `|y - x| := distrC x y.
+Definition normr_id x : `| `|x| | = `|x| := normr_id x.
+Definition normr_ge0 x : 0 <= `|x| := normr_ge0 x.
+Definition normr_le0 x : (`|x| <= 0) = (x == 0) := normr_le0 x.
+Definition normr_lt0 x : `|x| < 0 = false := normr_lt0 x.
+Definition normr_gt0 x : (`|x| > 0) = (x != 0) := normr_gt0 x.
+Definition normrE := (normr_id, normr0, @normr1 R, @normrN1 R, normr_ge0,
+                      normr_eq0, normr_lt0, normr_le0, normr_gt0, normrN).
 End NumIntegralDomainTheory.
 
 Section NumIntegralDomainMonotonyTheory.
@@ -5270,6 +5292,23 @@ Definition ger_lerif x y C : x <= y ?= iff C -> (y <= x) = C :=
   @ge_leif _ _ x y C.
 Definition ltr_lerif x y C : x <= y ?= iff C -> (x < y) = ~~ C :=
   @lt_leif _ _ x y C.
+Definition normr_real x : `|x| \is real := normr_real x.
+Definition ler_norm_sum I r (G : I -> R) (P : pred I):
+  `|\sum_(i <- r | P i) G i| <= \sum_(i <- r | P i) `|G i| :=
+  ler_norm_sum r G P.
+Definition ler_norm_sub x y : `|x - y| <= `|x| + `|y| := ler_norm_sub x y.
+Definition ler_dist_add z x y : `|x - y| <= `|x - z| + `|z - y| :=
+  ler_dist_add z x y.
+Definition ler_sub_norm_add x y : `|x| - `|y| <= `|x + y| :=
+  ler_sub_norm_add x y.
+Definition ler_sub_dist x y : `|x| - `|y| <= `|x - y| := ler_sub_dist x y.
+Definition ler_dist_dist x y : `| `|x| - `|y| | <= `|x - y| :=
+  ler_dist_dist x y.
+Definition ler_dist_norm_add x y : `| `|x| - `|y| | <= `|x + y| :=
+  ler_dist_norm_add x y.
+Definition ler_nnorml x y : y < 0 -> `|x| <= y = false := @ler_nnorml _ _ x y.
+Definition ltr_nnorml x y : y <= 0 -> `|x| < y = false := @ltr_nnorml _ _ x y.
+Definition lter_nnormr := (ler_nnorml, ltr_nnorml).
 Definition lerif_nat m n C :
   (m%:R <= n%:R ?= iff C :> R) = (m <= n ?= iff C)%N :=
   leif_nat_r _ m n C.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -233,7 +233,7 @@ Definition class := let: Pack _ c  as cT' := cT return class_of cT' in c.
 Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of xT).
 Definition clone c of phant_id class c := @Pack T c.
-Definition pack T b0 om0 nb0 (m0 : @mixin_of (ring_for T b0) om0 nb0) :=
+Definition pack b0 om0 nb0 (m0 : @mixin_of (ring_for T b0) om0 nb0) :=
   fun bT b & phant_id (@GRing.IntegralDomain.class bT) b =>
   fun om   & phant_id om0 om =>
   fun m    & phant_id m0 m =>
@@ -403,6 +403,11 @@ Notation ">< x" := (fun y => ~~ (@comparable ring_display _ x y)) : ring_scope.
 Notation ">< x :> T" := (>< (x : T)) (only parsing) : ring_scope.
 Notation "x >< y" := (~~ (@comparable ring_display _ x y)) : ring_scope.
 
+Notation "@ 'maxr'" := (@join ring_display).
+Notation maxr := (@join ring_display _).
+Notation "@ 'minr'" := (@meet ring_display).
+Notation minr := (@meet ring_display _).
+
 Canonical Rpos_keyed.
 Canonical Rneg_keyed.
 Canonical Rnneg_keyed.
@@ -411,6 +416,9 @@ Canonical Rreal_keyed.
 Export Order.POCoercions.
 
 End Syntax.
+
+Notation min := minr.
+Notation max := maxr.
 
 Section ExtensionAxioms.
 
@@ -3761,9 +3769,6 @@ Section MinMax.
 (* GG: Many of the first lemmas hold unconditionally, and others hold for    *)
 (* the real subset of a general domain.                                      *)
 
-Local Notation min := meet (only parsing).
-Local Notation max := join (only parsing).
-
 Lemma addr_min_max x y : min x y + max x y = x + y.
 Proof.
 case: (lerP x y)=> [| /ltW] hxy;
@@ -4989,8 +4994,6 @@ Notation ltr := lt (only parsing).
 Notation ger := ge (only parsing).
 Notation gtr := gt (only parsing).
 Notation lerif := leif (only parsing).
-Notation minr := meet (only parsing).
-Notation maxr := join (only parsing).
 End Def.
 
 Notation norm := normr (only parsing).
@@ -4998,8 +5001,6 @@ Notation le := ler (only parsing).
 Notation lt := ltr (only parsing).
 Notation ge := ger (only parsing).
 Notation gt := gtr (only parsing).
-Notation min := minr (only parsing).
-Notation max := maxr (only parsing).
 
 Module Import Syntax.
 Notation "`| x |" := (@norm _ (@Num.NumDomain.normedType _) x) : ring_scope.
@@ -5381,8 +5382,6 @@ Implicit Types x y z : R.
 Definition lerif_mean_square_scaled := leif_mean_square_scaled.
 Definition lerif_AGM2_scaled := leif_AGM2_scaled.
 Section MinMax.
-Local Notation min := meet (only parsing).
-Local Notation max := join (only parsing).
 Definition minrC : @commutative R R min := @meetC _ R.
 Definition minrr : @idempotent R min := @meetxx _ R.
 Definition minr_l x y : x <= y -> min x y = x := elimT meet_idPl.

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -1501,7 +1501,7 @@ Qed.
 Lemma max_cfRepr_mx1 n (rG : mx_representation algCF G n) x :
    x \in G -> cfRepr rG x = cfRepr rG 1%g -> rG x = 1%:M.
 Proof.
-move=> Gx kerGx; have [|c _ def_x] := @ max_cfRepr_norm_scalar n rG x Gx.
+move=> Gx kerGx; have [|c _ def_x] := @max_cfRepr_norm_scalar n rG x Gx.
   by rewrite kerGx cfRepr1 normr_nat.
 move/eqP: kerGx; rewrite cfRepr1 cfunE Gx {rG}def_x mxtrace_scalar.
 case: n => [_|n]; first by rewrite ![_%:M]flatmx0.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -582,17 +582,17 @@ have add_Rroot xR p c: {yR | extendsR xR yR & has_Rroot xR p c -> root_in yR p}.
       by rewrite rmorphM hornerM ler_pmul ?ltW ?v_gtd ?w_gte.
     rewrite -ltr_pdivr_mull ?mulr_gt0 // (le_lt_trans _ ub_rp) //.
     by rewrite -scalerAl hornerZ -rmorphM mulrN -normrN ler_norm.
-  pose le v w := (w == v) || lt v w.
+  pose le v w := (v == w) || lt v w.
   pose abs v := if le 0 v then v else - v.
   have absN v: abs (- v) = abs v.
-    rewrite /abs /le oppr_eq0 opprK posN.
+    rewrite /abs /le !(eq_sym 0) oppr_eq0 opprK posN.
     have [-> | /posVneg/orP[v_gt0 | v_lt0]] := altP eqP; first by rewrite oppr0.
       by rewrite v_gt0 /= -if_neg posNneg.
     by rewrite v_lt0 /= -if_neg -(opprK v) posN posNneg ?posN.
   have absE v: le 0 v -> abs v = v by rewrite /abs => ->.
   pose QyNum := RealLtMixin posD posM posNneg posB posVneg absN absE (rrefl _).
   pose QyNumField := [numFieldType of NumDomainType (Q y) QyNum].
-  pose Ry := [realFieldType of RealDomainType _ (RealLeTotal QyNumField)].
+  pose Ry := [realFieldType of RealDomainType _ (realLtMixin_total QyNumField)].
   have archiRy := @rat_algebraic_archimedean Ry _ alg_integral.
   by exists (ArchiFieldType Ry archiRy); apply: [rmorphism of idfun].
 have some_realC: realC.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -510,7 +510,7 @@ have add_Rroot xR p c: {yR | extendsR xR yR & has_Rroot xR p c -> root_in yR p}.
     have [M Mgt0 ubM]: {M | 0 < M & {in Iab_ n, forall a, `|r.2.[a]| <= M}}.
       have [M ubM] := poly_itv_bound r.2 (ab_ n).1 (ab_ n).2.
       exists (1 `|` M) => [|s /ubM vM]; first by rewrite ltxU ltr01.
-      by rewrite lexU_total orbC vM.
+      by rewrite lexU orbC vM.
     exists (h2 / M) => [|a xn_a]; first by rewrite divr_gt0 ?invr_gt0 ?ltr0n.
     rewrite ltr_pdivr_mulr // -(ltr_add2l h2) -mulr2n -mulr_natl divff //.
     rewrite -normr1 -(hornerC 1 a) -[1%:P]r_pq_1 hornerD.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -1725,10 +1725,10 @@ Lemma gtE x y : gt x y = (y < x). Proof. by []. Qed.
 
 Lemma lexx (x : T) : x <= x.
 Proof. by case: T x => ? [? []]. Qed.
-Hint Resolve lexx.
+Hint Resolve lexx : core.
 
 Definition le_refl : reflexive le := lexx.
-Hint Resolve le_refl.
+Hint Resolve le_refl : core.
 
 Lemma le_anti: antisymmetric (<=%O : rel T).
 Proof. by case: T => ? [? []]. Qed.
@@ -1746,7 +1746,7 @@ Lemma ltxx x: x < x = false.
 Proof. by rewrite lt_neqAle eqxx. Qed.
 
 Definition lt_irreflexive : irreflexive lt := ltxx.
-Hint Resolve lt_irreflexive.
+Hint Resolve lt_irreflexive : core.
 
 Definition ltexx := (lexx, ltxx).
 
@@ -1956,7 +1956,7 @@ Implicit Types (m n p : nat) (x y z : T) (u v w : T').
 Variable D D' : pred T.
 Variable (f : T -> T').
 
-Hint Resolve lexx lt_neqAle (@le_anti _ T) (@le_anti _ T') lt_def.
+Hint Resolve lexx lt_neqAle (@le_anti _ T) (@le_anti _ T') lt_def : core.
 
 Let ge_antiT : antisymmetric (>=%O : rel T).
 Proof. by move=> ?? /le_anti. Qed.
@@ -2026,7 +2026,7 @@ End POrderMonotonyTheory.
 
 End POrderTheory.
 
-Hint Resolve lexx le_refl ltxx lt_irreflexive ltW lt_eqF.
+Hint Resolve lexx le_refl ltxx lt_irreflexive ltW lt_eqF : core.
 
 Arguments leifP {display T x y C}.
 Arguments leif_refl {display T x C}.
@@ -2287,10 +2287,10 @@ Context {T : orderType}.
 Implicit Types (x y z t : T).
 
 Lemma le_total : total (<=%O : rel T). Proof. by case: T => [? [?]]. Qed.
-Hint Resolve le_total.
+Hint Resolve le_total : core.
 
 Lemma comparableT x y : x >=< y. Proof. exact: le_total. Qed.
-Hint Resolve comparableT.
+Hint Resolve comparableT : core.
 
 Lemma sort_le_sorted (s : seq T) : sorted <=%O (sort <=%O s).
 Proof. exact: sort_sorted. Qed.
@@ -2303,11 +2303,9 @@ Proof.
 by move=> ss; apply: eq_sorted_le; rewrite ?sort_le_sorted // perm_sort.
 Qed.
 
-Lemma leNgt x y : (x <= y) = ~~ (y < x).
-Proof. by rewrite comparable_leNgt. Qed.
+Lemma leNgt x y : (x <= y) = ~~ (y < x). Proof. exact: comparable_leNgt. Qed.
 
-Lemma ltNge x y : (x < y) = ~~ (y <= x).
-Proof. by rewrite comparable_ltNge. Qed.
+Lemma ltNge x y : (x < y) = ~~ (y <= x). Proof. exact: comparable_ltNge. Qed.
 
 Lemma wlog_le P :
      (forall x y, P y x -> P x y) -> (forall x y, x <= y -> P x y) ->
@@ -2331,11 +2329,9 @@ Definition ltgtP x y := LatticeTheoryJoin.lcomparable_ltgtP (comparableT x y).
 Definition leP x y := LatticeTheoryJoin.lcomparable_leP (comparableT x y).
 Definition ltP x y := LatticeTheoryJoin.lcomparable_ltP (comparableT x y).
 
-Lemma neq_lt x y : (x != y) = (x < y) || (y < x).
-Proof. by case: ltgtP. Qed.
+Lemma neq_lt x y : (x != y) = (x < y) || (y < x). Proof. by case: ltgtP. Qed.
 
-Lemma lt_total x y : x != y -> (x < y) || (y < x).
-Proof. by rewrite neq_lt. Qed.
+Lemma lt_total x y : x != y -> (x < y) || (y < x). Proof. by case: ltgtP. Qed.
 
 Lemma eq_leLR x y z t :
   (x <= y -> z <= t) -> (y < x -> t < z) -> (x <= y) = (z <= t).
@@ -2439,7 +2435,7 @@ Local Notation "0" := bottom.
 
 (* Distributive lattice theory with 0 & 1*)
 Lemma le0x x : 0 <= x. Proof. by case: L x => [?[?[]]]. Qed.
-Hint Resolve le0x.
+Hint Resolve le0x : core.
 
 Lemma lex0 x : (x <= 0) = (x == 0).
 Proof. by rewrite le_eqVlt (le_gtF (le0x _)) orbF. Qed.
@@ -2651,7 +2647,7 @@ Implicit Types (x y : L).
 
 Local Notation "1" := top.
 
-Hint Resolve le0x lex1.
+Hint Resolve le0x lex1 : core.
 
 Lemma meetx1 : right_id 1 (@meet _ L).
 Proof. exact: (@joinx0 _ [tblatticeType of L^r]). Qed.
@@ -2762,7 +2758,7 @@ Proof. by rewrite meetC joinBI. Qed.
 
 Lemma leBx x y : x `\` y <= x.
 Proof. by rewrite -{2}[x](joinIB y) lexU2 // lexx orbT. Qed.
-Hint Resolve leBx.
+Hint Resolve leBx : core.
 
 Lemma subxx x : x `\` x = 0.
 Proof. by have := subKI x x; rewrite (meet_idPr _). Qed.
@@ -3001,8 +2997,7 @@ Context {T : porderType}.
 Implicit Types (x y z : T).
 Hypothesis le_total : total (<=%O : rel T).
 
-Fact comparableT x y : x >=< y. Proof. exact: le_total. Qed.
-Hint Resolve comparableT.
+Let comparableT x y : x >=< y := le_total x y.
 
 Fact ltgtP x y :
   comparer x y (y == x) (x == y) (x <= y) (y <= x) (x < y) (x > y).

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -36,7 +36,7 @@ Require Import fintype tuple bigop path finset.
 (*        tlatticeType == ... with a top element                             *)
 (*       tblatticeType == ... with both a top and a bottom                   *)
 (*       cblatticeType == ... with a complement to, and bottom               *)
-(*      tcblatticeType == ... with a top, bottom, and general complement     *)
+(*      ctblatticeType == ... with a top, bottom, and general complement     *)
 (*                                                                           *)
 (* Each of these structure take a first argument named display, of type unit *)
 (* instanciating it with tt or an unknown key will lead to a default display *)
@@ -298,7 +298,7 @@ Module Order.
 
 Module POrder.
 Section ClassDef.
-Structure mixin_of (T : eqType) := Mixin {
+Record mixin_of (T : eqType) := Mixin {
   le : rel T;
   lt : rel T;
   _  : forall x y, lt x y = (x != y) && (le x y);
@@ -334,33 +334,32 @@ Definition eqType := @Equality.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
 End ClassDef.
 
-Module Import Exports.
-Coercion base   : class_of >-> Choice.class_of.
-Coercion mixin  : class_of >-> mixin_of.
-Coercion sort   : type >-> Sortclass.
+Module Exports.
+Coercion base : class_of >-> Choice.class_of.
+Coercion mixin : class_of >-> mixin_of.
+Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
-
 Canonical eqType.
 Canonical choiceType.
-
 Notation porderType := type.
 Notation porderMixin := mixin_of.
 Notation POrderMixin := Mixin.
 Notation POrderType disp T m := (@pack T disp _ _ id m).
-
 Notation "[ 'porderType' 'of' T 'for' cT ]" := (@clone T _ cT _ _ erefl id)
   (at level 0, format "[ 'porderType'  'of'  T  'for'  cT ]") : form_scope.
 Notation "[ 'porderType' 'of' T 'for' cT 'with' disp ]" :=
   (@clone T _ cT disp _ (unit_irrelevance _ _) id)
-  (at level 0, format "[ 'porderType'  'of'  T  'for'  cT  'with'  disp ]") : form_scope.
+  (at level 0, format "[ 'porderType'  'of'  T  'for'  cT  'with'  disp ]") :
+  form_scope.
 Notation "[ 'porderType' 'of' T ]" := [porderType of T for _]
   (at level 0, format "[ 'porderType'  'of'  T ]") : form_scope.
-Notation "[ 'porderType' 'of' T 'with' disp ]" := [porderType of T for _ with disp]
+Notation "[ 'porderType' 'of' T 'with' disp ]" :=
+  [porderType of T for _ with disp]
   (at level 0, format "[ 'porderType'  'of'  T  'with' disp ]") : form_scope.
 End Exports.
-End POrder.
 
+End POrder.
 Import POrder.Exports.
 Bind Scope cpo_sort with POrder.sort.
 
@@ -482,7 +481,7 @@ End POCoercions.
 Module Lattice.
 Section ClassDef.
 
-Structure mixin_of d (T : porderType d) := Mixin {
+Record mixin_of d (T : porderType d) := Mixin {
   meet : T -> T -> T;
   join : T -> T -> T;
   _ : commutative meet;
@@ -524,35 +523,34 @@ Definition choiceType := @Choice.Pack cT xclass.
 Definition porderType := @POrder.Pack disp cT xclass.
 End ClassDef.
 
-Module Import Exports.
-Coercion base      : class_of >-> POrder.class_of.
-Coercion mixin     : class_of >-> mixin_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
+Module Exports.
+Coercion base : class_of >-> POrder.class_of.
+Coercion mixin : class_of >-> mixin_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> POrder.type.
-
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
-
 Notation latticeType  := type.
 Notation latticeMixin := mixin_of.
 Notation LatticeMixin := Mixin.
 Notation LatticeType T m := (@pack T _ _ m _ _ id _ id).
-
 Notation "[ 'latticeType' 'of' T 'for' cT ]" := (@clone T _ cT _ _ erefl id)
   (at level 0, format "[ 'latticeType'  'of'  T  'for'  cT ]") : form_scope.
 Notation "[ 'latticeType' 'of' T 'for' cT 'with' disp ]" :=
   (@clone T _ cT disp _ (unit_irrelevance _ _) id)
-  (at level 0, format "[ 'latticeType'  'of'  T  'for'  cT  'with'  disp ]") : form_scope.
+  (at level 0, format "[ 'latticeType'  'of'  T  'for'  cT  'with'  disp ]") :
+  form_scope.
 Notation "[ 'latticeType' 'of' T ]" := [latticeType of T for _]
   (at level 0, format "[ 'latticeType'  'of'  T ]") : form_scope.
-Notation "[ 'latticeType' 'of' T 'with' disp ]" := [latticeType of T for _ with disp]
+Notation "[ 'latticeType' 'of' T 'with' disp ]" :=
+  [latticeType of T for _ with disp]
   (at level 0, format "[ 'latticeType'  'of'  T  'with' disp ]") : form_scope.
 End Exports.
-End Lattice.
 
+End Lattice.
 Export Lattice.Exports.
 
 Module Import LatticeDef.
@@ -637,35 +635,33 @@ Definition latticeType := @Lattice.Pack disp cT xclass.
 
 End ClassDef.
 
-Module Import Exports.
-Coercion base      : class_of >-> Lattice.class_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
+Module Exports.
+Coercion base : class_of >-> Lattice.class_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> POrder.type.
 Coercion latticeType : type >-> Lattice.type.
-
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
 Canonical latticeType.
-
 Notation orderType  := type.
 Notation OrderType T m := (@pack T _ _ m _ _ id _ id).
-
 Notation "[ 'orderType' 'of' T 'for' cT ]" := (@clone T _ cT _ _ erefl id)
   (at level 0, format "[ 'orderType'  'of'  T  'for'  cT ]") : form_scope.
 Notation "[ 'orderType' 'of' T 'for' cT 'with' disp ]" :=
   (@clone T _ cT disp _ (unit_irrelevance _ _) id)
-  (at level 0, format "[ 'orderType'  'of'  T  'for'  cT  'with'  disp ]") : form_scope.
+  (at level 0, format "[ 'orderType'  'of'  T  'for'  cT  'with'  disp ]") :
+  form_scope.
 Notation "[ 'orderType' 'of' T ]" := [orderType of T for _]
   (at level 0, format "[ 'orderType'  'of'  T ]") : form_scope.
-Notation "[ 'orderType' 'of' T 'with' disp ]" := [orderType of T for _ with disp]
+Notation "[ 'orderType' 'of' T 'with' disp ]" :=
+  [orderType of T for _ with disp]
   (at level 0, format "[ 'orderType'  'of'  T  'with' disp ]") : form_scope.
-
 End Exports.
-End Total.
 
+End Total.
 Module Import TotalSyntax.
 
 Fact total_display : unit. Proof. exact: tt. Qed.
@@ -707,7 +703,7 @@ Import Total.Exports.
 
 Module BLattice.
 Section ClassDef.
-Structure mixin_of d (T : porderType d) := Mixin {
+Record mixin_of d (T : porderType d) := Mixin {
   bottom : T;
   _ : forall x, bottom <= x;
 }.
@@ -741,37 +737,36 @@ Definition porderType := @POrder.Pack disp cT xclass.
 Definition latticeType := @Lattice.Pack disp cT xclass.
 End ClassDef.
 
-Module Import Exports.
-Coercion base      : class_of >-> Lattice.class_of.
-Coercion mixin     : class_of >-> mixin_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
+Module Exports.
+Coercion base : class_of >-> Lattice.class_of.
+Coercion mixin : class_of >-> mixin_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> POrder.type.
 Coercion latticeType : type >-> Lattice.type.
-
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
 Canonical latticeType.
-
 Notation blatticeType  := type.
 Notation blatticeMixin := mixin_of.
 Notation BLatticeMixin := Mixin.
 Notation BLatticeType T m := (@pack T _ _ m _ _ id _ id).
-
 Notation "[ 'blatticeType' 'of' T 'for' cT ]" := (@clone T _ cT _ _ erefl id)
   (at level 0, format "[ 'blatticeType'  'of'  T  'for'  cT ]") : form_scope.
 Notation "[ 'blatticeType' 'of' T 'for' cT 'with' disp ]" :=
   (@clone T _ cT disp _ (unit_irrelevance _ _) id)
-  (at level 0, format "[ 'blatticeType'  'of'  T  'for'  cT  'with'  disp ]") : form_scope.
+  (at level 0, format "[ 'blatticeType'  'of'  T  'for'  cT  'with'  disp ]") :
+  form_scope.
 Notation "[ 'blatticeType' 'of' T ]" := [blatticeType of T for _]
   (at level 0, format "[ 'blatticeType'  'of'  T ]") : form_scope.
-Notation "[ 'blatticeType' 'of' T 'with' disp ]" := [blatticeType of T for _ with disp]
+Notation "[ 'blatticeType' 'of' T 'with' disp ]" :=
+  [blatticeType of T for _ with disp]
   (at level 0, format "[ 'blatticeType'  'of'  T  'with' disp ]") : form_scope.
 End Exports.
-End BLattice.
 
+End BLattice.
 Export BLattice.Exports.
 
 Module Import BLatticeDef.
@@ -811,7 +806,7 @@ End BLatticeSyntax.
 
 Module TBLattice.
 Section ClassDef.
-Structure mixin_of d (T : porderType d) := Mixin {
+Record mixin_of d (T : porderType d) := Mixin {
   top : T;
   _ : forall x, x <= top;
 }.
@@ -846,39 +841,37 @@ Definition latticeType := @Lattice.Pack disp cT xclass.
 Definition blatticeType := @BLattice.Pack disp cT xclass.
 End ClassDef.
 
-Module Import Exports.
-Coercion base      : class_of >-> BLattice.class_of.
-Coercion mixin     : class_of >-> mixin_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
+Module Exports.
+Coercion base : class_of >-> BLattice.class_of.
+Coercion mixin : class_of >-> mixin_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
 Coercion porderType : type >-> POrder.type.
 Coercion latticeType : type >-> Lattice.type.
 Coercion blatticeType : type >-> BLattice.type.
-
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
 Canonical latticeType.
 Canonical blatticeType.
-
 Notation tblatticeType  := type.
 Notation tblatticeMixin := mixin_of.
 Notation TBLatticeMixin := Mixin.
 Notation TBLatticeType T m := (@pack T _ _ m _ _ id _ id).
-
 Notation "[ 'tblatticeType' 'of' T 'for' cT ]" := (@clone T _ cT _ _ erefl id)
   (at level 0, format "[ 'tblatticeType'  'of'  T  'for'  cT ]") : form_scope.
 Notation "[ 'tblatticeType' 'of' T 'for' cT 'with' disp ]" :=
   (@clone T _ cT disp _ (unit_irrelevance _ _) id)
-  (at level 0, format "[ 'tblatticeType'  'of'  T  'for'  cT  'with'  disp ]") : form_scope.
+  (at level 0, format "[ 'tblatticeType'  'of'  T  'for'  cT  'with'  disp ]") :
+  form_scope.
 Notation "[ 'tblatticeType' 'of' T ]" := [tblatticeType of T for _]
   (at level 0, format "[ 'tblatticeType'  'of'  T ]") : form_scope.
-Notation "[ 'tblatticeType' 'of' T 'with' disp ]" := [tblatticeType of T for _ with disp]
+Notation "[ 'tblatticeType' 'of' T 'with' disp ]" :=
+  [tblatticeType of T for _ with disp]
   (at level 0, format "[ 'tblatticeType'  'of'  T  'with' disp ]") : form_scope.
-
 End Exports.
-End TBLattice.
 
+End TBLattice.
 Export TBLattice.Exports.
 
 Module Import TBLatticeDef.
@@ -919,7 +912,7 @@ End TBLatticeSyntax.
 
 Module CBLattice.
 Section ClassDef.
-Structure mixin_of d (T : blatticeType d) := Mixin {
+Record mixin_of d (T : blatticeType d) := Mixin {
   sub : T -> T -> T;
   _ : forall x y, y `&` sub x y = bottom;
   _ : forall x y, (x `&` y) `|` sub x y = x
@@ -946,7 +939,7 @@ Notation xclass := (class : class_of _ xT).
 
 Definition pack b0 (m0 : mixin_of (@BLattice.Pack disp T b0)) :=
   fun bT b & phant_id (@BLattice.class disp bT) b =>
-    fun    m & phant_id m0 m => Pack (@Class disp T b m).
+  fun    m & phant_id m0 m => Pack (@Class disp T b m).
 
 Definition eqType := @Equality.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
@@ -955,40 +948,38 @@ Definition latticeType := @Lattice.Pack disp cT xclass.
 Definition blatticeType := @BLattice.Pack disp cT xclass.
 End ClassDef.
 
-Module Import Exports.
-Coercion base      : class_of >-> BLattice.class_of.
-Coercion mixin     : class_of >-> mixin_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
+Module Exports.
+Coercion base : class_of >-> BLattice.class_of.
+Coercion mixin : class_of >-> mixin_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> POrder.type.
 Coercion latticeType : type >-> Lattice.type.
 Coercion blatticeType : type >-> BLattice.type.
-
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
 Canonical latticeType.
 Canonical blatticeType.
-
 Notation cblatticeType  := type.
 Notation cblatticeMixin := mixin_of.
 Notation CBLatticeMixin := Mixin.
 Notation CBLatticeType T m := (@pack T _ _ m _ _ id _ id).
-
 Notation "[ 'cblatticeType' 'of' T 'for' cT ]" := (@clone T _ cT _ _ erefl id)
   (at level 0, format "[ 'cblatticeType'  'of'  T  'for'  cT ]") : form_scope.
 Notation "[ 'cblatticeType' 'of' T 'for' cT 'with' disp ]" :=
   (@clone T _ cT disp _ (unit_irrelevance _ _) id)
-  (at level 0, format "[ 'cblatticeType'  'of'  T  'for'  cT  'with'  disp ]") : form_scope.
+  (at level 0, format "[ 'cblatticeType'  'of'  T  'for'  cT  'with'  disp ]") :
+  form_scope.
 Notation "[ 'cblatticeType' 'of' T ]" := [cblatticeType of T for _]
   (at level 0, format "[ 'cblatticeType'  'of'  T ]") : form_scope.
-Notation "[ 'cblatticeType' 'of' T 'with' disp ]" := [cblatticeType of T for _ with disp]
+Notation "[ 'cblatticeType' 'of' T 'with' disp ]" :=
+  [cblatticeType of T for _ with disp]
   (at level 0, format "[ 'cblatticeType'  'of'  T  'with' disp ]") : form_scope.
-
 End Exports.
-End CBLattice.
 
+End CBLattice.
 Export CBLattice.Exports.
 
 Module Import CBLatticeDef.
@@ -1048,20 +1039,19 @@ Definition tbd_cblatticeType :=
   @CBLattice.Pack disp tblatticeType xclass.
 End ClassDef.
 
-Module Import Exports.
-Coercion base      : class_of >-> TBLattice.class_of.
-Coercion base2     : class_of >-> CBLattice.class_of.
-Coercion mixin1     : class_of >-> CBLattice.mixin_of.
-Coercion mixin2     : class_of >-> mixin_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
+Module Exports.
+Coercion base : class_of >-> TBLattice.class_of.
+Coercion base2 : class_of >-> CBLattice.class_of.
+Coercion mixin1 : class_of >-> CBLattice.mixin_of.
+Coercion mixin2 : class_of >-> mixin_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> POrder.type.
 Coercion latticeType : type >-> Lattice.type.
 Coercion blatticeType : type >-> BLattice.type.
 Coercion tblatticeType : type >-> TBLattice.type.
 Coercion cblatticeType : type >-> CBLattice.type.
-
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
@@ -1070,29 +1060,27 @@ Canonical blatticeType.
 Canonical tblatticeType.
 Canonical cblatticeType.
 Canonical tbd_cblatticeType.
-
 Notation ctblatticeType  := type.
 Notation ctblatticeMixin := mixin_of.
 Notation CTBLatticeMixin := Mixin.
 Notation CTBLatticeType T m := (@pack T _ _ _ id _ _ id m).
-
 Notation "[ 'cblatticeType' 'of' T 'for' cT ]" := (@clone T _ cT _ _ erefl id)
   (at level 0, format "[ 'cblatticeType'  'of'  T  'for'  cT ]") : form_scope.
 Notation "[ 'cblatticeType' 'of' T 'for' cT 'with' disp ]" :=
   (@clone T _ cT disp _ (unit_irrelevance _ _) id)
-  (at level 0, format "[ 'cblatticeType'  'of'  T  'for'  cT  'with'  disp ]") : form_scope.
+  (at level 0, format "[ 'cblatticeType'  'of'  T  'for'  cT  'with'  disp ]") :
+  form_scope.
 Notation "[ 'cblatticeType' 'of' T ]" := [cblatticeType of T for _]
   (at level 0, format "[ 'cblatticeType'  'of'  T ]") : form_scope.
-Notation "[ 'cblatticeType' 'of' T 'with' disp ]" := [cblatticeType of T for _ with disp]
+Notation "[ 'cblatticeType' 'of' T 'with' disp ]" :=
+  [cblatticeType of T for _ with disp]
   (at level 0, format "[ 'cblatticeType'  'of'  T  'with' disp ]") : form_scope.
-
 Notation "[ 'default_ctblatticeType' 'of' T ]" :=
   (@pack T _ _ _ id _ _ id (fun=> erefl))
   (at level 0, format "[ 'default_ctblatticeType'  'of'  T ]") : form_scope.
-
 End Exports.
-End CTBLattice.
 
+End CTBLattice.
 Export CTBLattice.Exports.
 
 Module Import CTBLatticeDef.
@@ -1136,34 +1124,35 @@ Definition pack :=
   Pack disp (@Class T b m).
 
 Definition eqType := @Equality.Pack cT xclass.
-Definition finType := @Finite.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
+Definition countType := @Countable.Pack cT xclass.
+Definition finType := @Finite.Pack cT xclass.
 Definition porderType := @POrder.Pack disp cT xclass.
 Definition fin_porderType := @POrder.Pack disp finType xclass.
 End ClassDef.
 
-Module Import Exports.
-Coercion base   : class_of >-> Finite.class_of.
-Coercion base2  : class_of >-> POrder.class_of.
-Coercion sort   : type >-> Sortclass.
+Module Exports.
+Coercion base : class_of >-> Finite.class_of.
+Coercion base2 : class_of >-> POrder.class_of.
+Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
-Coercion finType : type >-> Finite.type.
 Coercion choiceType : type >-> Choice.type.
+Coercion countType : type >-> Countable.type.
+Coercion finType : type >-> Finite.type.
 Coercion porderType : type >-> POrder.type.
-
 Canonical eqType.
-Canonical finType.
 Canonical choiceType.
+Canonical countType.
+Canonical finType.
 Canonical porderType.
 Canonical fin_porderType.
-
 Notation finPOrderType := type.
-Notation "[ 'finPOrderType' 'of' T ]" := (@pack T _ _ erefl _ _ phant_id  _ _ phant_id)
+Notation "[ 'finPOrderType' 'of' T ]" :=
+  (@pack T _ _ erefl _ _ phant_id  _ _ phant_id)
   (at level 0, format "[ 'finPOrderType'  'of'  T ]") : form_scope.
-
 End Exports.
-End FinPOrder.
 
+End FinPOrder.
 Import FinPOrder.Exports.
 Bind Scope cpo_sort with FinPOrder.sort.
 
@@ -1171,13 +1160,17 @@ Module FinLattice.
 Section ClassDef.
 
 Record class_of d (T : Type) := Class {
-  base  : FinPOrder.class_of T;
-  mixin : Lattice.mixin_of (POrder.Pack d base)
+  base : FinPOrder.class_of T;
+  mixin1 : Lattice.mixin_of (POrder.Pack d base);
+  mixin2 : BLattice.mixin_of (POrder.Pack d base);
+  mixin3 : TBLattice.mixin_of (POrder.Pack d base)
 }.
 
 Local Coercion base : class_of >-> FinPOrder.class_of.
-Definition base2 d T (c : class_of d T) := (Lattice.Class (mixin c)).
-Local Coercion base2 : class_of >-> Lattice.class_of.
+Local Coercion base2 d T (c : class_of d T) : TBLattice.class_of d T :=
+  (@TBLattice.Class
+     _ _ (@BLattice.Class _ _ (Lattice.Class (mixin1 c)) (mixin2 c))
+     (mixin3 c)).
 
 Structure type (display : unit) :=
   Pack { sort; _ : class_of display sort }.
@@ -1191,47 +1184,146 @@ Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of _ xT).
 
 Definition pack disp :=
-  fun bT b & phant_id (@FinPOrder.class disp bT) b =>
-  fun mT m & phant_id (@Lattice.mixin disp mT) m =>
-  Pack (@Class disp T b m).
+  fun bT  b  & phant_id (@FinPOrder.class disp bT) b =>
+  fun m1T m1 & phant_id (@Lattice.mixin disp m1T) m1 =>
+  fun m2T m2 & phant_id (@BLattice.mixin disp m2T) m2 =>
+  fun m3T m3 & phant_id (@TBLattice.mixin disp m3T) m3 =>
+  Pack (@Class disp T b m1 m2 m3).
 
 Definition eqType := @Equality.Pack cT xclass.
-Definition finType := @Finite.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
+Definition countType := @Countable.Pack cT xclass.
+Definition finType := @Finite.Pack cT xclass.
 Definition porderType := @POrder.Pack disp cT xclass.
 Definition finPOrderType := @FinPOrder.Pack disp cT xclass.
 Definition latticeType := @Lattice.Pack disp cT xclass.
-Definition fin_latticeType := @Lattice.Pack disp finPOrderType xclass.
+Definition blatticeType := @BLattice.Pack disp cT xclass.
+Definition tblatticeType := @TBLattice.Pack disp cT xclass.
+Definition fin_latticeType := @Lattice.Pack disp finType xclass.
+Definition fin_blatticeType := @BLattice.Pack disp finType xclass.
+Definition fin_tblatticeType := @TBLattice.Pack disp finType xclass.
 
 End ClassDef.
 
-Module Import Exports.
-Coercion base      : class_of >-> FinPOrder.class_of.
-Coercion base2     : class_of >-> Lattice.class_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
-Coercion finType : type >-> Finite.type.
+Module Exports.
+Coercion base : class_of >-> FinPOrder.class_of.
+Coercion base2 : class_of >-> TBLattice.class_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
+Coercion countType : type >-> Countable.type.
+Coercion finType : type >-> Finite.type.
 Coercion porderType : type >-> POrder.type.
 Coercion finPOrderType : type >-> FinPOrder.type.
 Coercion latticeType : type >-> Lattice.type.
-
+Coercion blatticeType : type >-> BLattice.type.
+Coercion tblatticeType : type >-> TBLattice.type.
 Canonical eqType.
-Canonical finType.
 Canonical choiceType.
+Canonical countType.
+Canonical finType.
 Canonical porderType.
 Canonical finPOrderType.
 Canonical latticeType.
+Canonical blatticeType.
+Canonical tblatticeType.
 Canonical fin_latticeType.
-
+Canonical fin_blatticeType.
+Canonical fin_tblatticeType.
 Notation finLatticeType  := type.
-
-Notation "[ 'finLatticeType' 'of' T ]" := (@pack T _ _ erefl _ _ phant_id  _ _ phant_id)
+Notation "[ 'finLatticeType' 'of' T ]" :=
+  (@pack T _ _ _ erefl _ _ phant_id  _ _ phant_id _ _ phant_id)
   (at level 0, format "[ 'finLatticeType'  'of'  T ]") : form_scope.
 End Exports.
-End FinLattice.
 
+End FinLattice.
 Export FinLattice.Exports.
+
+Module FinCLattice.
+Section ClassDef.
+
+Record class_of d (T : Type) := Class {
+  base  : FinLattice.class_of d T;
+  mixin1 : CBLattice.mixin_of (BLattice.Pack base);
+  mixin2 : @CTBLattice.mixin_of d (TBLattice.Pack base) (CBLattice.sub mixin1)
+}.
+
+Local Coercion base : class_of >-> FinLattice.class_of.
+Local Coercion base2 d T (c : class_of d T) : CTBLattice.class_of d T :=
+   (@CTBLattice.Class _ _ c (@mixin1 _ _ c) (@mixin2 _ _ c)).
+
+Structure type (display : unit) :=
+  Pack { sort; _ : class_of display sort }.
+
+Local Coercion sort : type >-> Sortclass.
+
+Variables (T : Type) (disp : unit) (cT : type disp).
+
+Definition class := let: Pack _ c as cT' := cT return class_of _ cT' in c.
+Let xT := let: Pack T _ := cT in T.
+Notation xclass := (class : class_of _ xT).
+
+Definition pack disp :=
+  fun bT b & phant_id (@FinLattice.class disp bT) b =>
+  fun m1T m1 & phant_id (@CTBLattice.mixin1 disp m1T) m1 =>
+  fun m2T m2 & phant_id (@CTBLattice.mixin2 disp m2T) m2 =>
+  Pack (@Class disp T b m1 m2).
+
+Definition eqType := @Equality.Pack cT xclass.
+Definition choiceType := @Choice.Pack cT xclass.
+Definition countType := @Countable.Pack cT xclass.
+Definition finType := @Finite.Pack cT xclass.
+Definition porderType := @POrder.Pack disp cT xclass.
+Definition finPOrderType := @FinPOrder.Pack disp cT xclass.
+Definition latticeType := @Lattice.Pack disp cT xclass.
+Definition blatticeType := @BLattice.Pack disp cT xclass.
+Definition tblatticeType := @TBLattice.Pack disp cT xclass.
+Definition finLatticeType := @FinLattice.Pack disp cT xclass.
+Definition cblatticeType := @CBLattice.Pack disp cT xclass.
+Definition ctblatticeType := @CTBLattice.Pack disp cT xclass.
+Definition fin_cblatticeType := @CBLattice.Pack disp finLatticeType xclass.
+Definition fin_ctblatticeType := @CTBLattice.Pack disp finLatticeType xclass.
+
+End ClassDef.
+
+Module Exports.
+Coercion base : class_of >-> FinLattice.class_of.
+Coercion base2 : class_of >-> CTBLattice.class_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
+Coercion choiceType : type >-> Choice.type.
+Coercion countType : type >-> Countable.type.
+Coercion finType : type >-> Finite.type.
+Coercion porderType : type >-> POrder.type.
+Coercion finPOrderType : type >-> FinPOrder.type.
+Coercion latticeType : type >-> Lattice.type.
+Coercion blatticeType : type >-> BLattice.type.
+Coercion tblatticeType : type >-> TBLattice.type.
+Coercion finLatticeType : type >-> FinLattice.type.
+Coercion cblatticeType : type >-> CBLattice.type.
+Coercion ctblatticeType : type >-> CTBLattice.type.
+Canonical eqType.
+Canonical choiceType.
+Canonical countType.
+Canonical finType.
+Canonical porderType.
+Canonical finPOrderType.
+Canonical latticeType.
+Canonical blatticeType.
+Canonical tblatticeType.
+Canonical finLatticeType.
+Canonical cblatticeType.
+Canonical ctblatticeType.
+Canonical fin_cblatticeType.
+Canonical fin_ctblatticeType.
+Notation finCLatticeType  := type.
+Notation "[ 'finCLatticeType' 'of' T ]" :=
+  (@pack T _ _ erefl _ _ phant_id  _ _ phant_id _ _ phant_id)
+  (at level 0, format "[ 'finCLatticeType'  'of'  T ]") : form_scope.
+End Exports.
+
+End FinCLattice.
+Export FinCLattice.Exports.
 
 Module FinTotal.
 Section ClassDef.
@@ -1263,383 +1355,65 @@ Definition pack disp :=
   Pack (@Class disp T b m).
 
 Definition eqType := @Equality.Pack cT xclass.
-Definition finType := @Finite.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
+Definition countType := @Countable.Pack cT xclass.
+Definition finType := @Finite.Pack cT xclass.
 Definition porderType := @POrder.Pack disp cT xclass.
 Definition finPOrderType := @FinPOrder.Pack disp cT xclass.
 Definition latticeType := @Lattice.Pack disp cT xclass.
+Definition blatticeType := @BLattice.Pack disp cT xclass.
+Definition tblatticeType := @TBLattice.Pack disp cT xclass.
 Definition finLatticeType := @FinLattice.Pack disp cT xclass.
 Definition orderType := @Total.Pack disp cT xclass.
-Definition fin_orderType := @Total.Pack disp finLatticeType xclass.
+Definition order_countType := @Countable.Pack orderType xclass.
+Definition order_finType := @Finite.Pack orderType xclass.
+Definition order_finPOrderType := @FinPOrder.Pack disp orderType xclass.
+Definition order_blatticeType := @BLattice.Pack disp orderType xclass.
+Definition order_tblatticeType := @TBLattice.Pack disp orderType xclass.
+Definition order_finLatticeType := @FinLattice.Pack disp orderType xclass.
 
 End ClassDef.
 
-Module Import Exports.
-Coercion base      : class_of >-> FinLattice.class_of.
-Coercion base2     : class_of >-> Total.class_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
-Coercion finType : type >-> Finite.type.
+Module Exports.
+Coercion base : class_of >-> FinLattice.class_of.
+Coercion base2 : class_of >-> Total.class_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
+Coercion countType : type >-> Countable.type.
+Coercion finType : type >-> Finite.type.
 Coercion porderType : type >-> POrder.type.
 Coercion finPOrderType : type >-> FinPOrder.type.
 Coercion latticeType : type >-> Lattice.type.
+Coercion blatticeType : type >-> BLattice.type.
+Coercion tblatticeType : type >-> TBLattice.type.
 Coercion finLatticeType : type >-> FinLattice.type.
 Coercion orderType : type >-> Total.type.
-
 Canonical eqType.
-Canonical finType.
 Canonical choiceType.
+Canonical countType.
+Canonical finType.
 Canonical porderType.
 Canonical finPOrderType.
 Canonical latticeType.
+Canonical blatticeType.
+Canonical tblatticeType.
 Canonical finLatticeType.
 Canonical orderType.
-Canonical fin_orderType.
-
-Notation finOrderType  := type.
-
-Notation "[ 'finOrderType' 'of' T ]" := (@pack T _ _ erefl _ _ phant_id  _ _ phant_id)
+Canonical order_countType.
+Canonical order_finType.
+Canonical order_finPOrderType.
+Canonical order_blatticeType.
+Canonical order_tblatticeType.
+Canonical order_finLatticeType.
+Notation finOrderType := type.
+Notation "[ 'finOrderType' 'of' T ]" :=
+  (@pack T _ _ erefl _ _ phant_id  _ _ phant_id)
   (at level 0, format "[ 'finOrderType'  'of'  T ]") : form_scope.
 End Exports.
+
 End FinTotal.
-
 Export Total.Exports.
-
-Module FinBLattice.
-Section ClassDef.
-
-Record class_of d (T : Type) := Class {
-  base  : FinLattice.class_of d T;
-  mixin : BLattice.mixin_of (FinPOrder.Pack d base)
-}.
-
-Local Coercion base : class_of >-> FinLattice.class_of.
-Definition base2 d T (c : class_of d T) :=
-   (@BLattice.Class _ _ (FinLattice.base2 c) (@mixin _ _ c)).
-Local Coercion base2 : class_of >-> BLattice.class_of.
-
-Structure type (display : unit) :=
-  Pack { sort; _ : class_of display sort }.
-
-Local Coercion sort : type >-> Sortclass.
-
-Variables (T : Type) (disp : unit) (cT : type disp).
-
-Definition class := let: Pack _ c as cT' := cT return class_of _ cT' in c.
-Let xT := let: Pack T _ := cT in T.
-Notation xclass := (class : class_of _ xT).
-
-Definition pack disp :=
-  fun bT b & phant_id (@FinPOrder.class disp bT) b =>
-  fun mT m & phant_id (@BLattice.mixin disp mT) m =>
-  Pack (@Class disp T b m).
-
-Definition eqType := @Equality.Pack cT xclass.
-Definition finType := @Finite.Pack cT xclass.
-Definition choiceType := @Choice.Pack cT xclass.
-Definition porderType := @POrder.Pack disp cT xclass.
-Definition finPOrderType := @FinPOrder.Pack disp cT xclass.
-Definition latticeType := @Lattice.Pack disp cT xclass.
-Definition finLatticeType := @FinLattice.Pack disp cT xclass.
-Definition blatticeType := @BLattice.Pack disp cT xclass.
-Definition fin_blatticeType := @BLattice.Pack disp finLatticeType xclass.
-
-End ClassDef.
-
-Module Import Exports.
-Coercion base      : class_of >-> FinLattice.class_of.
-Coercion base2     : class_of >-> BLattice.class_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
-Coercion finType : type >-> Finite.type.
-Coercion choiceType : type >-> Choice.type.
-Coercion porderType : type >-> POrder.type.
-Coercion finPOrderType : type >-> FinPOrder.type.
-Coercion latticeType : type >-> Lattice.type.
-Coercion finLatticeType : type >-> FinLattice.type.
-Coercion blatticeType : type >-> BLattice.type.
-
-Canonical eqType.
-Canonical finType.
-Canonical choiceType.
-Canonical porderType.
-Canonical finPOrderType.
-Canonical latticeType.
-Canonical finLatticeType.
-Canonical blatticeType.
-Canonical fin_blatticeType.
-
-Notation finBLatticeType  := type.
-
-Notation "[ 'finBLatticeType' 'of' T ]" := (@pack T _ _ erefl _ _ phant_id  _ _ phant_id)
-  (at level 0, format "[ 'finBLatticeType'  'of'  T ]") : form_scope.
-End Exports.
-End FinBLattice.
-
-Export FinBLattice.Exports.
-
-Module FinTBLattice.
-Section ClassDef.
-
-Record class_of d (T : Type) := Class {
-  base  : FinBLattice.class_of d T;
-  mixin : TBLattice.mixin_of (FinPOrder.Pack d base)
-}.
-
-Local Coercion base : class_of >-> FinBLattice.class_of.
-Definition base2 d T (c : class_of d T) :=
-   (@TBLattice.Class _ _ c (@mixin _ _ c)).
-Local Coercion base2 : class_of >-> TBLattice.class_of.
-
-Structure type (display : unit) :=
-  Pack { sort; _ : class_of display sort }.
-
-Local Coercion sort : type >-> Sortclass.
-
-Variables (T : Type) (disp : unit) (cT : type disp).
-
-Definition class := let: Pack _ c as cT' := cT return class_of _ cT' in c.
-Let xT := let: Pack T _ := cT in T.
-Notation xclass := (class : class_of _ xT).
-
-Definition pack disp :=
-  fun bT b & phant_id (@FinBLattice.class disp bT) b =>
-  fun mT m & phant_id (@TBLattice.mixin disp mT) m =>
-  Pack (@Class disp T b m).
-
-Definition eqType := @Equality.Pack cT xclass.
-Definition finType := @Finite.Pack cT xclass.
-Definition choiceType := @Choice.Pack cT xclass.
-Definition porderType := @POrder.Pack disp cT xclass.
-Definition finPOrderType := @FinPOrder.Pack disp cT xclass.
-Definition latticeType := @Lattice.Pack disp cT xclass.
-Definition finLatticeType := @FinLattice.Pack disp cT xclass.
-Definition blatticeType := @BLattice.Pack disp cT xclass.
-Definition finBLatticeType := @FinBLattice.Pack disp cT xclass.
-Definition tblatticeType := @TBLattice.Pack disp cT xclass.
-Definition fin_blatticeType := @TBLattice.Pack disp finBLatticeType xclass.
-
-End ClassDef.
-
-Module Import Exports.
-Coercion base      : class_of >-> FinBLattice.class_of.
-Coercion base2     : class_of >-> TBLattice.class_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
-Coercion finType : type >-> Finite.type.
-Coercion choiceType : type >-> Choice.type.
-Coercion porderType : type >-> POrder.type.
-Coercion finPOrderType : type >-> FinPOrder.type.
-Coercion latticeType : type >-> Lattice.type.
-Coercion finLatticeType : type >-> FinLattice.type.
-Coercion blatticeType : type >-> BLattice.type.
-Coercion finBLatticeType : type >-> FinBLattice.type.
-Coercion tblatticeType : type >-> TBLattice.type.
-
-Canonical eqType.
-Canonical finType.
-Canonical choiceType.
-Canonical porderType.
-Canonical finPOrderType.
-Canonical latticeType.
-Canonical finLatticeType.
-Canonical blatticeType.
-Canonical finBLatticeType.
-Canonical tblatticeType.
-Canonical fin_blatticeType.
-
-Notation finTBLatticeType  := type.
-
-Notation "[ 'finTBLatticeType' 'of' T ]" := (@pack T _ _ erefl _ _ phant_id  _ _ phant_id)
-  (at level 0, format "[ 'finTBLatticeType'  'of'  T ]") : form_scope.
-End Exports.
-End FinTBLattice.
-
-Export FinTBLattice.Exports.
-
-Module FinCBLattice.
-Section ClassDef.
-
-Record class_of d (T : Type) := Class {
-  base  : FinBLattice.class_of d T;
-  mixin : CBLattice.mixin_of (BLattice.Pack base)
-}.
-
-Local Coercion base : class_of >-> FinBLattice.class_of.
-Definition base2 d T (c : class_of d T) :=
-   (@CBLattice.Class _ _ c (@mixin _ _ c)).
-Local Coercion base2 : class_of >-> CBLattice.class_of.
-
-Structure type (display : unit) :=
-  Pack { sort; _ : class_of display sort }.
-
-Local Coercion sort : type >-> Sortclass.
-
-Variables (T : Type) (disp : unit) (cT : type disp).
-
-Definition class := let: Pack _ c as cT' := cT return class_of _ cT' in c.
-Let xT := let: Pack T _ := cT in T.
-Notation xclass := (class : class_of _ xT).
-
-Definition pack disp :=
-  fun bT b & phant_id (@FinBLattice.class disp bT) b =>
-  fun mT m & phant_id (@CBLattice.mixin disp mT) m =>
-  Pack (@Class disp T b m).
-
-Definition eqType := @Equality.Pack cT xclass.
-Definition finType := @Finite.Pack cT xclass.
-Definition choiceType := @Choice.Pack cT xclass.
-Definition porderType := @POrder.Pack disp cT xclass.
-Definition finPOrderType := @FinPOrder.Pack disp cT xclass.
-Definition latticeType := @Lattice.Pack disp cT xclass.
-Definition finLatticeType := @FinLattice.Pack disp cT xclass.
-Definition blatticeType := @BLattice.Pack disp cT xclass.
-Definition finBLatticeType := @FinBLattice.Pack disp cT xclass.
-Definition cblatticeType := @CBLattice.Pack disp cT xclass.
-Definition fin_blatticeType := @CBLattice.Pack disp finBLatticeType xclass.
-
-End ClassDef.
-
-Module Import Exports.
-Coercion base      : class_of >-> FinBLattice.class_of.
-Coercion base2     : class_of >-> CBLattice.class_of.
-Coercion sort      : type >-> Sortclass.
-Coercion eqType    : type >-> Equality.type.
-Coercion finType : type >-> Finite.type.
-Coercion choiceType : type >-> Choice.type.
-Coercion porderType : type >-> POrder.type.
-Coercion finPOrderType : type >-> FinPOrder.type.
-Coercion latticeType : type >-> Lattice.type.
-Coercion finLatticeType : type >-> FinLattice.type.
-Coercion blatticeType : type >-> BLattice.type.
-Coercion finBLatticeType : type >-> FinBLattice.type.
-Coercion cblatticeType : type >-> CBLattice.type.
-
-Canonical eqType.
-Canonical finType.
-Canonical choiceType.
-Canonical porderType.
-Canonical finPOrderType.
-Canonical latticeType.
-Canonical finLatticeType.
-Canonical blatticeType.
-Canonical finBLatticeType.
-Canonical cblatticeType.
-Canonical fin_blatticeType.
-
-Notation finCBLatticeType  := type.
-
-Notation "[ 'finCBLatticeType' 'of' T ]" := (@pack T _ _ erefl _ _ phant_id  _ _ phant_id)
-  (at level 0, format "[ 'finCBLatticeType'  'of'  T ]") : form_scope.
-End Exports.
-End FinCBLattice.
-
-Export FinCBLattice.Exports.
-
-Module FinCTBLattice.
-Section ClassDef.
-
-Record class_of d (T : Type) := Class {
-  base  : FinTBLattice.class_of d T;
-  mixin1 : CBLattice.mixin_of (BLattice.Pack base);
-  mixin2 : @CTBLattice.mixin_of d (TBLattice.Pack base) (CBLattice.sub mixin1)
-}.
-
-Local Coercion base : class_of >-> FinTBLattice.class_of.
-Definition base1 d T (c : class_of d T) :=
-   (@FinCBLattice.Class _ _ c (@mixin1 _ _ c)).
-Local Coercion base1 : class_of >-> FinCBLattice.class_of.
-Definition base2 d T (c : class_of d T) :=
-   (@CTBLattice.Class _ _ c (@mixin1 _ _ c) (@mixin2 _ _ c)).
-Local Coercion base2 : class_of >-> CTBLattice.class_of.
-
-Structure type (display : unit) :=
-  Pack { sort; _ : class_of display sort }.
-
-Local Coercion sort : type >-> Sortclass.
-
-Variables (T : Type) (disp : unit) (cT : type disp).
-
-Definition class := let: Pack _ c as cT' := cT return class_of _ cT' in c.
-Let xT := let: Pack T _ := cT in T.
-Notation xclass := (class : class_of _ xT).
-
-Definition pack disp :=
-  fun bT b & phant_id (@FinTBLattice.class disp bT) b =>
-  fun m1T m1 & phant_id (@CTBLattice.mixin1 disp m1T) m1 =>
-  fun m2T m2 & phant_id (@CTBLattice.mixin2 disp m2T) m2 =>
-  Pack (@Class disp T b m1 m2).
-
-Definition eqType := @Equality.Pack cT xclass.
-Definition finType := @Finite.Pack cT xclass.
-Definition choiceType := @Choice.Pack cT xclass.
-Definition porderType := @POrder.Pack disp cT xclass.
-Definition finPOrderType := @FinPOrder.Pack disp cT xclass.
-Definition latticeType := @Lattice.Pack disp cT xclass.
-Definition finLatticeType := @FinLattice.Pack disp cT xclass.
-Definition blatticeType := @BLattice.Pack disp cT xclass.
-Definition finBLatticeType := @FinBLattice.Pack disp cT xclass.
-Definition cblatticeType := @CBLattice.Pack disp cT xclass.
-Definition tblatticeType := @TBLattice.Pack disp cT xclass.
-Definition finTBLatticeType := @FinTBLattice.Pack disp cT xclass.
-Definition finCBLatticeType := @FinCBLattice.Pack disp cT xclass.
-Definition ctblatticeType := @CTBLattice.Pack disp cT xclass.
-Definition fintb_ctblatticeType := @CTBLattice.Pack disp finTBLatticeType xclass.
-Definition fincb_ctblatticeType := @CTBLattice.Pack disp finCBLatticeType xclass.
-
-End ClassDef.
-
-Module Import Exports.
-Coercion base      : class_of >-> FinTBLattice.class_of.
-Coercion base1     : class_of >-> FinCBLattice.class_of.
-Coercion base2     : class_of >-> CTBLattice.class_of.
-Coercion sort      : type >-> Sortclass.
-
-Coercion eqType : type >-> Equality.type.
-Coercion finType : type >-> Finite.type.
-Coercion choiceType : type >-> Choice.type.
-Coercion porderType : type >-> POrder.type.
-Coercion finPOrderType : type >-> FinPOrder.type.
-Coercion latticeType : type >-> Lattice.type.
-Coercion finLatticeType : type >-> FinLattice.type.
-Coercion blatticeType : type >-> BLattice.type.
-Coercion finBLatticeType : type >-> FinBLattice.type.
-Coercion cblatticeType : type >-> CBLattice.type.
-Coercion tblatticeType : type >-> TBLattice.type.
-Coercion finTBLatticeType : type >-> FinTBLattice.type.
-Coercion finCBLatticeType : type >-> FinCBLattice.type.
-Coercion ctblatticeType : type >-> CTBLattice.type.
-Coercion fintb_ctblatticeType : type >-> CTBLattice.type.
-Coercion fincb_ctblatticeType : type >-> CTBLattice.type.
-
-
-Canonical eqType.
-Canonical finType.
-Canonical choiceType.
-Canonical porderType.
-Canonical finPOrderType.
-Canonical latticeType.
-Canonical finLatticeType.
-Canonical blatticeType.
-Canonical finBLatticeType.
-Canonical cblatticeType.
-Canonical tblatticeType.
-Canonical finTBLatticeType.
-Canonical finCBLatticeType.
-Canonical ctblatticeType.
-Canonical fintb_ctblatticeType.
-Canonical fincb_ctblatticeType.
-
-Notation finCTBLatticeType  := type.
-
-Notation "[ 'finCTBLatticeType' 'of' T ]" :=
-  (@pack T _ _ erefl _ _ phant_id  _ _ phant_id _ _ phant_id)
-  (at level 0, format "[ 'finCTBLatticeType'  'of'  T ]") : form_scope.
-End Exports.
-End FinCTBLattice.
-
-Export FinCTBLattice.Exports.
 
 (***********)
 (* REVERSE *)
@@ -2047,7 +1821,8 @@ Variable T : porderType.
 Definition reverse_le (x y : T) := (y <= x).
 Definition reverse_lt (x y : T) := (y < x).
 
-Lemma reverse_lt_neqAle (x y : T) : reverse_lt x y = (x != y) && (reverse_le x y).
+Lemma reverse_lt_neqAle (x y : T) :
+  reverse_lt x y = (x != y) && (reverse_le x y).
 Proof. by rewrite eq_sym; apply: lt_neqAle. Qed.
 
 Fact reverse_le_anti : antisymmetric reverse_le.
@@ -3462,8 +3237,6 @@ Export POrder.Exports.
 Export Total.Exports.
 Export Lattice.Exports.
 Export FinPOrder.Exports.
-Export FinTotal.Exports.
-Export FinLattice.Exports.
 End UnboundedTheory.
 
 Module Theory.
@@ -3479,10 +3252,9 @@ Export BLattice.Exports.
 Export CBLattice.Exports.
 Export TBLattice.Exports.
 Export CTBLattice.Exports.
-Export FinBLattice.Exports.
-Export FinCBLattice.Exports.
-Export FinTBLattice.Exports.
-Export FinCTBLattice.Exports.
+Export FinLattice.Exports.
+Export FinCLattice.Exports.
+Export FinTotal.Exports.
 End Theory.
 
 End Order.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -666,6 +666,43 @@ Notation "[ 'orderType' 'of' T 'with' disp ]" := [orderType of T for _ with disp
 End Exports.
 End Total.
 
+Module Import TotalSyntax.
+
+Fact total_display : unit. Proof. exact: tt. Qed.
+
+Notation "@ 'max'" := (@join total_display).
+Notation max := (@join total_display _).
+Notation "@ 'min'" := (@meet total_display).
+Notation min := (@meet total_display _).
+
+Notation "\max_ ( i <- r | P ) F" :=
+  (\big[@join total_display _/0%O]_(i <- r | P%B) F%O) : order_scope.
+Notation "\max_ ( i <- r ) F" :=
+  (\big[@join total_display _/0%O]_(i <- r) F%O) : order_scope.
+Notation "\max_ ( i | P ) F" :=
+  (\big[@join total_display _/0%O]_(i | P%B) F%O) : order_scope.
+Notation "\max_ i F" :=
+  (\big[@join total_display _/0%O]_i F%O) : order_scope.
+Notation "\max_ ( i : I | P ) F" :=
+  (\big[@join total_display _/0%O]_(i : I | P%B) F%O) (only parsing) :
+  order_scope.
+Notation "\max_ ( i : I ) F" :=
+  (\big[@join total_display _/0%O]_(i : I) F%O) (only parsing) : order_scope.
+Notation "\max_ ( m <= i < n | P ) F" :=
+  (\big[@join total_display _/0%O]_(m <= i < n | P%B) F%O) : order_scope.
+Notation "\max_ ( m <= i < n ) F" :=
+  (\big[@join total_display _/0%O]_(m <= i < n) F%O) : order_scope.
+Notation "\max_ ( i < n | P ) F" :=
+  (\big[@join total_display _/0%O]_(i < n | P%B) F%O) : order_scope.
+Notation "\max_ ( i < n ) F" :=
+  (\big[@join total_display _/0%O]_(i < n) F%O) : order_scope.
+Notation "\max_ ( i 'in' A | P ) F" :=
+  (\big[@join total_display _/0%O]_(i in A | P%B) F%O) : order_scope.
+Notation "\max_ ( i 'in' A ) F" :=
+  (\big[@join total_display _/0%O]_(i in A) F%O) : order_scope.
+
+End TotalSyntax.
+
 Import Total.Exports.
 
 Module BLattice.
@@ -758,17 +795,17 @@ Notation "\join_ ( i : I | P ) F" :=
 Notation "\join_ ( i : I ) F" :=
   (\big[@join _ _/0%O]_(i : I) F%O) (only parsing) : order_scope.
 Notation "\join_ ( m <= i < n | P ) F" :=
- (\big[@join _ _/0%O]_(m <= i < n | P%B) F%O) : order_scope.
+  (\big[@join _ _/0%O]_(m <= i < n | P%B) F%O) : order_scope.
 Notation "\join_ ( m <= i < n ) F" :=
- (\big[@join _ _/0%O]_(m <= i < n) F%O) : order_scope.
+  (\big[@join _ _/0%O]_(m <= i < n) F%O) : order_scope.
 Notation "\join_ ( i < n | P ) F" :=
- (\big[@join _ _/0%O]_(i < n | P%B) F%O) : order_scope.
+  (\big[@join _ _/0%O]_(i < n | P%B) F%O) : order_scope.
 Notation "\join_ ( i < n ) F" :=
- (\big[@join _ _/0%O]_(i < n) F%O) : order_scope.
+  (\big[@join _ _/0%O]_(i < n) F%O) : order_scope.
 Notation "\join_ ( i 'in' A | P ) F" :=
- (\big[@join _ _/0%O]_(i in A | P%B) F%O) : order_scope.
+  (\big[@join _ _/0%O]_(i in A | P%B) F%O) : order_scope.
 Notation "\join_ ( i 'in' A ) F" :=
- (\big[@join _ _/0%O]_(i in A) F%O) : order_scope.
+  (\big[@join _ _/0%O]_(i in A) F%O) : order_scope.
 
 End BLatticeSyntax.
 
@@ -1911,18 +1948,6 @@ Lemma nmono_leif (f : T -> T) C :
 Proof. by move=> mf x y; rewrite /leif !eq_le !mf. Qed.
 
 End POrderTheory.
-End POrderTheory.
-
-Hint Resolve lexx le_refl ltxx lt_irreflexive ltW lt_eqF.
-
-Arguments leifP {display T x y C}.
-Arguments leif_refl {display T x C}.
-Arguments mono_in_leif [display T A f C].
-Arguments nmono_in_leif [display T A f C].
-Arguments mono_leif [display T f C].
-Arguments nmono_leif [display T f C].
-
-Module Import POrderMonotonyTheory.
 Section POrderMonotonyTheory.
 
 Context {display display' : unit}.
@@ -1931,24 +1956,10 @@ Implicit Types (m n p : nat) (x y z : T) (u v w : T').
 Variable D D' : pred T.
 Variable (f : T -> T').
 
-(****************************************************************************)
-(* This listing of "Let"s factor out the required premices for the          *)
-(* subsequent lemmas, putting them in the context so that "done" solves the *)
-(* goals quickly                                                            *)
-(****************************************************************************)
+Hint Resolve lexx lt_neqAle (@le_anti _ T) (@le_anti _ T') lt_def.
 
-Let ltE := @lt_neqAle _ T.
-Let lt'E := @lt_neqAle _ T'.
-Let gtE (x y : T) : (x > y) = (x != y) && (x >= y).
-Proof. by rewrite lt_neqAle eq_sym. Qed.
-Let gt'E (x y : T') : (x > y) = (x != y) && (x >= y).
-Proof. by rewrite lt_neqAle eq_sym. Qed.
-Let le_antiT := @le_anti _ T.
-Let le_antiT' := @le_anti _ T'.
 Let ge_antiT : antisymmetric (>=%O : rel T).
-Proof. by move=> ??; rewrite andbC; apply: le_anti. Qed.
-Let ge_antiT' : antisymmetric (>=%O : rel T').
-Proof. by move=> ??; rewrite andbC; apply: le_anti. Qed.
+Proof. by move=> ?? /le_anti. Qed.
 
 Lemma ltW_homo : {homo f : x y / x < y} -> {homo f : x y / x <= y}.
 Proof. exact: homoW. Qed.
@@ -2012,7 +2023,17 @@ Lemma leW_nmono_in :
 Proof. exact: anti_mono_in. Qed.
 
 End POrderMonotonyTheory.
-End POrderMonotonyTheory.
+
+End POrderTheory.
+
+Hint Resolve lexx le_refl ltxx lt_irreflexive ltW lt_eqF.
+
+Arguments leifP {display T x y C}.
+Arguments leif_refl {display T x C}.
+Arguments mono_in_leif [display T A f C].
+Arguments nmono_in_leif [display T A f C].
+Arguments mono_leif [display T f C].
+Arguments nmono_leif [display T f C].
 
 Module Import ReversePOrder.
 Section ReversePOrder.
@@ -2366,12 +2387,7 @@ Definition ltexU := (lexU, ltxU).
 Definition lteUx := (@leUx _ T, ltUx).
 
 End TotalTheory.
-End TotalTheory.
-
-Module Import TotalMonotonyTheory.
 Section TotalMonotonyTheory.
-
-Import TotalTheory.
 
 Context {display : unit} {display' : unit}.
 Context {T : orderType display} {T' : porderType display'}.
@@ -2411,7 +2427,7 @@ move=> mf x y Dx Dy; case: ltgtP;
 Qed.
 
 End TotalMonotonyTheory.
-End TotalMonotonyTheory.
+End TotalTheory.
 
 Module Import BLatticeTheory.
 Section BLatticeTheory.
@@ -3335,8 +3351,6 @@ Import LtOrderMixin.Exports.
 Module Import NatOrder.
 Section NatOrder.
 
-Fact nat_display : unit. Proof. exact: tt. Qed.
-
 Lemma minnE x y : minn x y = if (x <= y)%N then x else y.
 Proof. by case: leqP => [/minn_idPl|/ltnW /minn_idPr]. Qed.
 
@@ -3344,9 +3358,10 @@ Lemma maxnE x y : maxn x y = if (y <= x)%N then x else y.
 Proof. by case: leqP => [/maxn_idPl|/ltnW/maxn_idPr]. Qed.
 
 Definition natOrderMixin :=
-  LeOrderMixin nat_display anti_leq leq_trans leq_total ltn_neqAle minnE maxnE.
+  LeOrderMixin
+    total_display anti_leq leq_trans leq_total ltn_neqAle minnE maxnE.
 
-Canonical natPOrderType := POrderType nat_display nat natOrderMixin.
+Canonical natPOrderType  := POrderType total_display nat natOrderMixin.
 
 Lemma leEnat (n m : nat): (n <= m) = (n <= m)%N.
 Proof. by []. Qed.
@@ -3360,36 +3375,6 @@ Canonical natOrderType := OrderType nat natOrderMixin.
 Definition natBLatticeMixin := BLatticeMixin leq0n.
 Canonical natBLatticeType := BLatticeType nat natBLatticeMixin.
 End NatOrder.
-
-Notation "@max" := (@join nat_display).
-Notation max := (@join nat_display _).
-Notation "@min" := (@meet nat_display).
-Notation min := (@meet nat_display _).
-
-Notation "\max_ ( i <- r | P ) F" :=
-  (\big[@join nat_display _/0%O]_(i <- r | P%B) F%O) : order_scope.
-Notation "\max_ ( i <- r ) F" :=
-  (\big[@join nat_display _/0%O]_(i <- r) F%O) : order_scope.
-Notation "\max_ ( i | P ) F" :=
-  (\big[@join nat_display _/0%O]_(i | P%B) F%O) : order_scope.
-Notation "\max_ i F" :=
-  (\big[@join nat_display _/0%O]_i F%O) : order_scope.
-Notation "\max_ ( i : I | P ) F" :=
-  (\big[@join nat_display _/0%O]_(i : I | P%B) F%O) (only parsing) : order_scope.
-Notation "\max_ ( i : I ) F" :=
-  (\big[@join nat_display _/0%O]_(i : I) F%O) (only parsing) : order_scope.
-Notation "\max_ ( m <= i < n | P ) F" :=
- (\big[@join nat_display _/0%O]_(m <= i < n | P%B) F%O) : order_scope.
-Notation "\max_ ( m <= i < n ) F" :=
- (\big[@join nat_display _/0%O]_(m <= i < n) F%O) : order_scope.
-Notation "\max_ ( i < n | P ) F" :=
- (\big[@join nat_display _/0%O]_(i < n | P%B) F%O) : order_scope.
-Notation "\max_ ( i < n ) F" :=
- (\big[@join nat_display _/0%O]_(i < n) F%O) : order_scope.
-Notation "\max_ ( i 'in' A | P ) F" :=
- (\big[@join nat_display _/0%O]_(i in A | P%B) F%O) : order_scope.
-Notation "\max_ ( i 'in' A ) F" :=
- (\big[@join nat_display _/0%O]_(i in A) F%O) : order_scope.
 
 End NatOrder.
 
@@ -3453,6 +3438,7 @@ End Def.
 
 Module Syntax.
 Export POSyntax.
+Export TotalSyntax.
 Export LatticeSyntax.
 Export BLatticeSyntax.
 Export TBLatticeSyntax.
@@ -3466,8 +3452,6 @@ Export POCoercions.
 Export ReversePOrder.
 Export POrderTheory.
 Export TotalTheory.
-Export POrderMonotonyTheory.
-Export TotalMonotonyTheory.
 Export ReverseLattice.
 Export LatticeTheoryMeet.
 Export LatticeTheoryJoin.


### PR DESCRIPTION
- Renaming of `leIx*` and `lexU*` lemmas
- Factories (`LePOrderMixin`, `LtPOrderMixin`, `MeetJoinMixin`, `LeOrderMixin`, `LtOrderMixin` in order.v, and `RealLeMixin`, `RealLtMixin` in ssrnum.v)
- Adding `total_display` and `min`/`max` notations (`minr`/`maxr` for `ring_display`)
- Reorganize the structures of finite ordered sets (Some structures were useless and have been removed because nonempty finite lattices have top and bottom)