### PR TITLE
add non-negative numbers to generalize the type of ProdNormedZmodule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,7 +145,7 @@ coq-dev:
     - make install
   except:
     - /^experiment\/order$/
-    - /^pr-(270|388|402)$/
+    - /^pr-(270|388|402|417)$/
 
 ci-fourcolor-8.7:
   extends: .ci-fourcolor
@@ -182,7 +182,7 @@ ci-fourcolor-dev:
     - make install
   only:
     - /^experiment\/order$/
-    - /^pr-(270|388|402)$/
+    - /^pr-(270|388|402|417)$/
 
 ci-fourcolor-8.7-270:
   extends: .ci-fourcolor-270
@@ -210,7 +210,7 @@ ci-fourcolor-dev-270:
     - make install
   except:
     - /^experiment\/order$/
-    - /^pr-(270|388|402)$/
+    - /^pr-(270|388|402|417)$/
 
 ci-odd-order-8.7:
   extends: .ci-odd-order
@@ -247,7 +247,7 @@ ci-odd-order-dev:
     - make install
   only:
     - /^experiment\/order$/
-    - /^pr-(270|388|402)$/
+    - /^pr-(270|388|402|417)$/
 
 ci-odd-order-8.7-270:
  extends: .ci-odd-order-270


### PR DESCRIPTION
##### Motivation for this change

generalize the type of ProdNormedZmodule in ssrnum for use in mathcomp-analysis,
for that purpose add non-negative numbers on the model of posum's from mathcomp-analysis
preserving the naming scheme ("pos" becomes "nng") except for the main
notation ({posnum R} becomes {nonneg R}) and for %:num which becomes %:nngnum 

##### Things done/to do

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [ ] added corresponding documentation in the headers

I didn't have to fix the documentation because the module in question was not yet documented, TODO though

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
