### PR TITLE
Refactor CI with separate deploy jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,8 @@ stages:
     IMAGE: "mathcomp-dev:make_coq-${COQ_VERSION}"
     OPAM_SWITCH: "edge"
   before_script:
+    - echo "${OPAM_SWITCH}"
+    - echo "${COQ_VERSION}"
   script:
     - docker build -f Dockerfile.make --pull --build-arg=coq_image="coqorg/coq:${COQ_VERSION}" --build-arg=compiler="${OPAM_SWITCH}" -t "${IMAGE}" .
   except:
@@ -65,6 +67,7 @@ make-coq-latest:
     IMAGE: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_IID}_${CI_COMMIT_REF_SLUG}_${CI_JOB_NAME}"
     OPAM_SWITCH: "edge"
   before_script:
+    - echo "${OPAM_SWITCH}"
     - echo "${CI_JOB_TOKEN}" | docker login -u "${CI_REGISTRY_USER}" --password-stdin "${CI_REGISTRY}"
   script:
     - docker build --pull --build-arg=coq_image="coqorg/${CI_JOB_NAME//-/:}" --build-arg=compiler="${OPAM_SWITCH}" -t "${IMAGE}" .
@@ -98,11 +101,14 @@ coq-dev:
     GIT_STRATEGY: none
   before_script:
     - cat /proc/{cpu,mem}info || true
-    # don't printenv if there are private tokens
+    # don't printenv to avoid cluttering the log
     - opam config list
     - opam repo list
     - opam list
     - coqc --version
+    - echo "${COQ_VERSION}"
+    - echo "${CONTRIB_URL}"
+    - echo "${CONTRIB_VERSION}"
     - git clone -b "${CONTRIB_VERSION}" --depth 1 "${CONTRIB_URL}" /home/coq/ci
     - cd /home/coq/ci
     - git rev-parse --verify HEAD
@@ -186,7 +192,7 @@ ci-lemma-overloading-dev:
 ################
 
 # Changes below (or jobs extending .docker-deploy) should be carefully
-# reviewed to avoid unwanted "token leaks"
+# reviewed to avoid leaks of HUB_TOKEN
 .docker-deploy:
   stage: deploy
   image: docker:latest
@@ -200,9 +206,13 @@ ci-lemma-overloading-dev:
     IMAGE_PREFIX: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_IID}_${CI_COMMIT_REF_SLUG}"
   script:
     - export IMAGE="${IMAGE_PREFIX}_${CI_JOB_NAME##*:}"
+    - echo "${IMAGE}"
     - docker pull "${IMAGE}"
-    - echo "${HUB_TOKEN}" | docker login -u "${HUB_REGISTRY_USER}" --password-stdin "${HUB_REGISTRY}"
+    - echo "${HUB_IMAGE}"
     - docker tag "${IMAGE}" "${HUB_IMAGE}"
+    - test -n "${HUB_REGISTRY}"
+    - test -n "${HUB_REGISTRY_USER}"
+    - echo "${HUB_TOKEN}" | docker login -u "${HUB_REGISTRY_USER}" --password-stdin "${HUB_REGISTRY}"
     - docker push "${HUB_IMAGE}"
     - docker logout "${HUB_REGISTRY}"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,14 +2,15 @@
 # - build stage (e.g. docker build -t mathcomp-dev:$IID_$SLUG_coq-8.7 .)
 #   - choice of the OCaml compiler: var OPAM_SWITCH in {base, edge}
 #     (Dockerfile containing: "opam switch set $compiler && eval $(opam env)")
-#   - master (protected branch) => push on GitLab registry and Docker Hub
-#   - other branches (not tags) => push on GitLab registry
+#   - all branches (not tags) => push on GitLab registry
 #   - GitHub PRs => push on GitLab and report back thanks to @coqbot
 # - test stage (image: mathcomp-dev:$IID_$SLUG_coq-8.6)
 #   - script template foreach project (custom CONTRIB_URL, script)
 #   - jobs foreach project and Coq version (custom COQ_VERSION, CONTRIB_VERSION)
+# - deploy stage (only branch "master" and environment "deployment")
+#   - pull each built image from GitLab registry => push to Docker Hub
 #
