### PR TITLE
Refactoring allpairs to handle the dependent version as well

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -105,6 +105,14 @@
 	* Added lemmas `foldrE`, `foldlE`, `foldl_idx` and `sumnE`
 	  to turn "seq statements" into "bigop statements"
 
+	* Generalized the notation `[seq E | i <- s, j <- t]` to the case
+	  where `t` may depend on `i`. The notation is now primitive and
+	  expressed using `flatten` and `map` (see documentation of seq).
+	  `allpairs` now expands to this notation when fully applied.
+	  Added `allpairs_dep` and made it self-expanding as well.
+	  Generalized some lemmas in a backward compatible way.
+	  Some strictly more general lemmas now have suffix `_dep`.
+
 24/04/2018 - compatibility with Coq 8.8 and several small fixes - version 1.7
 
 	* Added compatibility with Coq 8.8 and lost compatibility with

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1193,13 +1193,19 @@ rewrite !(big_mkcond _ P) unlock.
 by elim: r1 => /= [|i r1 ->]; rewrite (mul1m, mulmA).
 Qed.
 
-Lemma big_allpairs I1 I2 (r1 : seq I1) (r2 : seq I2) F :
-  \big[*%M/1]_(i <- [seq (i1, i2) | i1 <- r1, i2 <- r2]) F i =
-    \big[*%M/1]_(i1 <- r1) \big[op/idx]_(i2 <- r2) F (i1, i2).
+Lemma big_allpairs_dep I1 (I2 : I1 -> Type) J (h : forall i1, I2 i1 -> J)
+    (r1 : seq I1) (r2 : forall i1, seq (I2 i1)) (F : J -> R) :
+  \big[*%M/1]_(i <- [seq h i1 i2 | i1 <- r1, i2 <- r2 i1]) F i =
+    \big[*%M/1]_(i1 <- r1) \big[*%M/1]_(i2 <- r2 i1) F (h i1 i2).
 Proof.
 elim: r1 => [|i1 r1 IHr1]; first by rewrite !big_nil.
 by rewrite big_cat IHr1 big_cons big_map.
 Qed.
+
+Lemma big_allpairs I1 I2 (r1 : seq I1) (r2 : seq I2) F :
+  \big[*%M/1]_(i <- [seq (i1, i2) | i1 <- r1, i2 <- r2]) F i =
+    \big[*%M/1]_(i1 <- r1) \big[op/idx]_(i2 <- r2) F (i1, i2).
+Proof. exact: big_allpairs_dep. Qed.
 
 Lemma big_pred1_eq (I : finType) (i : I) F :
   \big[*%M/1]_(j | j == i) F j = F i.
@@ -1546,6 +1552,7 @@ Arguments reindex [R idx op I J] h [P F].
 Arguments reindex_inj [R idx op I h P F].
 Arguments pair_big_dep [R idx op I J].
 Arguments pair_big [R idx op I J].
+Arguments big_allpairs_dep [R idx op I1 I2 J h r1 r2 F].
 Arguments big_allpairs [R idx op I1 I2 r1 r2 F].
 Arguments exchange_big_dep [R idx op I J rI rJ P Q] xQ [F].
 Arguments exchange_big_dep_nat [R idx op m1 n1 m2 n2 P Q] xQ [F].


### PR DESCRIPTION
The return of `allsigs` cf #236, math-comp/odd-order#5 and #217: refactoring with `allpairs` this time.