### PR TITLE
[doc] Mention that "connect" computes the reflexive transitive closure

### DIFF
--- a/mathcomp/ssreflect/fingraph.v
+++ b/mathcomp/ssreflect/fingraph.v
@@ -14,7 +14,7 @@ Require Import ssrbool ssrfun eqtype ssrnat seq path fintype.
 (*    dfs g n v x == the list of points traversed by a depth-first search of  *)
 (*                   the g, at depth n, starting from x, and avoiding v.      *)
 (* dfs_path g v x y <-> there is a path from x to y in g \ v.                 *)
-(*      connect e == the transitive closure of e (computed by dfs).           *)
+(*      connect e == the reflexive transitive closure of e (computed by dfs). *)
 (*  connect_sym e <-> connect e is symmetric, hence an equivalence relation.  *)
 (*       root e x == a representative of connect e x, which is the component  *)
 (*                   of x in the transitive closure of e.                     *)


### PR DESCRIPTION
This suggestion is a follow-up of an [old thread](https://sympa.inria.fr/sympa/arc/ssreflect/2018-05/msg00000.html) in the ssreflect mailing list.

(Note: as this is a tiny patch that only touches one Coq comment, I've just inserted a `[ci skip]` tag to avoid running all tests on this PR…)

For the record, dealing with the "non-reflexive transitive closure" could be done as follows (borrowing the definition proposed by Christian Doczkal on the list):

```
Definition trans_closure e x y := [exists z, e x z && connect e z y].
```