### PR TITLE
Removing duplicate lemma `addnKC` (= `addKn`)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -35,8 +35,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `big_enum_val`, `big_enum_rank`, `big_set`.
 
 - Arithmetic theorems in ssrnat and div:
-  - some trivial results in ssrnat: `addnKC`, `ltn_predl`,
-    `ltn_predr`, `ltn_subr` and `predn_sub`,
+  - some trivial results in ssrnat: `ltn_predl`, `ltn_predr`,
+    `ltn_subr` and `predn_sub`,
   - theorems about `n <=/< p +/- m` and `m +/- n <=/< p`:
     `leq_psubRL`, `ltn_psubLR`, `leq_subRL`, `ltn_subLR`, `leq_subCl`,
     `leq_psubCr`, `leq_subCr`, `ltn_subCr`, `ltn_psubCl` and

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -279,9 +279,6 @@ Proof. by move=> m; rewrite /= -{2}[n]addn0 subnDl subn0. Qed.
 Lemma addnK n : cancel (addn^~ n) (subn^~ n).
 Proof. by move=> m; rewrite /= (addnC m) addKn. Qed.
 
-Lemma addnKC n m : (n + m) - n = m.
-Proof. by rewrite addnC addnK. Qed.
-
 Lemma subSnn n : n.+1 - n = 1.
 Proof. exact (addnK n 1). Qed.
 
@@ -542,7 +539,7 @@ Lemma subnBA m n p : p <= n -> m - (n - p) = m + p - n.
 Proof. by move=> le_pn; rewrite -{2}(subnK le_pn) subnDr. Qed.
 
 Lemma ltn_subr m n : m <= n -> (n - m < n) = (m > 0).
-Proof. by move=> le_mn; rewrite -subn_gt0 subnBA// addnKC. Qed.
+Proof. by move=> le_mn; rewrite -subn_gt0 subnBA// addKn. Qed.
 
 Lemma subKn m n : m <= n -> n - (n - m) = m.
 Proof. by move/subnBA->; rewrite addKn. Qed.


### PR DESCRIPTION
##### Motivation for this change

Removing duplicate lemma `addnKC` (= `addKn`)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~[ ] added corresponding documentation in the headers~

<!-- if items above are irrelevant, explain what you did here -->

<!-- please fill in the following checklist -->
<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
