### PR TITLE
Modified the definition of sort to work on any type

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,11 +8,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added map/parametricity theorems about `path`, `sort` and `sorted`:
+  `homo_path`, `mono_path`, `homo_path_in`, `mono_path_in`,
+  `homo_sorted`, `mono_sorted`, `map_merge`, `merge_map`, `map_sort`,
+  `sort_map`, `sorted_map`, `homo_sorted_in`, `mono_sorted_in`,
+  `sort_map_in`/
+
+- Added the theorem `perm_iota_sort` to express that the sorting of
+  any sequence `s` is equal to a mapping of `iota 0 (size s)` to the
+  nth elements of `s`, so that one can still reason on `nat`, even
+  though the elements of `s` are not in an `eqType`.
+
+- Added a comment in the documentation to explain `sort` is stable,
+  without proving it formally, for now.
+
 ### Changed
+
+- Generalized `sort` to non-`eqType`s (as well as `merge`,
+  `merge_sort_push`, `merge_sort_pop`), together with all the lemmas
+  that did not really rely on an `eqType`: `size_merge`, `size_sort`,
+  `merge_path`, `merge_sorted`, `sort_sorted`, `path_min_sorted`
+  (which statement was modified to remove the dependency in `eqType`),
+  and `order_path_min`.
 
 - `eqVneq` lemma is changed from `{x = y} + {x != y}` to
   `eq_xor_neq x y (y == x) (x == y)`, on which a case analysis performs
   simultaneous replacement of expressions of the form `x == y` and `y == x`
   by `true` or `false`, while keeping the ability to use it in the way
   it was used before.
-

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -991,7 +991,7 @@ exists (block_mx 1 0 Ml L).
 exists (block_mx 1 Mu 0 R).
   by rewrite unitmxE det_ublock det_scalar1 mul1r.
 exists (1 :: d); set D1 := \matrix_(i, j) _ in dM1.
-  by rewrite /= path_min_sorted // => g _; apply: dvd1n.
+  by rewrite /= path_min_sorted //; apply/allP => g _; apply: dvd1n.
 rewrite [D in _ *m D *m _](_ : _ = block_mx 1 0 0 D1); last first.
   by apply/matrixP=> i j; do 3?[rewrite ?mxE ?ord1 //=; case: splitP => ? ->].
 rewrite !mulmx_block !(mul0mx, mulmx0, addr0) !mulmx1 add0r mul1mx -Da -dM1.

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -1766,7 +1766,7 @@ case/predU1P: b_y => [-> // | b'_y].
 have:= abelian_type_dvdn_sorted G; rewrite -def_t def_b.
 case/splitPr: b'_y => b1 b2; rewrite -cat_rcons rcons_cat map_cat !map_rcons.
 rewrite headI /= cat_path -(last_cons 2) -headI last_rcons.
-case/andP=> _ /order_path_min min_y.
+case/andP=> _ /(@order_path_min nat) min_y.
 apply: (allP (min_y _)) => [? ? ? ? dv|]; first exact: (dvdn_trans dv).
 by rewrite mem_rcons mem_head.
 Qed.


### PR DESCRIPTION
The sorting algorithm does not really rely on the element type being an eqType.
It may make sense for the proofs, but not for the algorithm per se.  Avoiding the reference to eqType
makes it easier to use the parametricity plugin on this algorithm.

EDIT by Cyril:
- [x] `CHANGELOG_UNRELEASE.md` updated
- [x] documentation updated