### PR TITLE
Stability proofs of sort

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -32,6 +32,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Arithmetic theorems: `modn_divl` and `divn_modl`.
 
+- Added map/parametricity theorems about `path`, `sort` and `sorted`:
+  `homo_path`, `mono_path`, `homo_path_in`, `mono_path_in`,
+  `homo_sorted`, `mono_sorted`, `map_merge`, `merge_map`, `map_sort`,
+  `sort_map`, `sorted_map`, `homo_sorted_in`, `mono_sorted_in`,
+  `sort_map_in`/
+
+- Added the theorem `perm_iota_sort` to express that the sorting of
+  any sequence `s` is equal to a mapping of `iota 0 (size s)` to the
+  nth elements of `s`, so that one can still reason on `nat`, even
+  though the elements of `s` are not in an `eqType`.
+
+- Added a comment in the documentation to explain `sort` is stable,
+  without proving it formally, for now.
+
 ### Changed
 
 - `eqVneq` lemma is changed from `{x = y} + {x != y}` to
@@ -44,6 +58,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `t1`, and `t2` are non-`eqType`s in `[seq E | i <- s, j <- t1 ++ t2]`.
 
 - Generalized `muln_modr` and `muln_modl` removing hypothesis `0 < p`.
+
+- Generalized `sort` to non-`eqType`s (as well as `merge`,
+  `merge_sort_push`, `merge_sort_pop`), together with all the lemmas
+  that did not really rely on an `eqType`: `size_merge`, `size_sort`,
+  `merge_path`, `merge_sorted`, `sort_sorted`, `path_min_sorted`
+  (which statement was modified to remove the dependency in `eqType`),
+  and `order_path_min`.
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added theorems `ffact_prod`, `prime_modn_expSn` and `fermat_little`
   in `binomial.v`
 
-- Added theorems `flatten_map1` and `allpairs_consr` in `seq.v`.
+- Added theorems `flatten_map1`, `allpairs_consr`, and `mask_filter` in `seq.v`.
 
 - Fintype theorems: `fintype0`, `card_le1P`, `mem_card1`,
   `card1P`, `fintype_le1P`, `fintype1`, `fintype1P`.
@@ -33,18 +33,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Arithmetic theorems: `modn_divl` and `divn_modl`.
 
 - Added map/parametricity theorems about `path`, `sort` and `sorted`:
+
+- Added `mem2E` in `path.v`.
+
+- Added `sort_rec1` and `sortE` to help inductive reasoning on `sort`.
+
+- Added map/parametricity theorems about `path`, `sort`, and `sorted`:
   `homo_path`, `mono_path`, `homo_path_in`, `mono_path_in`,
   `homo_sorted`, `mono_sorted`, `map_merge`, `merge_map`, `map_sort`,
-  `sort_map`, `sorted_map`, `homo_sorted_in`, `mono_sorted_in`,
-  `sort_map_in`/
+  `sort_map`, `sorted_map`, `homo_sorted_in`, `mono_sorted_in`.
 
 - Added the theorem `perm_iota_sort` to express that the sorting of
   any sequence `s` is equal to a mapping of `iota 0 (size s)` to the
   nth elements of `s`, so that one can still reason on `nat`, even
   though the elements of `s` are not in an `eqType`.
 
-- Added a comment in the documentation to explain `sort` is stable,
-  without proving it formally, for now.
+- Added stability theorems about `merge` and `sort`: `sorted_merge`,
+  `merge_stable_path`, `merge_stable_sorted`, `sorted_sort`, `sort_stable`,
+  `filter_sort`, `mask_sort`, `sorted_mask_sort`, `subseq_sort`,
+  `sorted_subseq_sort`, and `mem2_sort`.
 
 ### Changed
 

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -991,7 +991,7 @@ exists (block_mx 1 0 Ml L).
 exists (block_mx 1 Mu 0 R).
   by rewrite unitmxE det_ublock det_scalar1 mul1r.
 exists (1 :: d); set D1 := \matrix_(i, j) _ in dM1.
