### PR TITLE
Taking advantage of Coq 8.10 ssreflect new features

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,15 +77,6 @@ make-coq-latest:
     - tags
     - merge_requests
 
-coq-8.7:
-  extends: .opam-build
-
-coq-8.8:
-  extends: .opam-build
-
-coq-8.9:
-  extends: .opam-build
-
 coq-dev:
   extends: .opam-build
 
@@ -133,16 +124,6 @@ coq-dev:
     - make -j "${NJOBS}"
     - make install
 
-ci-fourcolor-8.7:
-  extends: .ci-fourcolor
-  variables:
-    COQ_VERSION: "8.7"
-
-ci-fourcolor-8.8:
-  extends: .ci-fourcolor
-  variables:
-    COQ_VERSION: "8.8"
-
 ci-fourcolor-dev:
   extends: .ci-fourcolor
   variables:
@@ -158,15 +139,6 @@ ci-fourcolor-dev:
     - make -j "${NJOBS}"
     - make install
 
-ci-odd-order-8.7:
- extends: .ci-odd-order
- variables:
-   COQ_VERSION: "8.7"
-
-ci-odd-order-8.8:
- extends: .ci-odd-order
- variables:
-   COQ_VERSION: "8.8"
 
 ci-odd-order-dev:
   extends: .ci-odd-order
@@ -183,15 +155,6 @@ ci-odd-order-dev:
     - opam pin add -n -k path coq-lemma-overloading .
     - opam install -y -v -j "${NJOBS}" coq-lemma-overloading
 
-ci-lemma-overloading-8.8:
-  extends: .ci-lemma-overloading
-  variables:
-    COQ_VERSION: "8.8"
-
-ci-lemma-overloading-8.9:
-  extends: .ci-lemma-overloading
-  variables:
-    COQ_VERSION: "8.9"
 
 ci-lemma-overloading-dev:
   extends: .ci-lemma-overloading
@@ -208,20 +171,6 @@ ci-lemma-overloading-dev:
     - opam pin add -n -k path coq-mathcomp-bigenough .
     - opam install -y -v -j "${NJOBS}" coq-mathcomp-bigenough
 
-ci-bigenough-8.7:
-  extends: .ci-bigenough
-  variables:
-    COQ_VERSION: "8.7"
-
-ci-bigenough-8.8:
-  extends: .ci-bigenough
-  variables:
-    COQ_VERSION: "8.8"
-
-ci-bigenough-8.9:
-  extends: .ci-bigenough
-  variables:
-    COQ_VERSION: "8.9"
 
 ci-bigenough-dev:
   extends: .ci-bigenough
@@ -239,46 +188,6 @@ ci-bigenough-dev:
 #     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-real-closed
 #     - opam install -y -v -j "${NJOBS}" coq-mathcomp-real-closed
 # 
-# ci-real-closed-8.7:
-#   extends: .ci-real-closed
-#   variables:
-#     COQ_VERSION: "8.7"
-# 
-# ci-real-closed-8.8:
-#   extends: .ci-real-closed
-#   variables:
-#     COQ_VERSION: "8.8"
-# 
-# ci-real-closed-8.9:
-#   extends: .ci-real-closed
-#   variables:
-#     COQ_VERSION: "8.9"
-# 
-# ci-real-closed-dev:
-#   extends: .ci-real-closed
-#   variables:
-#     COQ_VERSION: "dev"
-# 
-# # The analysis library
-# .ci-analysis:
-#   extends: .ci
-#   variables:
-#     CONTRIB_URL: "https://github.com/math-comp/analysis.git"
-#     CONTRIB_VERSION: master
-#   script:
-#     - opam pin add -n -k path coq-mathcomp-analysis .
-#     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-analysis
-#     - opam install -y -v -j "${NJOBS}" coq-mathcomp-analysis
-# 
-# ci-analysis-8.8:
-#   extends: .ci-analysis
-#   variables:
-#     COQ_VERSION: "8.8"
-# 
-# ci-analysis-8.9:
-#   extends: .ci-analysis
-#   variables:
-#     COQ_VERSION: "8.9"
 # 
 # ci-analysis-dev:
 #   extends: .ci-analysis
@@ -296,20 +205,6 @@ ci-bigenough-dev:
     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-finmap
     - opam install -y -v -j "${NJOBS}" coq-mathcomp-finmap
 
-ci-finmap-8.7:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "8.7"
-
-ci-finmap-8.8:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "8.8"
-
-ci-finmap-8.9:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "8.9"
 
 ci-finmap-dev:
   extends: .ci-finmap
@@ -346,15 +241,6 @@ ci-finmap-dev:
     - docker logout "${HUB_REGISTRY}"
   only:
     - master
-
-mathcomp-dev:coq-8.7:
-  extends: .docker-deploy
-
-mathcomp-dev:coq-8.8:
-  extends: .docker-deploy
-
-mathcomp-dev:coq-8.9:
-  extends: .docker-deploy
 
 mathcomp-dev:coq-dev:
   extends: .docker-deploy

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -554,8 +554,8 @@ Canonical unit_action :=
   @TotalAction _ _ unit_act (@GRing.mulr1 _) (fun _ _ _ => GRing.mulrA _ _ _).
 Lemma unit_is_groupAction : @is_groupAction _ R setT setT unit_action.
 Proof.
-move=> u _ /=; rewrite inE; apply/andP; split.
-  by apply/subsetP=> x _; rewrite inE.
+move=> u _ /= /1inE; apply/andP; split.
+  by apply/subsetP=> x _ /1inE.
 by apply/morphicP=> x y _ _; rewrite !actpermE /= [_ u]GRing.mulrDl.
 Qed.
 Canonical unit_groupAction := GroupAction unit_is_groupAction.

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -554,8 +554,8 @@ Canonical unit_action :=
   @TotalAction _ _ unit_act (@GRing.mulr1 _) (fun _ _ _ => GRing.mulrA _ _ _).
 Lemma unit_is_groupAction : @is_groupAction _ R setT setT unit_action.
 Proof.
-move=> u _ /= /1inE; apply/andP; split.
-  by apply/subsetP=> x _ /1inE.
+move=> u _ /= /[1inE]; apply/andP; split.
+  by apply/subsetP=> x _ /[1inE].
 by apply/morphicP=> x y _ _; rewrite !actpermE /= [_ u]GRing.mulrDl.
 Qed.
 Canonical unit_groupAction := GroupAction unit_is_groupAction.

--- a/mathcomp/algebra/fraction.v
+++ b/mathcomp/algebra/fraction.v
@@ -196,8 +196,8 @@ Proof.
 move=> x; unlock inv; apply/eqmodP=> /=; rewrite equivfE /invf eq_sym.
 do 2?case: RatioP=> /= [/eqP|];
   rewrite ?mul0r ?mul1r -?equivf_def ?numer0 ?reprK //.
-  by move=> hx /eqP hx'; rewrite hx' eqxx in hx.
-by move=> /eqP ->; rewrite eqxx.
+  by move=> + /eqP /[->]; rewrite eqxx.
+by move=> /eqP->; rewrite eqxx.
 Qed.
 Canonical pi_inv_morph := PiMorph1 pi_inv.
 

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -969,7 +969,7 @@ without loss{IHa} /forallP/(_ (_, _))/= a_dvM: / [forall k, a %| M k.1 k.2]%Z.
     by exists i; rewrite mxE.
   exists R^T; last exists L^T; rewrite ?unitmx_tr //; exists d => //.
   rewrite -[M]trmxK dM !trmx_mul mulmxA; congr (_ *m _ *m _).
-  by apply/matrixP=> i1 j1 /!mxE; case: eqVneq => // ->.
+  by apply/matrixP=> i1 j1 /[!mxE]; case: eqVneq => // ->.
 without loss{nz_a a_dvM} a1: M a Da / a = 1.
   pose M1 := map_mx (divz^~ a) M; case/(_ M1 1)=> // [k|L uL [R uR [d dvD dM]]].
     by rewrite !mxE Da divzz nz_a.
