### PR TITLE
Dependent positive finfun

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,6 +110,7 @@ make-coq-latest:
     - coqc --version
     - git clone -b "${CONTRIB_VERSION}" --depth 1 "${CONTRIB_URL}" /home/coq/ci
     - cd /home/coq/ci
+    - git rev-parse --verify HEAD
   except:
     - tags
     - merge_requests

--- a/ChangeLog
+++ b/ChangeLog
@@ -113,6 +113,14 @@
 	  Generalized some lemmas in a backward compatible way.
 	  Some strictly more general lemmas now have suffix `_dep`.
 
+	* Generalised {ffun A -> R} to handle dependent functions, and to be
+	  structurally positive so it can be used in recursive inductive type
+	  definitions. Minor backward incompatibilities: fgraph f is no longer
+	  a field accessor, and no longer equal to val f as {ffun A -> R} is no
+	  longer a subType; some instances of finfun, ffunE, ffunK may not unify
+	  with a generic nondependent function type A -> ?R due to a bug in
+	  Coq < 8.10.
+
 24/04/2018 - compatibility with Coq 8.8 and several small fixes - version 1.7
 
 	* Added compatibility with Coq 8.8 and lost compatibility with

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -215,7 +215,7 @@ Definition mx_val A := let: Matrix g := A in g.
 Canonical matrix_subType := Eval hnf in [newType for mx_val].
 
 Fact matrix_key : unit. Proof. by []. Qed.
-Definition matrix_of_fun_def F := Matrix [ffun ij => F ij.1 ij.2 : R].
+Definition matrix_of_fun_def F := Matrix [ffun ij => F ij.1 ij.2].
 Definition matrix_of_fun k := locked_with k matrix_of_fun_def.
 Canonical matrix_unlockable k := [unlockable fun matrix_of_fun k].
 
@@ -277,8 +277,7 @@ Notation "\row_ ( j < n ) E" := (@matrix_of_fun _ 1 n matrix_key (fun _ j => E))
 Notation "\row_ j E" := (\row_(j < _) E) : ring_scope.
 
 Definition matrix_eqMixin (R : eqType) m n :=
