### PR TITLE
Fix compatibility for #237

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -294,21 +294,29 @@ ci-bigenough-dev:
 ci-finmap-8.7:
   extends: .ci-finmap
   variables:
+    CONTRIB_URL: "https://github.com/ggonthier/finmap.git"
+    CONTRIB_VERSION: coq-9995-compatibility
     COQ_VERSION: "8.7"
 
 ci-finmap-8.8:
   extends: .ci-finmap
   variables:
+    CONTRIB_URL: "https://github.com/ggonthier/finmap.git"
+    CONTRIB_VERSION: coq-9995-compatibility
     COQ_VERSION: "8.8"
 
 ci-finmap-8.9:
   extends: .ci-finmap
   variables:
+    CONTRIB_URL: "https://github.com/ggonthier/finmap.git"
+    CONTRIB_VERSION: coq-9995-compatibility
     COQ_VERSION: "8.9"
 
 ci-finmap-dev:
   extends: .ci-finmap
   variables:
+    CONTRIB_URL: "https://github.com/ggonthier/finmap.git"
+    CONTRIB_VERSION: coq-9995-compatibility
     COQ_VERSION: "dev"
 
 ################

--- a/mathcomp/ssreflect/ssrfun.v
+++ b/mathcomp/ssreflect/ssrfun.v
@@ -2,4 +2,5 @@ From mathcomp Require Import ssreflect.
 From Coq Require Export ssrfun.
 From mathcomp Require Export ssrnotations.
 
-Definition Some_inj {T : nonPropType} := @Some_inj T.
+Lemma Some_inj {T : nonPropType} : injective (@Some T).
+Proof. by move=> x y []. Qed.


### PR DESCRIPTION
- reprove rather than specialize `Some_inj` to allow for redefinition
of `nonPropType` in `mathcomp.ssreflect.ssreflect`
- retarget finmap CI to coq-9995-compatibility