### PR TITLE
Add an explicit type annotation to GRing.scale

### DIFF
--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -1546,7 +1546,7 @@ End Exports.
 End Lmodule.
 Import Lmodule.Exports.
 
-Definition scale (R : ringType) (V : lmodType R) :=
+Definition scale (R : ringType) (V : lmodType R) : R -> V -> V :=
   Lmodule.scale (Lmodule.class V).
 
 Local Notation "*:%R" := (@scale _ _).


### PR DESCRIPTION
##### Motivation for this change

`V` was wrongly eta-expanded before this change:
```coq
GRing.scale
     : forall (R : ringType) (V : lmodType R),
       R -> GRing.Zmodule.Pack (GRing.Lmodule.class V) ->
       GRing.Zmodule.Pack (GRing.Lmodule.class V)
```

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~[ ] added corresponding documentation in the headers~

<!-- if items above are irrelevant, explain what you did here -->

<!-- please fill in the following checklist -->
<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
