### PR TITLE
Add build for mathcomp/mathcomp-dev:coq-8.10

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,6 +93,9 @@ coq-8.8:
 coq-8.9:
   extends: .opam-build-once
 
+coq-8.10:
+  extends: .opam-build-once
+
 coq-dev:
   extends: .opam-build
 
@@ -156,6 +159,11 @@ ci-fourcolor-8.9:
   variables:
     COQ_VERSION: "8.9"
 
+ci-fourcolor-8.10:
+  extends: .ci-fourcolor
+  variables:
+    COQ_VERSION: "8.10"
+
 ci-fourcolor-dev:
   extends: .ci-fourcolor
   variables:
@@ -186,6 +194,11 @@ ci-odd-order-8.9:
   variables:
     COQ_VERSION: "8.9"
 
+ci-odd-order-8.10:
+  extends: .ci-odd-order
+  variables:
+    COQ_VERSION: "8.10"
+
 ci-odd-order-dev:
   extends: .ci-odd-order
   variables:
@@ -210,6 +223,11 @@ ci-lemma-overloading-8.9:
   extends: .ci-lemma-overloading
   variables:
     COQ_VERSION: "8.9"
+
+ci-lemma-overloading-8.10:
+  extends: .ci-lemma-overloading
+  variables:
+    COQ_VERSION: "8.10"
 
 ci-lemma-overloading-dev:
   extends: .ci-lemma-overloading
@@ -240,6 +258,11 @@ ci-bigenough-8.9:
   extends: .ci-bigenough
   variables:
     COQ_VERSION: "8.9"
+
+ci-bigenough-8.9:
+  extends: .ci-bigenough
+  variables:
+    COQ_VERSION: "8.10"
 
 ci-bigenough-dev:
   extends: .ci-bigenough
@@ -329,6 +352,11 @@ ci-finmap-8.9:
   variables:
     COQ_VERSION: "8.9"
 
+ci-finmap-8.10:
+  extends: .ci-finmap
+  variables:
+    COQ_VERSION: "8.10"
+
 ci-finmap-dev:
   extends: .ci-finmap
   variables:
@@ -378,6 +406,9 @@ mathcomp-dev:coq-8.8:
   extends: .docker-deploy-once
 
 mathcomp-dev:coq-8.9:
+  extends: .docker-deploy-once
+
+mathcomp-dev:coq-8.10:
   extends: .docker-deploy-once
 
 mathcomp-dev:coq-dev:

--- a/coq-mathcomp-algebra.opam
+++ b/coq-mathcomp-algebra.opam
@@ -10,10 +10,9 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/algebra" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/algebra" "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/algebra'" ]
 depends: [ "coq-mathcomp-fingroup" { = "dev" } ]
 
-tags: [ "keyword:algebra" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:algebra" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.algebra" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]
 
 synopsis: "Mathematical Components Library on Algebra"

--- a/coq-mathcomp-character.opam
+++ b/coq-mathcomp-character.opam
@@ -10,10 +10,9 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/character" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/character" "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/character'" ]
 depends: [ "coq-mathcomp-field" { = "dev" } ]
 
-tags: [ "keyword:algebra" "keyword:character" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:algebra" "keyword:character" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.character" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]
 
 synopsis: "Mathematical Components Library on character theory"

--- a/coq-mathcomp-field.opam
+++ b/coq-mathcomp-field.opam
@@ -10,10 +10,9 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/field" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/field" "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/field'" ]
 depends: [ "coq-mathcomp-solvable" { = "dev" } ]
 
-tags: [ "keyword:algebra" "keyword:field" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:algebra" "keyword:field" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.field" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]
 
 synopsis: "Mathematical Components Library on Fields"

--- a/coq-mathcomp-fingroup.opam
+++ b/coq-mathcomp-fingroup.opam
@@ -10,10 +10,9 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/fingroup" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/fingroup" "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/fingroup'" ]
 depends: [ "coq-mathcomp-ssreflect" { = "dev" } ]
 
-tags: [ "keyword:finite groups" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:finite groups" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.fingroup" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]
 
 synopsis: "Mathematical Components Library on finite groups"

--- a/coq-mathcomp-solvable.opam
+++ b/coq-mathcomp-solvable.opam
@@ -10,10 +10,9 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/solvable" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/solvable"  "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/solvable'" ]
 depends: [ "coq-mathcomp-algebra" { = "dev" } ]
 
-tags: [ "keyword:finite groups" "keyword:Feit Thompson theorem" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:finite groups" "keyword:Feit Thompson theorem" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.solvable" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]
 
 synopsis: "Mathematical Components Library on finite groups (II)"

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -11,7 +11,7 @@ license: "CeCILL-B"
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp'" ]
-depends: [ "coq" { ((>= "8.7" & < "8.10~") | (= "dev"))} ]
+depends: [ "coq" { ((>= "8.7" & < "8.11~") | (= "dev"))} ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -10,10 +10,9 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp'" ]
 depends: [ "coq" { ((>= "8.7" & < "8.11~") | (= "dev"))} ]
 
-tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
+tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]
 
 synopsis: "Small Scale Reflection"


### PR DESCRIPTION
##### Motivation for this change

Add **build** with Coq 8.10.0, **deployment** to [`mathcomp/mathcomp-dev:coq-8.10`](https://hub.docker.com/r/mathcomp/mathcomp-dev) and accompanying **tests** with fourcolor, odd-order, lemma-overloading, bigenough, finmap.

(but feel free to react if you think that some **tests** with older versions of Coq should be dropped at the same time.)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~ [not relevant]
- [x] ~added corresponding documentation in the headers~ [not relevant]

<!-- if items above are irrelevant, explain what you did here -->

Related: https://github.com/coq-community/docker-coq/issues/2

<!-- please fill in the following checklist -->
<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