@@ -1049,7 +1049,7 @@ have{kerGu} defS: map_mx intr (rsubmx G'lr) *m T = S.
 pose vv := \row_j coord (vbasis <<s>>) j v.
 have uS: row_full S.
   apply/row_fullP; exists (\matrix_(i, j) coord s j (vbasis <<s>>)`_i).
-  apply/matrixP=> j1 j2 /!mxE.
+  apply/matrixP=> j1 j2 /[!mxE].
   rewrite -(coord_free _ _ (basis_free (vbasisP _))).
   rewrite -!tnth_nth (coord_span (vbasis_mem (mem_tnth j1 _))) linear_sum.
   by apply: eq_bigr => i _; rewrite !mxE (tnth_nth 0) !linearZ.

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -969,7 +969,7 @@ without loss{IHa} /forallP/(_ (_, _))/= a_dvM: / [forall k, a %| M k.1 k.2]%Z.
     by exists i; rewrite mxE.
   exists R^T; last exists L^T; rewrite ?unitmx_tr //; exists d => //.
   rewrite -[M]trmxK dM !trmx_mul mulmxA; congr (_ *m _ *m _).
-  by apply/matrixP=> i1 j1; rewrite !mxE; case: eqVneq => // ->.
+  by apply/matrixP=> i1 j1 /!mxE; case: eqVneq => // ->.
 without loss{nz_a a_dvM} a1: M a Da / a = 1.
   pose M1 := map_mx (divz^~ a) M; case/(_ M1 1)=> // [k|L uL [R uR [d dvD dM]]].
     by rewrite !mxE Da divzz nz_a.
@@ -1049,7 +1049,7 @@ have{kerGu} defS: map_mx intr (rsubmx G'lr) *m T = S.
 pose vv := \row_j coord (vbasis <<s>>) j v.
 have uS: row_full S.
   apply/row_fullP; exists (\matrix_(i, j) coord s j (vbasis <<s>>)`_i).
-  apply/matrixP=> j1 j2; rewrite !mxE.
+  apply/matrixP=> j1 j2 /!mxE.
   rewrite -(coord_free _ _ (basis_free (vbasisP _))).
   rewrite -!tnth_nth (coord_span (vbasis_mem (mem_tnth j1 _))) linear_sum.
   by apply: eq_bigr => i _; rewrite !mxE (tnth_nth 0) !linearZ.

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -353,13 +353,13 @@ Lemma castmx_const m' n' (eq_mn : (m = m') * (n = n')) a :
 Proof. by case: eq_mn; case: m' /; case: n' /. Qed.
 
 Lemma trmx_const a : trmx (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma row_perm_const s a : row_perm s (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma col_perm_const s a : col_perm s (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma xrow_const i1 i2 a : xrow i1 i2 (const_mx a) = const_mx a.
 Proof. exact: row_perm_const. Qed.
@@ -371,28 +371,28 @@ Lemma rowP (u v : 'rV[R]_n) : u 0 =1 v 0 <-> u = v.
 Proof. by split=> [eq_uv | -> //]; apply/matrixP=> i; rewrite ord1. Qed.
 
 Lemma rowK u_ i0 : row i0 (\matrix_i u_ i) = u_ i0.
-Proof. by apply/rowP=> i'; rewrite !mxE. Qed.
+Proof. by apply/rowP=> i' /!mxE. Qed.
 
 Lemma row_matrixP A B : (forall i, row i A = row i B) <-> A = B.
 Proof.
 split=> [eqAB | -> //]; apply/matrixP=> i j.
-by move/rowP/(_ j): (eqAB i); rewrite !mxE.
+by move/rowP/(_ j): (eqAB i) => /!mxE.
 Qed.
 
 Lemma colP (u v : 'cV[R]_m) : u^~ 0 =1 v^~ 0 <-> u = v.
 Proof. by split=> [eq_uv | -> //]; apply/matrixP=> i j; rewrite ord1. Qed.
 
 Lemma row_const i0 a : row i0 (const_mx a) = const_mx a.
-Proof. by apply/rowP=> j; rewrite !mxE. Qed.
+Proof. by apply/rowP=> j /!mxE. Qed.
 
 Lemma col_const j0 a : col j0 (const_mx a) = const_mx a.
-Proof. by apply/colP=> i; rewrite !mxE. Qed.
+Proof. by apply/colP=> i /!mxE. Qed.
 
 Lemma row'_const i0 a : row' i0 (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma col'_const j0 a : col' j0 (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma col_perm1 A : col_perm 1 A = A.
 Proof. by apply/matrixP=> i j; rewrite mxE perm1. Qed.
@@ -408,7 +408,7 @@ Proof. by apply/matrixP=> i j; rewrite !mxE permM. Qed.
 
 Lemma col_row_permC s t A :
   col_perm s (row_perm t A) = row_perm t (col_perm s A).
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 End FixedDim.
 
@@ -458,7 +458,7 @@ Lemma conform_castmx m1 n1 m2 n2 m3 n3
 Proof. by do [case: e_mn; case: m3 /; case: n3 /] in A *. Qed.
 
 Lemma trmxK m n : cancel (@trmx m n) (@trmx n m).
-Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by move=> A; apply/matrixP=> i j /!mxE. Qed.
 
 Lemma trmx_inj m n : injective (@trmx m n).
 Proof. exact: can_inj (@trmxK m n). Qed.
@@ -470,10 +470,10 @@ by case: eq_mn => eq_m eq_n; apply/matrixP=> i j; rewrite !(mxE, castmxE).
 Qed.
 
 Lemma tr_row_perm m n s (A : 'M_(m, n)) : (row_perm s A)^T = col_perm s A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma tr_col_perm m n s (A : 'M_(m, n)) : (col_perm s A)^T = row_perm s A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma tr_xrow m n i1 i2 (A : 'M_(m, n)) : (xrow i1 i2 A)^T = xcol i1 i2 A^T.
 Proof. exact: tr_row_perm. Qed.
@@ -489,37 +489,37 @@ Proof. by apply/colP=> i; rewrite mxE [j]ord1. Qed.
 
 Lemma row_eq m1 m2 n i1 i2 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   row i1 A1 = row i2 A2 -> A1 i1 =1 A2 i2.
-Proof. by move/rowP=> eqA12 j; have:= eqA12 j; rewrite !mxE. Qed.
+Proof. by move/rowP=> eqA12 j; have /!mxE := eqA12 j. Qed.
 
 Lemma col_eq m n1 n2 j1 j2 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   col j1 A1 = col j2 A2 -> A1^~ j1 =1 A2^~ j2.
-Proof. by move/colP=> eqA12 i; have:= eqA12 i; rewrite !mxE. Qed.
+Proof. by move/colP=> eqA12 i; have /!mxE := eqA12 i. Qed.
 
 Lemma row'_eq m n i0 (A B : 'M_(m, n)) :
   row' i0 A = row' i0 B -> {in predC1 i0, A =2 B}.
 Proof.
-move/matrixP=> eqAB' i; rewrite !inE eq_sym; case/unlift_some=> i' -> _ j.
-by have:= eqAB' i' j; rewrite !mxE.
+move=> /matrixP eqAB' i /!inE /[rw eq_sym] /unlift_some[i' -> _ j].
+by have /!mxE := eqAB' i' j.
 Qed.
 
 Lemma col'_eq m n j0 (A B : 'M_(m, n)) :
   col' j0 A = col' j0 B -> forall i, {in predC1 j0, A i =1 B i}.
 Proof.
-move/matrixP=> eqAB' i j; rewrite !inE eq_sym; case/unlift_some=> j' -> _.
-by have:= eqAB' i j'; rewrite !mxE.
+move=> /matrixP eqAB' i j /!inE /[rw eq_sym] /unlift_some[j' -> _].
+by have /!mxE := eqAB' i j'.
 Qed.
 
 Lemma tr_row m n i0 (A : 'M_(m, n)) : (row i0 A)^T = col i0 A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma tr_row' m n i0 (A : 'M_(m, n)) : (row' i0 A)^T = col' i0 A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma tr_col m n j0 (A : 'M_(m, n)) : (col j0 A)^T = row j0 A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma tr_col' m n j0 (A : 'M_(m, n)) : (col' j0 A)^T = row' j0 A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Ltac split_mxE := apply/matrixP=> i j; do ![rewrite mxE | case: split => ?].
 
@@ -573,7 +573,7 @@ Proof. by apply/matrixP=> i j; rewrite mxE row_mxEr. Qed.
 
 Lemma hsubmxK A : row_mx (lsubmx A) (rsubmx A) = A.
 Proof.
-apply/matrixP=> i j; rewrite !mxE.
+apply/matrixP=> i j /!mxE.
 by case: splitP => k Dk //=; rewrite !mxE //=; congr (A _ _); apply: val_inj.
 Qed.
 
@@ -651,7 +651,7 @@ apply: (canRL (castmxKV _ _)); apply/matrixP=> i j.
 rewrite castmxE !mxE cast_ord_id; case: splitP => j1 /= def_j.
   have: (j < n1 + n2) && (j < n1) by rewrite def_j lshift_subproof /=.
   by move: def_j; do 2![case: splitP => // ? ->; rewrite ?mxE] => /ord_inj->.
-case: splitP def_j => j2 ->{j} def_j; rewrite !mxE.
+case: splitP def_j => j2 ->{j} def_j /!mxE.
   have: ~~ (j2 < n1) by rewrite -leqNgt def_j leq_addr.
   have: j1 < n2 by rewrite -(ltn_add2l n1) -def_j.
   by move: def_j; do 2![case: splitP => // ? ->] => /addnI/val_inj->.
@@ -669,9 +669,7 @@ Definition col_mxAx := col_mxA. (* bypass Prenex Implicits. *)
 
 Lemma row_row_mx m n1 n2 i0 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   row i0 (row_mx A1 A2) = row_mx (row i0 A1) (row i0 A2).
-Proof.
-by apply/matrixP=> i j; rewrite !mxE; case: (split j) => j'; rewrite mxE.
-Qed.
+Proof. by apply/matrixP=> i j /!mxE; case: (split j) => j' /!mxE. Qed.
 
 Lemma col_col_mx m1 m2 n j0 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   col j0 (col_mx A1 A2) = col_mx (col j0 A1) (col j0 A2).
@@ -679,9 +677,7 @@ Proof. by apply: trmx_inj; rewrite !(tr_col, tr_col_mx, row_row_mx). Qed.
 
 Lemma row'_row_mx m n1 n2 i0 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   row' i0 (row_mx A1 A2) = row_mx (row' i0 A1) (row' i0 A2).
-Proof.
-by apply/matrixP=> i j; rewrite !mxE; case: (split j) => j'; rewrite mxE.
-Qed.
+Proof. by apply/matrixP=> i j /!mxE; case: (split j) => j' /!mxE. Qed.
 
 Lemma col'_col_mx m1 m2 n j0 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   col' j0 (col_mx A1 A2) = col_mx (col' j0 A1) (col' j0 A2).
@@ -689,19 +685,19 @@ Proof. by apply: trmx_inj; rewrite !(tr_col', tr_col_mx, row'_row_mx). Qed.
 
 Lemma colKl m n1 n2 j1 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   col (lshift n2 j1) (row_mx A1 A2) = col j1 A1.
-Proof. by apply/matrixP=> i j; rewrite !(row_mxEl, mxE). Qed.
+Proof. by apply/matrixP=> i j /!(row_mxEl, mxE). Qed.
 
 Lemma colKr m n1 n2 j2 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   col (rshift n1 j2) (row_mx A1 A2) = col j2 A2.
-Proof. by apply/matrixP=> i j; rewrite !(row_mxEr, mxE). Qed.
+Proof. by apply/matrixP=> i j /!(row_mxEr, mxE). Qed.
 
 Lemma rowKu m1 m2 n i1 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   row (lshift m2 i1) (col_mx A1 A2) = row i1 A1.
-Proof. by apply/matrixP=> i j; rewrite !(col_mxEu, mxE). Qed.
+Proof. by apply/matrixP=> i j /!(col_mxEu, mxE). Qed.
 
 Lemma rowKd m1 m2 n i2 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   row (rshift m1 i2) (col_mx A1 A2) = row i2 A2.
-Proof. by apply/matrixP=> i j; rewrite !(col_mxEd, mxE). Qed.
+Proof. by apply/matrixP=> i j /!(col_mxEd, mxE). Qed.
 
 Lemma col'Kl m n1 n2 j1 (A1 : 'M_(m, n1.+1)) (A2 : 'M_(m, n2)) :
   col' (lshift n2 j1) (row_mx A1 A2) = row_mx (col' j1 A1) A2.
@@ -813,16 +809,16 @@ Variables m1 m2 n1 n2 : nat.
 Variable A : 'M[R]_(m1 + m2, n1 + n2).
 
 Lemma trmx_ulsub : (ulsubmx A)^T = ulsubmx A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma trmx_ursub : (ursubmx A)^T = dlsubmx A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma trmx_dlsub : (dlsubmx A)^T = ursubmx A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma trmx_drsub : (drsubmx A)^T = drsubmx A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 End TrCutBlock.
 
@@ -939,34 +935,34 @@ Section OneMatrix.
 Variables (m n : nat) (A : 'M[aT]_(m, n)).
 
 Lemma map_trmx : A^f^T = A^T^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_const_mx a : (const_mx a)^f = const_mx (f a) :> 'M_(m, n).
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_row i : (row i A)^f = row i A^f.
-Proof. by apply/rowP=> j; rewrite !mxE. Qed.
+Proof. by apply/rowP=> j /!mxE. Qed.
 
 Lemma map_col j : (col j A)^f = col j A^f.
-Proof. by apply/colP=> i; rewrite !mxE. Qed.
+Proof. by apply/colP=> i /!mxE. Qed.
 
 Lemma map_row' i0 : (row' i0 A)^f = row' i0 A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_col' j0 : (col' j0 A)^f = col' j0 A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_row_perm s : (row_perm s A)^f = row_perm s A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_col_perm s : (col_perm s A)^f = col_perm s A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_xrow i1 i2 : (xrow i1 i2 A)^f = xrow i1 i2 A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_xcol j1 j2 : (xcol j1 j2 A)^f = xcol j1 j2 A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_castmx m' n' c : (castmx c A)^f = castmx c A^f :> 'M_(m', n').
 Proof. by apply/matrixP=> i j; rewrite !(castmxE, mxE). Qed.
@@ -983,7 +979,7 @@ Lemma map_mxvec : (mxvec A)^f = mxvec A^f.
 Proof. by apply/rowP=> i; rewrite !(castmxE, mxE). Qed.
 
 Lemma map_vec_mx (v : 'rV_(m * n)) : (vec_mx v)^f = vec_mx v^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 End OneMatrix.
 
@@ -1006,28 +1002,28 @@ Lemma map_block_mx :
 Proof. by apply/matrixP=> i j; do 3![rewrite !mxE //; case: split => ?]. Qed.
 
 Lemma map_lsubmx : (lsubmx Bh)^f = lsubmx Bh^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_rsubmx : (rsubmx Bh)^f = rsubmx Bh^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_usubmx : (usubmx Bv)^f = usubmx Bv^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_dsubmx : (dsubmx Bv)^f = dsubmx Bv^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_ulsubmx : (ulsubmx B)^f = ulsubmx B^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_ursubmx : (ursubmx B)^f = ursubmx B^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_dlsubmx : (dlsubmx B)^f = dlsubmx B^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma map_drsubmx : (drsubmx B)^f = drsubmx B^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 End Block.
 
@@ -1080,7 +1076,7 @@ Lemma summxE I r (P : pred I) (E : I -> 'M_(m, n)) i j :
 Proof. by apply: (big_morph (fun A => A i j)) => [A B|]; rewrite mxE. Qed.
 
 Lemma const_mx_is_additive : additive const_mx.
-Proof. by move=> a b; apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by move=> a b; apply/matrixP=> i j /!mxE. Qed.
 Canonical const_mx_additive := Additive const_mx_is_additive.
 
 End FixedDim.
@@ -1093,7 +1089,7 @@ Definition swizzle_mx k (A : 'M[V]_(m, n)) :=
   \matrix[k]_(i, j) A (f i j) (g i j).
 
 Lemma swizzle_mx_is_additive k : additive (swizzle_mx k).
-Proof. by move=> A B; apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by move=> A B; apply/matrixP=> i j /!mxE. Qed.
 Canonical swizzle_mx_additive k := Additive (swizzle_mx_is_additive k).
 
 End Additive.
@@ -1282,7 +1278,7 @@ Canonical matrix_lmodType :=
   Eval hnf in LmodType R 'M[R]_(m, n) matrix_lmodMixin.
 
 Lemma scalemx_const a b : a *: const_mx b = const_mx (a * b).
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma matrix_sum_delta A :
   A = \sum_(i < m) \sum_(j < n) A i j *: delta_mx i j.
@@ -1300,7 +1296,7 @@ Section StructuralLinear.
 
 Lemma swizzle_mx_is_scalable m n p q f g k :
   scalable (@swizzle_mx R m n p q f g k).
-Proof. by move=> a A; apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by move=> a A; apply/matrixP=> i j /!mxE. Qed.
 Canonical swizzle_mx_scalable m n p q f g k :=
   AddLinear (@swizzle_mx_is_scalable m n p q f g k).
 
@@ -1392,7 +1388,7 @@ Definition diag_mx n (d : 'rV[R]_n) :=
   \matrix[diag_mx_key]_(i, j) (d 0 i *+ (i == j)).
 
 Lemma tr_diag_mx n (d : 'rV_n) : (diag_mx d)^T = diag_mx d.
-Proof. by apply/matrixP=> i j; rewrite !mxE; case: eqVneq => // ->. Qed.
+Proof. by apply/matrixP=> i j /!mxE; case: eqVneq => // ->. Qed.
 
 Lemma diag_mx_is_linear n : linear (@diag_mx n).
 Proof.
@@ -1420,7 +1416,7 @@ Definition scalar_mx x : 'M[R]_n :=
 Notation "x %:M" := (scalar_mx x) : ring_scope.
 
 Lemma diag_const_mx a : diag_mx (const_mx a) = a%:M :> 'M_n.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma tr_scalar_mx a : (a%:M)^T = a%:M.
 Proof. by apply/matrixP=> i j; rewrite !mxE eq_sym. Qed.
@@ -1489,7 +1485,7 @@ Local Notation "A *m B" := (mulmx A B) : ring_scope.
 Lemma mulmxA m n p q (A : 'M_(m, n)) (B : 'M_(n, p)) (C : 'M_(p, q)) :
   A *m (B *m C) = A *m B *m C.
 Proof.
-apply/matrixP=> i l; rewrite !mxE.
+apply/matrixP=> i l /!mxE.
 transitivity (\sum_j (\sum_k (A i j * (B j k * C k l)))).
   by apply: eq_bigr => j _; rewrite mxE big_distrr.
 rewrite exchange_big; apply: eq_bigr => j _; rewrite mxE big_distrl /=.
@@ -1573,7 +1569,7 @@ Proof. by rewrite !rowE mulmxA. Qed.
 Lemma mulmx_sum_row m n (u : 'rV_m) (A : 'M_(m, n)) :
   u *m A = \sum_i u 0 i *: row i A.
 Proof.
-by apply/rowP=> j; rewrite mxE summxE; apply: eq_bigr => i _; rewrite !mxE.
+by apply/rowP=> j; rewrite mxE summxE; apply: eq_bigr => i _ /!mxE.
 Qed.
 
 Lemma mul_delta_mx_cond m n p (j1 j2 : 'I_n) (i1 : 'I_m) (k2 : 'I_p) :
@@ -1612,7 +1608,7 @@ Proof. by apply/matrixP=> i j; rewrite mul_diag_mx !mxE mulrnAr. Qed.
 
 Lemma mul_scalar_mx m n a (A : 'M_(m, n)) : a%:M *m A = a *: A.
 Proof.
-by rewrite -diag_const_mx mul_diag_mx; apply/matrixP=> i j; rewrite !mxE.
+by rewrite -diag_const_mx mul_diag_mx; apply/matrixP=> i j /!mxE.
 Qed.
 
 Lemma scalar_mxM n a b : (a * b)%:M = a%:M *m b%:M :> 'M_n.
@@ -1744,7 +1740,7 @@ by rewrite eqn_leq andbC leqNgt lshift_subproof.
 Qed.
 
 Lemma tr_pid_mx m n r : (pid_mx r)^T = pid_mx r :> 'M_(n, m).
-Proof. by apply/matrixP=> i j; rewrite !mxE; case: eqVneq => // ->. Qed.
+Proof. by apply/matrixP=> i j /!mxE; case: eqVneq => // ->. Qed.
 
 Lemma pid_mx_minv m n r : pid_mx (minn m r) = pid_mx r :> 'M_(m, n).
 Proof. by apply/matrixP=> i j; rewrite !mxE leq_min ltn_ord. Qed.
@@ -1788,14 +1784,14 @@ Qed.
 Lemma mul_mx_row m n p1 p2 (A : 'M_(m, n)) (Bl : 'M_(n, p1)) (Br : 'M_(n, p2)) :
   A *m row_mx Bl Br = row_mx (A *m Bl) (A *m Br).
 Proof.
-apply/matrixP=> i k; rewrite !mxE.
+apply/matrixP=> i k /!mxE.
 by case defk: (split k); rewrite mxE; apply: eq_bigr => j _; rewrite mxE defk.
 Qed.
 
 Lemma mul_col_mx m1 m2 n p (Au : 'M_(m1, n)) (Ad : 'M_(m2, n)) (B : 'M_(n, p)) :
   col_mx Au Ad *m B = col_mx (Au *m B) (Ad *m B).
 Proof.
-apply/matrixP=> i k; rewrite !mxE.
+apply/matrixP=> i k /!mxE.
 by case defi: (split i); rewrite mxE; apply: eq_bigr => j _; rewrite mxE defi.
 Qed.
 
@@ -2067,7 +2063,7 @@ Notation "'\adj' A" := (adjugate A) : ring_scope.
 Lemma trmx_mul_rev (R : ringType) m n p (A : 'M[R]_(m, n)) (B : 'M[R]_(n, p)) :
   (A *m B)^T = (B : 'M[R^c]_(n, p))^T *m (A : 'M[R^c]_(m, n))^T.
 Proof.
-by apply/matrixP=> k i; rewrite !mxE; apply: eq_bigr => j _; rewrite !mxE.
+by apply/matrixP=> k i /!mxE; apply: eq_bigr => j _ /!mxE.
 Qed.
 
 Canonical matrix_countZmodType (M : countZmodType) m n :=
@@ -2176,7 +2172,7 @@ Implicit Type B : 'M[R]_(n, p).
 
 Lemma trmx_mul A B : (A *m B)^T = B^T *m A^T.
 Proof.
-rewrite trmx_mul_rev; apply/matrixP=> k i; rewrite !mxE.
+rewrite trmx_mul_rev; apply/matrixP=> k i /!mxE.
 by apply: eq_bigr => j _; rewrite mulrC.
 Qed.
 
@@ -2370,7 +2366,7 @@ rewrite /(\det _) (bigD1 1%g) //= addrC big1 => [|p p1].
 have{p1}: ~~ perm_on set0 p.
   apply: contra p1; move/subsetP=> p1; apply/eqP; apply/permP=> i.
   by rewrite perm1; apply/eqP; apply/idPn; move/p1; rewrite inE.
-case/subsetPn=> i; rewrite !inE eq_sym; move/negbTE=> p_i _.
+case/subsetPn=> i /!inE /[rw eq_sym] /negbTE=> p_i _.
 by rewrite (bigD1 i) //= mulrCA mxE p_i mul0r.
 Qed.
 
@@ -2418,7 +2414,7 @@ Lemma cofactor_tr n (A : 'M[R]_n) i j : cofactor A^T i j = cofactor A j i.
 Proof.
 rewrite /cofactor addnC; congr (_ * _).
 rewrite -tr_row' -tr_col' det_tr; congr (\det _).
-by apply/matrixP=> ? ?; rewrite !mxE.
+by apply/matrixP=> ? ? /!mxE.
 Qed.
 
 Lemma cofactorZ n a (A : 'M[R]_n) i j : 
@@ -2441,7 +2437,7 @@ Proof. by apply/matrixP=> i j; rewrite !mxE cofactorZ. Qed.
 (* Cramer Rule : adjugate on the left *)
 Lemma mul_mx_adj n (A : 'M[R]_n) : A *m \adj A = (\det A)%:M.
 Proof.
-apply/matrixP=> i1 i2; rewrite !mxE; case Di: (i1 == i2).
+apply/matrixP=> i1 i2 /!mxE; case Di: (i1 == i2).
   rewrite (eqP Di) (expand_det_row _ i2) //=.
   by apply: eq_bigr => j _; congr (_ * _); rewrite mxE.
 pose B := \matrix_(i, j) (if i == i2 then A i1 j else A i j).
@@ -2753,7 +2749,7 @@ have [{detA0}A'0 | nzA'] := eqVneq (row 0 (\adj A)) 0; last first.
   by rewrite mul_mx_scalar scale0r.
 pose A' := col' 0 A; pose vA := col 0 A.
 have defA: A = row_mx vA A'.
-  apply/matrixP=> i j; rewrite !mxE.
+  apply/matrixP=> i j /!mxE.
   case: splitP => j' def_j; rewrite mxE; congr (A i _); apply: val_inj => //=.
   by rewrite def_j [j']ord1.
 have{IHn} w_ j : exists w : 'rV_n.+1, [/\ w != 0, w 0 j = 0 & w *m A' = 0].
@@ -2795,7 +2791,7 @@ Local Notation "A ^f" := (map_mx f A) : ring_scope.
 Lemma map_mx_inj {m n} : injective (map_mx f : 'M_(m, n) -> 'M_(m, n)).
 Proof.
 move=> A B eq_AB; apply/matrixP=> i j.
-by move/matrixP/(_ i j): eq_AB; rewrite !mxE; apply: fmorph_inj.
+by move: eq_AB => /matrixP/(_ i j)/!mxE; apply: fmorph_inj.
 Qed.
 
 Lemma map_mx_is_scalar n (A : 'M_n) : is_scalar_mx A^f = is_scalar_mx A.

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -353,13 +353,13 @@ Lemma castmx_const m' n' (eq_mn : (m = m') * (n = n')) a :
 Proof. by case: eq_mn; case: m' /; case: n' /. Qed.
 
 Lemma trmx_const a : trmx (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma row_perm_const s a : row_perm s (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma col_perm_const s a : col_perm s (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma xrow_const i1 i2 a : xrow i1 i2 (const_mx a) = const_mx a.
 Proof. exact: row_perm_const. Qed.
@@ -371,28 +371,28 @@ Lemma rowP (u v : 'rV[R]_n) : u 0 =1 v 0 <-> u = v.
 Proof. by split=> [eq_uv | -> //]; apply/matrixP=> i; rewrite ord1. Qed.
 
 Lemma rowK u_ i0 : row i0 (\matrix_i u_ i) = u_ i0.
-Proof. by apply/rowP=> i' /!mxE. Qed.
+Proof. by apply/rowP=> i' /[!mxE]. Qed.
 
 Lemma row_matrixP A B : (forall i, row i A = row i B) <-> A = B.
 Proof.
 split=> [eqAB | -> //]; apply/matrixP=> i j.
-by move/rowP/(_ j): (eqAB i) => /!mxE.
+by move/rowP/(_ j): (eqAB i) => /[!mxE].
 Qed.
 
 Lemma colP (u v : 'cV[R]_m) : u^~ 0 =1 v^~ 0 <-> u = v.
 Proof. by split=> [eq_uv | -> //]; apply/matrixP=> i j; rewrite ord1. Qed.
 
 Lemma row_const i0 a : row i0 (const_mx a) = const_mx a.
-Proof. by apply/rowP=> j /!mxE. Qed.
+Proof. by apply/rowP=> j /[!mxE]. Qed.
 
 Lemma col_const j0 a : col j0 (const_mx a) = const_mx a.
-Proof. by apply/colP=> i /!mxE. Qed.
+Proof. by apply/colP=> i /[!mxE]. Qed.
 
 Lemma row'_const i0 a : row' i0 (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma col'_const j0 a : col' j0 (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma col_perm1 A : col_perm 1 A = A.
 Proof. by apply/matrixP=> i j; rewrite mxE perm1. Qed.
@@ -408,7 +408,7 @@ Proof. by apply/matrixP=> i j; rewrite !mxE permM. Qed.
 
 Lemma col_row_permC s t A :
   col_perm s (row_perm t A) = row_perm t (col_perm s A).
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 End FixedDim.
 
@@ -458,7 +458,7 @@ Lemma conform_castmx m1 n1 m2 n2 m3 n3
 Proof. by do [case: e_mn; case: m3 /; case: n3 /] in A *. Qed.
 
 Lemma trmxK m n : cancel (@trmx m n) (@trmx n m).
-Proof. by move=> A; apply/matrixP=> i j /!mxE. Qed.
+Proof. by move=> A; apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma trmx_inj m n : injective (@trmx m n).
 Proof. exact: can_inj (@trmxK m n). Qed.
@@ -470,10 +470,10 @@ by case: eq_mn => eq_m eq_n; apply/matrixP=> i j; rewrite !(mxE, castmxE).
 Qed.
 
 Lemma tr_row_perm m n s (A : 'M_(m, n)) : (row_perm s A)^T = col_perm s A^T.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_col_perm m n s (A : 'M_(m, n)) : (col_perm s A)^T = row_perm s A^T.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_xrow m n i1 i2 (A : 'M_(m, n)) : (xrow i1 i2 A)^T = xcol i1 i2 A^T.
 Proof. exact: tr_row_perm. Qed.
@@ -489,37 +489,37 @@ Proof. by apply/colP=> i; rewrite mxE [j]ord1. Qed.
 
 Lemma row_eq m1 m2 n i1 i2 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   row i1 A1 = row i2 A2 -> A1 i1 =1 A2 i2.
-Proof. by move/rowP=> eqA12 j; have /!mxE := eqA12 j. Qed.
+Proof. by move/rowP=> eqA12 j; have /[!mxE] := eqA12 j. Qed.
 
 Lemma col_eq m n1 n2 j1 j2 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   col j1 A1 = col j2 A2 -> A1^~ j1 =1 A2^~ j2.
-Proof. by move/colP=> eqA12 i; have /!mxE := eqA12 i. Qed.
+Proof. by move/colP=> eqA12 i; have /[!mxE] := eqA12 i. Qed.
 
 Lemma row'_eq m n i0 (A B : 'M_(m, n)) :
   row' i0 A = row' i0 B -> {in predC1 i0, A =2 B}.
 Proof.
-move=> /matrixP eqAB' i /!inE /[rw eq_sym] /unlift_some[i' -> _ j].
-by have /!mxE := eqAB' i' j.
+move=> /matrixP eqAB' i /[!inE] /[1 eq_sym] /unlift_some[i' -> _ j].
+by have /[!mxE] := eqAB' i' j.
 Qed.
 
 Lemma col'_eq m n j0 (A B : 'M_(m, n)) :
   col' j0 A = col' j0 B -> forall i, {in predC1 j0, A i =1 B i}.
 Proof.
-move=> /matrixP eqAB' i j /!inE /[rw eq_sym] /unlift_some[j' -> _].
-by have /!mxE := eqAB' i j'.
+move=> /matrixP eqAB' i j /[!inE] /[1 eq_sym] /unlift_some[j' -> _].
+by have /[!mxE] := eqAB' i j'.
 Qed.
 
 Lemma tr_row m n i0 (A : 'M_(m, n)) : (row i0 A)^T = col i0 A^T.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_row' m n i0 (A : 'M_(m, n)) : (row' i0 A)^T = col' i0 A^T.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_col m n j0 (A : 'M_(m, n)) : (col j0 A)^T = row j0 A^T.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_col' m n j0 (A : 'M_(m, n)) : (col' j0 A)^T = row' j0 A^T.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Ltac split_mxE := apply/matrixP=> i j; do ![rewrite mxE | case: split => ?].
 
@@ -573,7 +573,7 @@ Proof. by apply/matrixP=> i j; rewrite mxE row_mxEr. Qed.
 
 Lemma hsubmxK A : row_mx (lsubmx A) (rsubmx A) = A.
 Proof.
-apply/matrixP=> i j /!mxE.
+apply/matrixP=> i j /[!mxE].
 by case: splitP => k Dk //=; rewrite !mxE //=; congr (A _ _); apply: val_inj.
 Qed.
 
@@ -651,7 +651,7 @@ apply: (canRL (castmxKV _ _)); apply/matrixP=> i j.
 rewrite castmxE !mxE cast_ord_id; case: splitP => j1 /= def_j.
   have: (j < n1 + n2) && (j < n1) by rewrite def_j lshift_subproof /=.
   by move: def_j; do 2![case: splitP => // ? ->; rewrite ?mxE] => /ord_inj->.
-case: splitP def_j => j2 ->{j} def_j /!mxE.
+case: splitP def_j => j2 ->{j} def_j /[!mxE].
   have: ~~ (j2 < n1) by rewrite -leqNgt def_j leq_addr.
   have: j1 < n2 by rewrite -(ltn_add2l n1) -def_j.
   by move: def_j; do 2![case: splitP => // ? ->] => /addnI/val_inj->.
@@ -669,7 +669,7 @@ Definition col_mxAx := col_mxA. (* bypass Prenex Implicits. *)
 
 Lemma row_row_mx m n1 n2 i0 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   row i0 (row_mx A1 A2) = row_mx (row i0 A1) (row i0 A2).
-Proof. by apply/matrixP=> i j /!mxE; case: (split j) => j' /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]; case: (split j) => j' /[!mxE]. Qed.
 
 Lemma col_col_mx m1 m2 n j0 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   col j0 (col_mx A1 A2) = col_mx (col j0 A1) (col j0 A2).
@@ -677,7 +677,7 @@ Proof. by apply: trmx_inj; rewrite !(tr_col, tr_col_mx, row_row_mx). Qed.
 
 Lemma row'_row_mx m n1 n2 i0 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   row' i0 (row_mx A1 A2) = row_mx (row' i0 A1) (row' i0 A2).
-Proof. by apply/matrixP=> i j /!mxE; case: (split j) => j' /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]; case: (split j) => j' /[!mxE]. Qed.
 
 Lemma col'_col_mx m1 m2 n j0 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   col' j0 (col_mx A1 A2) = col_mx (col' j0 A1) (col' j0 A2).
@@ -685,19 +685,19 @@ Proof. by apply: trmx_inj; rewrite !(tr_col', tr_col_mx, row'_row_mx). Qed.
 
 Lemma colKl m n1 n2 j1 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   col (lshift n2 j1) (row_mx A1 A2) = col j1 A1.
-Proof. by apply/matrixP=> i j /!(row_mxEl, mxE). Qed.
+Proof. by apply/matrixP=> i j /[!(row_mxEl, mxE)]. Qed.
 
 Lemma colKr m n1 n2 j2 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   col (rshift n1 j2) (row_mx A1 A2) = col j2 A2.
-Proof. by apply/matrixP=> i j /!(row_mxEr, mxE). Qed.
+Proof. by apply/matrixP=> i j /[!(row_mxEr, mxE)]. Qed.
 
 Lemma rowKu m1 m2 n i1 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   row (lshift m2 i1) (col_mx A1 A2) = row i1 A1.
-Proof. by apply/matrixP=> i j /!(col_mxEu, mxE). Qed.
+Proof. by apply/matrixP=> i j /[!(col_mxEu, mxE)]. Qed.
 
 Lemma rowKd m1 m2 n i2 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   row (rshift m1 i2) (col_mx A1 A2) = row i2 A2.
-Proof. by apply/matrixP=> i j /!(col_mxEd, mxE). Qed.
+Proof. by apply/matrixP=> i j /[!(col_mxEd, mxE)]. Qed.
 
 Lemma col'Kl m n1 n2 j1 (A1 : 'M_(m, n1.+1)) (A2 : 'M_(m, n2)) :
   col' (lshift n2 j1) (row_mx A1 A2) = row_mx (col' j1 A1) A2.
@@ -809,16 +809,16 @@ Variables m1 m2 n1 n2 : nat.
 Variable A : 'M[R]_(m1 + m2, n1 + n2).
 
 Lemma trmx_ulsub : (ulsubmx A)^T = ulsubmx A^T.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma trmx_ursub : (ursubmx A)^T = dlsubmx A^T.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma trmx_dlsub : (dlsubmx A)^T = ursubmx A^T.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma trmx_drsub : (drsubmx A)^T = drsubmx A^T.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 End TrCutBlock.
 
@@ -935,34 +935,34 @@ Section OneMatrix.
 Variables (m n : nat) (A : 'M[aT]_(m, n)).
 
 Lemma map_trmx : A^f^T = A^T^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_const_mx a : (const_mx a)^f = const_mx (f a) :> 'M_(m, n).
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_row i : (row i A)^f = row i A^f.
-Proof. by apply/rowP=> j /!mxE. Qed.
+Proof. by apply/rowP=> j /[!mxE]. Qed.
 
 Lemma map_col j : (col j A)^f = col j A^f.
-Proof. by apply/colP=> i /!mxE. Qed.
+Proof. by apply/colP=> i /[!mxE]. Qed.
 
 Lemma map_row' i0 : (row' i0 A)^f = row' i0 A^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_col' j0 : (col' j0 A)^f = col' j0 A^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_row_perm s : (row_perm s A)^f = row_perm s A^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_col_perm s : (col_perm s A)^f = col_perm s A^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_xrow i1 i2 : (xrow i1 i2 A)^f = xrow i1 i2 A^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_xcol j1 j2 : (xcol j1 j2 A)^f = xcol j1 j2 A^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_castmx m' n' c : (castmx c A)^f = castmx c A^f :> 'M_(m', n').
 Proof. by apply/matrixP=> i j; rewrite !(castmxE, mxE). Qed.
@@ -979,7 +979,7 @@ Lemma map_mxvec : (mxvec A)^f = mxvec A^f.
 Proof. by apply/rowP=> i; rewrite !(castmxE, mxE). Qed.
 
 Lemma map_vec_mx (v : 'rV_(m * n)) : (vec_mx v)^f = vec_mx v^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 End OneMatrix.
 
@@ -1002,28 +1002,28 @@ Lemma map_block_mx :
 Proof. by apply/matrixP=> i j; do 3![rewrite !mxE //; case: split => ?]. Qed.
 
 Lemma map_lsubmx : (lsubmx Bh)^f = lsubmx Bh^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_rsubmx : (rsubmx Bh)^f = rsubmx Bh^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_usubmx : (usubmx Bv)^f = usubmx Bv^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_dsubmx : (dsubmx Bv)^f = dsubmx Bv^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_ulsubmx : (ulsubmx B)^f = ulsubmx B^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_ursubmx : (ursubmx B)^f = ursubmx B^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_dlsubmx : (dlsubmx B)^f = dlsubmx B^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_drsubmx : (drsubmx B)^f = drsubmx B^f.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 End Block.
 
@@ -1076,7 +1076,7 @@ Lemma summxE I r (P : pred I) (E : I -> 'M_(m, n)) i j :
 Proof. by apply: (big_morph (fun A => A i j)) => [A B|]; rewrite mxE. Qed.
 
 Lemma const_mx_is_additive : additive const_mx.
-Proof. by move=> a b; apply/matrixP=> i j /!mxE. Qed.
+Proof. by move=> a b; apply/matrixP=> i j /[!mxE]. Qed.
 Canonical const_mx_additive := Additive const_mx_is_additive.
 
 End FixedDim.
@@ -1089,7 +1089,7 @@ Definition swizzle_mx k (A : 'M[V]_(m, n)) :=
   \matrix[k]_(i, j) A (f i j) (g i j).
 
 Lemma swizzle_mx_is_additive k : additive (swizzle_mx k).
-Proof. by move=> A B; apply/matrixP=> i j /!mxE. Qed.
+Proof. by move=> A B; apply/matrixP=> i j /[!mxE]. Qed.
 Canonical swizzle_mx_additive k := Additive (swizzle_mx_is_additive k).
 
 End Additive.
@@ -1278,7 +1278,7 @@ Canonical matrix_lmodType :=
   Eval hnf in LmodType R 'M[R]_(m, n) matrix_lmodMixin.
 
 Lemma scalemx_const a b : a *: const_mx b = const_mx (a * b).
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma matrix_sum_delta A :
   A = \sum_(i < m) \sum_(j < n) A i j *: delta_mx i j.
@@ -1296,7 +1296,7 @@ Section StructuralLinear.
 
 Lemma swizzle_mx_is_scalable m n p q f g k :
   scalable (@swizzle_mx R m n p q f g k).
-Proof. by move=> a A; apply/matrixP=> i j /!mxE. Qed.
+Proof. by move=> a A; apply/matrixP=> i j /[!mxE]. Qed.
 Canonical swizzle_mx_scalable m n p q f g k :=
   AddLinear (@swizzle_mx_is_scalable m n p q f g k).
 
@@ -1388,7 +1388,7 @@ Definition diag_mx n (d : 'rV[R]_n) :=
   \matrix[diag_mx_key]_(i, j) (d 0 i *+ (i == j)).
 
 Lemma tr_diag_mx n (d : 'rV_n) : (diag_mx d)^T = diag_mx d.
-Proof. by apply/matrixP=> i j /!mxE; case: eqVneq => // ->. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]; case: eqVneq => // ->. Qed.
 
 Lemma diag_mx_is_linear n : linear (@diag_mx n).
 Proof.
@@ -1416,7 +1416,7 @@ Definition scalar_mx x : 'M[R]_n :=
 Notation "x %:M" := (scalar_mx x) : ring_scope.
 
 Lemma diag_const_mx a : diag_mx (const_mx a) = a%:M :> 'M_n.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_scalar_mx a : (a%:M)^T = a%:M.
 Proof. by apply/matrixP=> i j; rewrite !mxE eq_sym. Qed.
@@ -1485,7 +1485,7 @@ Local Notation "A *m B" := (mulmx A B) : ring_scope.
 Lemma mulmxA m n p q (A : 'M_(m, n)) (B : 'M_(n, p)) (C : 'M_(p, q)) :
   A *m (B *m C) = A *m B *m C.
 Proof.
-apply/matrixP=> i l /!mxE.
+apply/matrixP=> i l /[!mxE].
 transitivity (\sum_j (\sum_k (A i j * (B j k * C k l)))).
   by apply: eq_bigr => j _; rewrite mxE big_distrr.
 rewrite exchange_big; apply: eq_bigr => j _; rewrite mxE big_distrl /=.
@@ -1569,7 +1569,7 @@ Proof. by rewrite !rowE mulmxA. Qed.
 Lemma mulmx_sum_row m n (u : 'rV_m) (A : 'M_(m, n)) :
   u *m A = \sum_i u 0 i *: row i A.
 Proof.
-by apply/rowP=> j; rewrite mxE summxE; apply: eq_bigr => i _ /!mxE.
+by apply/rowP=> j; rewrite mxE summxE; apply: eq_bigr => i _ /[!mxE].
 Qed.
 
 Lemma mul_delta_mx_cond m n p (j1 j2 : 'I_n) (i1 : 'I_m) (k2 : 'I_p) :
@@ -1608,7 +1608,7 @@ Proof. by apply/matrixP=> i j; rewrite mul_diag_mx !mxE mulrnAr. Qed.
 
 Lemma mul_scalar_mx m n a (A : 'M_(m, n)) : a%:M *m A = a *: A.
 Proof.
-by rewrite -diag_const_mx mul_diag_mx; apply/matrixP=> i j /!mxE.
+by rewrite -diag_const_mx mul_diag_mx; apply/matrixP=> i j /[!mxE].
 Qed.
 
 Lemma scalar_mxM n a b : (a * b)%:M = a%:M *m b%:M :> 'M_n.
@@ -1740,7 +1740,7 @@ by rewrite eqn_leq andbC leqNgt lshift_subproof.
 Qed.
 
 Lemma tr_pid_mx m n r : (pid_mx r)^T = pid_mx r :> 'M_(n, m).
-Proof. by apply/matrixP=> i j /!mxE; case: eqVneq => // ->. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]; case: eqVneq => // ->. Qed.
 
 Lemma pid_mx_minv m n r : pid_mx (minn m r) = pid_mx r :> 'M_(m, n).
 Proof. by apply/matrixP=> i j; rewrite !mxE leq_min ltn_ord. Qed.
@@ -1784,14 +1784,14 @@ Qed.
 Lemma mul_mx_row m n p1 p2 (A : 'M_(m, n)) (Bl : 'M_(n, p1)) (Br : 'M_(n, p2)) :
   A *m row_mx Bl Br = row_mx (A *m Bl) (A *m Br).
 Proof.
-apply/matrixP=> i k /!mxE.
+apply/matrixP=> i k /[!mxE].
 by case defk: (split k); rewrite mxE; apply: eq_bigr => j _; rewrite mxE defk.
 Qed.
 
 Lemma mul_col_mx m1 m2 n p (Au : 'M_(m1, n)) (Ad : 'M_(m2, n)) (B : 'M_(n, p)) :
   col_mx Au Ad *m B = col_mx (Au *m B) (Ad *m B).
 Proof.
-apply/matrixP=> i k /!mxE.
+apply/matrixP=> i k /[!mxE].
 by case defi: (split i); rewrite mxE; apply: eq_bigr => j _; rewrite mxE defi.
 Qed.
 
@@ -2063,7 +2063,7 @@ Notation "'\adj' A" := (adjugate A) : ring_scope.
 Lemma trmx_mul_rev (R : ringType) m n p (A : 'M[R]_(m, n)) (B : 'M[R]_(n, p)) :
   (A *m B)^T = (B : 'M[R^c]_(n, p))^T *m (A : 'M[R^c]_(m, n))^T.
 Proof.
-by apply/matrixP=> k i /!mxE; apply: eq_bigr => j _ /!mxE.
+by apply/matrixP=> k i /[!mxE]; apply: eq_bigr => j _ /[!mxE].
 Qed.
 
 Canonical matrix_countZmodType (M : countZmodType) m n :=
@@ -2172,7 +2172,7 @@ Implicit Type B : 'M[R]_(n, p).
 
 Lemma trmx_mul A B : (A *m B)^T = B^T *m A^T.
 Proof.
-rewrite trmx_mul_rev; apply/matrixP=> k i /!mxE.
+rewrite trmx_mul_rev; apply/matrixP=> k i /[!mxE].
 by apply: eq_bigr => j _; rewrite mulrC.
 Qed.
 
@@ -2366,7 +2366,7 @@ rewrite /(\det _) (bigD1 1%g) //= addrC big1 => [|p p1].
 have{p1}: ~~ perm_on set0 p.
   apply: contra p1; move/subsetP=> p1; apply/eqP; apply/permP=> i.
   by rewrite perm1; apply/eqP; apply/idPn; move/p1; rewrite inE.
-case/subsetPn=> i /!inE /[rw eq_sym] /negbTE=> p_i _.
+case/subsetPn=> i /[!inE] /[1 eq_sym] /negbTE=> p_i _.
 by rewrite (bigD1 i) //= mulrCA mxE p_i mul0r.
 Qed.
 
@@ -2414,7 +2414,7 @@ Lemma cofactor_tr n (A : 'M[R]_n) i j : cofactor A^T i j = cofactor A j i.
 Proof.
 rewrite /cofactor addnC; congr (_ * _).
 rewrite -tr_row' -tr_col' det_tr; congr (\det _).
-by apply/matrixP=> ? ? /!mxE.
+by apply/matrixP=> ? ? /[!mxE].
 Qed.
 
 Lemma cofactorZ n a (A : 'M[R]_n) i j : 
@@ -2437,7 +2437,7 @@ Proof. by apply/matrixP=> i j; rewrite !mxE cofactorZ. Qed.
 (* Cramer Rule : adjugate on the left *)
 Lemma mul_mx_adj n (A : 'M[R]_n) : A *m \adj A = (\det A)%:M.
 Proof.
-apply/matrixP=> i1 i2 /!mxE; case Di: (i1 == i2).
+apply/matrixP=> i1 i2 /[!mxE]; case Di: (i1 == i2).
   rewrite (eqP Di) (expand_det_row _ i2) //=.
   by apply: eq_bigr => j _; congr (_ * _); rewrite mxE.
 pose B := \matrix_(i, j) (if i == i2 then A i1 j else A i j).
@@ -2469,7 +2469,7 @@ Qed.
 Lemma mulmx1_min m n (A : 'M[R]_(m, n)) B : A *m B = 1%:M -> m <= n.
 Proof.
 move=> AB1; rewrite leqNgt; apply/negP=> /subnKC; rewrite addSnnS.
-move: (_ - _)%N => m' def_m; move: AB1; rewrite -{m}def_m in A B *.
+move: (_ - _)%N => m' /[<-]; move: AB1.
 rewrite -(vsubmxK A) -(hsubmxK B) mul_col_row scalar_mx_block.
 case/eq_block_mx=> /mulmx1C BlAu1 AuBr0 _ => /eqP/idPn[].
 by rewrite -[_ B]mul1mx -BlAu1 -mulmxA AuBr0 !mulmx0 eq_sym oner_neq0.
@@ -2749,7 +2749,7 @@ have [{detA0}A'0 | nzA'] := eqVneq (row 0 (\adj A)) 0; last first.
   by rewrite mul_mx_scalar scale0r.
 pose A' := col' 0 A; pose vA := col 0 A.
 have defA: A = row_mx vA A'.
-  apply/matrixP=> i j /!mxE.
+  apply/matrixP=> i j /[!mxE].
   case: splitP => j' def_j; rewrite mxE; congr (A i _); apply: val_inj => //=.
   by rewrite def_j [j']ord1.
 have{IHn} w_ j : exists w : 'rV_n.+1, [/\ w != 0, w 0 j = 0 & w *m A' = 0].
@@ -2791,7 +2791,7 @@ Local Notation "A ^f" := (map_mx f A) : ring_scope.
 Lemma map_mx_inj {m n} : injective (map_mx f : 'M_(m, n) -> 'M_(m, n)).
 Proof.
 move=> A B eq_AB; apply/matrixP=> i j.
-by move: eq_AB => /matrixP/(_ i j)/!mxE; apply: fmorph_inj.
+by move: eq_AB => /matrixP/(_ i j)/[!mxE]; apply: fmorph_inj.
 Qed.
 
 Lemma map_mx_is_scalar n (A : 'M_n) : is_scalar_mx A^f = is_scalar_mx A.

--- a/mathcomp/algebra/mxalgebra.v
+++ b/mathcomp/algebra/mxalgebra.v
@@ -2435,7 +2435,7 @@ apply: (iffP andP) => [[nzR] | [e [nz_e Re ideR idRe]]].
   - by rewrite -{2}[A]mxvecK defA idRe mulmxA mx_rV_lin -defA /= mxvecK.
   by rewrite -{2}[A]mxvecK defA ideR mulmxA mx_rV_lin -defA /= mxvecK.
 split.
-  by apply: contraNneq nz_e => R0; rewrite R0 eqmx0 in Re; rewrite (memmx0 Re).
+   by apply: contraNneq nz_e => /[->]; move: Re => /[1eqmx0]/memmx0->.
 apply/submxP; exists (mxvec e); rewrite !mul_mx_row !{1}mul_rV_lin1.
 rewrite submxE in Re; rewrite {Re}(eqP Re).
 congr (row_mx 0 (row_mx (mxvec _) (mxvec _))); apply/row_matrixP=> i.

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -157,7 +157,7 @@ exists (u _ (lshift dp), u _ ((rshift dq) _)).
   apply/bigmax_leqP=> i _.
   have ->: cofactor Ss (s i) j0 = (cofactor S (s i) j0)%:P.
     rewrite rmorphM rmorph_sign -det_map_mx; congr (_ * \det _).
-    by apply/matrixP=> i' j'; rewrite !mxE.
+    by apply/matrixP=> i' j' /!mxE.
   apply: leq_trans (size_mul_leq _ _) (leq_trans _ (valP i)).
   by rewrite size_polyC size_polyXn addnS /= -add1n leq_add2r leq_b1.
 transitivity (\det Ss); last first.
@@ -803,7 +803,7 @@ have tensorM E n1 n2 X Y: finM E (memM (memM E n2 Y) n1 X).
     by case/mxvec_indexP=> i j; rewrite mxvecE mxE; apply: Ea.
   rewrite -[mxvec _]trmxK -trmx_mul mxvec_dotmul -mulmxA trmx_mul !mxE.
   apply: eq_bigr => i _; rewrite Da1 !mxE; congr (_ * _).
-  by apply: eq_bigr => j _; rewrite !mxE.
+  by apply: eq_bigr => j _ /!mxE.
 suffices [m [X [[u [_ Du]] idealM]]]: exists m,
   exists X, let M := memM memR m X in M 1 /\ forall y, M y -> M (q.[w] * y).
 - do [set M := memM _ m X; move: q.[w] => z] in idealM *.
@@ -1053,7 +1053,7 @@ Definition eval_mx (e : seq F) := @map_mx term F (eval e).
 Definition mx_term := @map_mx F term GRing.Const.
 
 Lemma eval_mx_term e m n (A : 'M_(m, n)) : eval_mx e (mx_term A) = A.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Definition mulmx_term m n p (A : 'M[term]_(m, n)) (B : 'M_(n, p)) :=
   \matrix_(i, k) (\big[Add/0]_j (A i j * B j k))%T.
@@ -1098,7 +1098,7 @@ Qed.
 
 Lemma eval_vec_mx e m n (u : 'rV_(m * n)) :
   eval_mx e (vec_mx u) = vec_mx (eval_mx e u).
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /!mxE. Qed.
 
 Lemma eval_mxvec e m n (A : 'M_(m, n)) :
   eval_mx e (mxvec A) = mxvec (eval_mx e A).

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -157,7 +157,7 @@ exists (u _ (lshift dp), u _ ((rshift dq) _)).
   apply/bigmax_leqP=> i _.
   have ->: cofactor Ss (s i) j0 = (cofactor S (s i) j0)%:P.
     rewrite rmorphM rmorph_sign -det_map_mx; congr (_ * \det _).
-    by apply/matrixP=> i' j' /!mxE.
+    by apply/matrixP=> i' j' /[!mxE].
   apply: leq_trans (size_mul_leq _ _) (leq_trans _ (valP i)).
   by rewrite size_polyC size_polyXn addnS /= -add1n leq_add2r leq_b1.
 transitivity (\det Ss); last first.
@@ -803,7 +803,7 @@ have tensorM E n1 n2 X Y: finM E (memM (memM E n2 Y) n1 X).
     by case/mxvec_indexP=> i j; rewrite mxvecE mxE; apply: Ea.
   rewrite -[mxvec _]trmxK -trmx_mul mxvec_dotmul -mulmxA trmx_mul !mxE.
   apply: eq_bigr => i _; rewrite Da1 !mxE; congr (_ * _).
-  by apply: eq_bigr => j _ /!mxE.
+  by apply: eq_bigr => j _ /[!mxE].
 suffices [m [X [[u [_ Du]] idealM]]]: exists m,
   exists X, let M := memM memR m X in M 1 /\ forall y, M y -> M (q.[w] * y).
 - do [set M := memM _ m X; move: q.[w] => z] in idealM *.
@@ -1053,7 +1053,7 @@ Definition eval_mx (e : seq F) := @map_mx term F (eval e).
 Definition mx_term := @map_mx F term GRing.Const.
 
 Lemma eval_mx_term e m n (A : 'M_(m, n)) : eval_mx e (mx_term A) = A.
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Definition mulmx_term m n p (A : 'M[term]_(m, n)) (B : 'M_(n, p)) :=
   \matrix_(i, k) (\big[Add/0]_j (A i j * B j k))%T.
@@ -1098,7 +1098,7 @@ Qed.
 
 Lemma eval_vec_mx e m n (u : 'rV_(m * n)) :
   eval_mx e (vec_mx u) = vec_mx (eval_mx e u).
-Proof. by apply/matrixP=> i j /!mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma eval_mxvec e m n (A : 'M_(m, n)) :
   eval_mx e (mxvec A) = mxvec (eval_mx e A).

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -2465,7 +2465,7 @@ Qed.
 Theorem max_ring_poly_roots p rs :
   p != 0 -> all (root p) rs -> uniq_roots rs -> size rs < size p.
 Proof.
-move=> nz_p _ /(@uniq_roots_prod_XsubC p)[// | q def_p]; rewrite def_p in nz_p *.
+move=> nz_p _ /(@uniq_roots_prod_XsubC p)[// | q /[->]].
 have nz_q: q != 0 by apply: contraNneq nz_p => ->; rewrite mul0r.
 rewrite size_Mmonic ?monic_prod_XsubC // (polySpred nz_q) addSn /=.
 by rewrite size_prod_XsubC leq_addl.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -1683,13 +1683,13 @@ move=> xR /(real_leVge xR); have [le_xy _|Nle_xy /= le_yx] := boolP (_ <= _).
   by rewrite ler0_norm ?ger0_norm ?subr_cp0 ?opprB //; constructor.
 have [lt_yx|] := boolP (_ < _).
   by rewrite ger0_norm ?ler0_norm ?subr_cp0 ?opprB //; constructor.
-by rewrite ltr_def le_yx andbT negbK=> /eqP exy; rewrite exy lerr in Nle_xy.
+by rewrite ltr_def le_yx andbT negbK=> /eqP/[->]; rewrite lerr in Nle_xy.
 Qed.
 
 Lemma real_ltrP x y :
     x \is real -> y \is real ->
   ltr_xor_ge x y `|x - y| `|y - x| (y <= x) (x < y).
-Proof. by move=> xR yR; case: real_lerP=> //; constructor. Qed.
+Proof. by move=> xR yR; case: real_lerP => //; constructor. Qed.
 
 Lemma real_ltrNge : {in real &, forall x y, (x < y) = ~~ (y <= x)}.
 Proof. by move=> x y xR yR /=; case: real_lerP. Qed.
@@ -4392,7 +4392,7 @@ exists r`_0 => [|z n_gt0 /(mem_rP z n_gt0) r_z].
   have sz_r: size r = n by apply: succn_inj; rewrite -sz_p Dp size_prod_XsubC.
   case: posnP => [n0 | n_gt0]; first by rewrite nth_default // sz_r n0.
   by apply/mem_rP=> //; rewrite mem_nth ?sz_r.
-case: {Dp mem_rP}r r_z r_arg => // y r1 /1inE /predU1P[-> _|r1z].
+case: {Dp mem_rP}r r_z r_arg => // y r1 /[1inE] /predU1P[-> _|r1z].
   by apply/implyP=> ->; rewrite lerr.
 by move/(order_path_min argCle_trans)/allP->.
 Qed.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -1633,7 +1633,7 @@ Hint Resolve real1 : core.
 Lemma realn n : n%:R \is @real R. Proof. by rewrite ger0_real. Qed.
 
 Lemma ler_leVge x y : x <= 0 -> y <= 0 -> (x <= y) || (y <= x).
-Proof. by rewrite -!oppr_ge0 => /(ger_leVge _) h /h; rewrite !ler_opp2. Qed.
+Proof. by rewrite -!oppr_ge0 => /(ger_leVge _) /apply; rewrite !ler_opp2. Qed.
 
 Lemma real_leVge x y : x \is real -> y \is real -> (x <= y) || (y <= x).
 Proof.
@@ -4392,7 +4392,7 @@ exists r`_0 => [|z n_gt0 /(mem_rP z n_gt0) r_z].
   have sz_r: size r = n by apply: succn_inj; rewrite -sz_p Dp size_prod_XsubC.
   case: posnP => [n0 | n_gt0]; first by rewrite nth_default // sz_r n0.
   by apply/mem_rP=> //; rewrite mem_nth ?sz_r.
-case: {Dp mem_rP}r r_z r_arg => // y r1; rewrite inE => /predU1P[-> _|r1z].
+case: {Dp mem_rP}r r_z r_arg => // y r1 /1inE /predU1P[-> _|r1z].
   by apply/implyP=> ->; rewrite lerr.
 by move/(order_path_min argCle_trans)/allP->.
 Qed.

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -97,7 +97,7 @@ Lemma trow0 n1 m2 n2 B : @trow n1 0 m2 n2 B = 0.
 Proof.
 elim: n1=> //= n1 IH.
 rewrite !mxE scale0r linear0.
-rewrite IH //; apply/matrixP=> i j /!mxE.
+rewrite IH //; apply/matrixP=> i j /[!mxE].
 by case: split=> *; rewrite mxE.
 Qed.
 
@@ -124,7 +124,7 @@ Lemma trow_is_linear n1 m2 n2 (A : 'rV_n1) : linear (@trow n1 A m2 n2).
 Proof.
 elim: n1 A => [|n1 IH] //= A k A1 A2 /=; first by rewrite scaler0 add0r.
 rewrite linearD /= linearZ /=.
-apply/matrixP=> i j /!mxE.
+apply/matrixP=> i j /[!mxE].
 by case: split=> a; rewrite ?IH !mxE.
 Qed.
 
@@ -145,14 +145,14 @@ Fixpoint tprod  (m1 : nat) :
 Lemma dsumx_mul m1 m2 n p A B :
   dsubmx ((A *m B) : 'M[F]_(m1 + m2, n)) = dsubmx (A : 'M_(m1 + m2, p)) *m B.
 Proof.
-apply/matrixP=> i j /!mxE; apply: eq_bigr=> k _.
+apply/matrixP=> i j /[!mxE]; apply: eq_bigr=> k _.
 by rewrite !mxE.
 Qed.
 
 Lemma usumx_mul m1 m2 n p A B :
   usubmx ((A *m B) : 'M[F]_(m1 + m2, n)) = usubmx (A : 'M_(m1 + m2, p)) *m B.
 Proof.
-by apply/matrixP=> i j /!mxE; apply: eq_bigr=> k _ /!mxE.
+by apply/matrixP=> i j /[!mxE]; apply: eq_bigr=> k _ /[!mxE].
 Qed.
 
 Let trow_mul (m1 m2 n2 p2 : nat) 
@@ -196,11 +196,11 @@ elim: m1 n1 A m2 n2 B=> [|m1 IH] n1 A m2 n2 B //=.
 rewrite !IH.
 pose A1 := A :  'M_(1 + m1, 1 + n1).
 have F1: dsubmx (rsubmx A1) = rsubmx (dsubmx A1).
-  by apply/matrixP=> i j /!mxE.
+  by apply/matrixP=> i j /[!mxE].
 have F2: rsubmx (usubmx A1) = usubmx (rsubmx A1).
-  by apply/matrixP=> i j /!mxE.
+  by apply/matrixP=> i j /[!mxE].
 have F3: lsubmx (dsubmx A1) = dsubmx (lsubmx A1).
-  by apply/matrixP=> i j /!mxE.
+  by apply/matrixP=> i j /[!mxE].
 rewrite tr_row_mx -block_mxEv -block_mxEh !(F1,F2,F3); congr block_mx.
 - by rewrite !mxE linearZ /= trmxK.
 by rewrite -trmx_dsub.
@@ -211,13 +211,13 @@ Proof.
 elim: m n => [|m IH] n //=; first by rewrite [1%:M]flatmx0.
 rewrite tprod_tr.
 set u := rsubmx _; have->: u = 0.
-  apply/matrixP=> i j /!mxE.
+  apply/matrixP=> i j /[!mxE].
   by case: i; case: j=> /= j Hj; case.
 set v := lsubmx (dsubmx _); have->: v = 0.
-  apply/matrixP=> i j /!mxE.
+  apply/matrixP=> i j /[!mxE].
   by case: i; case: j; case.
 set w := rsubmx _; have->: w = 1%:M.
-  apply/matrixP=> i j /!mxE.
+  apply/matrixP=> i j /[!mxE].
   by case: i; case: j; case.
 rewrite IH -!trowbE !linear0.
 rewrite -block_mxEv.
@@ -232,8 +232,7 @@ Proof.
 elim: m n A B => [|m IH] n A B //=.
   by rewrite [A]flatmx0 mxtrace0 mul0r.
 rewrite tprod_tr -block_mxEv mxtrace_block IH.
-rewrite linearZ /= -mulrDl; congr (_ * _).
-rewrite -trace_mx11 .
+rewrite linearZ /= -mulrDl; congr (_ * _); rewrite -trace_mx11.
 pose A1 := A : 'M_(1 + m).
 rewrite -{3}[A](@submxK _ 1 m 1 m A1).
 by rewrite (@mxtrace_block _ _ _ (ulsubmx A1)).
@@ -277,8 +276,7 @@ Lemma mx_rsim_dadd  (U V W : 'M_n) (rU rV : representation)
 Proof.
 case: rU; case: rV=> nV rV nU rU defW dxUV /=.
 have tiUV := mxdirect_addsP dxUV.
-move=> [fU def_nU]; rewrite -{nU}def_nU in rU fU * => inv_fU hom_fU.
-move=> [fV def_nV]; rewrite -{nV}def_nV in rV fV * => inv_fV hom_fV.
+move=> [fU /[<-]] inv_fU hom_fU [fV /[<-]] inv_fV hom_fV.
 pose pU := in_submod U (proj_mx U V) *m fU.
 pose pV := in_submod V (proj_mx V U) *m fV.
 exists (val_submod 1%:M *m row_mx pU pV) => [||g Gg].
@@ -985,7 +983,7 @@ Proof. by rewrite qualifE cfun1_char /= cfun11. Qed.
 Lemma lin_charM : {in G &, {morph xi : x y / (x * y)%g >-> x * y}}.
 Proof.
 move=> x y Gx Gy; case/andP: CFxi => /char_reprP[[n rG] -> /=].
-rewrite cfRepr1 pnatr_eq1 => /eqP n1; rewrite {n}n1 in rG *.
+rewrite cfRepr1 pnatr_eq1 => /eqP /[->].
 rewrite !cfunE Gx Gy groupM //= !mulr1n repr_mxM //.
 by rewrite [rG x]mx11_scalar [rG y]mx11_scalar -scalar_mxM !mxtrace_scalar.
 Qed.
@@ -1324,7 +1322,7 @@ symmetry; transitivity (\tr Qa).
   rewrite reindex_irr_class; apply: eq_bigr => i _; rewrite !mxE invgK permE.
   by rewrite inE sub1set inE -(can_eq cK) iCK //; case: ifP.
 rewrite -[Pa](mulmxK uX) -[Qa](mulKmx uX) mxtrace_mulC; congr (\tr(_ *m _)).
-rewrite -row_permE -col_permE; apply/matrixP=> i j /!mxE.
+rewrite -row_permE -col_permE; apply/matrixP=> i j /[!mxE].
 rewrite -{2}[j](permKV qa); move: {j}(_ j) => j; rewrite !permE iCK //.
 apply: stabAchi; first by case/repr_classesP: (cP j).
 by rewrite repr_irr_classK (mem_repr_classes (Gca _)).
@@ -2756,7 +2754,7 @@ Lemma cfker_center_normal phi : cfker phi <| 'Z(phi)%CF.
 Proof.
 apply: normalS (cfcenter_sub phi) (cfker_normal phi).
 rewrite /= /cfcenter; case: ifP => // Hphi; rewrite cfkerEchar //.
-apply/subsetP=> x /!inE /andP[-> /eqP->] /=.
+apply/subsetP=> x /[!inE] /andP[-> /eqP->] /=.
 by rewrite ger0_norm ?char1_ge0.
 Qed.
 

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -97,7 +97,7 @@ Lemma trow0 n1 m2 n2 B : @trow n1 0 m2 n2 B = 0.
 Proof.
 elim: n1=> //= n1 IH.
 rewrite !mxE scale0r linear0.
-rewrite IH //; apply/matrixP=> i j; rewrite !mxE.
+rewrite IH //; apply/matrixP=> i j /!mxE.
 by case: split=> *; rewrite mxE.
 Qed.
 
@@ -124,7 +124,7 @@ Lemma trow_is_linear n1 m2 n2 (A : 'rV_n1) : linear (@trow n1 A m2 n2).
 Proof.
 elim: n1 A => [|n1 IH] //= A k A1 A2 /=; first by rewrite scaler0 add0r.
 rewrite linearD /= linearZ /=.
-apply/matrixP=> i j; rewrite !mxE.
+apply/matrixP=> i j /!mxE.
 by case: split=> a; rewrite ?IH !mxE.
 Qed.
 
@@ -145,14 +145,14 @@ Fixpoint tprod  (m1 : nat) :
 Lemma dsumx_mul m1 m2 n p A B :
   dsubmx ((A *m B) : 'M[F]_(m1 + m2, n)) = dsubmx (A : 'M_(m1 + m2, p)) *m B.
 Proof.
-apply/matrixP=> i j; rewrite !mxE; apply: eq_bigr=> k _.
+apply/matrixP=> i j /!mxE; apply: eq_bigr=> k _.
 by rewrite !mxE.
 Qed.
 
 Lemma usumx_mul m1 m2 n p A B :
   usubmx ((A *m B) : 'M[F]_(m1 + m2, n)) = usubmx (A : 'M_(m1 + m2, p)) *m B.
 Proof.
-by apply/matrixP=> i j; rewrite !mxE; apply: eq_bigr=> k _; rewrite !mxE.
+by apply/matrixP=> i j /!mxE; apply: eq_bigr=> k _ /!mxE.
 Qed.
 
 Let trow_mul (m1 m2 n2 p2 : nat) 
@@ -196,11 +196,11 @@ elim: m1 n1 A m2 n2 B=> [|m1 IH] n1 A m2 n2 B //=.
 rewrite !IH.
 pose A1 := A :  'M_(1 + m1, 1 + n1).
 have F1: dsubmx (rsubmx A1) = rsubmx (dsubmx A1).
-  by apply/matrixP=> i j; rewrite !mxE.
+  by apply/matrixP=> i j /!mxE.
 have F2: rsubmx (usubmx A1) = usubmx (rsubmx A1).
-  by apply/matrixP=> i j; rewrite !mxE.
+  by apply/matrixP=> i j /!mxE.
 have F3: lsubmx (dsubmx A1) = dsubmx (lsubmx A1).
-  by apply/matrixP=> i j; rewrite !mxE.
+  by apply/matrixP=> i j /!mxE.
 rewrite tr_row_mx -block_mxEv -block_mxEh !(F1,F2,F3); congr block_mx.
 - by rewrite !mxE linearZ /= trmxK.
 by rewrite -trmx_dsub.
@@ -211,13 +211,13 @@ Proof.
 elim: m n => [|m IH] n //=; first by rewrite [1%:M]flatmx0.
 rewrite tprod_tr.
 set u := rsubmx _; have->: u = 0.
-  apply/matrixP=> i j; rewrite !mxE.
+  apply/matrixP=> i j /!mxE.
   by case: i; case: j=> /= j Hj; case.
 set v := lsubmx (dsubmx _); have->: v = 0.
-  apply/matrixP=> i j; rewrite !mxE.
+  apply/matrixP=> i j /!mxE.
   by case: i; case: j; case.
 set w := rsubmx _; have->: w = 1%:M.
-  apply/matrixP=> i j; rewrite !mxE.
+  apply/matrixP=> i j /!mxE.
   by case: i; case: j; case.
 rewrite IH -!trowbE !linear0.
 rewrite -block_mxEv.
@@ -1324,7 +1324,7 @@ symmetry; transitivity (\tr Qa).
   rewrite reindex_irr_class; apply: eq_bigr => i _; rewrite !mxE invgK permE.
   by rewrite inE sub1set inE -(can_eq cK) iCK //; case: ifP.
 rewrite -[Pa](mulmxK uX) -[Qa](mulKmx uX) mxtrace_mulC; congr (\tr(_ *m _)).
-rewrite -row_permE -col_permE; apply/matrixP=> i j; rewrite !mxE.
+rewrite -row_permE -col_permE; apply/matrixP=> i j /!mxE.
 rewrite -{2}[j](permKV qa); move: {j}(_ j) => j; rewrite !permE iCK //.
 apply: stabAchi; first by case/repr_classesP: (cP j).
 by rewrite repr_irr_classK (mem_repr_classes (Gca _)).
@@ -2756,7 +2756,7 @@ Lemma cfker_center_normal phi : cfker phi <| 'Z(phi)%CF.
 Proof.
 apply: normalS (cfcenter_sub phi) (cfker_normal phi).
 rewrite /= /cfcenter; case: ifP => // Hphi; rewrite cfkerEchar //.
-apply/subsetP=> x; rewrite !inE => /andP[-> /eqP->] /=.
+apply/subsetP=> x /!inE /andP[-> /eqP->] /=.
 by rewrite ger0_norm ?char1_ge0.
 Qed.
 

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -1058,7 +1058,7 @@ pose Z := '[Y, V] / '[V] *: V; exists (X + Z).
   rewrite /Z -{4}(addKr U V) scalerDr scalerN addrA addrC span_cons.
   by rewrite memv_add ?memvB ?memvZ ?memv_line.
 exists (Y - Z); first by rewrite addrCA !addrA addrK addrC.
-apply/orthoPl=> psi /!inE /predU1P[-> | Spsi]; last first.
+apply/orthoPl=> psi /[!inE] /predU1P[-> | Spsi]; last first.
   by rewrite cfdotBl cfdotZl (orthoPl oVS _ Spsi) mulr0 subr0 (orthoPl oYS).
 rewrite cfdotBl !cfdotDr (span_orthogonal oYS) // ?memv_span ?mem_head //.
 rewrite !cfdotZl (span_orthogonal oVS _ S_U) ?mulr0 ?memv_span ?mem_head //.
@@ -1100,7 +1100,7 @@ have [opS | not_opS] := allP; last first.
 rewrite (contra (opS _)) /= ?cfnorm_eq0 //.
 apply: (iffP IH) => [] [uniqS oSS]; last first.
   by split=> //; apply: sub_in2 oSS => psi Spsi; apply: mem_behead.
-split=> // psi xi /!inE /predU1P[-> // | Spsi].
+split=> // psi xi /[!inE] /predU1P[-> // | Spsi].
   by case/predU1P=> [-> | /opS] /eqP.
 case/predU1P=> [-> _ | Sxi /oSS-> //].
 by apply/eqP; rewrite cfdotC conjC_eq0 [_ == 0]opS.
@@ -1141,7 +1141,7 @@ have /eqP: '[S`_i, 0]_G = 0 := cfdot0r _.
 rewrite -{2}aS0 raddf_sum /= (bigD1 i) //= big1 => [|j neq_ji]; last 1 first.
   by rewrite cfdotZr oSS ?mulr0 ?mem_nth // eq_sym nth_uniq.
 rewrite addr0 cfdotZr mulf_eq0 conjC_eq0 cfnorm_eq0.
-by case/pred2P=> // Si0; rewrite -Si0 S_i in notS0.
+by case/pred2P=> // /[->]; rewrite S_i in notS0.
 Qed.
 
 Lemma filter_pairwise_orthogonal S p :

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -1058,7 +1058,7 @@ pose Z := '[Y, V] / '[V] *: V; exists (X + Z).
   rewrite /Z -{4}(addKr U V) scalerDr scalerN addrA addrC span_cons.
   by rewrite memv_add ?memvB ?memvZ ?memv_line.
 exists (Y - Z); first by rewrite addrCA !addrA addrK addrC.
-apply/orthoPl=> psi; rewrite !inE => /predU1P[-> | Spsi]; last first.
+apply/orthoPl=> psi /!inE /predU1P[-> | Spsi]; last first.
   by rewrite cfdotBl cfdotZl (orthoPl oVS _ Spsi) mulr0 subr0 (orthoPl oYS).
 rewrite cfdotBl !cfdotDr (span_orthogonal oYS) // ?memv_span ?mem_head //.
 rewrite !cfdotZl (span_orthogonal oVS _ S_U) ?mulr0 ?memv_span ?mem_head //.
@@ -1100,7 +1100,7 @@ have [opS | not_opS] := allP; last first.
 rewrite (contra (opS _)) /= ?cfnorm_eq0 //.
 apply: (iffP IH) => [] [uniqS oSS]; last first.
   by split=> //; apply: sub_in2 oSS => psi Spsi; apply: mem_behead.
-split=> // psi xi; rewrite !inE => /predU1P[-> // | Spsi].
+split=> // psi xi /!inE /predU1P[-> // | Spsi].
   by case/predU1P=> [-> | /opS] /eqP.
 case/predU1P=> [-> _ | Sxi /oSS-> //].
 by apply/eqP; rewrite cfdotC conjC_eq0 [_ == 0]opS.

--- a/mathcomp/character/integral_char.v
+++ b/mathcomp/character/integral_char.v
@@ -117,7 +117,7 @@ have [w Gw Dg] := imsetP g1Gg; pose J2 (v : gT) xy := (xy.1 ^ v, xy.2 ^ v)%g.
 have J2inj: injective (J2 w).
   by apply: can_inj (J2 w^-1)%g _ => [[x y]]; rewrite /J2 /= !conjgK.
 rewrite -(card_imset _ J2inj) subset_leq_card //; apply/subsetP.
-move=> _ /imsetP[[x y] /setIdP[/andP[/= x1Gx y1Gy] Dxy1] ->] /!inE.
+move=> _ /imsetP[[x y] /setIdP[/andP[/= x1Gx y1Gy] Dxy1] ->] /[!inE]/=.
 rewrite !(class_sym _ (_ ^ _)) !classGidl // class_sym x1Gx class_sym y1Gy.
 by rewrite -conjMg (eqP Dxy1) /= -Dg.
 Qed.
@@ -395,7 +395,7 @@ apply: abelian_sol; have: (size (primes #|g ^: G|) <= 1)%N.
   rewrite -index_cent1 uniq_leq_size // => [/= | q].
     rewrite primes_uniq -p'natEpi ?(pnat_dvd _ p'GP) ?indexgS //.
     by rewrite subsetI sPG sub_cent1.
-  by move=> /1inE/predU1P[-> // |]; apply: pi_of_dvd; rewrite ?dvdn_indexg.
+  by move=> /[1inE]/predU1P[-> // |]; apply: pi_of_dvd; rewrite ?dvdn_indexg.
 rewrite leqNgt; apply: contraR => /primes_class_simple_gt1-> //.
 by rewrite !inE classG_eq1 nt_g mem_classes // (subsetP sPG).
 Qed.
@@ -477,7 +477,7 @@ rewrite -cardX card_in_image // => [] [y1 z1] [y2 z2] /=.
 move=> /andP[/=/imsetP[u1 Gu1 ->] Zz1] /andP[/=/imsetP[u2 Gu2 ->] Zz2] {y1 y2}.
 move=> eq12; have /eqP := congr1 'chi_i eq12.
 rewrite !(cfunJ, DchiZ) ?groupJ // (can_eq (mulKf nz_chi_x)).
-rewrite (inj_in_eq inj_lambda) // => /eqP eq_z12; rewrite eq_z12 in eq12 *.
+rewrite (inj_in_eq inj_lambda) // => /eqP /[->];
 by rewrite (mulIg _ _ _ eq12).
 Qed.
 

--- a/mathcomp/character/integral_char.v
+++ b/mathcomp/character/integral_char.v
@@ -117,7 +117,7 @@ have [w Gw Dg] := imsetP g1Gg; pose J2 (v : gT) xy := (xy.1 ^ v, xy.2 ^ v)%g.
 have J2inj: injective (J2 w).
   by apply: can_inj (J2 w^-1)%g _ => [[x y]]; rewrite /J2 /= !conjgK.
 rewrite -(card_imset _ J2inj) subset_leq_card //; apply/subsetP.
-move=> _ /imsetP[[x y] /setIdP[/andP[/= x1Gx y1Gy] Dxy1] ->]; rewrite !inE /=.
+move=> _ /imsetP[[x y] /setIdP[/andP[/= x1Gx y1Gy] Dxy1] ->] /!inE.
 rewrite !(class_sym _ (_ ^ _)) !classGidl // class_sym x1Gx class_sym y1Gy.
 by rewrite -conjMg (eqP Dxy1) /= -Dg.
 Qed.
@@ -395,7 +395,7 @@ apply: abelian_sol; have: (size (primes #|g ^: G|) <= 1)%N.
   rewrite -index_cent1 uniq_leq_size // => [/= | q].
     rewrite primes_uniq -p'natEpi ?(pnat_dvd _ p'GP) ?indexgS //.
     by rewrite subsetI sPG sub_cent1.
-  by rewrite inE => /predU1P[-> // |]; apply: pi_of_dvd; rewrite ?dvdn_indexg.
+  by move=> /1inE/predU1P[-> // |]; apply: pi_of_dvd; rewrite ?dvdn_indexg.
 rewrite leqNgt; apply: contraR => /primes_class_simple_gt1-> //.
 by rewrite !inE classG_eq1 nt_g mem_classes // (subsetP sPG).
 Qed.

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -638,7 +638,7 @@ Lemma rstab_abelem m (A : 'M_(m, n)) : rstab rG A = 'C_G(rV_E @* rowg A).
 Proof.
 apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
 apply/eqP/centP=> cAx => [_ /morphimP[u _ Au ->]|].
-  move: Au => /1inE /submxP[u' ->] {u}.
+  move: Au => /[1inE] /submxP[u' ->] {u}.
   by apply/esym/commgP/conjg_fixP; rewrite -rVabelemJ -?mulmxA ?cAx.
 apply/row_matrixP=> i; apply: rVabelem_inj.
 by rewrite row_mul rVabelemJ // /conjg -cAx ?mulKg ?mem_morphim // inE row_sub.
@@ -646,7 +646,7 @@ Qed.
 
 Lemma rstabs_abelem m (A : 'M_(m, n)) : rstabs rG A = 'N_G(rV_E @* rowg A).
 Proof.
-apply/setP=> x /!inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 by rewrite -rowgS -rVabelemS abelem_rowgJ.
 Qed.
 
@@ -699,7 +699,7 @@ Lemma rfix_abelem (H : {set gT}) :
 Proof.
 move/subsetP=> sHG; apply/eqmxP/andP; split.
   rewrite -rowgS rowg_mxK -sub_rVabelem_im // subsetI sub_rVabelem /=.
-  apply/centsP=> y /morphimP[v _] /1inE cGv ->{y} x Gx.
+  apply/centsP=> y /morphimP[v _] /[1inE] cGv ->{y} x Gx.
   by apply/commgP/conjg_fixP; rewrite /= -rVabelemJ ?sHG ?(rfix_mxP H _).
 rewrite genmxE; apply/rfix_mxP=> x Hx; apply/row_matrixP=> i.
 rewrite row_mul rowK; case/morphimP: (enum_valP i) => z Ez /setIP[_ cHz] ->.

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -638,7 +638,7 @@ Lemma rstab_abelem m (A : 'M_(m, n)) : rstab rG A = 'C_G(rV_E @* rowg A).
 Proof.
 apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
 apply/eqP/centP=> cAx => [_ /morphimP[u _ Au ->]|].
-  move: Au; rewrite inE => /submxP[u' ->] {u}.
+  move: Au => /1inE /submxP[u' ->] {u}.
   by apply/esym/commgP/conjg_fixP; rewrite -rVabelemJ -?mulmxA ?cAx.
 apply/row_matrixP=> i; apply: rVabelem_inj.
 by rewrite row_mul rVabelemJ // /conjg -cAx ?mulKg ?mem_morphim // inE row_sub.
@@ -646,7 +646,7 @@ Qed.
 
 Lemma rstabs_abelem m (A : 'M_(m, n)) : rstabs rG A = 'N_G(rV_E @* rowg A).
 Proof.
-apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
+apply/setP=> x /!inE; apply: andb_id2l => Gx.
 by rewrite -rowgS -rVabelemS abelem_rowgJ.
 Qed.
 
@@ -699,7 +699,7 @@ Lemma rfix_abelem (H : {set gT}) :
 Proof.
 move/subsetP=> sHG; apply/eqmxP/andP; split.
   rewrite -rowgS rowg_mxK -sub_rVabelem_im // subsetI sub_rVabelem /=.
-  apply/centsP=> y /morphimP[v _]; rewrite inE => cGv ->{y} x Gx.
+  apply/centsP=> y /morphimP[v _] /1inE cGv ->{y} x Gx.
   by apply/commgP/conjg_fixP; rewrite /= -rVabelemJ ?sHG ?(rfix_mxP H _).
 rewrite genmxE; apply/rfix_mxP=> x Hx; apply/row_matrixP=> i.
 rewrite row_mul rowK; case/morphimP: (enum_valP i) => z Ez /setIP[_ cHz] ->.

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -3012,7 +3012,7 @@ Qed.
 Lemma mx_rsim_sym n1 n2 (rG1 : reprG n1) (rG2 : reprG n2) :
   mx_rsim rG1 rG2 ->  mx_rsim rG2 rG1.
 Proof.
-case=> B def_n1; rewrite def_n1 in rG1 B *.
+case=> B /[->].
 rewrite row_free_unit => injB homB; exists (invmx B) => // [|x Gx].
   by rewrite row_free_unit unitmx_inv.
 by apply: canRL (mulKmx injB) _; rewrite mulmxA -homB ?mulmxK.
@@ -3032,7 +3032,7 @@ Lemma mx_rsim_def n1 n2 (rG1 : reprG n1) (rG2 : reprG n2) :
   exists B, exists2 B', B' *m B = 1%:M &
     forall x, x \in G -> rG1 x = B *m rG2 x *m B'.
 Proof.
-case=> B def_n1; rewrite def_n1 in rG1 B *; rewrite row_free_unit => injB homB.
+case=> B /[->]; rewrite row_free_unit => injB homB.
 by exists B, (invmx B) => [|x Gx]; rewrite ?mulVmx // -homB // mulmxK.
 Qed.
 
@@ -3066,7 +3066,7 @@ Qed.
 Lemma mx_rsim_irr n1 n2 (rG1 : reprG n1) (rG2 : reprG n2) :
   mx_rsim rG1 rG2 -> mx_irreducible rG1 -> mx_irreducible rG2.
 Proof.
-case/mx_rsim_sym=> f def_n2; rewrite {n2}def_n2 in f rG2 * => injf homf.
+case/mx_rsim_sym=> f /[->] injf homf.
 case/mx_irrP=> n1_gt0 minG; apply/mx_irrP; split=> // U modU nzU.
 rewrite /row_full -(mxrankMfree _ injf) -genmxE.
 apply: minG; last by rewrite -mxrank_eq0 genmxE mxrankMfree // mxrank_eq0.
@@ -3078,8 +3078,7 @@ Lemma mx_rsim_abs_irr n1 n2 (rG1 : reprG n1) (rG2 : reprG n2) :
     mx_rsim rG1 rG2 ->
   mx_absolutely_irreducible rG1 = mx_absolutely_irreducible rG2.
 Proof.
-case=> f def_n2; rewrite -{n2}def_n2 in f rG2 *.
-rewrite row_free_unit => injf homf; congr (_ && (_ == _)).
+case=> f /[<-]; rewrite row_free_unit => injf homf; congr (_ && (_ == _)).
 pose Eg (g : 'M[F]_n1) := lin_mx (mulmxr (invmx g) \o mulmx g).
 have free_Ef: row_free (Eg f).
   apply/row_freeP; exists (Eg (invmx f)); apply/row_matrixP=> i.
@@ -3093,8 +3092,7 @@ Qed.
 Lemma rker_mx_rsim n1 n2 (rG1 : reprG n1) (rG2 : reprG n2) :
   mx_rsim rG1 rG2 -> rker rG1 = rker rG2.
 Proof.
-case=> f def_n2; rewrite -{n2}def_n2 in f rG2 *.
-rewrite row_free_unit => injf homf.
+case=> f /[<-]; rewrite row_free_unit => injf homf.
 apply/setP=> x; rewrite !inE !mul1mx; apply: andb_id2l => Gx.
 by rewrite -(can_eq (mulmxK injf)) homf // -scalar_mxC (can_eq (mulKmx injf)).
 Qed.
@@ -4366,7 +4364,7 @@ End IrrComponent.
 Lemma irr_comp_rsim n1 n2 rG1 rG2 :
   @mx_rsim _ G n1 rG1 n2 rG2 -> irr_comp rG1 = irr_comp rG2.
 Proof.
-case=> f eq_n12; rewrite -eq_n12 in rG2 f * => inj_f hom_f.
+case=> f /[<-] inj_f hom_f.
 congr (odflt _ _); apply: eq_pick => i; rewrite -!mxrank_eq0.
 rewrite -(mxrankMfree _ inj_f); symmetry; rewrite -(eqmxMfull _ inj_f).
 have /envelop_mxP[e ->{i}]: ('e_i \in R_G)%MS.
@@ -4580,7 +4578,7 @@ rewrite (reindex (fun j => irr_comp sG (rG j))) /=.
   by rewrite inE -lin_j -irr_degreeE irr_degree_abelian.
 pose sGlin := {i | i \in linear_irr sG}.
 have sG'k (i : sGlin) : G^`(1)%g \subset rker (irr_repr (val i)).
-  by case: i => i /= /!inE lin; rewrite rker_linear //=; apply/eqP.
+  by case: i => i /= /[!inE] lin; rewrite rker_linear //=; apply/eqP.
 pose h' u := irr_comp sGq (quo_repr (sG'k u) nG'G).
 have irrGq u: mx_irreducible (quo_repr (sG'k u) nG'G).
   by apply/quo_mx_irr; apply: socle_irr.
@@ -5431,7 +5429,7 @@ Variable m : nat.
 Lemma val_gen_row W (i : 'I_m) : val_gen (row i W) = row i (val_gen W).
 Proof.
 rewrite val_gen_rV rowK; congr (mxvec _ *m _).
-by apply/matrixP=> j k /!mxE.
+by apply/matrixP=> j k /[!mxE].
 Qed.
 
 Lemma in_gen_row W (i : 'I_m) : in_gen (row i W) = row i (in_gen W).
@@ -5571,7 +5569,7 @@ Qed.
 Lemma rstabs_in_gen m (U : 'M_(m, n)) :
   rstabs rG U \subset rstabs rGA (in_gen U).
 Proof.
-apply/subsetP=> x /!inE /andP[Gx nUx].
+apply/subsetP=> x /[!inE] /andP[Gx nUx].
 by rewrite -in_genJ Gx // submx_in_gen.
 Qed.
 
@@ -5685,8 +5683,8 @@ elim: t => //=.
 - by move=> x _; rewrite eval_mx_term.
 - by move=> x _; rewrite eval_mx_term.
 - move=> t1 IH1 t2 IH2 /andP[rt1 rt2]; rewrite -{}IH1 // -{}IH2 //.
-  by apply/rowP=> k /!mxE.
-- by move=> t1 IH1 rt1; rewrite -{}IH1 //; apply/rowP=> k /!mxE.
+  by apply/rowP=> k /[!mxE].
+- by move=> t1 IH1 rt1; rewrite -{}IH1 //; apply/rowP=> k /[!mxE].
 - move=> t1 IH1 n1 rt1; rewrite eval_mulmx eval_mx_term mul_scalar_mx.
   by rewrite scaler_nat {}IH1 //; elim: n1 => //= n1 IHn1; rewrite !mulrS IHn1.
 - by move=> t1 IH1 t2 IH2 /andP[rt1 rt2]; rewrite eval_mulT IH1 ?IH2.

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -4580,7 +4580,7 @@ rewrite (reindex (fun j => irr_comp sG (rG j))) /=.
   by rewrite inE -lin_j -irr_degreeE irr_degree_abelian.
 pose sGlin := {i | i \in linear_irr sG}.
 have sG'k (i : sGlin) : G^`(1)%g \subset rker (irr_repr (val i)).
-  by case: i => i /=; rewrite !inE => lin; rewrite rker_linear //=; apply/eqP.
+  by case: i => i /= /!inE lin; rewrite rker_linear //=; apply/eqP.
 pose h' u := irr_comp sGq (quo_repr (sG'k u) nG'G).
 have irrGq u: mx_irreducible (quo_repr (sG'k u) nG'G).
   by apply/quo_mx_irr; apply: socle_irr.
@@ -5431,7 +5431,7 @@ Variable m : nat.
 Lemma val_gen_row W (i : 'I_m) : val_gen (row i W) = row i (val_gen W).
 Proof.
 rewrite val_gen_rV rowK; congr (mxvec _ *m _).
-by apply/matrixP=> j k; rewrite !mxE.
+by apply/matrixP=> j k /!mxE.
 Qed.
 
 Lemma in_gen_row W (i : 'I_m) : in_gen (row i W) = row i (in_gen W).
@@ -5571,7 +5571,7 @@ Qed.
 Lemma rstabs_in_gen m (U : 'M_(m, n)) :
   rstabs rG U \subset rstabs rGA (in_gen U).
 Proof.
-apply/subsetP=> x; rewrite !inE => /andP[Gx nUx].
+apply/subsetP=> x /!inE /andP[Gx nUx].
 by rewrite -in_genJ Gx // submx_in_gen.
 Qed.
 
@@ -5685,8 +5685,8 @@ elim: t => //=.
 - by move=> x _; rewrite eval_mx_term.
 - by move=> x _; rewrite eval_mx_term.
 - move=> t1 IH1 t2 IH2 /andP[rt1 rt2]; rewrite -{}IH1 // -{}IH2 //.
-  by apply/rowP=> k; rewrite !mxE.
-- by move=> t1 IH1 rt1; rewrite -{}IH1 //; apply/rowP=> k; rewrite !mxE.
+  by apply/rowP=> k /!mxE.
+- by move=> t1 IH1 rt1; rewrite -{}IH1 //; apply/rowP=> k /!mxE.
 - move=> t1 IH1 n1 rt1; rewrite eval_mulmx eval_mx_term mul_scalar_mx.
   by rewrite scaler_nat {}IH1 //; elim: n1 => //= n1 IHn1; rewrite !mulrS IHn1.
 - by move=> t1 IH1 t2 IH2 /andP[rt1 rt2]; rewrite eval_mulT IH1 ?IH2.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -243,7 +243,7 @@ pose B := [set j in mask m (enum I)]; have{Dq} Dq: q ^ FtoL = p_ B.
   congr (_ %= _): Dq; apply: perm_big => //.
   by rewrite uniq_perm ?mask_uniq ?enum_uniq // => j; rewrite mem_enum inE.
 rewrite -!(size_map_poly FtoL) Dq -DpI (minI B) // -?Dq ?FpxF //.
-by apply/subsetP=> j; rewrite inE => /mem_mask; rewrite mem_enum.
+by apply/subsetP=> j /1inE /mem_mask; rewrite mem_enum.
 Qed.
 
 Lemma alg_integral (F : fieldType) (L : fieldExtType F) :

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -243,7 +243,7 @@ pose B := [set j in mask m (enum I)]; have{Dq} Dq: q ^ FtoL = p_ B.
   congr (_ %= _): Dq; apply: perm_big => //.
   by rewrite uniq_perm ?mask_uniq ?enum_uniq // => j; rewrite mem_enum inE.
 rewrite -!(size_map_poly FtoL) Dq -DpI (minI B) // -?Dq ?FpxF //.
-by apply/subsetP=> j /1inE /mem_mask; rewrite mem_enum.
+by apply/subsetP=> j /[1inE] /mem_mask; rewrite mem_enum.
 Qed.
 
 Lemma alg_integral (F : fieldType) (L : fieldExtType F) :

--- a/mathcomp/field/algnum.v
+++ b/mathcomp/field/algnum.v
@@ -261,7 +261,7 @@ Proof.
 have s_s (i : 'I_m): s`_i \in <<s>>%VS by rewrite memv_span ?memt_nth.
 have s_Zs a: \sum_(i < m) s`_i *~ a i \in <<s>>%VS.
   by rewrite memv_suml // => i _; rewrite -scaler_int memvZ.
-case s_v: (v \in <<s>>%VS); last by right=> [[a Dv]]; rewrite Dv s_Zs in s_v.
+case s_v: (v \in <<s>>%VS); last by right=> [[a /[->]]]; rewrite s_Zs in s_v.
 pose IzT := {: 'I_m * 'I_(\dim <<s>>)}; pose Iz := 'I_#|IzT|.
 pose b := vbasis <<s>>.
 pose z_s := [seq coord b ij.2 (tnth s ij.1) | ij : IzT].
@@ -277,7 +277,7 @@ have Qz_Zs a: inQzs (\sum_(i < m) s`_i *~ a i).
   rewrite (can2_eq (@enum_rankK _) (@enum_valK _)) ffunE -scaler_int /val21.
   case Dij: (enum_val ij) => [i j1]; rewrite xpair_eqE eqxx /= eq_sym -mulrb.
   by rewrite linearZ rmorphMn rmorph_int mulrnAl; case: eqP => // ->.
-case Qz_v: (inQzs v); last by right=> [[a Dv]]; rewrite Dv Qz_Zs in Qz_v.
+case Qz_v: (inQzs v); last by right=> [[a /[->]]]; rewrite Qz_Zs in Qz_v.
 have [Qz [QzC [z1s Dz_s _]]] := num_field_exists z_s.
 have sz_z1s: size z1s = #|IzT| by rewrite -(size_map QzC) Dz_s size_map cardE.
 have xv j: {x | coord b j v = QzC x}.

--- a/mathcomp/field/closed_field.v
+++ b/mathcomp/field/closed_field.v
@@ -673,7 +673,7 @@ have dv_d i j: i <= j -> d j %| d i.
   exact: dvdp_trans (dvdp_gcdl _ _) IHj.
 pose I : pred {poly F} := [pred q | d (pickle q).+1 %| q].
 have I'co q i: q \notin I -> i > pickle q -> coprimep q (d i).
-  move=> /1inE I'q /dv_d/coprimep_dvdl-> //; apply: contraR I'q.
+  move=> /[1inE] I'q /dv_d/coprimep_dvdl-> //; apply: contraR I'q.
   rewrite coprimep_sym /coprimep /= pickleK /= neq_ltn.
   case: ifP => [_ _| ->]; first exact: dvdp_gcdr.
   rewrite orbF ltnS leqn0 size_poly_eq0 gcdp_eq0 -size_poly_eq0.

--- a/mathcomp/field/closed_field.v
+++ b/mathcomp/field/closed_field.v
@@ -673,7 +673,7 @@ have dv_d i j: i <= j -> d j %| d i.
   exact: dvdp_trans (dvdp_gcdl _ _) IHj.
 pose I : pred {poly F} := [pred q | d (pickle q).+1 %| q].
 have I'co q i: q \notin I -> i > pickle q -> coprimep q (d i).
-  rewrite inE => I'q /dv_d/coprimep_dvdl-> //; apply: contraR I'q.
+  move=> /1inE I'q /dv_d/coprimep_dvdl-> //; apply: contraR I'q.
   rewrite coprimep_sym /coprimep /= pickleK /= neq_ltn.
   case: ifP => [_ _| ->]; first exact: dvdp_gcdr.
   rewrite orbF ltnS leqn0 size_poly_eq0 gcdp_eq0 -size_poly_eq0.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -600,7 +600,7 @@ Proof.
 have polyKx q i: q \is a polyOver K -> q`_i * x ^+ i \in (K * <[x ^+ i]>)%VS.
   by move/polyOverP=> Kq; rewrite memv_mul ?Kq ?memv_line.
 move=> Kp szp Dv; have /Fadjoin_poly_eq/eqP := mempx_Fadjoin Kp.
-rewrite {1}Dv {Dv} !(@horner_coef_wide _ n) ?size_poly //.
+rewrite {1}Dv {Dv} /= !(@horner_coef_wide _ n) ?size_poly //.
 move/polyKx in Kp; have /polyKx K_pv := Fadjoin_polyOver K x v.
 rewrite (directv_sum_unique Fadjoin_sum_direct) // => /eqfunP eq_pq.
 apply/polyP=> i; have [leni|?] := leqP n i; last exact: mulIf (eq_pq (Sub i _)).

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -608,7 +608,7 @@ pose C u := 'C[ofG u]%AS; pose Q := 'C(L)%AS; pose q := (p ^ \dim Q)%N.
 have defC u: 'C[u] =i projG (C u).
   by move=> v; rewrite cent1E !inE (sameP cent1vP eqP).
 have defQ: 'Z(G) =i projG Q.
-  move=> u; rewrite !inE.
+  move=> u /!inE.
   apply/centP/centvP=> cGu v _; last exact/val_inj/cGu/memvf.
   by have [-> | /inG/cGu[]] := eqVneq v 0; first by rewrite commr0.
 have q_gt1: (1 < q)%N by rewrite (ltn_exp2l 0) ?prime_gt1 ?adim_gt0.

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -608,7 +608,7 @@ pose C u := 'C[ofG u]%AS; pose Q := 'C(L)%AS; pose q := (p ^ \dim Q)%N.
 have defC u: 'C[u] =i projG (C u).
   by move=> v; rewrite cent1E !inE (sameP cent1vP eqP).
 have defQ: 'Z(G) =i projG Q.
-  move=> u /!inE.
+  move=> u /[!inE].
   apply/centP/centvP=> cGu v _; last exact/val_inj/cGu/memvf.
   by have [-> | /inG/cGu[]] := eqVneq v 0; first by rewrite commr0.
 have q_gt1: (1 < q)%N by rewrite (ltn_exp2l 0) ?prime_gt1 ?adim_gt0.

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -1444,7 +1444,7 @@ have [w [Ew nzw] uM]: {w : #|A|.-tuple L | nzE w & M w \in unitmx}.
   congr (_ != 0): nzS; rewrite [_ - _]mx11_scalar det_scalar !mxE opprB /=.
   rewrite -big_uniq // big_cons /= cx_n1 mulN1r addrC; congr (_ + _).
   rewrite (big_nth 1%g) big_mkord; apply: eq_bigr => j _.
-  by rewrite /c_ index_uniq // valK; congr (_ * _) => /!mxE.
+  by rewrite /c_ index_uniq // valK; congr (_ * _) => /[!mxE].
 exists w => [//|]; split=> [||gA].
 - by congr (_ \in unitmx): uM; apply/matrixP=> i j; rewrite !mxE -enum_val_nth.
 - apply/directv_sum_independent=> kw_ Kw_kw sum_kw_0 j _.
@@ -1452,7 +1452,7 @@ exists w => [//|]; split=> [||gA].
   pose kv := \col_i k_ i.
   transitivity (kv j 0 * tnth w j); first by rewrite !mxE.
   suffices{j}/(canRL (mulKmx uM))->: M w *m kv = 0 by rewrite mulmx0 mxE mul0r.
-  apply/colP=> i /!mxE; pose Ai := nth 1%g (enum A) i.
+  apply/colP=> i /[!mxE]; pose Ai := nth 1%g (enum A) i.
   transitivity (Ai (\sum_j kw_ j)); last by rewrite sum_kw_0 rmorph0.
   rewrite rmorph_sum; apply: eq_bigr => j _; rewrite !mxE /= -/Ai.
   rewrite Dk_ mulrC rmorphM /=; congr (_ * _).
@@ -1477,7 +1477,7 @@ rewrite mulrC memv_mul ?memv_line //; apply/fixedFieldP=> [|x Gx].
 suffices{i} {2}<-: map_mx x v = v by rewrite [map_mx x v i 0]mxE.
 have uMx: map_mx x (M w) \in unitmx by rewrite map_unitmx.
 rewrite map_mxM map_invmx /=; apply: canLR {uMx}(mulKmx uMx) _.
-apply/colP=> i /!mxE; pose ix := iG (enum_val i * x)%g.
+apply/colP=> i /[!mxE]; pose ix := iG (enum_val i * x)%g.
 have Dix b: b \in E -> enum_val ix b = x (enum_val i b).
   by move=> Eb; rewrite enum_rankK_in ?groupM ?enum_valP // galM ?lfunE.
 transitivity ((M w *m v) ix 0); first by rewrite mulKVmx // mxE Dix.

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -1444,7 +1444,7 @@ have [w [Ew nzw] uM]: {w : #|A|.-tuple L | nzE w & M w \in unitmx}.
   congr (_ != 0): nzS; rewrite [_ - _]mx11_scalar det_scalar !mxE opprB /=.
   rewrite -big_uniq // big_cons /= cx_n1 mulN1r addrC; congr (_ + _).
   rewrite (big_nth 1%g) big_mkord; apply: eq_bigr => j _.
-  by rewrite /c_ index_uniq // valK; congr (_ * _); rewrite !mxE.
+  by rewrite /c_ index_uniq // valK; congr (_ * _) => /!mxE.
 exists w => [//|]; split=> [||gA].
 - by congr (_ \in unitmx): uM; apply/matrixP=> i j; rewrite !mxE -enum_val_nth.
 - apply/directv_sum_independent=> kw_ Kw_kw sum_kw_0 j _.
@@ -1452,7 +1452,7 @@ exists w => [//|]; split=> [||gA].
   pose kv := \col_i k_ i.
   transitivity (kv j 0 * tnth w j); first by rewrite !mxE.
   suffices{j}/(canRL (mulKmx uM))->: M w *m kv = 0 by rewrite mulmx0 mxE mul0r.
-  apply/colP=> i; rewrite !mxE; pose Ai := nth 1%g (enum A) i.
+  apply/colP=> i /!mxE; pose Ai := nth 1%g (enum A) i.
   transitivity (Ai (\sum_j kw_ j)); last by rewrite sum_kw_0 rmorph0.
   rewrite rmorph_sum; apply: eq_bigr => j _; rewrite !mxE /= -/Ai.
   rewrite Dk_ mulrC rmorphM /=; congr (_ * _).
@@ -1477,7 +1477,7 @@ rewrite mulrC memv_mul ?memv_line //; apply/fixedFieldP=> [|x Gx].
 suffices{i} {2}<-: map_mx x v = v by rewrite [map_mx x v i 0]mxE.
 have uMx: map_mx x (M w) \in unitmx by rewrite map_unitmx.
 rewrite map_mxM map_invmx /=; apply: canLR {uMx}(mulKmx uMx) _.
-apply/colP=> i; rewrite !mxE; pose ix := iG (enum_val i * x)%g.
+apply/colP=> i /!mxE; pose ix := iG (enum_val i * x)%g.
 have Dix b: b \in E -> enum_val ix b = x (enum_val i b).
   by move=> Eb; rewrite enum_rankK_in ?groupM ?enum_valP // galM ?lfunE.
 transitivity ((M w *m v) ix 0); first by rewrite mulKVmx // mxE Dix.

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -326,11 +326,11 @@ Proof. exact: mem_imset. Qed.
 Lemma afixP A x : reflect (forall a, a \in A -> to x a = x) (x \in 'Fix_to(A)).
 Proof.
 by rewrite inE; apply: (iffP subsetP) => [+ a|+ a Aa]
-   => [/apply/1inE/eqP|/1inE->].
+   => [/apply/[1inE]/eqP|/[1inE]->].
 Qed.
 
 Lemma afixS A B : A \subset B -> 'Fix_to(B) \subset 'Fix_to(A).
-Proof. by move=> sAB; apply/subsetP=> u /!inE /(subset_trans sAB). Qed.
+Proof. by move=> sAB; apply/subsetP=> u /[!inE] /(subset_trans sAB). Qed.
 
 Lemma afixU A B : 'Fix_to(A :|: B) = 'Fix_to(A) :&: 'Fix_to(B).
 Proof. by apply/setP=> x; rewrite !inE subUset. Qed.
@@ -346,13 +346,13 @@ Proof. by move=> a /setIP[]. Qed.
 
 Lemma astab_act S a x : a \in 'C(S | to) -> x \in S -> to x a = x.
 Proof.
-move=> /!inE /andP[_ cSa] Sx; apply/eqP.
+move=> /[!inE] /andP[_ cSa] Sx; apply/eqP.
 by have:= subsetP cSa x Sx; rewrite inE.
 Qed.
 
 Lemma astabS S1 S2 : S1 \subset S2 -> 'C(S2 | to) \subset 'C(S1 | to).
 Proof.
-move=> sS12; apply/subsetP=> x /!inE /andP[->].
+move=> sS12; apply/subsetP=> x /[!inE] /andP[->].
 exact: subset_trans.
 Qed.
 
@@ -420,7 +420,7 @@ Proof.
 move=> sAD; apply/subsetP/subsetP=> [sAC x xS | sSF a aA].
   by apply/afixP=> a aA; apply: astab_act (sAC _ aA) xS.
 rewrite !inE (subsetP sAD _ aA); apply/subsetP=> x xS.
-by move/afixP/(_ _ aA): (sSF _ xS) => /1inE ->.
+by move/afixP/(_ _ aA): (sSF _ xS) => /[1inE] ->.
 Qed.
 
 Section ActsSetop.
@@ -1273,18 +1273,18 @@ Lemma astabs_subact S : 'N(S | subaction) = subact_dom :&: 'N(val @: S | to).
 Proof.
 apply/setP=> a; rewrite inE in_setI; apply: andb_id2l => sDa.
 have [Da _] := setIP sDa; rewrite !inE Da.
-apply/subsetP/subsetP=> [nSa _ /imsetP[x Sx ->] | nSa x Sx] /!inE.
-  by have /1inE /(mem_imset val) := nSa x Sx; rewrite val_subact sDa.
-have /1inE /imsetP[y Sy def_y] := nSa _ (mem_imset val Sx).
+apply/subsetP/subsetP=> [nSa _ /imsetP[x Sx ->] | nSa x Sx] /[!inE].
+  by have /[1inE] /(mem_imset val) := nSa x Sx; rewrite val_subact sDa.
+have /[1inE] /imsetP[y Sy def_y] := nSa _ (mem_imset val Sx).
 by rewrite ((_ a =P y) _) // -val_eqE val_subact sDa def_y.
 Qed.
 
 Lemma afix_subact A :
   A \subset subact_dom -> 'Fix_subaction(A) = val @^-1: 'Fix_to(A).
 Proof.
-move/subsetP=> sAD; apply/setP=> u /!inE.
+move/subsetP=> sAD; apply/setP=> u /[!inE].
 rewrite !(sameP setIidPl eqP); congr (_ == A).
-apply/setP=> a /!inE; apply: andb_id2l => Aa.
+apply/setP=> a /[!inE]; apply: andb_id2l => Aa.
 by rewrite -val_eqE val_subact sAD.
 Qed.
 
@@ -2163,7 +2163,7 @@ move=> sHR; apply/setP=> a; apply/idP/idP=> nHa; have Da := astabs_dom nHa.
   have /rcosetsP[y Ny defHy]: to^~ a @: H \in rcosets H 'N(H).
     by rewrite (astabs_act _ nHa); apply/rcosetsP; exists 1; rewrite ?mulg1.
   by rewrite (rcoset_eqP (_ : 1 \in H :* y)) -defHy -1?(gact1 Da) mem_setact.
-rewrite !inE Da; apply/subsetP=> Hx /1inE /rcosetsP[x Nx ->{Hx}].
+rewrite !inE Da; apply/subsetP=> Hx /[1inE] /rcosetsP[x Nx ->{Hx}].
 apply/imsetP; exists (to x a).
   case Rx: (x \in R); last by rewrite gact_out ?Rx.
   rewrite inE; apply/subsetP=> _ /imsetP[y Hy ->].

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -325,13 +325,12 @@ Proof. exact: mem_imset. Qed.
 
 Lemma afixP A x : reflect (forall a, a \in A -> to x a = x) (x \in 'Fix_to(A)).
 Proof.
-rewrite inE; apply: (iffP subsetP) => [xfix a /xfix | xfix a Aa].
-  by rewrite inE => /eqP.
-by rewrite inE xfix.
+by rewrite inE; apply: (iffP subsetP) => [+ a|+ a Aa]
+   => [/apply/1inE/eqP|/1inE->].
 Qed.
 
 Lemma afixS A B : A \subset B -> 'Fix_to(B) \subset 'Fix_to(A).
-Proof. by move=> sAB; apply/subsetP=> u; rewrite !inE; apply: subset_trans. Qed.
+Proof. by move=> sAB; apply/subsetP=> u /!inE /(subset_trans sAB). Qed.
 
 Lemma afixU A B : 'Fix_to(A :|: B) = 'Fix_to(A) :&: 'Fix_to(B).
 Proof. by apply/setP=> x; rewrite !inE subUset. Qed.
@@ -347,13 +346,13 @@ Proof. by move=> a /setIP[]. Qed.
 
 Lemma astab_act S a x : a \in 'C(S | to) -> x \in S -> to x a = x.
 Proof.
-rewrite 2!inE => /andP[_ cSa] Sx; apply/eqP.
+move=> /!inE /andP[_ cSa] Sx; apply/eqP.
 by have:= subsetP cSa x Sx; rewrite inE.
 Qed.
 
 Lemma astabS S1 S2 : S1 \subset S2 -> 'C(S2 | to) \subset 'C(S1 | to).
 Proof.
-move=> sS12; apply/subsetP=> x; rewrite !inE => /andP[->].
+move=> sS12; apply/subsetP=> x /!inE /andP[->].
 exact: subset_trans.
 Qed.
 
@@ -421,7 +420,7 @@ Proof.
 move=> sAD; apply/subsetP/subsetP=> [sAC x xS | sSF a aA].
   by apply/afixP=> a aA; apply: astab_act (sAC _ aA) xS.
 rewrite !inE (subsetP sAD _ aA); apply/subsetP=> x xS.
-by move/afixP/(_ _ aA): (sSF _ xS); rewrite inE => ->.
+by move/afixP/(_ _ aA): (sSF _ xS) => /1inE ->.
 Qed.
 
 Section ActsSetop.
@@ -1274,20 +1273,19 @@ Lemma astabs_subact S : 'N(S | subaction) = subact_dom :&: 'N(val @: S | to).
 Proof.
 apply/setP=> a; rewrite inE in_setI; apply: andb_id2l => sDa.
 have [Da _] := setIP sDa; rewrite !inE Da.
-apply/subsetP/subsetP=> [nSa _ /imsetP[x Sx ->] | nSa x Sx]; rewrite !inE.
-  by have:= nSa x Sx; rewrite inE => /(mem_imset val); rewrite val_subact sDa.
-have:= nSa _ (mem_imset val Sx); rewrite inE => /imsetP[y Sy def_y].
+apply/subsetP/subsetP=> [nSa _ /imsetP[x Sx ->] | nSa x Sx] /!inE.
+  by have /1inE /(mem_imset val) := nSa x Sx; rewrite val_subact sDa.
+have /1inE /imsetP[y Sy def_y] := nSa _ (mem_imset val Sx).
 by rewrite ((_ a =P y) _) // -val_eqE val_subact sDa def_y.
 Qed.
 
 Lemma afix_subact A :
   A \subset subact_dom -> 'Fix_subaction(A) = val @^-1: 'Fix_to(A).
 Proof.
-move/subsetP=> sAD; apply/setP=> u.
-rewrite !inE !(sameP setIidPl eqP); congr (_ == A).
-apply/setP=> a; rewrite !inE; apply: andb_id2l => Aa.
+move/subsetP=> sAD; apply/setP=> u /!inE.
+rewrite !(sameP setIidPl eqP); congr (_ == A).
+apply/setP=> a /!inE; apply: andb_id2l => Aa.
 by rewrite -val_eqE val_subact sAD.
-
 Qed.
 
 End SubAction.
@@ -2165,7 +2163,7 @@ move=> sHR; apply/setP=> a; apply/idP/idP=> nHa; have Da := astabs_dom nHa.
   have /rcosetsP[y Ny defHy]: to^~ a @: H \in rcosets H 'N(H).
     by rewrite (astabs_act _ nHa); apply/rcosetsP; exists 1; rewrite ?mulg1.
   by rewrite (rcoset_eqP (_ : 1 \in H :* y)) -defHy -1?(gact1 Da) mem_setact.
-rewrite !inE Da; apply/subsetP=> Hx; rewrite inE => /rcosetsP[x Nx ->{Hx}].
+rewrite !inE Da; apply/subsetP=> Hx /1inE /rcosetsP[x Nx ->{Hx}].
 apply/imsetP; exists (to x a).
   case Rx: (x \in R); last by rewrite gact_out ?Rx.
   rewrite inE; apply/subsetP=> _ /imsetP[y Hy ->].

--- a/mathcomp/fingroup/automorphism.v
+++ b/mathcomp/fingroup/automorphism.v
@@ -76,7 +76,7 @@ Lemma Aut_group_set : group_set (Aut G).
 Proof.
 apply/group_setP; split=> [|a b].
   by rewrite inE perm_on1; apply/morphicP=> ? *; rewrite !permE.
-rewrite !inE => /andP[Ga aM] /andP[Gb bM]; rewrite perm_onM //=.
+move=> /!inE /andP[Ga aM] /andP[Gb bM]; rewrite perm_onM //=.
 apply/morphicP=> x y Gx Gy; rewrite !permM (morphicP aM) //.
 by rewrite (morphicP bM) ?perm_closed.
 Qed.
@@ -95,7 +95,7 @@ Lemma ker_autm : 'ker f = 1. Proof. by move/trivgP: injm_autm. Qed.
 Lemma im_autm : f @* G = G.
 Proof.
 apply/setP=> x; rewrite morphimEdom (can_imset_pre _ (permK a)) inE.
-by have:= AutGa; rewrite inE => /andP[/perm_closed <-]; rewrite permKV.
+by have /1inE/andP[/perm_closed <-] := AutGa; rewrite permKV.
 Qed.
 
 Lemma Aut_closed x : x \in G -> a x \in G.

--- a/mathcomp/fingroup/automorphism.v
+++ b/mathcomp/fingroup/automorphism.v
@@ -76,7 +76,7 @@ Lemma Aut_group_set : group_set (Aut G).
 Proof.
 apply/group_setP; split=> [|a b].
   by rewrite inE perm_on1; apply/morphicP=> ? *; rewrite !permE.
-move=> /!inE /andP[Ga aM] /andP[Gb bM]; rewrite perm_onM //=.
+move=> /[!inE] /andP[Ga aM] /andP[Gb bM]; rewrite perm_onM //=.
 apply/morphicP=> x y Gx Gy; rewrite !permM (morphicP aM) //.
 by rewrite (morphicP bM) ?perm_closed.
 Qed.
@@ -95,7 +95,7 @@ Lemma ker_autm : 'ker f = 1. Proof. by move/trivgP: injm_autm. Qed.
 Lemma im_autm : f @* G = G.
 Proof.
 apply/setP=> x; rewrite morphimEdom (can_imset_pre _ (permK a)) inE.
-by have /1inE/andP[/perm_closed <-] := AutGa; rewrite permKV.
+by have /[1inE]/andP[/perm_closed <-] := AutGa; rewrite permKV.
 Qed.
 
 Lemma Aut_closed x : x \in G -> a x \in G.

--- a/mathcomp/fingroup/fingroup.v
+++ b/mathcomp/fingroup/fingroup.v
@@ -1678,7 +1678,7 @@ Lemma classes_gt1 : (#|classes G| > 1) = (G :!=: 1).
 Proof.
 rewrite (cardsD1 1) classes1 ltnS lt0n cards_eq0.
 apply/set0Pn/trivgPn=> [[xG /setD1P[nt_xG]] | [x Gx ntx]].
-  by case/imsetP=> x Gx def_xG; rewrite def_xG classG_eq1 in nt_xG; exists x.
+  by case/imsetP=> x Gx /[->]; rewrite classG_eq1 in nt_xG; exists x.
 by exists (x ^: G); rewrite !inE classG_eq1 ntx; apply: mem_imset.
 Qed.
 

--- a/mathcomp/fingroup/gproduct.v
+++ b/mathcomp/fingroup/gproduct.v
@@ -853,7 +853,7 @@ exists c; split=> // e Fe eq_ce i Pi.
 set r := index_enum _ in defG eq_ce.
 have: i \in r by rewrite -[r]enumT mem_enum.
 elim: r G defG eq_ce => // j r IHr G; rewrite !big_cons inE.
-case Pj: (P j); last by case: eqP (IHr G) => // eq_ij; rewrite eq_ij Pj in Pi.
+case Pj: (P j); last by case: eqP (IHr G) => // /[->]; rewrite Pj in Pi.
 case/dprodP=> [[K H defK defH] _ _]; rewrite defK defH => tiFjH eq_ce.
 suffices{i Pi IHr} eq_cej: c j = e j.
   case/predU1P=> [-> //|]; apply: IHr defH _.

--- a/mathcomp/fingroup/morphism.v
+++ b/mathcomp/fingroup/morphism.v
@@ -660,7 +660,7 @@ Proof. exact: morphim_cents. Qed.
 
 Lemma morphpre_norm R : f @*^-1 'N(R) \subset 'N(f @*^-1 R).
 Proof.
-apply/subsetP=> x /!inE /andP[Dx Nfx].
+apply/subsetP=> x /[!inE] /andP[Dx Nfx].
 by rewrite -morphpreJ ?morphpreS.
 Qed.
 

--- a/mathcomp/fingroup/morphism.v
+++ b/mathcomp/fingroup/morphism.v
@@ -660,7 +660,7 @@ Proof. exact: morphim_cents. Qed.
 
 Lemma morphpre_norm R : f @*^-1 'N(R) \subset 'N(f @*^-1 R).
 Proof.
-apply/subsetP=> x; rewrite !inE => /andP[Dx Nfx].
+apply/subsetP=> x /!inE /andP[Dx Nfx].
 by rewrite -morphpreJ ?morphpreS.
 Qed.
 

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -272,8 +272,8 @@ case/andP=> /forallP-onA /injectiveP-f_inj.
 apply/ffunP=> u; rewrite ffunE -pvalE insubdK; first by rewrite ffunE valK.
 apply/injectiveP=> {u} x y; rewrite !ffunE.
 case: insubP => [u _ <-|]; case: insubP => [v _ <-|] //=; first by move/f_inj->.
-  by move=> Ay' def_y; rewrite -def_y [_ \in A]onA in Ay'.
-by move=> Ax' def_x; rewrite def_x [_ \in A]onA in Ax'.
+  by move=> Ay' /[<-]; rewrite [_ \in A]onA in Ay'.
+by move=> Ax' /[->]; rewrite [_ \in A]onA in Ax'.
 Qed.
 
 End Theory.

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -348,7 +348,7 @@ by apply: cprod_exponent; rewrite cprodE.
 Qed.
 
 Lemma sub_LdivT A n : (A \subset 'Ldiv_n()) = (exponent A %| n).
-Proof. by apply/subsetP/exponentP=> eAn x /eAn /1inE /eqP. Qed.
+Proof. by apply/subsetP/exponentP=> eAn x /eAn /[1inE] /eqP. Qed.
 
 Lemma LdivT_J n x : 'Ldiv_n() :^ x = 'Ldiv_n().
 Proof.
@@ -495,7 +495,7 @@ Arguments pElemP {p A E}.
 
 Lemma pElemS p A B : A \subset B -> 'E_p(A) \subset 'E_p(B).
 Proof.
-by move=> sAB; apply/subsetP=> E /!inE /andP[/subset_trans->].
+by move=> sAB; apply/subsetP=> E /[!inE] /andP[/subset_trans->].
 Qed.
 
 Lemma pElemI p A B : 'E_p(A :&: B) = 'E_p(A) :&: subgroups B.
@@ -744,7 +744,7 @@ Qed.
 
 Lemma p_rank_geP p n G : reflect (exists E, E \in 'E_p^n(G)) (n <= 'r_p(G)).
 Proof.
-apply: (iffP idP) => [|[E] /1inE /andP[Ep_E /eqP <-]]; last first.
+apply: (iffP idP) => [|[E] /[1inE] /andP[Ep_E /eqP <-]]; last first.
   by rewrite (bigmax_sup E).
 have [D /pnElemP[sDG abelD <-]] := p_rank_witness p G.
 by case/abelem_pnElem=> // E; exists E; apply: (subsetP (pnElemS _ _ sDG)).
@@ -774,7 +774,7 @@ Qed.
 Lemma p_rank_abelem p G : p.-abelem G -> 'r_p(G) = logn p #|G|.
 Proof.
 move=> abelG; apply/eqP; rewrite eqn_leq andbC (bigmax_sup G) //.
-  by apply/bigmax_leqP=> E /1inE /andP[/lognSg->].
+  by apply/bigmax_leqP=> E /[1inE] /andP[/lognSg->].
 by rewrite inE subxx.
 Qed.
 
@@ -803,7 +803,7 @@ Qed.
 Lemma p_rank_Sylow p G H : p.-Sylow(G) H -> 'r_p(H) = 'r_p(G).
 Proof.
 move=> sylH; apply/eqP; rewrite eqn_leq (p_rankS _ (pHall_sub sylH)) /=.
-apply/bigmax_leqP=> E /1inE /andP[sEG abelE].
+apply/bigmax_leqP=> E /[1inE] /andP[sEG abelE].
 have [P sylP sEP] := Sylow_superset sEG (abelem_pgroup abelE).
 have [x _ ->] := Sylow_trans sylP sylH.
 by rewrite p_rankJ -(p_rank_abelem abelE) (p_rankS _ sEP).
@@ -889,7 +889,7 @@ Proof.
 apply: (iffP idP) => [|[E]].
   have [p _ ->] := rank_witness G; case/p_rank_geP=> E.
   by rewrite def_pnElem; case/setIP; exists E.
-case/nElemP=> p /1inE /andP[EpG_E /eqP <-].
+case/nElemP=> p /[1inE] /andP[EpG_E /eqP <-].
 by rewrite (leq_trans (logn_le_p_rank EpG_E)) ?p_rank_le_rank.
 Qed.
 
@@ -921,7 +921,7 @@ Qed.
 
 Lemma morphim_LdivT n : f @* 'Ldiv_n() \subset 'Ldiv_n().
 Proof.
-apply/subsetP=> _ /morphimP[x Dx xn ->]; rewrite inE in xn.
+apply/subsetP=> _ /morphimP[x Dx /[1inE] xn ->].
 by rewrite inE -morphX // (eqP xn) morph1.
 Qed.
 
@@ -946,7 +946,7 @@ Qed.
 Lemma morphim_pnElem p n G E :
   E \in 'E_p^n(G) -> {m | m <= n & (f @* E)%G \in 'E_p^m(f @* G)}.
 Proof.
-move=> /1inE/andP[EpE /eqP <-].
+move=> /[1inE]/andP[EpE /eqP <-].
 by exists (logn p #|f @* E|); rewrite ?logn_morphim // inE morphim_pElem /=.
 Qed.
 
@@ -1159,7 +1159,7 @@ Qed.
 
 Lemma OhmS H G : H \subset G -> 'Ohm_n(H) \subset 'Ohm_n(G).
 Proof.
-move=> sHG; apply: genS; apply/subsetP=> x /!inE /andP[Hx ->].
+move=> sHG; apply: genS; apply/subsetP=> x /[!inE] /andP[Hx ->].
 by rewrite (subsetP sHG).
 Qed.
 

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -348,7 +348,7 @@ by apply: cprod_exponent; rewrite cprodE.
 Qed.
 
 Lemma sub_LdivT A n : (A \subset 'Ldiv_n()) = (exponent A %| n).
-Proof. by apply/subsetP/exponentP=> eAn x /eAn; rewrite inE => /eqP. Qed.
+Proof. by apply/subsetP/exponentP=> eAn x /eAn /1inE /eqP. Qed.
 
 Lemma LdivT_J n x : 'Ldiv_n() :^ x = 'Ldiv_n().
 Proof.
@@ -495,7 +495,7 @@ Arguments pElemP {p A E}.
 
 Lemma pElemS p A B : A \subset B -> 'E_p(A) \subset 'E_p(B).
 Proof.
-by move=> sAB; apply/subsetP=> E; rewrite !inE => /andP[/subset_trans->].
+by move=> sAB; apply/subsetP=> E /!inE /andP[/subset_trans->].
 Qed.
 
 Lemma pElemI p A B : 'E_p(A :&: B) = 'E_p(A) :&: subgroups B.
@@ -744,8 +744,8 @@ Qed.
 
 Lemma p_rank_geP p n G : reflect (exists E, E \in 'E_p^n(G)) (n <= 'r_p(G)).
 Proof.
-apply: (iffP idP) => [|[E]]; last first.
-  by rewrite inE => /andP[Ep_E /eqP <-]; rewrite (bigmax_sup E).
+apply: (iffP idP) => [|[E] /1inE /andP[Ep_E /eqP <-]]; last first.
+  by rewrite (bigmax_sup E).
 have [D /pnElemP[sDG abelD <-]] := p_rank_witness p G.
 by case/abelem_pnElem=> // E; exists E; apply: (subsetP (pnElemS _ _ sDG)).
 Qed.
@@ -774,7 +774,7 @@ Qed.
 Lemma p_rank_abelem p G : p.-abelem G -> 'r_p(G) = logn p #|G|.
 Proof.
 move=> abelG; apply/eqP; rewrite eqn_leq andbC (bigmax_sup G) //.
-  by apply/bigmax_leqP=> E; rewrite inE => /andP[/lognSg->].
+  by apply/bigmax_leqP=> E /1inE /andP[/lognSg->].
 by rewrite inE subxx.
 Qed.
 
@@ -803,7 +803,7 @@ Qed.
 Lemma p_rank_Sylow p G H : p.-Sylow(G) H -> 'r_p(H) = 'r_p(G).
 Proof.
 move=> sylH; apply/eqP; rewrite eqn_leq (p_rankS _ (pHall_sub sylH)) /=.
-apply/bigmax_leqP=> E; rewrite inE => /andP[sEG abelE].
+apply/bigmax_leqP=> E /1inE /andP[sEG abelE].
 have [P sylP sEP] := Sylow_superset sEG (abelem_pgroup abelE).
 have [x _ ->] := Sylow_trans sylP sylH.
 by rewrite p_rankJ -(p_rank_abelem abelE) (p_rankS _ sEP).
@@ -889,7 +889,7 @@ Proof.
 apply: (iffP idP) => [|[E]].
   have [p _ ->] := rank_witness G; case/p_rank_geP=> E.
   by rewrite def_pnElem; case/setIP; exists E.
-case/nElemP=> p; rewrite inE => /andP[EpG_E /eqP <-].
+case/nElemP=> p /1inE /andP[EpG_E /eqP <-].
 by rewrite (leq_trans (logn_le_p_rank EpG_E)) ?p_rank_le_rank.
 Qed.
 
@@ -946,7 +946,7 @@ Qed.
 Lemma morphim_pnElem p n G E :
   E \in 'E_p^n(G) -> {m | m <= n & (f @* E)%G \in 'E_p^m(f @* G)}.
 Proof.
-rewrite inE => /andP[EpE /eqP <-].
+move=> /1inE/andP[EpE /eqP <-].
 by exists (logn p #|f @* E|); rewrite ?logn_morphim // inE morphim_pElem /=.
 Qed.
 
@@ -1159,7 +1159,7 @@ Qed.
 
 Lemma OhmS H G : H \subset G -> 'Ohm_n(H) \subset 'Ohm_n(G).
 Proof.
-move=> sHG; apply: genS; apply/subsetP=> x; rewrite !inE => /andP[Hx ->].
+move=> sHG; apply: genS; apply/subsetP=> x /!inE /andP[Hx ->].
 by rewrite (subsetP sHG).
 Qed.
 

--- a/mathcomp/solvable/alt.v
+++ b/mathcomp/solvable/alt.v
@@ -160,7 +160,7 @@ pose A3 := [set x : {perm T} | #[x] == 3]; suffices oA3: #|A :&: A3| = 8.
     rewrite inE pHallE oA p_part -natTrecE /= => /andP[sPA /eqP oP].
     apply/eqP; rewrite eqEcard -(leq_add2l 8) -{1}oA3 cardsID oA oP.
     rewrite andbT subsetD sPA; apply/exists_inP=> -[x] /= Px.
-    by rewrite inE => /eqP ox; have:= order_dvdG Px; rewrite oP ox.
+    by move=> /1inE /eqP ox; have:= order_dvdG Px; rewrite oP ox.
   have [/= P sylP] := Sylow_exists 2 [group of A].
   rewrite -(([set P] =P 'Syl_2(A)) _) ?cards1 // eqEsubset sub1set inE sylP.
   by apply/subsetP=> Q sylQ; rewrite inE -val_eqE /= !sQ2 // inE.

--- a/mathcomp/solvable/alt.v
+++ b/mathcomp/solvable/alt.v
@@ -150,7 +150,7 @@ have oA: #|A| = 12 by apply: double_inj; rewrite -mul2n card_Alt oT.
 suffices [p]: exists p, [/\ prime p, 1 < #|A|`_p < #|A| & #|'Syl_p(A)| == 1%N].
   case=> p_pr pA_int; rewrite /A; case/normal_sylowP=> P; case/pHallP.
   rewrite /= -/A => sPA pP nPA; apply/simpleP=> [] [_]; rewrite -pP in pA_int.
-  by case/(_ P)=> // defP; rewrite defP oA ?cards1 in pA_int.
+  by case/(_ P)=> // /[->]; rewrite oA ?cards1 in pA_int.
 have: #|'Syl_3(A)| \in filter [pred d | d %% 3 == 1%N] (divisors 12).
   by rewrite mem_filter -dvdn_divisors //= -oA card_Syl_dvd ?card_Syl_mod.
 rewrite /= oA mem_seq2 orbC.
@@ -160,7 +160,7 @@ pose A3 := [set x : {perm T} | #[x] == 3]; suffices oA3: #|A :&: A3| = 8.
     rewrite inE pHallE oA p_part -natTrecE /= => /andP[sPA /eqP oP].
     apply/eqP; rewrite eqEcard -(leq_add2l 8) -{1}oA3 cardsID oA oP.
     rewrite andbT subsetD sPA; apply/exists_inP=> -[x] /= Px.
-    by move=> /1inE /eqP ox; have:= order_dvdG Px; rewrite oP ox.
+    by move=> /[1inE] /eqP ox; have:= order_dvdG Px; rewrite oP ox.
   have [/= P sylP] := Sylow_exists 2 [group of A].
   rewrite -(([set P] =P 'Syl_2(A)) _) ?cards1 // eqEsubset sub1set inE sylP.
   by apply/subsetP=> Q sylQ; rewrite inE -val_eqE /= !sQ2 // inE.
@@ -336,9 +336,9 @@ have HP0 (t : {perm T}): #|[set x | t x != x]| = 0 -> rfd t = t :> bool.
 elim: #|_| {-2}p (leqnn #|[set x | p x != x]|) => {p}[|n Hrec] p Hp Hpx.
   by apply: HP0; move: Hp; case: card.
 case Ex: (pred0b (mem [set x | p x != x])); first by apply: HP0; move/eqnP: Ex.
-case/pred0Pn: Ex => x1; rewrite /= inE => Hx1.
-have nx1x: x1 != x by apply/eqP => HH; rewrite HH Hpx eqxx in Hx1.
-have npxx1: p x != x1 by apply/eqP => HH; rewrite -HH !Hpx eqxx in Hx1.
+case/pred0Pn: Ex => x1 /= /[1inE] Hx1.
+have nx1x: x1 != x by apply/eqP => /[->]; rewrite Hpx eqxx in Hx1.
+have npxx1: p x != x1 by apply/eqP => /[->]; rewrite !Hpx eqxx in nx1x.
 have npx1x: p x1 != x.
   by apply/eqP; rewrite -Hpx; move/perm_inj => HH; case/eqP: nx1x.
 pose p1 := p * tperm x1 (p x1).
@@ -355,7 +355,7 @@ have Hcp1: #|[set x | p1 x != x]| <= n.
     - rewrite eq_sym HH1 andbb; apply/eqP=> dx1.
       by rewrite dx1 HH1 dx1 eqxx in HH2.
     - by rewrite (perm_inj HH1) eqxx in HH2.
-    by move->; rewrite andbT; apply/eqP => HH3; rewrite HH3 in HH2.
+    by move->; rewrite andbT; apply/eqP => /[->].
   apply: (leq_trans (subset_leq_card F3)).
   by move: Hp; rewrite (cardD1 x1) inE Hx1.
 have ->: p = p1 * tperm x1 (p x1) by rewrite -mulgA tperm2 mulg1.

--- a/mathcomp/solvable/burnside_app.v
+++ b/mathcomp/solvable/burnside_app.v
@@ -381,7 +381,7 @@ move=> x y z t Uxt; rewrite -[n]card_ord.
 pose f (p : col_squares) := (p x, p z); rewrite -(@card_in_image _ _ f).
   rewrite -mulnn -card_prod; apply: eq_card => [] [c d] /=; apply/imageP.
   rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-  rewrite /= !orbF !andbT; case/norP; rewrite !inE => nxzt nyzt _.
+  rewrite /= !orbF !andbT => /norP[] /!inE nxzt nyzt _.
   exists [ffun i => if pred2 x y i then c else d].
     by rewrite inE !ffunE /= !eqxx orbT (negbTE nxzt) (negbTE nyzt) !eqxx.
   by rewrite {}/f !ffunE /= eqxx (negbTE nxzt).
@@ -1171,7 +1171,7 @@ rewrite (cat_uniq [::x; y; z; t]) in Uxv; case/and3P: Uxv => _ hasxt.
 rewrite /= !inE andbT.
 move/negbTE=> nuv .
 rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-rewrite /= !andbT orbF; case/norP; rewrite !inE => nxyz nxyt _.
+rewrite /= !andbT orbF => /norP[] /!inE nxyz nxyt _.
 move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE orbA.
 case/norP  => nxyu nztu.
 rewrite orbA; case/norP=> nxyv nztv.
@@ -1229,7 +1229,7 @@ pose ff (p : col_cubes) := (p x, p t); rewrite -(@card_in_image _ _ ff); first l
 have ->:forall n, (n ^ 2)%N= (n*n)%N by move=> n0; rewrite -mulnn .
    rewrite -!card_prod; apply: eq_card => [] [c d]/=; apply/imageP.
 rewrite (cat_uniq [::x; y; z]) in Uxv; case/and3P: Uxv => Uxt hasxt nuv .
-move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE => nxyzt.
+move: hasxt; rewrite /= !orbF => /norP[] /!inE nxyzt.
 case/norP => nxyzu nxyzv.
 exists [ffun i =>  if (i \in [:: x; y; z] ) then c else  d].
   rewrite !inE /= !ffunE !inE //= !eqxx !orbT !eqxx //=.
@@ -1257,7 +1257,7 @@ have ->:forall n, (n ^ 3)%N= (n*n*n)%N.
 rewrite -!card_prod. apply: eq_card => [] [[c d]e ] /=; apply/imageP.
 rewrite (cat_uniq [::x; y; z; t]) in Uxv; case/and3P: Uxv => Uxt hasxt nuv .
 rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-rewrite /= !orbF !andbT; case/norP; rewrite !inE => nxyz nxyt _.
+rewrite /= !orbF !andbT => /norP[] /!inE nxyz nxyt _.
 move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE orbA.
 case/norP => nxyu nztu.
 rewrite orbA; case/norP=> nxyv nztv.

--- a/mathcomp/solvable/burnside_app.v
+++ b/mathcomp/solvable/burnside_app.v
@@ -381,7 +381,7 @@ move=> x y z t Uxt; rewrite -[n]card_ord.
 pose f (p : col_squares) := (p x, p z); rewrite -(@card_in_image _ _ f).
   rewrite -mulnn -card_prod; apply: eq_card => [] [c d] /=; apply/imageP.
   rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-  rewrite /= !orbF !andbT => /norP[] /!inE nxzt nyzt _.
+  rewrite /= !orbF !andbT => /norP[] /[!inE] nxzt nyzt _.
   exists [ffun i => if pred2 x y i then c else d].
     by rewrite inE !ffunE /= !eqxx orbT (negbTE nxzt) (negbTE nyzt) !eqxx.
   by rewrite {}/f !ffunE /= eqxx (negbTE nxzt).
@@ -1171,7 +1171,7 @@ rewrite (cat_uniq [::x; y; z; t]) in Uxv; case/and3P: Uxv => _ hasxt.
 rewrite /= !inE andbT.
 move/negbTE=> nuv .
 rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-rewrite /= !andbT orbF => /norP[] /!inE nxyz nxyt _.
+rewrite /= !andbT orbF => /norP[] /[!inE] nxyz nxyt _.
 move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE orbA.
 case/norP  => nxyu nztu.
 rewrite orbA; case/norP=> nxyv nztv.
@@ -1229,7 +1229,7 @@ pose ff (p : col_cubes) := (p x, p t); rewrite -(@card_in_image _ _ ff); first l
 have ->:forall n, (n ^ 2)%N= (n*n)%N by move=> n0; rewrite -mulnn .
    rewrite -!card_prod; apply: eq_card => [] [c d]/=; apply/imageP.
 rewrite (cat_uniq [::x; y; z]) in Uxv; case/and3P: Uxv => Uxt hasxt nuv .
-move: hasxt; rewrite /= !orbF => /norP[] /!inE nxyzt.
+move: hasxt; rewrite /= !orbF => /norP[] /[!inE] nxyzt.
 case/norP => nxyzu nxyzv.
 exists [ffun i =>  if (i \in [:: x; y; z] ) then c else  d].
   rewrite !inE /= !ffunE !inE //= !eqxx !orbT !eqxx //=.
@@ -1257,7 +1257,7 @@ have ->:forall n, (n ^ 3)%N= (n*n*n)%N.
 rewrite -!card_prod. apply: eq_card => [] [[c d]e ] /=; apply/imageP.
 rewrite (cat_uniq [::x; y; z; t]) in Uxv; case/and3P: Uxv => Uxt hasxt nuv .
 rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-rewrite /= !orbF !andbT => /norP[] /!inE nxyz nxyt _.
+rewrite /= !orbF !andbT => /norP[] /[!inE] nxyz nxyt _.
 move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE orbA.
 case/norP => nxyu nztu.
 rewrite orbA; case/norP=> nxyv nztv.

--- a/mathcomp/solvable/center.v
+++ b/mathcomp/solvable/center.v
@@ -309,7 +309,7 @@ Proof.
 rewrite -(center_dprod (setX_dprod H K)) -morphim_pairg1 -morphim_pair1g.
 rewrite -!injm_center ?subsetT ?injm_pair1g ?injm_pairg1 //=.
 rewrite morphim_pairg1 morphim_pair1g setX_dprod.
-apply/subsetP=> [[x y]] /1inE /andP[Zx /eqP->].
+apply/subsetP=> [[x y]] /[1inE] /andP[Zx /eqP->].
 by rewrite inE /= Zx groupV (subsetP sgzZZ) ?mem_morphim.
 Qed.
 

--- a/mathcomp/solvable/center.v
+++ b/mathcomp/solvable/center.v
@@ -309,7 +309,7 @@ Proof.
 rewrite -(center_dprod (setX_dprod H K)) -morphim_pairg1 -morphim_pair1g.
 rewrite -!injm_center ?subsetT ?injm_pair1g ?injm_pairg1 //=.
 rewrite morphim_pairg1 morphim_pair1g setX_dprod.
-apply/subsetP=> [[x y]]; rewrite inE => /andP[Zx /eqP->].
+apply/subsetP=> [[x y]] /1inE /andP[Zx /eqP->].
 by rewrite inE /= Zx groupV (subsetP sgzZZ) ?mem_morphim.
 Qed.
 

--- a/mathcomp/solvable/cyclic.v
+++ b/mathcomp/solvable/cyclic.v
@@ -429,7 +429,7 @@ Lemma cardSg_cyclic G H K :
   cyclic G -> H \subset G -> K \subset G -> (#|H| %| #|K|) = (H \subset K).
 Proof.
 move=> cycG sHG sKG; apply/idP/idP; last exact: cardSg.
-case/cyclicP: (cyclicS sKG cycG) => x defK; rewrite {K}defK in sKG *.
+case/cyclicP: (cyclicS sKG cycG) => x /[->].
 case/dvdnP=> k ox; suffices ->: H :=: <[x ^+ k]> by apply: cycleX.
 apply/eqP; rewrite (eq_subG_cyclic cycG) ?(subset_trans (cycleX _ _)) //.
 rewrite -orderE orderXdiv orderE ox ?dvdn_mulr ?mulKn //.

--- a/mathcomp/solvable/extremal.v
+++ b/mathcomp/solvable/extremal.v
@@ -1810,7 +1810,7 @@ case=> [[n_gt23 xy] | [p2 Z_xxy]].
     by rewrite -order_dvdn bin2odd ?dvdn_mulr // -oZ order_dvdG in not_cyxi.
   have def_yxi: [~ y, x ^+ i] = x ^+ r.
     have:= Zyxj i; rewrite /Z cycle_traject orderE oZ p2 !inE mulg1.
-    by case/pred2P=> // cyxi; rewrite cyxi p2 eqxx in not_cyxi.
+    by case/pred2P=> // /[->]; rewrite p2 eqxx in not_cyxi.
   apply/existsP; exists (x, x ^+ (i + r %/ 2) * y); rewrite /= !xpair_eqE.
   rewrite defG x_xjy -order_dvdn ox dvdnn !eqxx andbT /=.
   rewrite expMg_Rmul /commute ?(centsP cGZ _ (Zyxj _)) ?groupX // def_yxj.

--- a/mathcomp/solvable/frobenius.v
+++ b/mathcomp/solvable/frobenius.v
@@ -513,7 +513,7 @@ Lemma prime_FrobeniusP G K H :
 Proof.
 move=> ntK H_pr; have ntH: H :!=: 1 by rewrite -cardG_gt1 prime_gt1.
 have [defG | not_sdG] := eqVneq (K ><| H) G; last first.
-  by apply: (iffP andP) => [] [defG]; rewrite defG ?eqxx in not_sdG.
+  by apply: (iffP andP) => [] [/[->]]; rewrite ?eqxx in not_sdG.
 apply: (iffP (Frobenius_semiregularP defG ntK ntH)) => [regH | [_ regH x]].
   split=> //; have [x defH] := cyclicP (prime_cyclic H_pr).
   by rewrite defH cent_cycle regH // !inE defH cycle_id andbT -cycle_eq1 -defH.

--- a/mathcomp/solvable/jordanholder.v
+++ b/mathcomp/solvable/jordanholder.v
@@ -431,8 +431,7 @@ Proof. by apply: (iffP andP); case; move/eqP. Qed.
 
 Lemma trivg_acomps K s : acomps K s -> (K :==: 1) = (s == [::]).
 Proof.
-case/andP=> ls cs; apply/eqP/eqP; last first.
-  by move=> se; rewrite se /= in ls; apply/eqP.
+case/andP=> ls cs; apply/eqP/eqP; last by move=> /[->]; apply/eqP.
 move=> G1; case: s ls cs => // H s _ /=; case/andP; case/maxgroupP.
 by rewrite G1 sub1G andbF.
 Qed.

--- a/mathcomp/solvable/maximal.v
+++ b/mathcomp/solvable/maximal.v
@@ -1523,7 +1523,7 @@ have{nsXG} pU := pgroupS (subset_trans sUX (normal_sub nsXG)) pG.
 case gsetU1: (group_set 'Ldiv_p(U)).
   by rewrite -defU1 (OhmE 1 pU) gen_set_id // -sub_LdivT subsetIr.
 move: gsetU1; rewrite /group_set 2!inE group1 expg1n eqxx; case/subsetPn=> xy.
-case/imset2P=> x y /!inE /andP[Ux xp1] /andP[Uy yp1] ->{xy}.
+case/imset2P=> x y /[!inE] /andP[Ux xp1] /andP[Uy yp1] ->{xy}.
 rewrite groupM //= => nt_xyp; pose XY := <[x]> <*> <[y]>.
 have{yp1 nt_xyp} defXY: XY = U.
   have sXY_U: XY \subset U by rewrite join_subG !cycle_subG Ux Uy.

--- a/mathcomp/solvable/maximal.v
+++ b/mathcomp/solvable/maximal.v
@@ -1523,7 +1523,7 @@ have{nsXG} pU := pgroupS (subset_trans sUX (normal_sub nsXG)) pG.
 case gsetU1: (group_set 'Ldiv_p(U)).
   by rewrite -defU1 (OhmE 1 pU) gen_set_id // -sub_LdivT subsetIr.
 move: gsetU1; rewrite /group_set 2!inE group1 expg1n eqxx; case/subsetPn=> xy.
-case/imset2P=> x y; rewrite !inE => /andP[Ux xp1] /andP[Uy yp1] ->{xy}.
+case/imset2P=> x y /!inE /andP[Ux xp1] /andP[Uy yp1] ->{xy}.
 rewrite groupM //= => nt_xyp; pose XY := <[x]> <*> <[y]>.
 have{yp1 nt_xyp} defXY: XY = U.
   have sXY_U: XY \subset U by rewrite join_subG !cycle_subG Ux Uy.

--- a/mathcomp/solvable/primitive_action.v
+++ b/mathcomp/solvable/primitive_action.v
@@ -213,7 +213,7 @@ Qed.
 
 Lemma dtuple_on_subset n (S1 S2 : {set sT}) t :
   S1 \subset S2 -> t \in n.-dtuple(S1) -> t \in n.-dtuple(S2).
-Proof. by move=> sS12; rewrite !inE => /andP[-> /subset_trans]; apply. Qed.
+Proof. by move=> sS12 /!inE /andP[-> /subset_trans]; apply. Qed.
 
 Lemma n_act_add n x (t : n.-tuple sT) a :
   n_act to [tuple of x :: t] a = [tuple of to x a :: n_act to t a].
@@ -236,7 +236,7 @@ have ext_t t: t \in dtuple_on m S ->
 - move=> dt.
   have [sSt | /subsetPn[x Sx ntx]] := boolP (S \subset t); last first.
     by exists x; rewrite dtuple_on_add andbA /= Sx ntx.
-  case/imsetP: tr_m1 dt => t1; rewrite !inE => /andP[Ut1 St1] _ /andP[Ut _].
+  case/imsetP: tr_m1 dt => t1 /!inE /andP[Ut1 St1] _ /andP[Ut _].
   have /subset_leq_card := subset_trans St1 sSt.
   by rewrite !card_uniq_tuple // ltnn.
 case/imsetP: (tr_m1); case/tupleP=> [x t]; rewrite dtuple_on_add.

--- a/mathcomp/solvable/primitive_action.v
+++ b/mathcomp/solvable/primitive_action.v
@@ -213,7 +213,7 @@ Qed.
 
 Lemma dtuple_on_subset n (S1 S2 : {set sT}) t :
   S1 \subset S2 -> t \in n.-dtuple(S1) -> t \in n.-dtuple(S2).
-Proof. by move=> sS12 /!inE /andP[-> /subset_trans]; apply. Qed.
+Proof. by move=> sS12 /[!inE] /andP[-> /subset_trans]; apply. Qed.
 
 Lemma n_act_add n x (t : n.-tuple sT) a :
   n_act to [tuple of x :: t] a = [tuple of to x a :: n_act to t a].
@@ -236,7 +236,7 @@ have ext_t t: t \in dtuple_on m S ->
 - move=> dt.
   have [sSt | /subsetPn[x Sx ntx]] := boolP (S \subset t); last first.
     by exists x; rewrite dtuple_on_add andbA /= Sx ntx.
-  case/imsetP: tr_m1 dt => t1 /!inE /andP[Ut1 St1] _ /andP[Ut _].
+  case/imsetP: tr_m1 dt => t1 /[!inE] /andP[Ut1 St1] _ /andP[Ut _].
   have /subset_leq_card := subset_trans St1 sSt.
   by rewrite !card_uniq_tuple // ltnn.
 case/imsetP: (tr_m1); case/tupleP=> [x t]; rewrite dtuple_on_add.

--- a/mathcomp/solvable/sylow.v
+++ b/mathcomp/solvable/sylow.v
@@ -97,9 +97,9 @@ have actS: [acts G, on S | 'JG].
   apply/subsetP=> x Gx; rewrite 3!inE; apply/subsetP=> P; rewrite 3!inE.
   exact: max_pgroupJ.
 have S_pG P: P \in S -> P \subset G /\ p.-group P.
-  by rewrite inE => /maxgroupp/andP[].
+  by move=> /1inE /maxgroupp/andP[].
 have SmaxN P Q: Q \in S -> Q \subset 'N(P) -> maxp 'N_G(P) Q.
-  rewrite inE => /maxgroupP[/andP[sQG pQ] maxQ] nPQ.
+  move=> /1inE /maxgroupP[/andP[sQG pQ] maxQ] nPQ.
   apply/maxgroupP; rewrite /psubgroup subsetI sQG nPQ.
   by split=> // R; rewrite subsetI -andbA andbCA => /andP[_]; apply: maxQ.
 have nrmG P: P \subset G -> P <| 'N_G(P).
@@ -126,7 +126,7 @@ have [P S_P]: exists P, P \in S.
 have trS: [transitive G, on S | 'JG].
   apply/imsetP; exists P => //; apply/eqP.
   rewrite eqEsubset andbC acts_sub_orbit // S_P; apply/subsetP=> Q S_Q.
-  have:= S_P; rewrite inE => /maxgroupP[/andP[_ pP]].
+  have /1inE /maxgroupP[/andP[_ pP]] := S_P.
   have [-> max1 | ntP _] := eqVneq P 1%G.
     move/andP/max1: (S_pG _ S_Q) => Q1.
     by rewrite (group_inj (Q1 (sub1G Q))) orbit_refl.
@@ -287,7 +287,7 @@ Proof.
 set T := [set P : {group gT} | Sylow G P].
 rewrite -{2}(@Sylow_transversal_gen T G) => [|P | q _].
 - by congr <<_>>; apply: eq_bigl => P; rewrite inE.
-- by rewrite inE => /and3P[].
+- by move=> /1inE /and3P[].
 by case: (Sylow_exists q G) => P sylP; exists P; rewrite // inE (p_Sylow sylP).
 Qed.
 

--- a/mathcomp/solvable/sylow.v
+++ b/mathcomp/solvable/sylow.v
@@ -97,9 +97,9 @@ have actS: [acts G, on S | 'JG].
   apply/subsetP=> x Gx; rewrite 3!inE; apply/subsetP=> P; rewrite 3!inE.
   exact: max_pgroupJ.
 have S_pG P: P \in S -> P \subset G /\ p.-group P.
-  by move=> /1inE /maxgroupp/andP[].
+  by move=> /[1inE] /maxgroupp/andP[].
 have SmaxN P Q: Q \in S -> Q \subset 'N(P) -> maxp 'N_G(P) Q.
-  move=> /1inE /maxgroupP[/andP[sQG pQ] maxQ] nPQ.
+  move=> /[1inE] /maxgroupP[/andP[sQG pQ] maxQ] nPQ.
   apply/maxgroupP; rewrite /psubgroup subsetI sQG nPQ.
   by split=> // R; rewrite subsetI -andbA andbCA => /andP[_]; apply: maxQ.
 have nrmG P: P \subset G -> P <| 'N_G(P).
@@ -126,7 +126,7 @@ have [P S_P]: exists P, P \in S.
 have trS: [transitive G, on S | 'JG].
   apply/imsetP; exists P => //; apply/eqP.
   rewrite eqEsubset andbC acts_sub_orbit // S_P; apply/subsetP=> Q S_Q.
-  have /1inE /maxgroupP[/andP[_ pP]] := S_P.
+  have /[1inE] /maxgroupP[/andP[_ pP]] := S_P.
   have [-> max1 | ntP _] := eqVneq P 1%G.
     move/andP/max1: (S_pG _ S_Q) => Q1.
     by rewrite (group_inj (Q1 (sub1G Q))) orbit_refl.
@@ -287,7 +287,7 @@ Proof.
 set T := [set P : {group gT} | Sylow G P].
 rewrite -{2}(@Sylow_transversal_gen T G) => [|P | q _].
 - by congr <<_>>; apply: eq_bigl => P; rewrite inE.
-- by move=> /1inE /and3P[].
+- by move=> /[1inE] /and3P[].
 by case: (Sylow_exists q G) => P sylP; exists P; rewrite // inE (p_Sylow sylP).
 Qed.
 

--- a/mathcomp/ssreflect/div.v
+++ b/mathcomp/ssreflect/div.v
@@ -124,7 +124,7 @@ Proof. by case: d => // d; rewrite -{1}[d.+1]muln1 mulKn. Qed.
 Lemma divnMl p m d : p > 0 -> p * m %/ (p * d) = m %/ d.
 Proof.
 move=> p_gt0; case: (posnP d) => [-> | d_gt0]; first by rewrite muln0.
-rewrite {2}/divn; case: edivnP => /[rw d_gt0] /= q r ->{m} lt_rd.
+rewrite {2}/divn; case: edivnP => /[1 d_gt0] /= q r ->{m} lt_rd.
 rewrite mulnDr mulnCA divnMDl; last by rewrite muln_gt0 p_gt0.
 by rewrite addnC divn_small // ltn_pmul2l.
 Qed.
@@ -346,14 +346,14 @@ Proof. by rewrite /dvdn modn2; case (odd n). Qed.
 
 Lemma dvdn_odd m n : m %| n -> odd n -> odd m.
 Proof.
-by move=> m_dv_n; apply: contraTT => /[rw -!dvdn2] /dvdn_trans->.
+by move=> m_dv_n; apply: contraTT => /[-!dvdn2] /dvdn_trans->.
 Qed.
 
 Lemma divnK d m : d %| m -> m %/ d * d = m.
 Proof. by rewrite dvdn_eq; move/eqP. Qed.
 
 Lemma leq_divLR d m n : d %| m -> (m %/ d <= n) = (m <= n * d).
-Proof. by case: d m => [|d] [|m] ///divnK=> {2}<- /[rw leq_pmul2r]. Qed.
+Proof. by case: d m => [|d] [|m] ///divnK=> {2}<- /[1 leq_pmul2r]. Qed.
 
 Lemma ltn_divRL d m n : d %| m -> (n < m %/ d) = (n * d < m).
 Proof. by move=> dv_d_m; rewrite !ltnNge leq_divLR. Qed.

--- a/mathcomp/ssreflect/div.v
+++ b/mathcomp/ssreflect/div.v
@@ -124,7 +124,7 @@ Proof. by case: d => // d; rewrite -{1}[d.+1]muln1 mulKn. Qed.
 Lemma divnMl p m d : p > 0 -> p * m %/ (p * d) = m %/ d.
 Proof.
 move=> p_gt0; case: (posnP d) => [-> | d_gt0]; first by rewrite muln0.
-rewrite {2}/divn; case: edivnP; rewrite d_gt0 /= => q r ->{m} lt_rd.
+rewrite {2}/divn; case: edivnP => /[rw d_gt0] /= q r ->{m} lt_rd.
 rewrite mulnDr mulnCA divnMDl; last by rewrite muln_gt0 p_gt0.
 by rewrite addnC divn_small // ltn_pmul2l.
 Qed.
@@ -346,14 +346,14 @@ Proof. by rewrite /dvdn modn2; case (odd n). Qed.
 
 Lemma dvdn_odd m n : m %| n -> odd n -> odd m.
 Proof.
-by move=> m_dv_n; apply: contraTT; rewrite -!dvdn2 => /dvdn_trans->.
+by move=> m_dv_n; apply: contraTT => /[rw -!dvdn2] /dvdn_trans->.
 Qed.
 
 Lemma divnK d m : d %| m -> m %/ d * d = m.
 Proof. by rewrite dvdn_eq; move/eqP. Qed.
 
 Lemma leq_divLR d m n : d %| m -> (m %/ d <= n) = (m <= n * d).
-Proof. by case: d m => [|d] [|m] ///divnK=> {2}<-; rewrite leq_pmul2r. Qed.
+Proof. by case: d m => [|d] [|m] ///divnK=> {2}<- /[rw leq_pmul2r]. Qed.
 
 Lemma ltn_divRL d m n : d %| m -> (n < m %/ d) = (n * d < m).
 Proof. by move=> dv_d_m; rewrite !ltnNge leq_divLR. Qed.

--- a/mathcomp/ssreflect/eqtype.v
+++ b/mathcomp/ssreflect/eqtype.v
@@ -934,7 +934,7 @@ Lemma inj_homo_in : {in D & D', injective f} ->
   {in D & D', {homo f : x y / aR x y >-> rR x y}} ->
   {in D & D', {homo f : x y / aR' x y >-> rR' x y}}.
 Proof.
-move=> fI mf x y xD yD /=; rewrite aR'E rR'E => /andP[neq_xy xy].
+move=> fI mf x y xD yD /= /[rws aR'E rR'E] /andP[neq_xy xy].
 by rewrite mf ?andbT //; apply: contra_neq neq_xy => /fI; apply.
 Qed.
 
@@ -961,10 +961,9 @@ Proof.
 move=> aR_tot mf x y xD yD.
 have [->|neq_xy] := altP (x =P y); first by rewrite ?eqxx ?aR_refl ?rR_refl.
 have [xy|] := (boolP (aR x y)); first by rewrite rRE mf ?orbT// aR'E neq_xy.
-have /orP [->//|] := aR_tot x y.
-rewrite aRE eq_sym (negPf neq_xy) /= => /mf -/(_ yD xD).
-rewrite rR'E => /andP[Nfxfy fyfx] _; apply: contra_neqF Nfxfy => fxfy.
-by apply/rR_anti; rewrite fyfx fxfy.
+have /orP [->//|/[rws aRE eq_sym (negPf neq_xy)] /=] := aR_tot x y.
+move=> /mf -/(_ yD xD) /[rw rR'E] /andP[Nfxfy fyfx] _.
+by apply: contra_neqF Nfxfy => fxfy; apply/rR_anti; rewrite fyfx fxfy.
 Qed.
 
 End InDom.
@@ -978,9 +977,7 @@ Proof. by move=> mf ???; apply: (@homoW_in D D) => // ????; apply: mf. Qed.
 Lemma inj_homo : injective f ->
   {homo f : x y / aR x y >-> rR x y} ->
   {homo f : x y / aR' x y >-> rR' x y}.
-Proof.
-by move=> fI mf ???; apply: (@inj_homo_in D D) => //????; [apply: fI|apply: mf].
-Qed.
+Proof. by move=> /in2W /(@inj_homo_in D D)/= /(_ (in2W _))/apply/in2T. Qed.
 
 Hypothesis aR_anti : antisymmetric aR.
 Hypothesis rR_anti : antisymmetric rR.
@@ -990,7 +987,7 @@ Proof. by move=> mf x y eqf; apply/aR_anti; rewrite -!mf eqf rR_refl. Qed.
 
 Lemma anti_mono : {mono f : x y / aR x y >-> rR x y} ->
                   {mono f : x y / aR' x y >-> rR' x y}.
-Proof. by move=> mf x y; rewrite rR'E aR'E mf inj_eq //; apply: mono_inj. Qed.
+Proof. by move=> mf x y /[rws rR'E aR'E mf inj_eq]//; apply: mono_inj. Qed.
 
 Lemma total_homo_mono : total aR ->
     {homo f : x y / aR' x y >-> rR' x y} ->

--- a/mathcomp/ssreflect/eqtype.v
+++ b/mathcomp/ssreflect/eqtype.v
@@ -934,7 +934,7 @@ Lemma inj_homo_in : {in D & D', injective f} ->
   {in D & D', {homo f : x y / aR x y >-> rR x y}} ->
   {in D & D', {homo f : x y / aR' x y >-> rR' x y}}.
 Proof.
-move=> fI mf x y xD yD /= /[rws aR'E rR'E] /andP[neq_xy xy].
+move=> fI mf x y xD yD /= /[rw aR'E rR'E] /andP[neq_xy xy].
 by rewrite mf ?andbT //; apply: contra_neq neq_xy => /fI; apply.
 Qed.
 
@@ -961,8 +961,8 @@ Proof.
 move=> aR_tot mf x y xD yD.
 have [->|neq_xy] := altP (x =P y); first by rewrite ?eqxx ?aR_refl ?rR_refl.
 have [xy|] := (boolP (aR x y)); first by rewrite rRE mf ?orbT// aR'E neq_xy.
-have /orP [->//|/[rws aRE eq_sym (negPf neq_xy)] /=] := aR_tot x y.
-move=> /mf -/(_ yD xD) /[rw rR'E] /andP[Nfxfy fyfx] _.
+have /orP [->//|/[rw aRE eq_sym (negPf neq_xy)] /=] := aR_tot x y.
+move=> /mf -/(_ yD xD) /[1 rR'E] /andP[Nfxfy fyfx] _.
 by apply: contra_neqF Nfxfy => fxfy; apply/rR_anti; rewrite fyfx fxfy.
 Qed.
 
@@ -987,7 +987,7 @@ Proof. by move=> mf x y eqf; apply/aR_anti; rewrite -!mf eqf rR_refl. Qed.
 
 Lemma anti_mono : {mono f : x y / aR x y >-> rR x y} ->
                   {mono f : x y / aR' x y >-> rR' x y}.
-Proof. by move=> mf x y /[rws rR'E aR'E mf inj_eq]//; apply: mono_inj. Qed.
+Proof. by move=> mf x y /[rw rR'E aR'E mf inj_eq]//; apply: mono_inj. Qed.
 
 Lemma total_homo_mono : total aR ->
     {homo f : x y / aR' x y >-> rR' x y} ->

--- a/mathcomp/ssreflect/fingraph.v
+++ b/mathcomp/ssreflect/fingraph.v
@@ -318,7 +318,7 @@ Lemma connect_closed x : closed e (connect e x).
 Proof. by move=> y z /connect1/same_connect_r; apply. Qed.
 
 Lemma predC_closed a : closed e a -> closed e [predC a].
-Proof. by move=> cl_a x y /cl_a; rewrite !inE => ->. Qed.
+Proof. by move=> cl_a x y /cl_a /!inE ->. Qed.
 
 Lemma closure_closed a : closed e (closure e a).
 Proof.

--- a/mathcomp/ssreflect/fingraph.v
+++ b/mathcomp/ssreflect/fingraph.v
@@ -318,7 +318,7 @@ Lemma connect_closed x : closed e (connect e x).
 Proof. by move=> y z /connect1/same_connect_r; apply. Qed.
 
 Lemma predC_closed a : closed e a -> closed e [predC a].
-Proof. by move=> cl_a x y /cl_a /!inE ->. Qed.
+Proof. by move=> cl_a x y /cl_a /[!inE] ->. Qed.
 
 Lemma closure_closed a : closed e (closure e a).
 Proof.

--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -359,7 +359,7 @@ Lemma subsetT A : A \subset setT.
 Proof. by apply/subsetP=> x; rewrite inE. Qed.
 
 Lemma subsetT_hint mA : subset mA (mem [set: T]).
-Proof. by rewrite unlock; apply/pred0P=> x; rewrite !inE. Qed.
+Proof. by rewrite unlock; apply/pred0P=> x /!inE. Qed.
 Hint Resolve subsetT_hint : core.
 
 Lemma subTset A : (setT \subset A) = (A == setT).
@@ -393,7 +393,7 @@ Lemma in_setU1 x a B : (x \in a |: B) = (x == a) || (x \in B).
 Proof. by rewrite !inE. Qed.
 
 Lemma set_cons a s : [set x in a :: s] = a |: [set x in s].
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /!inE. Qed.
 
 Lemma setU11 x B : x \in x |: B.
 Proof. by rewrite !inE eqxx. Qed.
@@ -404,7 +404,7 @@ Proof. by move=> Bx; rewrite !inE predU1r. Qed.
 (* We need separate lemmas for the explicit enumerations since they *)
 (* associate on the left.                                           *)
 Lemma set1Ul x A b : x \in A -> x \in A :|: [set b].
-Proof. by move=> Ax; rewrite !inE Ax. Qed.
+Proof. by move=> + /!inE => ->. Qed.
 
 Lemma set1Ur A b : b \in A :|: [set b].
 Proof. by rewrite !inE eqxx orbT. Qed.
@@ -455,7 +455,7 @@ Proof. by apply/setP => x; rewrite !inE orbC. Qed.
 
 Lemma setUS A B C : A \subset B -> C :|: A \subset C :|: B.
 Proof.
-move=> sAB; apply/subsetP=> x; rewrite !inE.
+move=> sAB; apply/subsetP=> x /!inE.
 by case: (x \in C) => //; apply: (subsetP sAB).
 Qed.
 
@@ -509,7 +509,7 @@ Lemma setId2P x pA pB pC :
 Proof. by rewrite !inE; apply: and3P. Qed.
 
 Lemma setIdE A pB : [set x in A | pB x] = A :&: [set x | pB x].
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /!inE. Qed.
 
 Lemma setIP x A B : reflect (x \in A /\ x \in B) (x \in A :&: B).
 Proof. exact: (iffP (@setIdP _ _ _)). Qed.
@@ -522,7 +522,7 @@ Proof. by apply/setP => x; rewrite !inE andbC. Qed.
 
 Lemma setIS A B C : A \subset B -> C :&: A \subset C :&: B.
 Proof.
-move=> sAB; apply/subsetP=> x; rewrite !inE.
+move=> sAB; apply/subsetP=> x /!inE.
 by case: (x \in C) => //; apply: (subsetP sAB).
 Qed.
 
@@ -607,7 +607,7 @@ Lemma setC_inj : injective (@setC T).
 Proof. exact: can_inj setCK. Qed.
 
 Lemma subsets_disjoint A B : (A \subset B) = [disjoint A & ~: B].
-Proof. by rewrite subset_disjoint; apply: eq_disjoint_r => x; rewrite !inE. Qed.
+Proof. by rewrite subset_disjoint; apply: eq_disjoint_r => x /!inE. Qed.
 
 Lemma disjoints_subset A B : [disjoint A & B] = (A \subset ~: B).
 Proof. by rewrite subsets_disjoint setCK. Qed.
@@ -631,7 +631,7 @@ Lemma setICr A : A :&: ~: A = set0.
 Proof. by apply/setP=> x; rewrite !inE andbN. Qed.
 
 Lemma setC0 : ~: set0 = [set: T].
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /!inE. Qed.
 
 Lemma setCT : ~: [set: T] = set0.
 Proof. by rewrite -setC0 setCK. Qed.
@@ -657,13 +657,13 @@ Lemma setDSS A B C D : A \subset C -> D \subset B -> A :\: B \subset C :\: D.
 Proof. by move=> /(setSD B) /subset_trans sAC /(setDS C) /sAC. Qed.
 
 Lemma setD0 A : A :\: set0 = A.
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /!inE. Qed.
 
 Lemma set0D A : set0 :\: A = set0.
 Proof. by apply/setP=> x; rewrite !inE andbF. Qed.
 
 Lemma setDT A : A :\: setT = set0.
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /!inE. Qed.
 
 Lemma setTD A : setT :\: A = ~: A.
 Proof. by apply/setP=> x; rewrite !inE andbT. Qed.
@@ -708,18 +708,18 @@ Proof. by rewrite inE. Qed.
 
 Lemma powersetS A B : (powerset A \subset powerset B) = (A \subset B).
 Proof.
-apply/subsetP/idP=> [sAB | sAB C]; last by rewrite !inE => /subset_trans ->.
+apply/subsetP/idP=> [sAB | sAB C /!inE/subset_trans->//].
 by rewrite -powersetE sAB // inE.
 Qed.
 
 Lemma powerset0 : powerset set0 = [set set0] :> {set {set T}}.
-Proof. by apply/setP=> A; rewrite !inE subset0. Qed.
+Proof. by apply/setP=> A /!inE; rewrite subset0. Qed.
 
 Lemma powersetT : powerset [set: T] = [set: {set T}].
-Proof. by apply/setP=> A; rewrite !inE subsetT. Qed.
+Proof. by apply/setP=> A /!inE; rewrite subsetT. Qed.
 
 Lemma setI_powerset P A : P :&: powerset A = P ::&: A.
-Proof. by apply/setP=> B; rewrite !inE. Qed.
+Proof. by apply/setP=> B /!inE. Qed.
 
 (* cardinal lemmas for sets *)
 
@@ -745,7 +745,7 @@ Lemma card_gt0 A : (0 < #|A|) = (A != set0).
 Proof. by rewrite lt0n cards_eq0. Qed.
 
 Lemma cards0_eq A : #|A| = 0 -> A = set0.
-Proof. by move=> A_0; apply/setP=> x; rewrite inE (card0_eq A_0). Qed.
+Proof. by move=> A_0; apply/setP=> x /1inE; rewrite (card0_eq A_0). Qed.
 
 Lemma cards1 x : #|[set x]| = 1.
 Proof. by rewrite cardsE card1. Qed.
@@ -775,17 +775,17 @@ Lemma cardsCs A : #|A| = #|T| - #|~: A|.
 Proof. by rewrite -(cardsC A) addnK. Qed.
 
 Lemma cardsU1 a A : #|a |: A| = (a \notin A) + #|A|.
-Proof. by rewrite -cardU1; apply: eq_card=> x; rewrite !inE. Qed.
+Proof. by rewrite -cardU1; apply: eq_card=> x /!inE. Qed.
 
 Lemma cards2 a b : #|[set a; b]| = (a != b).+1.
-Proof. by rewrite -card2; apply: eq_card=> x; rewrite !inE. Qed.
+Proof. by rewrite -card2; apply: eq_card=> x /!inE. Qed.
 
 Lemma cardsC1 a : #|[set~ a]| = #|T|.-1.
-Proof. by rewrite -(cardC1 a); apply: eq_card=> x; rewrite !inE. Qed.
+Proof. by rewrite -(cardC1 a); apply: eq_card=> x /!inE. Qed.
 
 Lemma cardsD1 a A : #|A| = (a \in A) + #|A :\ a|.
 Proof.
-by rewrite (cardD1 a); congr (_ + _); apply: eq_card => x; rewrite !inE.
+by rewrite (cardD1 a); congr (_ + _); apply: eq_card => x /!inE.
 Qed.
 
 (* other inclusions *)
@@ -797,7 +797,7 @@ Lemma subsetIr A B : A :&: B \subset B.
 Proof. by apply/subsetP=> x; rewrite inE; case/andP. Qed.
 
 Lemma subsetUl A B : A \subset A :|: B.
-Proof. by apply/subsetP=> x; rewrite inE => ->. Qed.
+Proof. by apply/subsetP=> x /1inE ->. Qed.
 
 Lemma subsetUr A B : B \subset A :|: B.
 Proof. by apply/subsetP=> x; rewrite inE orbC => ->. Qed.
@@ -815,7 +815,7 @@ Lemma subsetDr A B : A :\: B \subset ~: B.
 Proof. by rewrite setDE subsetIr. Qed.
 
 Lemma sub1set A x : ([set x] \subset A) = (x \in A).
-Proof. by rewrite -subset_pred1; apply: eq_subset=> y; rewrite !inE. Qed.
+Proof. by rewrite -subset_pred1; apply: eq_subset=> y /!inE. Qed.
 
 Lemma cards1P A : reflect (exists x, A = [set x]) (#|A| == 1).
 Proof.
@@ -898,7 +898,7 @@ Proof. by rewrite setDE subsetI -disjoints_subset. Qed.
 
 Lemma subDset A B C : (A :\: B \subset C) = (A \subset B :|: C).
 Proof.
-apply/subsetP/subsetP=> sABC x; rewrite !inE.
+apply/subsetP/subsetP=> sABC x /!inE.
   by case Bx: (x \in B) => // Ax; rewrite sABC ?inE ?Bx.
 by case Bx: (x \in B) => //; move/sABC; rewrite inE Bx.
 Qed.
@@ -1252,25 +1252,25 @@ Lemma preimsetS (A B : {pred rT}) :
 Proof. by move=> sAB; apply/subsetP=> y; rewrite !inE; apply: subsetP. Qed.
 
 Lemma preimset0 : f @^-1: set0 = set0.
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /!inE. Qed.
 
 Lemma preimsetT : f @^-1: setT = setT.
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /!inE. Qed.
 
 Lemma preimsetI (A B : {set rT}) :
   f @^-1: (A :&: B) = (f @^-1: A) :&: (f @^-1: B).
-Proof. by apply/setP=> y; rewrite !inE. Qed.
+Proof. by apply/setP=> y /!inE. Qed.
 
 Lemma preimsetU (A B : {set rT}) :
   f @^-1: (A :|: B) = (f @^-1: A) :|: (f @^-1: B).
-Proof. by apply/setP=> y; rewrite !inE. Qed.
+Proof. by apply/setP=> y /!inE. Qed.
 
 Lemma preimsetD (A B : {set rT}) :
   f @^-1: (A :\: B) = (f @^-1: A) :\: (f @^-1: B).
-Proof. by apply/setP=> y; rewrite !inE. Qed.
+Proof. by apply/setP=> y /!inE. Qed.
 
 Lemma preimsetC (A : {set rT}) : f @^-1: (~: A) = ~: f @^-1: A.
-Proof. by apply/setP=> y; rewrite !inE. Qed.
+Proof. by apply/setP=> y /!inE. Qed.
 
 Lemma imsetS (A B : {pred aT}) : A \subset B -> f @: A \subset f @: B.
 Proof.
@@ -1390,7 +1390,7 @@ Lemma big_set0 F : \big[op/idx]_(i in set0) F i = idx.
 Proof. by apply: big_pred0 => i; rewrite inE. Qed.
 
 Lemma big_set1 a F : \big[op/idx]_(i in [set a]) F i = F a.
-Proof. by apply: big_pred1 => i; rewrite !inE. Qed.
+Proof. by apply: big_pred1 => i /!inE. Qed.
 
 Lemma big_setID A B F :
   \big[aop/idx]_(i in A) F i =
@@ -1398,7 +1398,7 @@ Lemma big_setID A B F :
          (\big[aop/idx]_(i in A :\: B) F i).
 Proof.
 rewrite (bigID (mem B)) setDE.
-by congr (aop _ _); apply: eq_bigl => i; rewrite !inE.
+by congr (aop _ _); apply: eq_bigl => i /!inE.
 Qed.
 
 Lemma big_setIDcond A B P F :
@@ -1730,7 +1730,7 @@ Variables (D1 : {pred aT1}) (D2 : {pred aT2}).
 Lemma curry_imset2X : f @2: (A1, A2) = prod_curry f @: (setX A1 A2).
 Proof.
 rewrite [@imset]unlock unlock; apply/setP=> x; rewrite !in_set; congr (x \in _).
-by apply: eq_image => u //=; rewrite !inE.
+by apply: eq_image => u //= /!inE.
 Qed.
 
 Lemma curry_imset2l : f @2: (D1, D2) = \bigcup_(x1 in D1) f x1 @: D2.
@@ -1822,7 +1822,7 @@ Lemma mem_pblock P x : (x \in pblock P x) = (x \in cover P).
 Proof.
 rewrite /pblock; apply/esym/bigcupP.
 case: pickP => /= [A /andP[PA Ax]| noA]; first by rewrite Ax; exists A.
-by rewrite inE => [[A PA Ax]]; case/andP: (noA A).
+by move=> /1inE [[A PA Ax]]; case/andP: (noA A).
 Qed.
 
 Lemma pblock_mem P x : x \in cover P -> pblock P x \in P.
@@ -1966,7 +1966,7 @@ have defD: cover P == D.
   by apply/subsetP=> x Dx; apply/bigcupP; exists (Px x); rewrite (Pxx, PPx).
 have tiP: trivIset P.
   apply/trivIsetP=> _ _ /imsetP[x Dx ->] /imsetP[y Dy ->]; apply: contraR.
-  case/pred0Pn=> z /andP[]; rewrite !inE => /andP[Dz Rxz] /andP[_ Ryz].
+  case/pred0Pn=> z /andP[] /!inE /andP[Dz Rxz] /andP[_ Ryz].
   apply/eqP/setP=> t; rewrite !inE; apply: andb_id2l => Dt.
   by rewrite (eqiR Dx Dz Dt) // (eqiR Dy Dz Dt).
 rewrite /partition tiP defD /=.

--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -359,7 +359,7 @@ Lemma subsetT A : A \subset setT.
 Proof. by apply/subsetP=> x; rewrite inE. Qed.
 
 Lemma subsetT_hint mA : subset mA (mem [set: T]).
-Proof. by rewrite unlock; apply/pred0P=> x /!inE. Qed.
+Proof. by rewrite unlock; apply/pred0P=> x /[!inE]. Qed.
 Hint Resolve subsetT_hint : core.
 
 Lemma subTset A : (setT \subset A) = (A == setT).
@@ -393,7 +393,7 @@ Lemma in_setU1 x a B : (x \in a |: B) = (x == a) || (x \in B).
 Proof. by rewrite !inE. Qed.
 
 Lemma set_cons a s : [set x in a :: s] = a |: [set x in s].
-Proof. by apply/setP=> x /!inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma setU11 x B : x \in x |: B.
 Proof. by rewrite !inE eqxx. Qed.
@@ -404,7 +404,7 @@ Proof. by move=> Bx; rewrite !inE predU1r. Qed.
 (* We need separate lemmas for the explicit enumerations since they *)
 (* associate on the left.                                           *)
 Lemma set1Ul x A b : x \in A -> x \in A :|: [set b].
-Proof. by move=> + /!inE => ->. Qed.
+Proof. by move=> + /[!inE] => ->. Qed.
 
 Lemma set1Ur A b : b \in A :|: [set b].
 Proof. by rewrite !inE eqxx orbT. Qed.
@@ -455,7 +455,7 @@ Proof. by apply/setP => x; rewrite !inE orbC. Qed.
 
 Lemma setUS A B C : A \subset B -> C :|: A \subset C :|: B.
 Proof.
-move=> sAB; apply/subsetP=> x /!inE.
+move=> sAB; apply/subsetP=> x /[!inE].
 by case: (x \in C) => //; apply: (subsetP sAB).
 Qed.
 
@@ -509,7 +509,7 @@ Lemma setId2P x pA pB pC :
 Proof. by rewrite !inE; apply: and3P. Qed.
 
 Lemma setIdE A pB : [set x in A | pB x] = A :&: [set x | pB x].
-Proof. by apply/setP=> x /!inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma setIP x A B : reflect (x \in A /\ x \in B) (x \in A :&: B).
 Proof. exact: (iffP (@setIdP _ _ _)). Qed.
@@ -522,7 +522,7 @@ Proof. by apply/setP => x; rewrite !inE andbC. Qed.
 
 Lemma setIS A B C : A \subset B -> C :&: A \subset C :&: B.
 Proof.
-move=> sAB; apply/subsetP=> x /!inE.
+move=> sAB; apply/subsetP=> x /[!inE].
 by case: (x \in C) => //; apply: (subsetP sAB).
 Qed.
 
@@ -607,7 +607,7 @@ Lemma setC_inj : injective (@setC T).
 Proof. exact: can_inj setCK. Qed.
 
 Lemma subsets_disjoint A B : (A \subset B) = [disjoint A & ~: B].
-Proof. by rewrite subset_disjoint; apply: eq_disjoint_r => x /!inE. Qed.
+Proof. by rewrite subset_disjoint; apply: eq_disjoint_r => x /[!inE]. Qed.
 
 Lemma disjoints_subset A B : [disjoint A & B] = (A \subset ~: B).
 Proof. by rewrite subsets_disjoint setCK. Qed.
@@ -631,7 +631,7 @@ Lemma setICr A : A :&: ~: A = set0.
 Proof. by apply/setP=> x; rewrite !inE andbN. Qed.
 
 Lemma setC0 : ~: set0 = [set: T].
-Proof. by apply/setP=> x /!inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma setCT : ~: [set: T] = set0.
 Proof. by rewrite -setC0 setCK. Qed.
@@ -657,13 +657,13 @@ Lemma setDSS A B C D : A \subset C -> D \subset B -> A :\: B \subset C :\: D.
 Proof. by move=> /(setSD B) /subset_trans sAC /(setDS C) /sAC. Qed.
 
 Lemma setD0 A : A :\: set0 = A.
-Proof. by apply/setP=> x /!inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma set0D A : set0 :\: A = set0.
 Proof. by apply/setP=> x; rewrite !inE andbF. Qed.
 
 Lemma setDT A : A :\: setT = set0.
-Proof. by apply/setP=> x /!inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma setTD A : setT :\: A = ~: A.
 Proof. by apply/setP=> x; rewrite !inE andbT. Qed.
@@ -708,18 +708,18 @@ Proof. by rewrite inE. Qed.
 
 Lemma powersetS A B : (powerset A \subset powerset B) = (A \subset B).
 Proof.
-apply/subsetP/idP=> [sAB | sAB C /!inE/subset_trans->//].
+apply/subsetP/idP=> [sAB | sAB C /[!inE]/subset_trans->//].
 by rewrite -powersetE sAB // inE.
 Qed.
 
 Lemma powerset0 : powerset set0 = [set set0] :> {set {set T}}.
-Proof. by apply/setP=> A /!inE; rewrite subset0. Qed.
+Proof. by apply/setP=> A /[!inE]; rewrite subset0. Qed.
 
 Lemma powersetT : powerset [set: T] = [set: {set T}].
-Proof. by apply/setP=> A /!inE; rewrite subsetT. Qed.
+Proof. by apply/setP=> A /[!inE]; rewrite subsetT. Qed.
 
 Lemma setI_powerset P A : P :&: powerset A = P ::&: A.
-Proof. by apply/setP=> B /!inE. Qed.
+Proof. by apply/setP=> B /[!inE]. Qed.
 
 (* cardinal lemmas for sets *)
 
@@ -745,7 +745,7 @@ Lemma card_gt0 A : (0 < #|A|) = (A != set0).
 Proof. by rewrite lt0n cards_eq0. Qed.
 
 Lemma cards0_eq A : #|A| = 0 -> A = set0.
-Proof. by move=> A_0; apply/setP=> x /1inE; rewrite (card0_eq A_0). Qed.
+Proof. by move=> A_0; apply/setP=> x /[1inE]; rewrite (card0_eq A_0). Qed.
 
 Lemma cards1 x : #|[set x]| = 1.
 Proof. by rewrite cardsE card1. Qed.
@@ -775,17 +775,17 @@ Lemma cardsCs A : #|A| = #|T| - #|~: A|.
 Proof. by rewrite -(cardsC A) addnK. Qed.
 
 Lemma cardsU1 a A : #|a |: A| = (a \notin A) + #|A|.
-Proof. by rewrite -cardU1; apply: eq_card=> x /!inE. Qed.
+Proof. by rewrite -cardU1; apply: eq_card=> x /[!inE]. Qed.
 
 Lemma cards2 a b : #|[set a; b]| = (a != b).+1.
-Proof. by rewrite -card2; apply: eq_card=> x /!inE. Qed.
+Proof. by rewrite -card2; apply: eq_card=> x /[!inE]. Qed.
 
 Lemma cardsC1 a : #|[set~ a]| = #|T|.-1.
-Proof. by rewrite -(cardC1 a); apply: eq_card=> x /!inE. Qed.
+Proof. by rewrite -(cardC1 a); apply: eq_card=> x /[!inE]. Qed.
 
 Lemma cardsD1 a A : #|A| = (a \in A) + #|A :\ a|.
 Proof.
-by rewrite (cardD1 a); congr (_ + _); apply: eq_card => x /!inE.
+by rewrite (cardD1 a); congr (_ + _); apply: eq_card => x /[!inE].
 Qed.
 
 (* other inclusions *)
@@ -797,7 +797,7 @@ Lemma subsetIr A B : A :&: B \subset B.
 Proof. by apply/subsetP=> x; rewrite inE; case/andP. Qed.
 
 Lemma subsetUl A B : A \subset A :|: B.
-Proof. by apply/subsetP=> x /1inE ->. Qed.
+Proof. by apply/subsetP=> x /[1inE] ->. Qed.
 
 Lemma subsetUr A B : B \subset A :|: B.
 Proof. by apply/subsetP=> x; rewrite inE orbC => ->. Qed.
@@ -815,7 +815,7 @@ Lemma subsetDr A B : A :\: B \subset ~: B.
 Proof. by rewrite setDE subsetIr. Qed.
 
 Lemma sub1set A x : ([set x] \subset A) = (x \in A).
-Proof. by rewrite -subset_pred1; apply: eq_subset=> y /!inE. Qed.
+Proof. by rewrite -subset_pred1; apply: eq_subset=> y /[!inE]. Qed.
 
 Lemma cards1P A : reflect (exists x, A = [set x]) (#|A| == 1).
 Proof.
@@ -898,7 +898,7 @@ Proof. by rewrite setDE subsetI -disjoints_subset. Qed.
 
 Lemma subDset A B C : (A :\: B \subset C) = (A \subset B :|: C).
 Proof.
-apply/subsetP/subsetP=> sABC x /!inE.
+apply/subsetP/subsetP=> sABC x /[!inE].
   by case Bx: (x \in B) => // Ax; rewrite sABC ?inE ?Bx.
 by case Bx: (x \in B) => //; move/sABC; rewrite inE Bx.
 Qed.
@@ -1252,25 +1252,25 @@ Lemma preimsetS (A B : {pred rT}) :
 Proof. by move=> sAB; apply/subsetP=> y; rewrite !inE; apply: subsetP. Qed.
 
 Lemma preimset0 : f @^-1: set0 = set0.
-Proof. by apply/setP=> x /!inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma preimsetT : f @^-1: setT = setT.
-Proof. by apply/setP=> x /!inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma preimsetI (A B : {set rT}) :
   f @^-1: (A :&: B) = (f @^-1: A) :&: (f @^-1: B).
-Proof. by apply/setP=> y /!inE. Qed.
+Proof. by apply/setP=> y /[!inE]. Qed.
 
 Lemma preimsetU (A B : {set rT}) :
   f @^-1: (A :|: B) = (f @^-1: A) :|: (f @^-1: B).
-Proof. by apply/setP=> y /!inE. Qed.
+Proof. by apply/setP=> y /[!inE]. Qed.
 
 Lemma preimsetD (A B : {set rT}) :
   f @^-1: (A :\: B) = (f @^-1: A) :\: (f @^-1: B).
-Proof. by apply/setP=> y /!inE. Qed.
+Proof. by apply/setP=> y /[!inE]. Qed.
 
 Lemma preimsetC (A : {set rT}) : f @^-1: (~: A) = ~: f @^-1: A.
-Proof. by apply/setP=> y /!inE. Qed.
+Proof. by apply/setP=> y /[!inE]. Qed.
 
 Lemma imsetS (A B : {pred aT}) : A \subset B -> f @: A \subset f @: B.
 Proof.
@@ -1390,7 +1390,7 @@ Lemma big_set0 F : \big[op/idx]_(i in set0) F i = idx.
 Proof. by apply: big_pred0 => i; rewrite inE. Qed.
 
 Lemma big_set1 a F : \big[op/idx]_(i in [set a]) F i = F a.
-Proof. by apply: big_pred1 => i /!inE. Qed.
+Proof. by apply: big_pred1 => i /[!inE]. Qed.
 
 Lemma big_setID A B F :
   \big[aop/idx]_(i in A) F i =
@@ -1398,7 +1398,7 @@ Lemma big_setID A B F :
          (\big[aop/idx]_(i in A :\: B) F i).
 Proof.
 rewrite (bigID (mem B)) setDE.
-by congr (aop _ _); apply: eq_bigl => i /!inE.
+by congr (aop _ _); apply: eq_bigl => i /[!inE].
 Qed.
 
 Lemma big_setIDcond A B P F :
@@ -1730,7 +1730,7 @@ Variables (D1 : {pred aT1}) (D2 : {pred aT2}).
 Lemma curry_imset2X : f @2: (A1, A2) = prod_curry f @: (setX A1 A2).
 Proof.
 rewrite [@imset]unlock unlock; apply/setP=> x; rewrite !in_set; congr (x \in _).
-by apply: eq_image => u //= /!inE.
+by apply: eq_image => u //= /[!inE].
 Qed.
 
 Lemma curry_imset2l : f @2: (D1, D2) = \bigcup_(x1 in D1) f x1 @: D2.
@@ -1822,7 +1822,7 @@ Lemma mem_pblock P x : (x \in pblock P x) = (x \in cover P).
 Proof.
 rewrite /pblock; apply/esym/bigcupP.
 case: pickP => /= [A /andP[PA Ax]| noA]; first by rewrite Ax; exists A.
-by move=> /1inE [[A PA Ax]]; case/andP: (noA A).
+by move=> /[1inE] [[A PA Ax]]; case/andP: (noA A).
 Qed.
 
 Lemma pblock_mem P x : x \in cover P -> pblock P x \in P.
@@ -1966,11 +1966,11 @@ have defD: cover P == D.
   by apply/subsetP=> x Dx; apply/bigcupP; exists (Px x); rewrite (Pxx, PPx).
 have tiP: trivIset P.
   apply/trivIsetP=> _ _ /imsetP[x Dx ->] /imsetP[y Dy ->]; apply: contraR.
-  case/pred0Pn=> z /andP[] /!inE /andP[Dz Rxz] /andP[_ Ryz].
+  case/pred0Pn=> z /andP[] /[!inE] /andP[Dz Rxz] /andP[_ Ryz].
   apply/eqP/setP=> t; rewrite !inE; apply: andb_id2l => Dt.
   by rewrite (eqiR Dx Dz Dt) // (eqiR Dy Dz Dt).
 rewrite /partition tiP defD /=.
-by apply/imsetP=> [[x /Pxx Px_x Px0]]; rewrite -Px0 inE in Px_x.
+by apply/imsetP=> [[x /Pxx Px_x /[<-]]]; rewrite inE in Px_x.
 Qed.
 
 Lemma pblock_equivalence_partition :

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -675,7 +675,8 @@ move=> eqcAB; case: (subsetP A B) (subset_eqP A B) => //= sAB.
 case: (subsetP B A) => [//|[]] x Bx; apply/idPn => Ax.
 case/idP: (ltnn #|A|); rewrite {2}eqcAB (cardD1 x B) Bx /=.
 apply: subset_leq_card; apply/subsetP=> y Ay; rewrite inE /= andbC.
-by rewrite sAB //; apply/eqP => eqyx; rewrite -eqyx Ay in Ax.
+by rewrite sAB //; apply/eqP; move=> /[->]; rewrite Ay in Ax.
+(* BUG: apply/eqP => /[->] does not work *)
 Qed.
 
 Lemma subset_leqif_card A B : A \subset B -> #|A| <= #|B| ?= iff (B \subset A).

--- a/mathcomp/ssreflect/prime.v
+++ b/mathcomp/ssreflect/prime.v
@@ -189,7 +189,7 @@ have leq_pd_ok m p q pd: q <= p -> pd_ok p m pd -> pd_ok q m pd.
   by case/andP=> /(leq_trans _)->.
 have apd_ok m e q p pd: lb_dvd p p || (e == 0) -> q < p ->
      pd_ok p m pd -> pd_ok q (p ^ e * m) (p ^? e :: pd).
-- case: e => [|e]; rewrite orbC /= => pr_p ltqp.
+- case: e => [|e] /[rw orbC] /= pr_p ltqp.
     by rewrite mul1n; apply: leq_pd_ok; apply: ltnW.
   by rewrite /pd_ok /pd_ord /pf_ok /= pr_p ltqp => [[<- -> ->]].
 case=> // n _; rewrite /prime_decomp.
@@ -227,7 +227,7 @@ case def_a: a => [|a'] /= in le_a_n *; rewrite !natTrecE -/p {}eq_bc_0.
     by split; rewrite /pd_ord /pf_ok /= ?muln1 ?pr_p ?leqnn.
   apply: apd_ok; rewrite // /pd_ok /= /pfactor expn1 muln1 /pd_ord /= ltpm.
   rewrite /pf_ok !andbT /=; split=> //; apply: contra leppm.
-  case/hasP=> r /=; rewrite mem_index_iota => /andP[lt1r ltrm] dvrm; apply/hasP.
+  case/hasP=> r /= /[rw mem_index_iota] /andP[lt1r ltrm] dvrm; apply/hasP.
   have [ltrp | lepr] := ltnP r p.
     by exists r; rewrite // mem_index_iota lt1r.
   case/dvdnP: dvrm => q def_q; exists q; last by rewrite def_q /= dvdn_mulr.
@@ -277,13 +277,13 @@ have next_pm: lb_dvd p.+2 m.
     by rewrite /= def_q dvdn_mull // dvdn2 /= odd_double.
   move/(congr1 (dvdn p)): def_m; rewrite -mulnn -!mul2n mulnA -mulnDl.
   rewrite dvdn_mull // dvdn_addr; last by rewrite def_q dvdn_mull.
-  case/dvdnP=> r; rewrite mul2n => def_r; move: ltdp (congr1 odd def_r).
+  case/dvdnP=> r /[rw mul2n] def_r; move: ltdp (congr1 odd def_r).
   rewrite odd_double -ltn_double {1}def_r -mul2n ltn_pmul2r //.
   by case: r def_r => [|[|[]]] //; rewrite def_d // mul1n /= odd_double.
 apply: apd_ok => //; case: a' def_a le_a_n => [|a'] def_a => [_ | lta] /=.
   rewrite /pd_ok /= /pfactor expn1 muln1 /pd_ord /= ltpm /pf_ok !andbT /=.
   split=> //; apply: contra next_pm.
-  case/hasP=> q; rewrite mem_index_iota => /andP[lt1q ltqm] dvqm; apply/hasP.
+  case/hasP=> q /[rw mem_index_iota] /andP[lt1q ltqm] dvqm; apply/hasP.
   have [ltqp | lepq] := ltnP q p.+2.
     by exists q; rewrite // mem_index_iota lt1q.
   case/dvdnP: dvqm => r def_r; exists r; last by rewrite def_r /= dvdn_mulr.
@@ -482,7 +482,7 @@ Proof. by rewrite -pi_max_pdiv mem_primes => /andP[]. Qed.
 
 Lemma max_pdiv_dvd n : max_pdiv n %| n.
 Proof.
-by case: n (pi_max_pdiv n) => [|[|n]] //; rewrite mem_primes => /andP[].
+by case: n (pi_max_pdiv n) => [|[|n]] // /[rw mem_primes] /andP[].
 Qed.
 
 Lemma pdiv_leq n : 0 < n -> pdiv n <= n.
@@ -505,8 +505,7 @@ rewrite /pdiv; apply: leq_trans (pdiv_leq (ltnW lt1d)).
 have: pdiv d \in primes m.
   by rewrite mem_primes mpos pdiv_prime // (dvdn_trans (pdiv_dvd d)).
 case: (primes m) (sorted_primes m) => //= p pm ord_pm.
-rewrite inE => /predU1P[-> //|].
-by move/(allP (order_path_min ltn_trans ord_pm)); apply: ltnW.
+by move=> /1inE /predU1P[->|/(allP (order_path_min ltn_trans ord_pm)) /ltnW].
 Qed.
 
 Lemma max_pdiv_max n p : p \in \pi(n) -> p <= max_pdiv n.

--- a/mathcomp/ssreflect/prime.v
+++ b/mathcomp/ssreflect/prime.v
@@ -189,7 +189,7 @@ have leq_pd_ok m p q pd: q <= p -> pd_ok p m pd -> pd_ok q m pd.
   by case/andP=> /(leq_trans _)->.
 have apd_ok m e q p pd: lb_dvd p p || (e == 0) -> q < p ->
      pd_ok p m pd -> pd_ok q (p ^ e * m) (p ^? e :: pd).
-- case: e => [|e] /[rw orbC] /= pr_p ltqp.
+- case: e => [|e] /[1 orbC] /= pr_p ltqp.
     by rewrite mul1n; apply: leq_pd_ok; apply: ltnW.
   by rewrite /pd_ok /pd_ord /pf_ok /= pr_p ltqp => [[<- -> ->]].
 case=> // n _; rewrite /prime_decomp.
@@ -227,7 +227,7 @@ case def_a: a => [|a'] /= in le_a_n *; rewrite !natTrecE -/p {}eq_bc_0.
     by split; rewrite /pd_ord /pf_ok /= ?muln1 ?pr_p ?leqnn.
   apply: apd_ok; rewrite // /pd_ok /= /pfactor expn1 muln1 /pd_ord /= ltpm.
   rewrite /pf_ok !andbT /=; split=> //; apply: contra leppm.
-  case/hasP=> r /= /[rw mem_index_iota] /andP[lt1r ltrm] dvrm; apply/hasP.
+  case/hasP=> r /= /[1 mem_index_iota] /andP[lt1r ltrm] dvrm; apply/hasP.
   have [ltrp | lepr] := ltnP r p.
     by exists r; rewrite // mem_index_iota lt1r.
   case/dvdnP: dvrm => q def_q; exists q; last by rewrite def_q /= dvdn_mulr.
@@ -277,13 +277,13 @@ have next_pm: lb_dvd p.+2 m.
     by rewrite /= def_q dvdn_mull // dvdn2 /= odd_double.
   move/(congr1 (dvdn p)): def_m; rewrite -mulnn -!mul2n mulnA -mulnDl.
   rewrite dvdn_mull // dvdn_addr; last by rewrite def_q dvdn_mull.
-  case/dvdnP=> r /[rw mul2n] def_r; move: ltdp (congr1 odd def_r).
+  case/dvdnP=> r /[1 mul2n] def_r; move: ltdp (congr1 odd def_r).
   rewrite odd_double -ltn_double {1}def_r -mul2n ltn_pmul2r //.
   by case: r def_r => [|[|[]]] //; rewrite def_d // mul1n /= odd_double.
 apply: apd_ok => //; case: a' def_a le_a_n => [|a'] def_a => [_ | lta] /=.
   rewrite /pd_ok /= /pfactor expn1 muln1 /pd_ord /= ltpm /pf_ok !andbT /=.
   split=> //; apply: contra next_pm.
-  case/hasP=> q /[rw mem_index_iota] /andP[lt1q ltqm] dvqm; apply/hasP.
+  case/hasP=> q /[1 mem_index_iota] /andP[lt1q ltqm] dvqm; apply/hasP.
   have [ltqp | lepq] := ltnP q p.+2.
     by exists q; rewrite // mem_index_iota lt1q.
   case/dvdnP: dvqm => r def_r; exists r; last by rewrite def_r /= dvdn_mulr.
@@ -338,7 +338,7 @@ Proof.
 rewrite -[prime p]negbK; have [npr_p | pr_p] := primePn p.
   right=> [[lt1p pr_p]]; case: npr_p => [|[d n1pd]].
     by rewrite ltnNge lt1p.
-  by move/pr_p=> /orP[] /eqP def_d; rewrite def_d ltnn ?andbF in n1pd.
+  by move/pr_p=> /orP[] /eqP /[->]; rewrite ltnn ?andbF in n1pd.
 have [lep1 | lt1p] := leqP; first by case: pr_p; left.
 left; split=> // d dv_d_p; apply/norP=> [[nd1 ndp]]; case: pr_p; right.
 exists d; rewrite // andbC 2!ltn_neqAle ndp eq_sym nd1.
@@ -482,7 +482,7 @@ Proof. by rewrite -pi_max_pdiv mem_primes => /andP[]. Qed.
 
 Lemma max_pdiv_dvd n : max_pdiv n %| n.
 Proof.
-by case: n (pi_max_pdiv n) => [|[|n]] // /[rw mem_primes] /andP[].
+by case: n (pi_max_pdiv n) => [|[|n]] // /[1 mem_primes] /andP[].
 Qed.
 
 Lemma pdiv_leq n : 0 < n -> pdiv n <= n.
@@ -505,7 +505,7 @@ rewrite /pdiv; apply: leq_trans (pdiv_leq (ltnW lt1d)).
 have: pdiv d \in primes m.
   by rewrite mem_primes mpos pdiv_prime // (dvdn_trans (pdiv_dvd d)).
 case: (primes m) (sorted_primes m) => //= p pm ord_pm.
-by move=> /1inE /predU1P[->|/(allP (order_path_min ltn_trans ord_pm)) /ltnW].
+by move=> /[1inE] /predU1P[->|/(allP (order_path_min ltn_trans ord_pm)) /ltnW].
 Qed.
 
 Lemma max_pdiv_max n p : p \in \pi(n) -> p <= max_pdiv n.

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -988,7 +988,7 @@ Lemma mem_seq4 x y z t u : (x \in [:: y; z; t; u]) = xpred4 y z t u x.
 Proof. by rewrite !inE. Qed.
 
 Lemma mem_cat x s1 s2 : (x \in s1 ++ s2) = (x \in s1) || (x \in s2).
-Proof. by elim: s1 => //= y s1 IHs /1inE; rewrite -orbA -IHs. Qed.
+Proof. by elim: s1 => //= y s1 IHs /[1inE]; rewrite -orbA -IHs. Qed.
 
 Lemma mem_rcons s y : rcons s y =i y :: s.
 Proof. by move=> x; rewrite -cats1 /= mem_cat mem_seq1 orbC in_cons. Qed.
@@ -1073,13 +1073,13 @@ Variables a1 a2 : pred T.
 
 Lemma eq_in_filter s : {in s, a1 =1 a2} -> filter a1 s = filter a2 s.
 Proof.
-elim: s => //= x s IHs /dup eq_a -> /[rw? (mem_head, IHs)]// y s_y.
+elim: s => //= x s IHs /dup eq_a -> /[? (mem_head, IHs)]// y s_y.
 by apply: eq_a; apply: mem_behead.
 Qed.
 
 Lemma eq_in_find s : {in s, a1 =1 a2} -> find a1 s = find a2 s.
 Proof.
-elim: s => //= x s + /dup eq_a12 -> /[rw? mem_head] // => -> // y s'y.
+elim: s => //= x s + /dup eq_a12 -> /[? mem_head] // => -> // y s'y.
 by rewrite eq_a12 // mem_behead.
 Qed.
 
@@ -1535,7 +1535,7 @@ Proof. by move/perm_mem/eq_all_r. Qed.
 Lemma perm_small_eq s1 s2 : size s2 <= 1 -> perm_eq s1 s2 -> s1 = s2.
 Proof.
 move=> s2_le1 eqs12; move/perm_size: eqs12 s2_le1 (perm_mem eqs12).
-by case: s2 s1 => [|x []] // [|y []] // _ _ /(_ x) /!inE /[rw eqxx] /eqP->.
+by case: s2 s1 => [|x []] // [|y []] // _ _ /(_ x) /[!inE] /[1 eqxx] /eqP->.
 Qed.
 
 Lemma uniq_leq_size s1 s2 : uniq s1 -> {subset s1 <= s2} -> size s1 <= size s2.
@@ -1948,7 +1948,7 @@ Qed.
 
 Lemma perm_to_rem s : x \in s -> perm_eq s (x :: rem s).
 Proof.
-elim: s => // y s IHs /1inE/= /[rws eq_sym perm_sym].
+elim: s => // y s IHs /[1inE]/= /[rw eq_sym perm_sym].
 case: eqP => [-> // | _ /IHs].
 by rewrite (perm_catCA [:: x] [:: y]) perm_cons perm_sym.
 Qed.
@@ -2138,14 +2138,14 @@ Qed.
 
 Lemma mapP s y : reflect (exists2 x, x \in s & y = f x) (y \in map f s).
 Proof.
-elim: s => [|x s IHs /= /1inE]; first by right; case.
+elim: s => [|x s IHs /= /[1inE]]; first by right; case.
 have [Dy | fx'y] := y =P f x; first by left; exists x; rewrite ?mem_head.
 by apply: (iffP IHs) => [[z]|[z /predU1P[->|]]]; exists z; do ?apply: predU1r.
 Qed.
 
 Lemma map_uniq s : uniq (map f s) -> uniq s.
 Proof.
-elim: s => //= x s IHs /andP[not_sfx /IHs->] /[rw andbT].
+elim: s => //= x s IHs /andP[not_sfx /IHs->] /[1 andbT].
 by apply: contra not_sfx => sx; apply/mapP; exists x.
 Qed.
 
@@ -2166,7 +2166,7 @@ Qed.
 Lemma nth_index_map s x0 x :
   {in s &, injective f} -> x \in s -> nth x0 s (index (f x) (map f s)) = x.
 Proof.
-elim: s => //= y s IHs inj_f /1inE s_x; rewrite (inj_in_eq inj_f) ?mem_head//.
+elim: s => //= y s IHs inj_f /[1inE] s_x; rewrite (inj_in_eq inj_f) ?mem_head//.
 case: eqVneq s_x => [-> | _] //=; apply: IHs.
 by apply: sub_in2 inj_f => z; apply: predU1r.
 Qed.
@@ -2180,7 +2180,7 @@ Lemma mem_map s x : (f x \in map f s) = (x \in s).
 Proof. by apply/mapP/idP=> [[y Hy /Hf->] //|]; exists x. Qed.
 
 Lemma index_map s x : index (f x) (map f s) = index x s.
-Proof. by rewrite /index; elim: s => //= y s + /[rw inj_eq Hf] => ->. Qed.
+Proof. by rewrite /index; elim: s => //= y s + /[1 inj_eq Hf] => ->. Qed.
 
 Lemma map_inj_uniq s : uniq (map f s) = uniq s.
 Proof. by apply: map_inj_in_uniq; apply: in2W. Qed.
@@ -2447,7 +2447,7 @@ Proof. by apply/perm_sumn; rewrite perm_rev. Qed.
 Lemma natnseq0P s : reflect (s = nseq (size s) 0) (sumn s == 0).
 Proof.
 apply: (iffP idP) => [|->]; last by rewrite sumn_nseq.
-by elim: s => //= x s IHs /[rw addn_eq0] /andP[/eqP-> /IHs <-].
+by elim: s => //= x s IHs /[1 addn_eq0] /andP[/eqP-> /IHs <-].
 Qed.
 
 Section FoldLeft.
@@ -3010,7 +3010,7 @@ move=> bs /andP[]; elim: bs => [|[x [|n]] bs IHbs] //= /andP[bs'x Ubs] bs'0.
 rewrite inE /tseq /tally /= -[n.+1]addn1 in bs'0 *.
 elim: n 1 => /= [|n IHn] m; last by rewrite eqxx IHn addnS.
 rewrite -{}[in RHS]IHbs {Ubs bs'0}// /tally /tally_seq add0n.
-elim: bs bs'x [::] => [|[y n] bs IHbs] //= /1inE /norP[y'x bs'x].
+elim: bs bs'x [::] => [|[y n] bs IHbs] //= /[1inE] /norP[y'x bs'x].
 by elim: n => [|n IHn] bs1 /=; [rewrite IHbs | rewrite eq_sym ifN // IHn].
 Qed.
 
@@ -3150,7 +3150,7 @@ rewrite {}IHbs; first 1 last; first by rewrite (perm_size (perm_tseq bsCA)).
 rewrite (map_inj_uniq (rcons_injl x)) {}IHn {Dn}//=.
 have: x \notin unzip1 bs by apply: contraL Ubs; rewrite map_cat mem_cat => ->.
 move: {bs2 m Ubs}(perms_rec n _ _ _) (_ :: bs2) => ts.
-elim: bs => [|[y [|m]] bs IHbs] //= /1inE bs2 /norP[x'y /IHbs//].
+elim: bs => [|[y [|m]] bs IHbs] //= /[1inE] bs2 /norP[x'y /IHbs//].
 rewrite cons_permsE has_cat negb_or has_map => ->.
 by apply/hasPn=> t _; apply: contra x'y => /mapP[t1 _ /rcons_inj[_ ->]].
 Qed.

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -988,7 +988,7 @@ Lemma mem_seq4 x y z t u : (x \in [:: y; z; t; u]) = xpred4 y z t u x.
 Proof. by rewrite !inE. Qed.
 
 Lemma mem_cat x s1 s2 : (x \in s1 ++ s2) = (x \in s1) || (x \in s2).
-Proof. by elim: s1 => //= y s1 IHs; rewrite !inE /= -orbA -IHs. Qed.
+Proof. by elim: s1 => //= y s1 IHs /1inE; rewrite -orbA -IHs. Qed.
 
 Lemma mem_rcons s y : rcons s y =i y :: s.
 Proof. by move=> x; rewrite -cats1 /= mem_cat mem_seq1 orbC in_cons. Qed.
@@ -1073,13 +1073,13 @@ Variables a1 a2 : pred T.
 
 Lemma eq_in_filter s : {in s, a1 =1 a2} -> filter a1 s = filter a2 s.
 Proof.
-elim: s => //= x s IHs eq_a.
-by rewrite eq_a ?mem_head ?IHs // => y s_y; apply: eq_a; apply: mem_behead.
+elim: s => //= x s IHs /dup eq_a -> /[rw? (mem_head, IHs)]// y s_y.
+by apply: eq_a; apply: mem_behead.
 Qed.
 
 Lemma eq_in_find s : {in s, a1 =1 a2} -> find a1 s = find a2 s.
 Proof.
-elim: s => //= x s IHs eq_a12; rewrite eq_a12 ?mem_head // IHs // => y s'y.
+elim: s => //= x s + /dup eq_a12 -> /[rw? mem_head] // => -> // y s'y.
 by rewrite eq_a12 // mem_behead.
 Qed.
 
@@ -1535,7 +1535,7 @@ Proof. by move/perm_mem/eq_all_r. Qed.
 Lemma perm_small_eq s1 s2 : size s2 <= 1 -> perm_eq s1 s2 -> s1 = s2.
 Proof.
 move=> s2_le1 eqs12; move/perm_size: eqs12 s2_le1 (perm_mem eqs12).
-by case: s2 s1 => [|x []] // [|y []] // _ _ /(_ x); rewrite !inE eqxx => /eqP->.
+by case: s2 s1 => [|x []] // [|y []] // _ _ /(_ x) /!inE /[rw eqxx] /eqP->.
 Qed.
 
 Lemma uniq_leq_size s1 s2 : uniq s1 -> {subset s1 <= s2} -> size s1 <= size s2.
@@ -1948,7 +1948,7 @@ Qed.
 
 Lemma perm_to_rem s : x \in s -> perm_eq s (x :: rem s).
 Proof.
-elim: s => // y s IHs; rewrite inE /= eq_sym perm_sym.
+elim: s => // y s IHs /1inE/= /[rws eq_sym perm_sym].
 case: eqP => [-> // | _ /IHs].
 by rewrite (perm_catCA [:: x] [:: y]) perm_cons perm_sym.
 Qed.
@@ -2138,14 +2138,14 @@ Qed.
 
 Lemma mapP s y : reflect (exists2 x, x \in s & y = f x) (y \in map f s).
 Proof.
-elim: s => [|x s IHs]; [by right; case | rewrite /= inE].
+elim: s => [|x s IHs /= /1inE]; first by right; case.
 have [Dy | fx'y] := y =P f x; first by left; exists x; rewrite ?mem_head.
 by apply: (iffP IHs) => [[z]|[z /predU1P[->|]]]; exists z; do ?apply: predU1r.
 Qed.
 
 Lemma map_uniq s : uniq (map f s) -> uniq s.
 Proof.
-elim: s => //= x s IHs /andP[not_sfx /IHs->]; rewrite andbT.
+elim: s => //= x s IHs /andP[not_sfx /IHs->] /[rw andbT].
 by apply: contra not_sfx => sx; apply/mapP; exists x.
 Qed.
 
@@ -2166,8 +2166,8 @@ Qed.
 Lemma nth_index_map s x0 x :
   {in s &, injective f} -> x \in s -> nth x0 s (index (f x) (map f s)) = x.
 Proof.
-elim: s => //= y s IHs inj_f s_x; rewrite (inj_in_eq inj_f) ?mem_head //.
-move: s_x; rewrite inE; case: eqVneq => [-> | _] //=; apply: IHs.
+elim: s => //= y s IHs inj_f /1inE s_x; rewrite (inj_in_eq inj_f) ?mem_head//.
+case: eqVneq s_x => [-> | _] //=; apply: IHs.
 by apply: sub_in2 inj_f => z; apply: predU1r.
 Qed.
 
@@ -2180,7 +2180,7 @@ Lemma mem_map s x : (f x \in map f s) = (x \in s).
 Proof. by apply/mapP/idP=> [[y Hy /Hf->] //|]; exists x. Qed.
 
 Lemma index_map s x : index (f x) (map f s) = index x s.
-Proof. by rewrite /index; elim: s => //= y s IHs; rewrite (inj_eq Hf) IHs. Qed.
+Proof. by rewrite /index; elim: s => //= y s + /[rw inj_eq Hf] => ->. Qed.
 
 Lemma map_inj_uniq s : uniq (map f s) = uniq s.
 Proof. by apply: map_inj_in_uniq; apply: in2W. Qed.
@@ -2447,7 +2447,7 @@ Proof. by apply/perm_sumn; rewrite perm_rev. Qed.
 Lemma natnseq0P s : reflect (s = nseq (size s) 0) (sumn s == 0).
 Proof.
 apply: (iffP idP) => [|->]; last by rewrite sumn_nseq.
-by elim: s => //= x s IHs; rewrite addn_eq0 => /andP[/eqP-> /IHs <-].
+by elim: s => //= x s IHs /[rw addn_eq0] /andP[/eqP-> /IHs <-].
 Qed.
 
 Section FoldLeft.
@@ -3010,7 +3010,7 @@ move=> bs /andP[]; elim: bs => [|[x [|n]] bs IHbs] //= /andP[bs'x Ubs] bs'0.
 rewrite inE /tseq /tally /= -[n.+1]addn1 in bs'0 *.
 elim: n 1 => /= [|n IHn] m; last by rewrite eqxx IHn addnS.
 rewrite -{}[in RHS]IHbs {Ubs bs'0}// /tally /tally_seq add0n.
-elim: bs bs'x [::] => [|[y n] bs IHbs] //=; rewrite inE => /norP[y'x bs'x].
+elim: bs bs'x [::] => [|[y n] bs IHbs] //= /1inE /norP[y'x bs'x].
 by elim: n => [|n IHn] bs1 /=; [rewrite IHbs | rewrite eq_sym ifN // IHn].
 Qed.
 
@@ -3150,7 +3150,7 @@ rewrite {}IHbs; first 1 last; first by rewrite (perm_size (perm_tseq bsCA)).
 rewrite (map_inj_uniq (rcons_injl x)) {}IHn {Dn}//=.
 have: x \notin unzip1 bs by apply: contraL Ubs; rewrite map_cat mem_cat => ->.
 move: {bs2 m Ubs}(perms_rec n _ _ _) (_ :: bs2) => ts.
-elim: bs => [|[y [|m]] bs IHbs] //=; rewrite inE => bs2 /norP[x'y /IHbs//].
+elim: bs => [|[y [|m]] bs IHbs] //= /1inE bs2 /norP[x'y /IHbs//].
 rewrite cons_permsE has_cat negb_or has_map => ->.
 by apply/hasPn=> t _; apply: contra x'y => /mapP[t1 _ /rcons_inj[_ ->]].
 Qed.

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -49,3 +49,5 @@ Notation "[ 'rel' x y 'in' A ]" := [rel x y in A & A] (at level 0,
 Notation xrelpre := (fun f (r : rel _) x y => r (f x) (f y)).
 Definition relpre {T rT} (f : T -> rT)  (r : rel rT) :=
   [rel x y | r (f x) (f y)].
+
+Notation "'1' 'inE'" := (ltac:(rewrite inE)) (at level 0) : ssripat_scope.

--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -94,3 +94,68 @@ End Exports.
 
 End Deprecation.
 Export Deprecation.Exports.
+
+Ltac subst_eq := let eq := fresh "_eq_" in intro eq; induction eq.
+Notation "'[' '<-' ']'" := (ltac:(subst_eq)) (at level 0): ssripat_scope.
+Notation "'[' '->' ']'" :=
+  (ltac:(move/(@eq_sym _ _ _); subst_eq)) (at level 0): ssripat_scope.
+Notation "'[' 'rw' rules ']'" :=
+  (ltac:(rewrite rules)) (at level 0, rules at level 0) : ssripat_scope.
+Notation "'[' 'rw' '-' rules ']'" :=
+  (ltac:(rewrite -rules)) (at level 0, rules at level 0) : ssripat_scope.
+Notation "'[' 'rws' r1 ']'" :=
+  (ltac:(rewrite r1)) (at level 0, r1 at level 0) : ssripat_scope.
+Notation "'[' 'rws' r1 r2 ']'" :=
+  (ltac:(rewrite r1 r2)) (at level 0, r1, r2 at level 0) : ssripat_scope.
+Notation "'[' 'rws' r1 r2 r3 ']'" :=
+  (ltac:(rewrite r1 r2 r3))
+  (at level 0, r1, r2, r3 at level 0) : ssripat_scope.
+Notation "'[' 'rws' r1 r2 r3 r4 ']'" :=
+  (ltac:(rewrite r1 r2 r3 r4))
+  (at level 0, r1, r2, r3, r4 at level 0) : ssripat_scope.
+Notation "'[' 'rws' r1 r2 r3 r4 r5 ']'" :=
+  (ltac:(rewrite r1 r2 r3 r4 r5))
+  (at level 0, r1, r2, r3, r4, r5 at level 0) : ssripat_scope.
+Notation "'[' 'rws' '-' r1 ']'" :=
+  (ltac:(rewrite -r1)) (at level 0, r1 at level 0) : ssripat_scope.
+Notation "'[' 'rws' '-' r1 r2 ']'" :=
+  (ltac:(rewrite -r1 -r2)) (at level 0, r1, r2 at level 0) : ssripat_scope.
+Notation "'[' 'rws' '-' r1 r2 r3 ']'" :=
+  (ltac:(rewrite -r1 -r2 -r3))
+  (at level 0, r1, r2, r3 at level 0) : ssripat_scope.
+Notation "'[' 'rws' '-' r1 r2 r3 r4 ']'" :=
+  (ltac:(rewrite -r1 -r2 -r3 -r4))
+  (at level 0, r1, r2, r3, r4 at level 0) : ssripat_scope.
+Notation "'[' 'rws' '-' r1 r2 r3 r4 r5 ']'" :=
+  (ltac:(rewrite -r1 -r2 -r3 -r4 -r5))
+  (at level 0, r1, r2, r3, r4, r5 at level 0) : ssripat_scope.
+Notation "'[' 'rw' '!' rules ']'" :=
+  (ltac:(rewrite !rules)) (at level 0) : ssripat_scope.
+Notation "'[' 'rw' '?' rules ']'" :=
+  (ltac:(rewrite ?rules)) (at level 0) : ssripat_scope.
+Notation "'[' 'rw' '-' '!' rules ']'" :=
+  (ltac:(rewrite -!rules)) (at level 0) : ssripat_scope.
+Notation "'[' 'rw' '-' '?' rules ']'" :=
+  (ltac:(rewrite -?rules)) (at level 0) : ssripat_scope.
+Notation "'[' 'rw' '/' r1 ']'" :=
+  (ltac:(rewrite /r1)) (at level 0, r1 at level 0) : ssripat_scope.
+Notation "'[' 'rw' '/' r1 r2 ']'" :=
+  (ltac:(rewrite /r1 /r2)) (at level 0, r1, r2 at level 0) : ssripat_scope.
+Notation "'[' 'rw' '/' r1 r2 r3 ']'" :=
+  (ltac:(rewrite /r1 /r2 /r3))
+  (at level 0, r1, r2, r3 at level 0) : ssripat_scope.
+Notation "'[' 'rw' '/' r1 r2 r3 r4 ']'" :=
+  (ltac:(rewrite /r1 /r2 /r3 /r4))
+  (at level 0, r1, r2, r3, r4 at level 0) : ssripat_scope.
+Notation "'[' 'rw' '/' r1 r2 r3 r4 r5 ']'" :=
+  (ltac:(rewrite /r1 /r2 /r3 /r4 /r5))
+  (at level 0, r1, r2, r3, r4, r5 at level 0) : ssripat_scope.
+
+Notation "'!' rule" := (ltac:(do !rewrite rule/=))
+   (at level 0, rule at level 0) : ssripat_scope.
+Notation "'?' rule" := (ltac:(do ?rewrite rule/=))
+   (at level 0, rule at level 0) : ssripat_scope.
+
+Notation dup := (ltac:(let x := fresh "_top_" in move=> x; move: x (x))).
+Notation swap := (ltac:(let x := fresh "_top_" in let y := fresh "_top_" in move=> x y; move: y x)).
+Notation apply := (ltac:(let f := fresh "_top_" in move=> f /f)).

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -209,7 +209,7 @@ Lemma addnS m n : m + n.+1 = (m + n).+1. Proof. by apply/eqP; elim: m. Qed.
 Lemma addSnnS m n : m.+1 + n = m + n.+1. Proof. by rewrite addnS. Qed.
 
 Lemma addnCA : left_commutative addn.
-Proof. by move=> m n p; elim: m => //= m; rewrite addnS => <-. Qed.
+Proof. by move=> m n p; elim: m => //= m /[rw addnS]<-. Qed.
 
 Lemma addnC : commutative addn.
 Proof. by move=> m n; rewrite -{1}[n]addn0 addnCA addn0. Qed.
@@ -352,7 +352,7 @@ Lemma eqn_leq m n : (m == n) = (m <= n <= m).
 Proof. by elim: m n => [|m IHm] []. Qed.
 
 Lemma anti_leq : antisymmetric leq.
-Proof. by move=> m n; rewrite -eqn_leq => /eqP. Qed.
+Proof. by move=> m n /[rw -eqn_leq] /eqP. Qed.
 
 Lemma neq_ltn m n : (m != n) = (m < n) || (n < m).
 Proof. by rewrite eqn_leq negb_and orbC -!ltnNge. Qed.
@@ -879,11 +879,11 @@ Proof. by move=> n; rewrite mulnSr muln0. Qed.
 
 Lemma mulnC : commutative muln.
 Proof.
-by move=> m n; elim: m => [|m]; rewrite (muln0, mulnS) // mulSn => ->.
+by move=> + n; elim=> [|m]; rewrite (muln0, mulnS) // mulSn => ->.
 Qed.
 
 Lemma mulnDl : left_distributive muln addn.
-Proof. by move=> m1 m2 n; elim: m1 => //= m1 IHm; rewrite -addnA -IHm. Qed.
+Proof. by move=> + m2 n; elim=> //= m1 IHm; rewrite -addnA -IHm. Qed.
 
 Lemma mulnDr : right_distributive muln addn.
 Proof. by move=> m n1 n2; rewrite !(mulnC m) mulnDl. Qed.
@@ -898,7 +898,7 @@ Lemma mulnBr : right_distributive muln subn.
 Proof. by move=> m n p; rewrite !(mulnC m) mulnBl. Qed.
 
 Lemma mulnA : associative muln.
-Proof. by move=> m n p; elim: m => //= m; rewrite mulSn mulnDl => ->. Qed.
+Proof. by move=> + n p; elim=> //= m; rewrite mulSn mulnDl => ->. Qed.
 
 Lemma mulnCA : left_commutative muln.
 Proof. by move=> m n1 n2; rewrite !mulnA (mulnC m). Qed.
@@ -1436,7 +1436,7 @@ Let gtn_neqAge x y : (y < x) = (x != y) && (y <= x).
 Proof. by rewrite ltn_neqAle eq_sym. Qed.
 Let anti_leq := anti_leq.
 Let anti_geq : antisymmetric geq.
-Proof. by move=> m n /=; rewrite andbC => /anti_leq. Qed.
+Proof. by move=> m n /= /[rw andbC] /anti_leq. Qed.
 Let leq_total := leq_total.
 
 Lemma ltnW_homo : {homo f : m n / m < n} -> {homo f : m n / m <= n}.

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -209,7 +209,7 @@ Lemma addnS m n : m + n.+1 = (m + n).+1. Proof. by apply/eqP; elim: m. Qed.
 Lemma addSnnS m n : m.+1 + n = m + n.+1. Proof. by rewrite addnS. Qed.
 
 Lemma addnCA : left_commutative addn.
-Proof. by move=> m n p; elim: m => //= m /[rw addnS]<-. Qed.
+Proof. by move=> m n p; elim: m => //= m /[1 addnS]<-. Qed.
 
 Lemma addnC : commutative addn.
 Proof. by move=> m n; rewrite -{1}[n]addn0 addnCA addn0. Qed.
@@ -352,7 +352,7 @@ Lemma eqn_leq m n : (m == n) = (m <= n <= m).
 Proof. by elim: m n => [|m IHm] []. Qed.
 
 Lemma anti_leq : antisymmetric leq.
-Proof. by move=> m n /[rw -eqn_leq] /eqP. Qed.
+Proof. by move=> m n /[-1 eqn_leq] /eqP. Qed.
 
 Lemma neq_ltn m n : (m != n) = (m < n) || (n < m).
 Proof. by rewrite eqn_leq negb_and orbC -!ltnNge. Qed.
@@ -1436,7 +1436,7 @@ Let gtn_neqAge x y : (y < x) = (x != y) && (y <= x).
 Proof. by rewrite ltn_neqAle eq_sym. Qed.
 Let anti_leq := anti_leq.
 Let anti_geq : antisymmetric geq.
-Proof. by move=> m n /= /[rw andbC] /anti_leq. Qed.
+Proof. by move=> m n /= /[1 andbC] /anti_leq. Qed.
 Let leq_total := leq_total.
 
 Lemma ltnW_homo : {homo f : m n / m < n} -> {homo f : m n / m <= n}.


### PR DESCRIPTION
##### Motivation for this change

<!-- please explain your reason for doing this change -->
Mostly testing ltac in notations in views:
- Proposing a few different syntax for rewriting in views, up to debate.
While doing so, I encountered a problem with parsing `! term` in ssr rewrite but only when followed by a clear. Cf https://github.com/coq/coq/issues/10531. The original intent was to be able to use `=> x /!inE x_mem` to perform simplification between two introductions.
- Proposing `=> /[->]`syntax to substitute with an equality everywhere in the goal and context. 

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [ ] added corresponding documentation in the headers

<!-- if items above are irrelevant, explain what you did here -->

<!-- please fill in the following checklist -->
<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
