### PR TITLE
Fix CI overlays for #270

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,7 +141,8 @@ coq-dev:
     - make -j "${NJOBS}"
     - make install
   except:
-    - /^pr-(270|377)$/
+    - /^experiment\/order$/
+    - /^pr-(270|382)$/
 
 ci-fourcolor-8.7:
   extends: .ci-fourcolor
@@ -172,7 +173,8 @@ ci-fourcolor-dev:
     - make -j "${NJOBS}"
     - make install
   only:
-    - /^pr-(270|377)$/
+    - /^experiment\/order$/
+    - /^pr-(270|382)$/
 
 ci-fourcolor-8.7-270:
   extends: .ci-fourcolor-270
@@ -199,7 +201,8 @@ ci-fourcolor-dev-270:
     - make -j "${NJOBS}"
     - make install
   except:
-    - /^pr-(270|377)$/
+    - /^experiment\/order$/
+    - /^pr-(270|382)$/
 
 ci-odd-order-8.7:
   extends: .ci-odd-order
@@ -230,7 +233,8 @@ ci-odd-order-dev:
     - make -j "${NJOBS}"
     - make install
   only:
-    - /^pr-(270|377)$/
+    - /^experiment\/order$/
+    - /^pr-(270|382)$/
 
 ci-odd-order-8.7-270:
  extends: .ci-odd-order-270


### PR DESCRIPTION
##### Motivation for this change

This PR manages to fix broken CI overlays in #270 which uses upstream branch. But I'm not sure this regex syntax is correct: `/^experiment\/order$/`.

cc: @CohenCyril

##### Things done/to do

None.

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