-# Config for protected branches:
+# Config for protected environment "deployment":
 # - set vars HUB_REGISTRY, HUB_REGISTRY_USER, HUB_REGISTRY_IMAGE, HUB_TOKEN
 #
 # Remark:
@@ -26,6 +27,7 @@
 stages:
   - build
   - test
+  - deploy
 
 ################
 #### build stage
@@ -61,7 +63,6 @@ make-coq-latest:
     - docker:dind
   variables:
     IMAGE: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_IID}_${CI_COMMIT_REF_SLUG}_${CI_JOB_NAME}"
-    HUB_IMAGE: "${HUB_REGISTRY_IMAGE}:${CI_JOB_NAME}"
     OPAM_SWITCH: "edge"
   before_script:
     - echo "${CI_JOB_TOKEN}" | docker login -u "${CI_REGISTRY_USER}" --password-stdin "${CI_REGISTRY}"
@@ -69,15 +70,6 @@ make-coq-latest:
     - docker build --pull --build-arg=coq_image="coqorg/${CI_JOB_NAME//-/:}" --build-arg=compiler="${OPAM_SWITCH}" -t "${IMAGE}" .
     - docker push "${IMAGE}"
     - docker logout "${CI_REGISTRY}"
-    - |
-      if [ -n "${HUB_REGISTRY_IMAGE}" ]; then
-        set -e
-        echo "${HUB_TOKEN}" | docker login -u "${HUB_REGISTRY_USER}" --password-stdin "${HUB_REGISTRY}"
-        docker tag "${IMAGE}" "${HUB_IMAGE}"
-        docker push "${HUB_IMAGE}"
-        docker logout "${HUB_REGISTRY}"
-        set +e
-      fi
   except:
     - tags
     - merge_requests
@@ -192,3 +184,38 @@ ci-lemma-overloading-dev:
 ################
 ### deploy stage
 ################
+
+# Changes below (or jobs extending .docker-deploy) should be carefully
+# reviewed to avoid unwanted "token leaks"
+.docker-deploy:
+  stage: deploy
+  image: docker:latest
+  services:
+    - docker:dind
+  environment:
+    name: deployment
+    url: https://hub.docker.com/r/mathcomp/mathcomp-dev
+  variables:
+    HUB_IMAGE: "mathcomp/${CI_JOB_NAME}"
+    IMAGE_PREFIX: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_IID}_${CI_COMMIT_REF_SLUG}"
+  script:
+    - export IMAGE="${IMAGE_PREFIX}_${CI_JOB_NAME##*:}"
+    - docker pull "${IMAGE}"
+    - echo "${HUB_TOKEN}" | docker login -u "${HUB_REGISTRY_USER}" --password-stdin "${HUB_REGISTRY}"
+    - docker tag "${IMAGE}" "${HUB_IMAGE}"
+    - docker push "${HUB_IMAGE}"
+    - docker logout "${HUB_REGISTRY}"
+  only:
+    - master
+
+mathcomp-dev:coq-8.7:
+  extends: .docker-deploy
+
+mathcomp-dev:coq-8.8:
+  extends: .docker-deploy
+
+mathcomp-dev:coq-8.9:
+  extends: .docker-deploy
+
+mathcomp-dev:coq-dev:
+  extends: .docker-deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,8 +26,8 @@
 
 stages:
   - build
-  - test
   - deploy
+  - test
 
 ################
 #### build stage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,32 @@ stages:
   - build
   - test
 
+################
+#### build stage
+################
+
+# set var OPAM_SWITCH (if need be) and COQ_VERSION when using
+.make-build:
+  stage: build
+  image: docker:latest
+  services:
+    - docker:dind
+  variables:
+    # This image will be built locally only (not pushed)
+    IMAGE: "mathcomp-dev:make_coq-${COQ_VERSION}"
+    OPAM_SWITCH: "edge"
+  before_script:
+  script:
+    - docker build -f Dockerfile.make --pull --build-arg=coq_image="coqorg/coq:${COQ_VERSION}" --build-arg=compiler="${OPAM_SWITCH}" -t "${IMAGE}" .
+  except:
+    - tags
+    - merge_requests
+
+make-coq-latest:
+  extends: .make-build
+  variables:
+    COQ_VERSION: "latest"
+
 # set var OPAM_SWITCH (if need be) when using
 .opam-build:
   stage: build
