### PR TITLE
Reorder the arguments of (comparable_)ltgtP and remove the use of the compatibility module `ssrnum.mc_1_9` (part of #270)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,6 +132,8 @@ coq-dev:
   script:
     - make -j "${NJOBS}"
     - make install
+  except:
+    - /^pr-(270|377)$/
 
 ci-fourcolor-8.7:
   extends: .ci-fourcolor
@@ -148,6 +150,32 @@ ci-fourcolor-dev:
   variables:
     COQ_VERSION: "dev"
 
+.ci-fourcolor-270:
+  extends: .ci
+  variables:
+    CONTRIB_URL: "https://github.com/pi8027/fourcolor.git"
+    CONTRIB_VERSION: fix-mathcomp-270
+  script:
+    - make -j "${NJOBS}"
+    - make install
+  only:
+    - /^pr-(270|377)$/
+
+ci-fourcolor-8.7-270:
+  extends: .ci-fourcolor-270
+  variables:
+    COQ_VERSION: "8.7"
+
+ci-fourcolor-8.8-270:
+  extends: .ci-fourcolor-270
+  variables:
+    COQ_VERSION: "8.8"
+
+ci-fourcolor-dev-270:
+  extends: .ci-fourcolor-270
+  variables:
+    COQ_VERSION: "dev"
+
 # The Odd Order Theorem
 .ci-odd-order:
   extends: .ci
@@ -157,6 +185,8 @@ ci-fourcolor-dev:
   script:
     - make -j "${NJOBS}"
     - make install
+  except:
+    - /^pr-(270|377)$/
 
 ci-odd-order-8.7:
  extends: .ci-odd-order
@@ -170,6 +200,32 @@ ci-odd-order-8.8:
 
 ci-odd-order-dev:
   extends: .ci-odd-order
+  variables:
+    COQ_VERSION: "dev"
+
+.ci-odd-order-270:
+  extends: .ci
+  variables:
+    CONTRIB_URL: "https://github.com/pi8027/odd-order.git"
+    CONTRIB_VERSION: fix-mathcomp-270
+  script:
+    - make -j "${NJOBS}"
+    - make install
+  only:
+    - /^pr-(270|377)$/
+
+ci-odd-order-8.7-270:
+ extends: .ci-odd-order-270
+ variables:
+   COQ_VERSION: "8.7"
+
+ci-odd-order-8.8-270:
+ extends: .ci-odd-order-270
+ variables:
+   COQ_VERSION: "8.8"
+
+ci-odd-order-dev-270:
+  extends: .ci-odd-order-270
   variables:
     COQ_VERSION: "dev"
 

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -46,7 +46,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.Theory GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
 Definition divz (m d : int) :=

--- a/mathcomp/algebra/interval.v
+++ b/mathcomp/algebra/interval.v
@@ -40,7 +40,7 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Local Open Scope ring_scope.
-Import Order.Theory Order.Syntax GRing.Theory Num.Theory.
+Import Order.TTheory Order.Syntax GRing.Theory Num.Theory.
 
 Local Notation mid x y := ((x + y) / 2%:R).
 

--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -19,7 +19,7 @@ From mathcomp Require Import ssrint.
 (*       ratr x == generic embedding of  (r : R) into an arbitrary unitring.  *)
 (******************************************************************************)
 
-Import Order.Theory GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -40,7 +40,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.Theory GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
 Delimit Scope int_scope with Z.
 Local Open Scope int_scope.
 

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -1637,12 +1637,9 @@ Lemma real_leP x y :
     x \is real -> y \is real ->
   ler_xor_gt x y `|x - y| `|y - x| (x <= y) (y < x).
 Proof.
-move=> xR /(real_leVge xR); have [le_xy _|Nle_xy /= le_yx] := boolP (_ <= _).
-  have [/(le_lt_trans le_xy)|] := boolP (_ < _); first by rewrite ltxx.
-  by rewrite ler0_norm ?ger0_norm ?subr_cp0 ?opprB //; constructor.
-have [lt_yx|] := boolP (_ < _).
-  by rewrite ger0_norm ?ler0_norm ?subr_cp0 ?opprB //; constructor.
-by rewrite lt_def le_yx andbT negbK=> /eqP exy; rewrite exy lexx in Nle_xy.
+move=> xR yR; case: (comparable_leP (real_leVge xR yR)) => xy.
+- by rewrite [`|x - y|]distrC !ger0_norm ?subr_cp0 //; constructor.
+- by rewrite [`|y - x|]distrC !gtr0_norm ?subr_cp0 //; constructor.
 Qed.
 
 Lemma real_ltP x y :
@@ -1660,7 +1657,7 @@ Lemma real_ltgtP x y : x \is real -> y \is real ->
   comparer x y `|x - y| `|y - x|
                 (y == x) (x == y) (x >= y) (x <= y) (x > y) (x < y).
 Proof.
-move=> xR yR; case: comparable_ltgtP => [|xy|xy|->]; first exact: real_leVge.
+move=> xR yR; case: (comparable_ltgtP (real_leVge xR yR)) => [?|?|->].
 - by rewrite [`|x - y|]distrC !gtr0_norm ?subr_gt0//; constructor.
 - by rewrite [`|y - x|]distrC !gtr0_norm ?subr_gt0//; constructor.
 - by rewrite subrr normr0; constructor.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -5674,5 +5674,3 @@ Notation "[ 'arg' 'maxr_' ( i > i0 ) F ]" := [arg maxr_(i > i0 | true) F]
 
 End Num.
 End mc_1_9.
-
-Export mc_1_9 mc_1_9.Num.Syntax.

--- a/mathcomp/character/vcharacter.v
+++ b/mathcomp/character/vcharacter.v
@@ -40,7 +40,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.Theory GroupScope GRing.Theory Num.Theory.
+Import Order.TTheory GroupScope GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
 Section Basics.

--- a/mathcomp/field/algC.v
+++ b/mathcomp/field/algC.v
@@ -53,7 +53,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.Theory GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
 (* The Num mixin for an algebraically closed field with an automorphism of    *)

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -567,7 +567,7 @@ End FinFieldExists.
 
 Section FinDomain.
 
-Import order ssrnum ssrint algC cyclotomic Order.Theory Num.Theory.
+Import order ssrnum ssrint algC cyclotomic Order.TTheory Num.Theory.
 Local Infix "%|" := dvdn. (* Hide polynomial divisibility. *)
 
 Variable R : finUnitRingType.


### PR DESCRIPTION
##### Motivation for this change

- The order of arguments in `compare` and `(comparable_)ltgtP` was wrong. This PR fixes it.
- This PR adds CI overlays which don't use the compatibility module `ssrnum.mc_1_9`. 

I have also fixed `ltngtP`, but it's independent of #270. So I separated it off to #378.

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
