### PR TITLE
remove deprecated use of `if ... return`

### DIFF
--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -977,7 +977,7 @@ Variable R : rcfType.
 Lemma poly_ivt : real_closed_axiom R. Proof. by case: R => ? []. Qed.
 
 Fact sqrtr_subproof (x : R) :
-  exists2 y,  0 <= y & if 0 <= x return bool then y ^+ 2 == x else y == 0.
+  exists2 y, 0 <= y & (if 0 <= x then y ^+ 2 == x else y == 0) : bool.
 Proof.
 case x_ge0: (0 <= x); last by exists 0; rewrite ?lerr.
 have le0x1: 0 <= x + 1 by rewrite -nnegrE rpredD ?rpred1.


### PR DESCRIPTION
Replace improper use of non-dependent `return` clause in `if` with a
type cast; an upcoming coq-side PR will discontinue support for this,
in order to support dependent return clauses with an implicit `as`
annotation.