@@ -68,28 +94,10 @@ coq-8.9:
 coq-dev:
   extends: .opam-build
 
-# set var OPAM_SWITCH (if need be) and COQ_VERSION when using
-.make-build:
-  stage: build
-  image: docker:latest
-  services:
-    - docker:dind
-  variables:
-    # This image will be built locally only (not pushed)
-    IMAGE: "mathcomp-dev:make_coq-${COQ_VERSION}"
-    OPAM_SWITCH: "edge"
-  before_script:
-  script:
-    - docker build -f Dockerfile.make --pull --build-arg=coq_image="coqorg/coq:${COQ_VERSION}" --build-arg=compiler="${OPAM_SWITCH}" -t "${IMAGE}" .
-  except:
-    - tags
-    - merge_requests
+################
+##### test stage
+################
 
-make-coq-latest:
-  extends: .make-build
-  variables:
-    COQ_VERSION: "latest"
-  
 # set CONTRIB_URL, script, COQ_VERSION, CONTRIB_VERSION when using
 .ci:
   stage: test
@@ -180,3 +188,7 @@ ci-lemma-overloading-dev:
   extends: .ci-lemma-overloading
   variables:
     COQ_VERSION: "dev"
+
+################
+### deploy stage
+################

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN ["/bin/bash", "--login", "-c", "set -x \
   && opam pin add -n -k path coq-mathcomp-field . \
   && opam pin add -n -k path coq-mathcomp-character . \
   && opam install -y -v -j ${NJOBS} coq-mathcomp-character \
-  && opam clean -a -c -s --logs"]
+  && opam clean -a -s --logs"]
 
 FROM coqorg/base:bare
 

--- a/Dockerfile.make
+++ b/Dockerfile.make
@@ -21,7 +21,7 @@ RUN ["/bin/bash", "--login", "-c", "set -x \
   && opam repository add --all-switches --set-default coq-core-dev https://coq.inria.fr/opam/core-dev \
   && opam update -y \
   && opam config list && opam repo list && opam list && coqc --version \
-  && opam clean -a -c -s --logs \
+  && opam clean -a -s --logs \
   && sudo chown -R coq:coq /home/coq/mathcomp \
   && cd mathcomp \
   && make Makefile.coq \


### PR DESCRIPTION
Dear @CohenCyril,
Following @ejgallego's suggestion I've carefully read the GitLab CI doc related to environments and in particular [this section](https://gitlab.com/help/ci/variables/README.md#limiting-environment-scopes-of-variables-premium).

Note: the docker push to Docker Hub will only work in `master`, in the `deployment` environment but I wasn't able to easily test this "environment" feature as it is limited to Premium accounts… (it doesn't work with *private* repos on gitlab.com) so I'm afraid we'll be able to really test whether the deploy still work only after the PR is merged in master…

I also added some `echo` commands and `git rev-parse --verify HEAD` to print more debugging info.

Summary of advantages/drawbacks:

* Pros:
  * as pointed out by Emilio, this new design is more safe as external code cloned by GItLab CI won't be able to read the environment variables specific to the `.docker-deploy` trusted jobs.
  * the semantics of the CI is slightly changed as `mathcomp-dev` for coq-(8.6, 8.7, 8.8, 8.9, dev) will be pushed to Docker Hub **only** if the build stage **and** the test stage were both successful. This is the breaking change of the PR, but I put it in the Pros list as it seems something desirable (?) 
* Cons:
  * the overall time of the CI may be a bit longer as there is an additional `docker pull "${IMAGE}"` command.

Note: I've just switched the **protected variables** related to Docker Hub to **scoped protected variables** using [this url](https://gitlab.com/math-comp/math-comp/settings/ci_cd) (scoped = specific to the `deployment` environment), so if another PR is merged in master before that PR, it won't be able to push to Docker Hub.

Feel free to comment if you have questions/remarks.