### PR TITLE
Add (meet|join)_(l|r), rename some lemmas to avoid name conflicts, and small cleanup (part of #270)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,7 +142,7 @@ coq-dev:
     - make install
   except:
     - /^experiment\/order$/
-    - /^pr-(270|382)$/
+    - /^pr-(270|383)$/
 
 ci-fourcolor-8.7:
   extends: .ci-fourcolor
@@ -174,7 +174,7 @@ ci-fourcolor-dev:
     - make install
   only:
     - /^experiment\/order$/
-    - /^pr-(270|382)$/
+    - /^pr-(270|383)$/
 
 ci-fourcolor-8.7-270:
   extends: .ci-fourcolor-270
@@ -202,7 +202,7 @@ ci-fourcolor-dev-270:
     - make install
   except:
     - /^experiment\/order$/
-    - /^pr-(270|382)$/
+    - /^pr-(270|383)$/
 
 ci-odd-order-8.7:
   extends: .ci-odd-order
@@ -234,7 +234,7 @@ ci-odd-order-dev:
     - make install
   only:
     - /^experiment\/order$/
-    - /^pr-(270|382)$/
+    - /^pr-(270|383)$/
 
 ci-odd-order-8.7-270:
  extends: .ci-odd-order-270

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -87,10 +87,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     * `minr_max(l|r)` -> `meetU(l|r)`
     * `minrP`, `maxrP` -> `leP`, `ltP`
     * `(minr|maxr)(r|C|A|CA|AC)` -> `(meet|join)(xx|C|A|CA|AC)`
-    * `minr_l` -> `elimT meet_idPl`
-    * `minr_r` -> `elimT meet_idPr`
-    * `maxr_l` -> `elimT join_idPr`
-    * `maxr_r` -> `elimT join_idPl`
+    * `minr_(l|r)` -> `meet_(l|r)`
+    * `maxr_(l|r)` -> `join_(l|r)`
     * `arg_minrP` -> `arg_minP`
     * `arg_maxrP` -> `arg_maxP`
   + Generalized the following lemmas as properties of `normedDomainType`:

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -125,7 +125,7 @@ Unset Printing Implicit Defensive.
 
 Local Open Scope order_scope.
 Local Open Scope ring_scope.
-Import Order.Theory Order.Def Order.Syntax GRing.Theory.
+Import Order.TTheory Order.Def Order.Syntax GRing.Theory.
 
 Reserved Notation "<= y" (at level 35).
 Reserved Notation ">= y" (at level 35).
@@ -5478,12 +5478,12 @@ Implicit Types x y z : R.
 Section MinMax.
 Definition minrC : @commutative R R min := @meetC _ R.
 Definition minrr : @idempotent R min := @meetxx _ R.
-Definition minr_l x y : x <= y -> min x y = x := elimT meet_idPl.
-Definition minr_r x y : y <= x -> min x y = y := elimT meet_idPr.
+Definition minr_l x y : x <= y -> min x y = x := @meet_l _ _ x y.
+Definition minr_r x y : y <= x -> min x y = y := @meet_r _ _ x y.
 Definition maxrC : @commutative R R max := @joinC _ R.
 Definition maxrr : @idempotent R max := @joinxx _ R.
-Definition maxr_l x y : y <= x -> max x y = x := elimT join_idPr.
-Definition maxr_r x y : x <= y -> max x y = y := elimT join_idPl.
+Definition maxr_l x y : y <= x -> max x y = x := @join_l _ _ x y.
+Definition maxr_r x y : x <= y -> max x y = y := @join_r _ _ x y.
 Definition minrA x y z : min x (min y z) = min (min x y) z := meetA x y z.
 Definition minrCA : @left_commutative R R min := meetCA.
 Definition minrAC : @right_commutative R R min := meetAC.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -112,7 +112,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.Theory Order.Syntax GroupScope GRing.Theory Num.Theory.
+Import Order.TTheory Order.Syntax GroupScope GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
 Local Notation "p ^ f" := (map_poly f p) : ring_scope.


### PR DESCRIPTION
##### Motivation for this change

- Add `meet_l`, `meet_r`, `join_l`, and `join_r` lemmas.
- Rename lemmas to avoid name conflicts:
  - `Order.BLatticeTheory.lexU(l|r)` -> `disjoint_lexU(l|r)`,
  - `Order.TBLatticeTheory.lexI(l|r)` -> `cover_leIx(l|r)`.
- Use `T` rather than `R` for metavariables of ordered types in `order.v`.
- Use section variables if applicable.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~[ ] added corresponding documentation in the headers~

<!-- if items above are irrelevant, explain what you did here -->

<!-- please fill in the following checklist -->
<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.

EDIT 2019-10-04