### PR TITLE
Add tuple_of_finfun, finfun_of_tuple & cancel lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added fixpoint and cofixpoint constructions to `finset`: `fixset`,
   `cofixset` and `fix_order`, with a few theorems about them
 
+- Added functions `tuple_of_finfun`, `finfun_of_tuple`, and their
+  "cancellation" lemmas.
+
 ### Changed
 
 - `eqVneq` lemma is changed from `{x = y} + {x != y}` to

--- a/mathcomp/ssreflect/finfun.v
+++ b/mathcomp/ssreflect/finfun.v
@@ -270,6 +270,26 @@ Canonical dfinfun_finType rT :=
 
 End InheritedStructures.
 
+Section FinFunTuple.
+
+Context {T : Type} {n : nat}.
+
+Definition tuple_of_finfun (f : T ^ n) : n.-tuple T := [tuple f i | i < n].
+
+Definition finfun_of_tuple (t : n.-tuple T) : (T ^ n) := [ffun i => tnth t i].
+
+Lemma finfun_of_tupleK : cancel finfun_of_tuple tuple_of_finfun.
+Proof.
+by move=> t; apply: eq_from_tnth => i; rewrite tnth_map ffunE tnth_ord_tuple.
+Qed.
+
+Lemma tuple_of_finfunK : cancel tuple_of_finfun finfun_of_tuple.
+Proof.
+by move=> f; apply/ffunP => i; rewrite ffunE tnth_map tnth_ord_tuple.
+Qed.
+
+End FinFunTuple.
+
 Section FunPlainTheory.
 
 Variables (aT : finType) (rT : Type).


### PR DESCRIPTION
##### Motivation for this change

Add two functions and lemmas following this Gitter discussion:
https://gitter.im/math-comp/Lobby?at=5d11e92a154d273638db5253

##### Things done/to do

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] ~added corresponding documentation in the headers~ (→ no relevant at first sight)

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