-  @SubEqMixin (@finfun_eqType _ (fun=> _)) _ (matrix_subType R m n).
-(*  Eval hnf in [eqMixin of 'M[R]_(m, n) by <:]. *)
+  Eval hnf in [eqMixin of 'M[R]_(m, n) by <:].
 Canonical matrix_eqType (R : eqType) m n:=
   Eval hnf in EqType 'M[R]_(m, n) (matrix_eqMixin R m n).
 Definition matrix_choiceMixin (R : choiceType) m n :=

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -215,7 +215,7 @@ Definition mx_val A := let: Matrix g := A in g.
 Canonical matrix_subType := Eval hnf in [newType for mx_val].
 
 Fact matrix_key : unit. Proof. by []. Qed.
-Definition matrix_of_fun_def F := Matrix [ffun ij => F ij.1 ij.2].
+Definition matrix_of_fun_def F := Matrix [ffun ij => F ij.1 ij.2 : R].
 Definition matrix_of_fun k := locked_with k matrix_of_fun_def.
 Canonical matrix_unlockable k := [unlockable fun matrix_of_fun k].
 
@@ -277,7 +277,8 @@ Notation "\row_ ( j < n ) E" := (@matrix_of_fun _ 1 n matrix_key (fun _ j => E))
 Notation "\row_ j E" := (\row_(j < _) E) : ring_scope.
 
 Definition matrix_eqMixin (R : eqType) m n :=
-  Eval hnf in [eqMixin of 'M[R]_(m, n) by <:].
+  @SubEqMixin (@finfun_eqType _ (fun=> _)) _ (matrix_subType R m n).
+(*  Eval hnf in [eqMixin of 'M[R]_(m, n) by <:]. *)
 Canonical matrix_eqType (R : eqType) m n:=
   Eval hnf in EqType 'M[R]_(m, n) (matrix_eqMixin R m n).
 Definition matrix_choiceMixin (R : choiceType) m n :=

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -667,11 +667,13 @@ Proof. by rewrite eqr_le ltr_geF ?irr1_gt0. Qed.
 Lemma irr_neq0 i : 'chi_i != 0.
 Proof. by apply: contraNneq (irr1_neq0 i) => ->; rewrite cfunE. Qed.
 
-Definition cfIirr B (chi : 'CF(B)) : Iirr B := inord (index chi (irr B)).
+Local Remark cfIirr_key : unit. Proof. by []. Qed.
+Definition cfIirr : forall B, 'CF(B) -> Iirr B :=
+  locked_with cfIirr_key (fun B chi => inord (index chi (irr B))).
 
 Lemma cfIirrE chi : chi \in irr G -> 'chi_(cfIirr chi) = chi.
 Proof.
-move=> chi_irr; rewrite (tnth_nth 0) inordK ?nth_index //.
+move=> chi_irr; rewrite (tnth_nth 0) [cfIirr]unlock inordK ?nth_index //.
 by rewrite -index_mem size_tuple in chi_irr.
 Qed.
 

--- a/mathcomp/character/integral_char.v
+++ b/mathcomp/character/integral_char.v
@@ -423,7 +423,7 @@ Theorem dvd_irr1_index_center gT (G : {group gT}) i :
   ('chi[G]_i 1%g %| #|G : 'Z('chi_i)%CF|)%C.
 Proof.
 without loss fful: gT G i / cfaithful 'chi_i.
-  rewrite -{2}[i](quo_IirrK _ (subxx _)) ?mod_IirrE ?cfModE ?cfker_normal //.
+  rewrite -{2}[i](quo_IirrK _ (subxx _)) 1?mod_IirrE ?cfModE ?cfker_normal //.
   rewrite morph1; set i1 := quo_Iirr _ i => /(_ _ _ i1) IH.
   have fful_i1: cfaithful 'chi_i1.
     by rewrite quo_IirrE ?cfker_normal ?cfaithful_quo.

--- a/mathcomp/solvable/burnside_app.v
+++ b/mathcomp/solvable/burnside_app.v
@@ -694,8 +694,8 @@ Proof. by move=> p1 p2 /val_inj/(can_inj fgraphK)/val_inj. Qed.
 Definition prod_tuple (t1 t2 : seq cube) :=
   map (fun n : 'I_6 => nth F0 t2 n) t1.
 
-Lemma sop_spec : forall x (n0 : 'I_6), nth F0 (sop x) n0 = x n0.
-Proof. by move=> x n0; rewrite -pvalE unlock enum_rank_ord (tnth_nth F0). Qed.
+Lemma sop_spec x (n0 : 'I_6): nth F0 (sop x) n0 = x n0.
+Proof. by rewrite nth_fgraph_ord pvalE. Qed.
 
 Lemma prod_t_correct : forall (x y : {perm cube}) (i : cube),
   (x * y) i = nth F0 (prod_tuple (sop x) (sop y)) i.

--- a/mathcomp/solvable/burnside_app.v
+++ b/mathcomp/solvable/burnside_app.v
@@ -686,10 +686,10 @@ move=> p; rewrite inE.
 by do ?case/orP; move/eqP=> <- a; rewrite !(permM, permE); case: a; do 6?case.
 Qed.
 
-Definition sop (p : {perm cube}) : seq cube := val (val (val p)).
+Definition sop (p : {perm cube}) : seq cube := fgraph (val p).
 
 Lemma sop_inj : injective sop.
-Proof. by do 2!apply: (inj_comp val_inj); apply: val_inj. Qed.
+Proof. by move=> p1 p2 /val_inj/(can_inj fgraphK)/val_inj. Qed.
 
 Definition prod_tuple (t1 t2 : seq cube) :=
   map (fun n : 'I_6 => nth F0 t2 n) t1.
@@ -700,7 +700,7 @@ Proof. by move=> x n0; rewrite -pvalE unlock enum_rank_ord (tnth_nth F0). Qed.
 Lemma prod_t_correct : forall (x y : {perm cube}) (i : cube),
   (x * y) i = nth F0 (prod_tuple (sop x) (sop y)) i.
 Proof.
-move=> x y i; rewrite permM -!sop_spec (nth_map F0) // size_tuple /=.
+move=> x y i; rewrite permM -!sop_spec [RHS](nth_map F0) // size_tuple /=.
 by rewrite card_ord ltn_ord.
 Qed.
 

--- a/mathcomp/ssreflect/binomial.v
+++ b/mathcomp/ssreflect/binomial.v
@@ -365,10 +365,10 @@ Lemma card_inj_ffuns_on D T (R : pred T) :
 Proof.
 rewrite -card_uniq_tuples.
 have bijFF: {on (_ : pred _), bijective (@Finfun D T)}.
-  by exists val => // x _; apply: val_inj.
-rewrite -(on_card_preimset (bijFF _)); apply: eq_card => t.
-rewrite !inE -(codom_ffun (Finfun t)); congr (_ && _); apply: negb_inj.
-by rewrite -has_predC has_map enumT has_filter -size_eq0 -cardE.
+  by exists fgraph => x _; [apply: FinfunK | apply: fgraphK].
+rewrite -(on_card_preimset (bijFF _)); apply: eq_card => /= t.
+rewrite !inE -(big_andE predT) -big_filter big_all -all_map.
+by rewrite -[injectiveb _]/(uniq _) [map _ _]codom_ffun FinfunK.
 Qed.
 
 Lemma card_inj_ffuns D T :

--- a/mathcomp/ssreflect/finfun.v
+++ b/mathcomp/ssreflect/finfun.v
@@ -239,34 +239,35 @@ Notation family F := (family_mem (fmem F)).
 Section InheritedStructures.
 
 Variable aT : finType.
+Notation dffun_aT rT rS := {dffun forall x : aT, rT x : rS}.
 
-Definition finfun_eqMixin (rT : _ -> eqType) :=
-  @PcanEqMixin {dffun finPi aT rT} _ _ _ tfgraphK.
+Local Remark eqMixin rT : Equality.mixin_of (dffun_aT rT eqType).
+Proof. exact: PcanEqMixin tfgraphK. Qed.
 Canonical finfun_eqType (rT : eqType) :=
-  EqType {ffun aT -> rT} (finfun_eqMixin _).
-Canonical dfinfun_eqType (rT : _ -> eqType) :=
-  EqType {dffun finPi aT rT} (finfun_eqMixin _).
+  EqType {ffun aT -> rT} (eqMixin (fun=> rT)).
+Canonical dfinfun_eqType rT :=
+  EqType (dffun_aT rT eqType) (eqMixin rT).
 
-Definition finfun_choiceMixin (rT : _ -> choiceType) :=
-  @PcanChoiceMixin _ {dffun finPi aT rT} _ _ tfgraphK.
+Local Remark choiceMixin rT : Choice.mixin_of (dffun_aT rT choiceType).
+Proof. exact: PcanChoiceMixin tfgraphK. Qed.
 Canonical finfun_choiceType (rT : choiceType) :=
-  ChoiceType {ffun aT -> rT} (finfun_choiceMixin _).
-Canonical dfinfun_choiceType (rT : _ -> choiceType) :=
-  ChoiceType {dffun finPi aT _} (finfun_choiceMixin rT).
+  ChoiceType {ffun aT -> rT} (choiceMixin (fun=> rT)).
+Canonical dfinfun_choiceType rT :=
+  ChoiceType (dffun_aT rT choiceType) (choiceMixin rT).
 
-Definition finfun_countMixin (rT : _ -> countType) :=
-  @PcanCountMixin _ {dffun finPi aT rT} _ _ tfgraphK.
+Local Remark countMixin rT : Countable.mixin_of (dffun_aT rT countType).
+Proof. exact: PcanCountMixin tfgraphK. Qed.
 Canonical finfun_countType (rT : countType) :=
-  CountType {ffun aT -> rT} (finfun_countMixin _).
-Canonical dfinfun_countType (rT : _ -> countType) :=
-  CountType {dffun finPi aT rT} (finfun_countMixin _).
+  CountType {ffun aT -> rT} (countMixin (fun => rT)).
+Canonical dfinfun_countType rT :=
+  CountType (dffun_aT rT countType) (countMixin rT).
 
-Definition finfun_finMixin (rT : _ -> finType) :=
-  @PcanFinMixin (dfinfun_countType rT) _ _ _ tfgraphK.
+Local Definition finMixin rT :=
+  PcanFinMixin (tfgraphK : @pcancel _ (dffun_aT rT finType) _ _).
 Canonical finfun_finType (rT : finType) :=
-  FinType {ffun aT -> rT} (finfun_finMixin _).
-Canonical dfinfun_finType (rT : _ -> finType) :=
-  FinType {dffun finPi aT rT} (finfun_finMixin _).
+  FinType {ffun aT -> rT} (finMixin (fun=> rT)).
+Canonical dfinfun_finType rT :=
+  FinType (dffun_aT rT finType) (finMixin rT).
 
 End InheritedStructures.
 

--- a/mathcomp/ssreflect/finfun.v
+++ b/mathcomp/ssreflect/finfun.v
@@ -13,7 +13,8 @@ Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype tuple.
 (* {ffun aT -> rT} as Leibnitz equality and extensional equalities coincide.  *)
 (*     (T ^ n)%type is notation for {ffun 'I_n -> T}, which is isomorphic     *)
 (*   to n.-tuple T, but is structurally positive and thus can be used to      *)
-(*   define inductive types, e.g., Inductive tree := node n of tree ^ n.      *)
+(*   define inductive types, e.g., Inductive tree := node n of tree ^ n (see  *)
+(*   mid-file for an expanded example).                                       *)
 (* --> More generally, {ffun fT} is always structurally positive.             *)
 (*  For f : {ffun fT} with fT := forall x : aT -> rT x, we define             *)
 (*              f x == the image of x under f (f coerces to a CiC function)   *)
@@ -115,16 +116,30 @@ Notation "[ 'ffun' x => F ]" := [ffun x : _ => F]
 Notation "[ 'ffun' => F ]" := [ffun _ => F]
   (at level 0, format "[ 'ffun' =>  F ]") : fun_scope.
 
-(* Test that the type and accessor are structurally positive and decreasing,
-   respectively.
+(* Example outcommented.
+(* Examples of using finite functions as containers in recursive inductive    *)
+(* types, and making use of the fact that the type and accessor are           *)
+(* structurally positive and decreasing, respectively.                        *)
+Unset Elimination Schemes.
 Inductive tree := node n of tree ^ n.
 Fixpoint size t := let: node n f := t in sumn (codom (size \o f)) + 1.
+Example tree_step (K : tree -> Type) :=
+  forall n st (t := node st) & forall i : 'I_n, K (st i), K t.
+Example tree_rect K (Kstep : tree_step K) : forall t, K t.
+Proof. by fix IHt 1 => -[n st]; apply/Kstep=> i; apply: IHt. Defined.
+
+(* An artificial example use of dependent functions.                          *)
 Inductive tri_tree n := tri_row of {ffun forall i : 'I_n, tri_tree i}.
 Fixpoint tri_size n (t : tri_tree n) :=
   let: tri_row f := t in sumn [seq tri_size (f i) | i : 'I_n] + 1.
-*)
+Example tri_tree_step (K : forall n, tri_tree n -> Type) :=
+  forall n st (t := tri_row st) & forall i : 'I_n, K i (st i), K n t.
+Example tri_tree_rect K (Kstep : tri_tree_step K) : forall n t, K n t.
+Proof. by fix IHt 2 => n [st]; apply/Kstep=> i; apply: IHt. Defined.
+Set Elimination Schemes.
+(* End example. *) *)
 
-(* Lemmas on the correspondance between finfun_of and CiC dependent functions. *)
+(* The correspondance between finfun_of and CiC dependent functions.          *)
 Section DepPlainTheory.
 Variables (aT : finType) (rT : aT -> Type).
 Notation fT := {ffun finPi aT rT}.


### PR DESCRIPTION
Generalise the finite function library to support dependently typed functions with a structurally positive representation and a structurally decreasing coercion to `Funclass`.
   Removes the `subType` instance for `finfun_of`, which is no longer used in inheriting combinatorial structures of the return type. The function graph `fgraph` projector is however retained for plain functions, and supplemented with a total function graph projector `tfgraph` in the general case.
   This PR runs into issue coq/coq#9663 (partial solution: https://github.com/coq/coq/pull/9690) which prevents type inference from matching generic dependent and non-dependent function types, and thereby includes some workarounds for this shortcoming. There is a companion PR math-comp/odd-order#11 that fixes one residual instance of this issue in the Odd Order proof.
  This PR also fixes a performance regression in `integral_char.v` that appears to have gone undetected - see the commit comment for a more detailed analysis.
