### PR TITLE
Added ssrfun theorem `inj_compr`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -89,6 +89,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `nseq_addn`, `take_take`, `take_drop`, `take_addn`, `takeC`,
   `take_nseq`, `drop_nseq`, `rev_nseq`, `take_iota`, `drop_iota`.
 
+- Added ssrfun theorem `inj_compr`.
 
 ### Changed
 

--- a/mathcomp/ssreflect/ssrfun.v
+++ b/mathcomp/ssreflect/ssrfun.v
@@ -17,3 +17,7 @@ Definition of_void T (x : void) : T := match x with end.
 
 Lemma of_voidK T : pcancel (of_void T) [fun _ => None].
 Proof. by case. Qed.
+
+Lemma inj_compr A B C (f : B -> A) (h : C -> B) :
+   injective (f \o h) -> injective h.
+Proof. by move=> fh_inj x y /(congr1 f) /fh_inj. Qed.


### PR DESCRIPTION
##### Motivation for this change

Missing theorem about injectivity of the right member of a composition of two functions.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~added corresponding documentation in the headers~
- [x] backport the theorem to Coq (see coq/coq#11136)
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
