### PR TITLE
fingraph: remove fin_inj_bij lemma as duplicate of injF_bij from fintype

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -111,6 +111,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `ssrnat.mc_1_9` module. One may compile proofs compatible with the version
     1.9 in newer versions by using this module.
 
+### Removed
+
+- `fin_inj_bij` lemma is removed as a duplicate of `injF_bij` lemma
+  from `fintype` library.
+
 ### Infrastructure
 
 - `Makefile` now supports the `test-suite` and `only` targets. Currently,

--- a/mathcomp/ssreflect/fingraph.v
+++ b/mathcomp/ssreflect/fingraph.v
@@ -543,9 +543,6 @@ Lemma f_finv : cancel finv f. Proof. exact: (in1T (f_finv_in _ (in2W _))). Qed.
 
 Lemma finv_f : cancel f finv. Proof. exact: (in1T (finv_f_in _ (in2W _))). Qed.
 
-Lemma fin_inj_bij : bijective f.
-Proof. by exists finv; [apply: finv_f|apply: f_finv]. Qed.
-
 Lemma finv_bij : bijective finv.
 Proof. by exists f; [apply: f_finv|apply: finv_f]. Qed.
 
@@ -643,7 +640,7 @@ Variables (T : finType) (f f' : T -> T).
 Lemma finv_eq_can : cancel f f' -> finv f =1 f'.
 Proof.
 move=> fK; have inj_f := can_inj fK.
-by apply: bij_can_eq fK; [apply: fin_inj_bij | apply: finv_f].
+by apply: bij_can_eq fK; [apply: injF_bij | apply: finv_f].
 Qed.
 
 Hypothesis eq_f : f =1 f'.


### PR DESCRIPTION
##### Motivation for this change

This PR removes `fin_inj_bij` lemma as a duplicate of `injF_bij` from `fintype.v`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [ ] added corresponding documentation in the headers (`fin_inj_bij` is not documented, thus this bullet does not apply)

<!-- if items above are irrelevant, explain what you did here -->

<!-- please fill in the following checklist -->
<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.