### PR TITLE
[ci] a few improvements of the GitLab CI setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -327,6 +327,8 @@ ci-finmap-dev:
   image: docker:latest
   services:
     - docker:dind
+  variables:
+    GIT_STRATEGY: none
   environment:
     name: deployment
     url: https://hub.docker.com/r/mathcomp/mathcomp-dev

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,14 +159,14 @@ ci-fourcolor-dev:
     - make install
 
 ci-odd-order-8.7:
- extends: .ci-odd-order
- variables:
-   COQ_VERSION: "8.7"
+  extends: .ci-odd-order
+  variables:
+    COQ_VERSION: "8.7"
 
 ci-odd-order-8.8:
- extends: .ci-odd-order
- variables:
-   COQ_VERSION: "8.8"
+  extends: .ci-odd-order
+  variables:
+    COQ_VERSION: "8.8"
 
 ci-odd-order-dev:
   extends: .ci-odd-order

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,6 +143,11 @@ ci-fourcolor-8.8:
   variables:
     COQ_VERSION: "8.8"
 
+ci-fourcolor-8.9:
+  extends: .ci-fourcolor
+  variables:
+    COQ_VERSION: "8.9"
+
 ci-fourcolor-dev:
   extends: .ci-fourcolor
   variables:
@@ -167,6 +172,11 @@ ci-odd-order-8.8:
   extends: .ci-odd-order
   variables:
     COQ_VERSION: "8.8"
+
+ci-odd-order-8.9:
+  extends: .ci-odd-order
+  variables:
+    COQ_VERSION: "8.9"
 
 ci-odd-order-dev:
   extends: .ci-odd-order

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,11 +4,12 @@
 #     (Dockerfile containing: "opam switch set $compiler && eval $(opam env)")
 #   - all branches (not tags) => push on GitLab registry
 #   - GitHub PRs => push on GitLab and report back thanks to @coqbot
-# - test stage (image: mathcomp-dev:$IID_$SLUG_coq-8.6)
+# - test stage (image: mathcomp-dev:$IID_$SLUG_coq-8.7)
 #   - script template foreach project (custom CONTRIB_URL, script)
 #   - jobs foreach project and Coq version (custom COQ_VERSION, CONTRIB_VERSION)
 # - deploy stage (only branch "master" and environment "deployment")
 #   - pull each built image from GitLab registry => push to Docker Hub
+# + scheduled build & deploy for mathcomp/mathcomp-dev:coq-dev
 #
 # Config for protected environment "deployment":
 # - set vars HUB_REGISTRY, HUB_REGISTRY_USER, HUB_REGISTRY_IMAGE, HUB_TOKEN
@@ -51,6 +52,7 @@ stages:
   except:
     - tags
     - merge_requests
+    - schedules
 
 make-coq-latest:
   extends: .make-build
@@ -77,14 +79,19 @@ make-coq-latest:
     - tags
     - merge_requests
 
-coq-8.7:
+.opam-build-once:
   extends: .opam-build
+  except:
+    - schedules
+  
+coq-8.7:
+  extends: .opam-build-once
 
 coq-8.8:
-  extends: .opam-build
+  extends: .opam-build-once
 
 coq-8.9:
-  extends: .opam-build
+  extends: .opam-build-once
 
 coq-dev:
   extends: .opam-build
@@ -116,6 +123,7 @@ coq-dev:
   except:
     - tags
     - merge_requests
+    - schedules
 
 # Guidelines to add a library to mathcomp CI:
 # - Add a hidden job (starting with a .) .ci-lib that extends the .ci job,
@@ -359,14 +367,19 @@ ci-finmap-dev:
   only:
     - master
 
-mathcomp-dev:coq-8.7:
+.docker-deploy-once:
   extends: .docker-deploy
+  except:
+    - schedules
+
+mathcomp-dev:coq-8.7:
+  extends: .docker-deploy-once
 
 mathcomp-dev:coq-8.8:
-  extends: .docker-deploy
+  extends: .docker-deploy-once
 
 mathcomp-dev:coq-8.9:
-  extends: .docker-deploy
+  extends: .docker-deploy-once
 
 mathcomp-dev:coq-dev:
   extends: .docker-deploy


### PR DESCRIPTION
##### Motivation for this change

This commit performs 3 independent changes related to the GitLab CI config:

1. It sets a variable `GIT_STRATEGY: none` for deployments to skip the `git clone` step (which is unneeded as the underlying logic of these deploy jobs is just `docker pull … && docker push …`)
2. It adds Coq 8.9 for testing fourcolor and odd-order (only Coq 8.7, 8.8, dev were tested)
    (see also <https://github.com/math-comp/odd-order/pull/16>)
3. It adds some properties to most jobs to skip them in case of [**scheduled pipelines**](https://docs.gitlab.com/ce/user/project/pipelines/schedules.html).

To elaborate a bit more on the item 3. above:

- I have configured an automatic task that triggers a new build of the image `coqorg/coq:dev` on Docker Hub every night.
- This image is used by the GitLab CI jobs {coq-dev, mathcomp-dev:coq-dev} (to build math-comp with coq.dev and deploy the corresponding image to `mathcomp/mathcomp-dev:coq-dev` on Docker Hub).
- Up to now, this deployment was only done when a new PR is merged in math-comp. As a result, the underlying coq version of both images [`coqorg/coq:dev`](https://hub.docker.com/r/coqorg/coq/) and [`mathcomp/mathcomp-dev:coq-dev`](https://hub.docker.com/r/mathcomp/mathcomp-dev/) may diverge if no math-comp PR is merged for a while.
- Hence this proposed configuration, that I'll be able to complement with a scheduled pipeline on https://gitlab.com/math-comp/math-comp after merging this PR.

##### Things done/to do

- [x] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~ (no needed at first sight)
- [x] added corresponding documentation in the headers (added in `.gitlab-ci.yml`)

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.

Cc @CohenCyril