### PR TITLE
[ci] fix .gitlab-ci.yml regarding "GIT_STRATEGY: none"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -345,12 +345,11 @@ ci-finmap-dev:
   image: docker:latest
   services:
     - docker:dind
-  variables:
-    GIT_STRATEGY: none
   environment:
     name: deployment
     url: https://hub.docker.com/r/mathcomp/mathcomp-dev
   variables:
+    GIT_STRATEGY: none
     HUB_IMAGE: "mathcomp/${CI_JOB_NAME}"
     IMAGE_PREFIX: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_IID}_${CI_COMMIT_REF_SLUG}"
   script:


### PR DESCRIPTION
##### Motivation for this change

This small PR is a CI bugfix so that `GIT_STRATEGY: none` can be taken into account (and speed-up the deploy jobs accordingly).

Cc @CohenCyril

##### Things done/to do

- [x] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~ [not relevant]
- [x] ~added corresponding documentation in the headers~ [not relevant]

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.