-  by rewrite /= path_min_sorted // => g _; apply: dvd1n.
+  by rewrite /= path_min_sorted //; apply/allP => g _; apply: dvd1n.
 rewrite [D in _ *m D *m _](_ : _ = block_mx 1 0 0 D1); last first.
   by apply/matrixP=> i j; do 3?[rewrite ?mxE ?ord1 //=; case: splitP => ? ->].
 rewrite !mulmx_block !(mul0mx, mulmx0, addr0) !mulmx1 add0r mul1mx -Da -dM1.

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -1766,7 +1766,7 @@ case/predU1P: b_y => [-> // | b'_y].
 have:= abelian_type_dvdn_sorted G; rewrite -def_t def_b.
 case/splitPr: b'_y => b1 b2; rewrite -cat_rcons rcons_cat map_cat !map_rcons.
 rewrite headI /= cat_path -(last_cons 2) -headI last_rcons.
-case/andP=> _ /order_path_min min_y.
+case/andP=> _ /(@order_path_min nat) min_y.
 apply: (allP (min_y _)) => [? ? ? ? dv|]; first exact: (dvdn_trans dv).
 by rewrite mem_rcons mem_head.
 Qed.

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -1766,7 +1766,7 @@ case/predU1P: b_y => [-> // | b'_y].
 have:= abelian_type_dvdn_sorted G; rewrite -def_t def_b.
 case/splitPr: b'_y => b1 b2; rewrite -cat_rcons rcons_cat map_cat !map_rcons.
 rewrite headI /= cat_path -(last_cons 2) -headI last_rcons.
-case/andP=> _ /(@order_path_min nat) min_y.
+case/andP=> _ /order_path_min min_y.
 apply: (allP (min_y _)) => [? ? ? ? dv|]; first exact: (dvdn_trans dv).
 by rewrite mem_rcons mem_head.
 Qed.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -519,18 +519,18 @@ elim=> //= [|y s2 IH2]; first by rewrite addn0.
 by case: leT; rewrite /= ?IH1 ?IH2 !addnS.
 Qed.
 
-Hypothesis leT_tr : transitive leT.
-
-Lemma order_path_min x s : path leT x s -> all (leT x) s.
+Lemma order_path_min x s : transitive leT -> path leT x s -> all (leT x) s.
 Proof.
-elim: s => //= y [//|z s] ihs /andP[xy yz]; rewrite xy {}ihs//.
-by move: yz => /= /andP[/(leT_tr _)->].
+move=> leT_tr; elim: s => //= y [//|z s] ihs /andP[xy yz]; rewrite xy {}ihs//.
+by move: yz => /= /andP [/(leT_tr _ _ _ xy) ->].
 Qed.
+
+Hypothesis leT_tr : transitive leT.
 
 Lemma sorted_merge s t : sorted (s ++ t) -> merge s t = s ++ t.
 Proof.
 elim: s => //= x s; case: t; rewrite ?cats0 //= => y t ih hp.
-move: (order_path_min hp).
+move: (order_path_min leT_tr hp).
 by rewrite ih ?(path_sorted hp) // all_cat /= => /and3P [_ -> _].
 Qed.
 
@@ -573,7 +573,7 @@ Proof. rewrite filter_mask; exact: sorted_mask. Qed.
 End SortSeq.
 
 Arguments path_sorted {T leT x s}.
-Arguments order_path_min {T leT} leT_tr {x s}.
+Arguments order_path_min {T leT x s}.
 Arguments path_min_sorted {T leT x s}.
 Arguments merge {T} relT !s1 !s2 : rename.
 
@@ -765,20 +765,6 @@ End EqHomoSortSeq.
 
 Arguments homo_sorted_in {T T' f leT leT'}.
 Arguments mono_sorted_in {T T' f leT leT'}.
-
-Lemma sort_map_in (T T' : eqType) (f : T -> T') (leT : rel T) (leT' : rel T')
-      (leT'_sym : antisymmetric leT') (leT'_tr : transitive leT')
-      (leT_total : total leT) (leT'_total : total leT') (s : seq T) :
-  {in s &, {homo f : x y / leT x y >-> leT' x y}} ->
-  sort leT' (map f s) = map f (sort leT s).
-Proof.
-move=> fP; apply: (@eq_sorted _ leT'); rewrite ?sort_sorted//; last first.
-  by rewrite perm_sort perm_map// perm_sym perm_sort.
-rewrite (homo_sorted_in (leT := leT)) ?sort_sorted // => x y.
-rewrite !mem_sort; apply: fP.
-Qed.
-
-Arguments sort_map_in {T T' f leT leT'}.
 
 Lemma ltn_sorted_uniq_leq s : sorted ltn s = uniq s && sorted leq s.
 Proof.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -463,6 +463,10 @@ Fixpoint merge_sort_rec ss s :=
 
 Definition sort := merge_sort_rec [::].
 
+(* The following definition `sort_rec1` is an auxiliary function for          *)
+(* inductive reasoning on `sort`. One can rewrite `sort le s` to              *)
+(* `sort_rec1 le [::] s` by `sortE` and apply the simple structural induction *)
+(* on `s` to reason about it.                                                 *)
 Fixpoint sort_rec1 ss s :=
   if s is x :: s then sort_rec1 (merge_sort_push [:: x] ss) s else
   merge_sort_pop [::] ss.
@@ -939,7 +943,7 @@ rewrite -map_mask -filter_mask {2}mask_filter ?iota_uniq ?filter_sort //.
 move=> ? ? ?; exact/leT_tr.
 Qed.
 
-Lemma mask_sort' s m :
+Lemma sorted_mask_sort s m :
   sorted leT (mask m s) -> {m_s | mask m_s (sort leT s) = mask m s}.
 Proof. by move/(sorted_sort leT_tr) => <-; exact: mask_sort. Qed.
 
@@ -956,7 +960,8 @@ move=> t s /subseqP [m _ ->].
 case: (mask_sort leT_total leT_tr s m) => m' <-; exact: mask_subseq.
 Qed.
 
-Lemma subseq_sort' t s : subseq t s -> sorted leT t -> subseq t (sort leT s).
+Lemma sorted_subseq_sort t s :
+  subseq t s -> sorted leT t -> subseq t (sort leT s).
 Proof. by move=> subseq_ts /(sorted_sort leT_tr) <-; exact: subseq_sort. Qed.
 
 Lemma mem2_sort s x y : leT x y -> mem2 s x y -> mem2 (sort leT s) x y.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -164,14 +164,14 @@ Section HomoPath.
 Variables (T T' : Type) (leT : rel T) (leT' : rel T').
 
 Lemma homo_path f x s : {homo f : x y / leT x y >-> leT' x y} ->
-  path leT x s -> path leT' (f x) [seq f x | x <- s].
+  path leT x s -> path leT' (f x) (map f s).
 Proof.
 move=> f_homo; elim: s => //= y s IHs in x *.
 by move=> /andP[le_xy path_y_s]; rewrite f_homo//= IHs.
 Qed.
 
 Lemma mono_path f x s : {mono f : x y / leT x y >-> leT' x y} ->
-  path leT' (f x) [seq f x | x <- s] = path leT x s.
+  path leT' (f x) (map f s) = path leT x s.
 Proof. by move=> f_mon; elim: s => //= y s IHs in x *; rewrite f_mon IHs. Qed.
 
 End HomoPath.
@@ -400,7 +400,7 @@ Section EqHomoPath.
 Variables (T T' : eqType) (leT : rel T) (leT' : rel T').
 
 Lemma homo_path_in f x s : {in x :: s &, {homo f : x y / leT x y >-> leT' x y}} ->
-  path leT x s -> path leT' (f x) [seq f x | x <- s].
+  path leT x s -> path leT' (f x) (map f s).
 Proof.
 move=> f_homo; elim: s => //= y s IHs in x f_homo *; move=> /andP[x_y y_s].
 rewrite f_homo ?(in_cons, mem_head, eqxx, orbT) ?IHs//= => z t z_mem t_mem.
@@ -408,7 +408,7 @@ by apply: f_homo; rewrite in_cons ?(z_mem, t_mem, orbT).
 Qed.
 
 Lemma mono_path_in f x s : {in x :: s &, {mono f : x y / leT x y >-> leT' x y}} ->
-  path leT' (f x) [seq f x | x <- s] = path leT x s.
+  path leT' (f x) (map f s) = path leT x s.
 Proof.
 move=> f_mono; elim: s => //= y s IHs in x f_mono *.
 rewrite f_mono ?(in_cons, mem_head, eqxx, orbT) ?IHs//= => z t z_mem t_mem.
@@ -491,8 +491,7 @@ case/andP=> ord_s2 ord_ss ord_s1.
 by case: {1}s2=> /= [|_ _]; [rewrite ord_s1 | apply: IHss (merge_sorted _ _)].
 Qed.
 
-Lemma path_min_sorted x s :
-  all [pred y | leT x y] s -> path leT x s = sorted s.
+Lemma path_min_sorted x s : all (leT x) s -> path leT x s = sorted s.
 Proof. by case: s => //= y s /andP [->]. Qed.
 
 Lemma size_merge s1 s2 : size (merge s1 s2) = size (s1 ++ s2).
@@ -716,18 +715,18 @@ Variables (T T' : eqType) (f : T' -> T) (leT' : rel T') (leT : rel T).
 Implicit Types (s : seq T').
 
 Lemma homo_sorted_in s : {in s &, {homo f : x y / leT' x y >-> leT x y}} ->
-  sorted leT' s -> sorted leT [seq f x | x <- s].
+  sorted leT' s -> sorted leT (map f s).
 Proof. by case: s => //= x s /homo_path_in. Qed.
 
 Lemma mono_sorted_in s : {in s &, {mono f : x y / leT' x y >-> leT x y}} ->
-  sorted leT [seq f x | x <- s] = sorted leT' s.
+  sorted leT (map f s) = sorted leT' s.
 Proof. by case: s => // x s /mono_path_in /= ->. Qed.
 
 Hypothesis (leT'_sym : antisymmetric leT) (leT_tr : transitive leT).
 Hypothesis (leT'_total : total leT') (leT_total : total leT).
 
 Lemma sort_map_in s : {in s &, {homo f : x y / leT' x y >-> leT x y}} ->
-  sort leT [seq f x | x <- s] = [seq f x | x <- sort leT' s].
+  sort leT (map f s) = map f (sort leT' s).
 Proof.
 move=> fP; apply: (@eq_sorted _ leT); rewrite ?sort_sorted//; last first.
   by rewrite perm_sort perm_map// perm_sym perm_sort.

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2077,6 +2077,16 @@ Notation "[ 'seq' E : R | i : T <- s & C ]" :=
 Lemma filter_mask T a (s : seq T) : filter a s = mask (map a s) s.
 Proof. by elim: s => //= x s <-; case: (a x). Qed.
 
+Lemma mask_filter (T : eqType) (s : seq T) (m : bitseq) :
+  uniq s -> mask m s = [seq i <- s | i \in mask m s].
+Proof.
+elim: m s => [|[] m ih] [|x s] //=.
+- by move=> _; elim: s.
+- case/andP => /negP x_notin_s /ih {1}->; rewrite inE eqxx /=; congr cons.
+  by apply/eq_in_filter => ?; rewrite inE; case: eqP => // ->.
+- by case: ifP => [/mem_mask -> // | _ /andP [] _ /ih].
+Qed.
+
 Section FilterSubseq.
 
 Variable T : eqType.


### PR DESCRIPTION
##### Motivation for this change

This PR adds the following lemmas which state the stability of `path.merge` and `path.sort` in various ways.

```coq
sorted_merge
     : forall (T : Type) (leT : rel T),
       transitive leT ->
       forall s t : seq T, sorted leT (s ++ t) -> merge leT s t = s ++ t
merge_stable_path
     : forall (T : Type) (leT leT' : rel T),
       total leT ->
       forall (x : T) (s1 s2 : seq T),
       all (fun y : T => all (leT' y) s2) s1 ->
       path [rel x0 y | leT x0 y && (leT y x0 ==> leT' x0 y)] x s1 ->
       path [rel x0 y | leT x0 y && (leT y x0 ==> leT' x0 y)] x s2 ->
       path [rel x0 y | leT x0 y && (leT y x0 ==> leT' x0 y)] x
         (merge leT s1 s2)
merge_stable_sorted
     : forall (T : Type) (leT leT' : rel T),
       total leT ->
       forall s1 s2 : seq T,
       all (fun x : T => all (leT' x) s2) s1 ->
       sorted [rel x y | leT x y && (leT y x ==> leT' x y)] s1 ->
       sorted [rel x y | leT x y && (leT y x ==> leT' x y)] s2 ->
       sorted [rel x y | leT x y && (leT y x ==> leT' x y)] (merge leT s1 s2)
sorted_sort
     : forall (T : Type) (leT : rel T),
       transitive leT -> forall s : seq T, sorted leT s -> sort leT s = s
sort_stable
     : forall (T : Type) (leT leT' : rel T),
       total leT -> transitive leT' ->
       forall s : seq T,
       sorted leT' s ->
       sorted [rel x y | leT x y && (leT y x ==> leT' x y)] (sort leT s)
filter_sort
     : forall (T : Type) (leT : rel T),
       total leT -> transitive leT ->
       forall (p : pred T) (s : seq T),
       [seq x <- sort leT s | p x] = sort leT [seq x <- s | p x]
mask_sort
     : forall (T : Type) (leT : rel T),
       total leT -> transitive leT ->
       forall (s : seq T) (m : bitseq),
       {m_s : bitseq | mask m_s (sort leT s) = sort leT (mask m s)}
sorted_mask_sort
     : forall (T : Type) (leT : rel T),
       total leT -> transitive leT ->
       forall (s : seq T) (m : bitseq),
       sorted leT (mask m s) ->
       {m_s : bitseq | mask m_s (sort leT s) = mask m s}
subseq_sort
     : forall (T : eqType) (leT : rel T),
       total leT -> transitive leT -> {homo sort leT : t s / subseq t s}
sorted_subseq_sort
     : forall (T : eqType) (leT : rel T),
       total leT -> transitive leT ->
       forall t s : seq T, subseq t s -> sorted leT t -> subseq t (sort leT s)
mem2_sort
     : forall (T : eqType) (leT : rel T),
       total leT -> transitive leT ->
       forall (s : seq T) (x y : T),
       leT x y -> mem2 s x y -> mem2 (sort leT s) x y
```

Closes: #328

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers

<!-- if items above are irrelevant, explain what you did here -->

<!-- please fill in the following checklist -->
<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
