### PR TITLE
New generalised induction idiom

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added a `void` notation for the `Empty_set` type of the standard library, the
   canonical injection `of_void` and its cancellation lemma `of_voidK`, and
   `eq`, `choice`, `count` and `fin` instances.
+  
+- Added `ltn_ind` general induction principle for `nat` variables, helper lemmas `ubnP`, `ltnSE`, ubnPleq, ubnPgeq and ubnPeq, in support of a generalized induction idiom for `nat` measures that does not rely on the `{-2}` numerical occurrence selector, and purged this idiom from the `mathcomp` library (see below).
 
 - Added fixpoint and cofixpoint constructions to `finset`: `fixset`,
   `cofixset` and `fix_order`, with a few theorems about them
@@ -84,6 +86,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Replaced the legacy generalised induction idiom with a more robust one
+that does not rely on the `{-2}` numerical occurrence selector, using
+new `ssrnat` helper lemmas `ltn_ind`, `ubnP`, `ubnPleq`,  ...., (see above). The new idiom is documented in `ssrnat`.
+   This change anticipates an expected evolution of `fintype` to integrate `finmap`. It is likely that the new definition of the `#|A|` notation will hide multiple occurrences of `A`, which will break the `{-2}` induction idiom. Client libraries should update before the 1.11 release.
+   
 - `eqVneq` lemma is changed from `{x = y} + {x != y}` to
   `eq_xor_neq x y (y == x) (x == y)`, on which a case analysis performs
   simultaneous replacement of expressions of the form `x == y` and `y == x`

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -909,7 +909,7 @@ wlog Dj: j M nzMij / j = 0; last rewrite {j}Dj in nzMij.
      by rewrite xcolE unitmx_mul uR unitmx_perm.
   by rewrite xcolE !mulmxA -dM xcolE -mulmxA -perm_mxM tperm2 perm_mx1 mulmx1.
 move Da: (M i 0) nzMij => a nz_a.
-elim: {a}_.+1 {-2}a (ltnSn `|a|) => // A IHa a leA in m n M i Da nz_a le_mn *.
+have [A leA] := ubnP `|a|; elim: A => // A IHa in a leA m n M i Da nz_a le_mn *.
 wlog [j a'Mij]: m n M i Da le_mn / {j | ~~ (a %| M i j)%Z}; last first.
   have nz_j: j != 0 by apply: contraNneq a'Mij => ->; rewrite Da.
   case: n => [[[]//]|n] in j le_mn nz_j M a'Mij Da *.

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -179,13 +179,13 @@ have{Ss u} ->: Ss = Ss_ dS.
       by rewrite ltn_subRL (leq_trans _ k_ge_dS) // addnC ltn_add2l.
   by rewrite insubdK //; case: (split i) => {i}i;
      rewrite !mxE coefMXn; case: leqP.
-elim: {-2}dS (leqnn dS) (dS_gt0) => // dj IHj dj_lt_dS _.
-pose j1 := Ordinal dj_lt_dS; pose rj0T (A : 'M[{poly R}]_dS) := row j0 A^T.
+case: (ubnPgeq dS) (dS_gt0); elim=> // dj IHj ltjS _; pose j1 := Ordinal ltjS.
+pose rj0T (A : 'M[{poly R}]_dS) := row j0 A^T.
 have: rj0T (Ss_ dj.+1) = 'X^dj *: rj0T (S_ j1) + 1 *: rj0T (Ss_ dj).
   apply/rowP=> i; apply/polyP=> k; rewrite scale1r !(Sylvester_mxE, mxE) eqxx.
   rewrite coefD coefXnM coefC !coef_poly ltnS subn_eq0 ltn_neqAle andbC.
   case: (leqP k dj) => [k_le_dj | k_gt_dj] /=; last by rewrite addr0.
-  rewrite Sylvester_mxE insubdK; last exact: leq_ltn_trans (dj_lt_dS).
+  rewrite Sylvester_mxE insubdK; last exact: leq_ltn_trans (ltjS).
   by case: eqP => [-> | _]; rewrite (addr0, add0r).
 rewrite -det_tr => /determinant_multilinear->;
   try by apply/matrixP=> i j; rewrite !mxE eq_sym (negPf (neq_lift _ _)).
@@ -858,8 +858,8 @@ have{mon_p pw0 intRp intRq}: genI S.
   split; set S1 := _ ++ _; first exists p.
     split=> // i; rewrite -[p]coefK coef_poly; case: ifP => // lt_i_p.
     by apply: genS; rewrite mem_cat orbC mem_nth.
-  have: all (mem S1) S1 by apply/allP.
-  elim: {-1}S1 => //= y S2 IH /andP[S1y S12]; split; last exact: IH.
+  set S2 := S1; have: all (mem S1) S2 by apply/allP.
+  elim: S2 => //= y S2 IH /andP[S1y S12]; split; last exact: IH.
   have{q S S1 IH S1y S12 intRp intRq} [q mon_q qx0]: integralOver RtoK y.
     by move: S1y; rewrite mem_cat => /orP[]; [apply: intRq | apply: intRp].
   exists (map_poly RtoK q); split=> // [|i]; first exact: monic_map.

--- a/mathcomp/algebra/polyXY.v
+++ b/mathcomp/algebra/polyXY.v
@@ -374,7 +374,7 @@ move=> nz_px [q nz_q qx0].
 have [/size1_polyC Dp | p_gt1] := leqP (size p) 1.
   by rewrite {}/pEx Dp map_polyC hornerC map_poly_eq0 in nz_px *; exists p`_0.
 have nz_p: p != 0 by rewrite -size_poly_gt0 ltnW.
-elim: {q}_.+1 {-2}q (ltnSn (size q)) => // m IHm q le_qm in nz_q qx0 *.
+have [m le_qm] := ubnP (size q); elim: m => // m IHm in q le_qm nz_q qx0 *.
 have nz_q1: q^:P != 0 by rewrite map_poly_eq0.
 have sz_q1: size q^:P = size q by rewrite size_map_polyC.
 have q1_gt1: size q^:P > 1.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -3185,7 +3185,7 @@ Lemma lerif_AGM_scaled (I : finType) (A : {pred I}) (E : I -> R) (n := #|A|) :
   \prod_(i in A) (E i *+ n) <= (\sum_(i in A) E i) ^+ n
                             ?= iff [forall i in A, forall j in A, E i == E j].
 Proof.
-elim: {A}_.+1 {-2}A (ltnSn #|A|) => // m IHm A leAm in E n * => Ege0.
+have [m leAm] := ubnP #|A|; elim: m => // m IHm in A leAm E n * => Ege0.
 apply/lerifP; case: ifPn => [/forall_inP-Econstant | Enonconstant].
   have [i /= Ai | A0] := pickP (mem A); last by rewrite [n]eq_card0 ?big_pred0.
   have /eqfun_inP-E_i := Econstant i Ai; rewrite -(eq_bigr _ E_i) sumr_const.
@@ -4990,8 +4990,9 @@ Qed.
 Lemma normC_sub_eq x y :
   `|x - y| = `|x| - `|y| -> {t | `|t| == 1 & (x, y) = (`|x| * t, `|y| * t)}.
 Proof.
-rewrite -{-1}(subrK y x) => /(canLR (subrK _))/esym-Dx; rewrite Dx.
-by have [t ? [Dxy Dy]] := normC_add_eq Dx; exists t; rewrite // mulrDl -Dxy -Dy.
+set z := x - y; rewrite -(subrK y x) -/z => /(canLR (subrK _))/esym-Dx.
+have [t t_1 [Dz Dy]] := normC_add_eq Dx.
+by exists t; rewrite // Dx mulrDl -Dz -Dy.
 Qed.
 
 End ClosedFieldTheory.

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -1887,7 +1887,7 @@ Qed.
 Lemma mx_reducible_semisimple V :
   mxmodule V -> mx_completely_reducible V -> classically (mxsemisimple V).
 Proof.
-move=> modV redV [] // nssimV; move: {-1}_.+1 (ltnSn (\rank V)) => r leVr.
+move=> modV redV [] // nssimV; have [r leVr] := ubnP (\rank V).
 elim: r => // r IHr in V leVr modV redV nssimV.
 have [V0 | nzV] := eqVneq V 0.
   by rewrite nssimV ?V0 //; apply: mxsemisimple0.
@@ -3212,8 +3212,8 @@ Lemma mxtrace_dsum_mod (I : finType) (P : pred I) U W
     let S := (\sum_(i | P i) U i)%MS in (S :=: W)%MS -> mxdirect S -> 
   {in G, forall x, \sum_(i | P i) \tr (sr (modU i) x) = \tr (sr modW x)}.
 Proof.
-move=> /= sumS dxS x Gx.
-elim: {P}_.+1 {-2}P (ltnSn #|P|) => // m IHm P lePm in W modW sumS dxS *.
+move=> /= sumS dxS x Gx; have [m lePm] := ubnP #|P|.
+elim: m => // m IHm in P lePm W modW sumS dxS *.
 have [j /= Pj | P0] := pickP P; last first.
   case: sumS (_ x); rewrite !big_pred0 // mxrank0 => <- _ rWx.
   by rewrite [rWx]flatmx0 linear0.
@@ -3781,7 +3781,8 @@ Lemma mx_JordanHolder U V compU compV :
   m = size V  /\ (exists p : 'S_m, forall i : 'I_m,
      mx_rsim (@series_repr U i compU) (@series_repr V (p i) compV)).
 Proof.
-elim: {U}(size U) {-2}U V (eqxx (size U)) compU compV => /= [|r IHr] U V.
+move Dr: {-}(size U) => r; move/eqP in Dr.
+elim: r U V Dr compU compV => /= [|r IHr] U V.
   move/nilP->; case/lastP: V => [|V Vm] /= ? compVm; rewrite ?last_rcons => Vm0.
     by split=> //; exists 1%g; case.
   by case/mx_series_rcons: (compVm) => _ _ []; rewrite -(lt_eqmx Vm0) ltmx0.
@@ -4796,7 +4797,7 @@ Qed.
 Lemma dec_mxsimple_exists (U : 'M_n) :
   mxmodule rG U -> U != 0 -> {V | mxsimple rG V & V <= U}%MS.
 Proof.
-elim: {U}_.+1 {-2}U (ltnSn (\rank U)) => // m IHm U leUm modU nzU.
+have [m] := ubnP (\rank U); elim: m U => // m IHm U leUm modU nzU.
 have [nsimU | simU] := mxnonsimpleP nzU; last first.
   by exists U; first apply/mxsimpleP.
 move: (xchooseP nsimU); move: (xchoose _) => W /and4P[modW sWU nzW ltWU].
@@ -4807,7 +4808,7 @@ Qed.
 Lemma dec_mx_reducible_semisimple U :
   mxmodule rG U -> mx_completely_reducible rG U -> mxsemisimple rG U.
 Proof.
-elim: {U}_.+1 {-2}U (ltnSn (\rank U)) => // m IHm U leUm modU redU.
+have [m] := ubnP (\rank U); elim: m U => // m IHm U leUm modU redU.
 have [U0 | nzU] := eqVneq U 0.
   have{U0} U0: (\sum_(i < 0) 0 :=: U)%MS by rewrite big_ord0 U0.
   by apply: (intro_mxsemisimple U0); case.
@@ -4833,8 +4834,9 @@ have [n0 | n_gt0] := posnP n.
 have n2_gt0: n ^ 2 > 0 by rewrite muln_gt0 n_gt0.
 pose span Ms := (\sum_(M <- Ms) component_mx rG M)%MS.
 have: {in [::], forall M, mxsimple rG M} by [].
-elim: _.+1 {-2}nil (ltnSn (n - \rank (span nil))) => // m IHm Ms Ms_ge_n simMs.
-rewrite ltnS in Ms_ge_n; pose V := span Ms; pose Vt := mx_term V.
+have [m] := ubnP (n - \rank (span [::])).
+elim: m [::] => // m IHm Ms /ltnSE-Ms_ge_n simMs.
+pose V := span Ms; pose Vt := mx_term V.
 pose Ut i := vec_mx (row_var F (n * n) i); pose Zt := mx_term (0 : 'M[F]_n).
 pose exU i f := Exists_row_form (n * n) i (~ submx_form (Ut i) Zt /\ f (Ut i)).
 pose meetUVf U := exU 1%N (fun W => submx_form W Vt /\ submx_form W U)%T.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -648,7 +648,7 @@ have /all_sig[n_ FTA] z: {n | z \in sQ (z_ n)}.
   have [p]: exists p, [&& p \is monic, root p z & p \is a polyOver (sQ (z_ n))].
     have [p mon_p pz0] := algC z; exists (p ^ QtoC).
     by rewrite map_monic mon_p pz0 -(pQof (z_ n)); apply/polyOver_poly.
-  elim: {p}_.+1 {-2}p n (ltnSn (size p)) => // d IHd p n lepd pz0.
+  have [d lepd] := ubnP (size p); elim: d => // d IHd in p n lepd * => pz0.
   have [t [t_C t_z gal_t]]: exists t, [/\ z_ n \in sQ t, z \in sQ t & is_Gal t].
     have [y /and3P[y_C y_z _]] := PET [:: z_ n; z].
     by have [t /(sQtrans y)t_y] := galQ y; exists t; rewrite !t_y.

--- a/mathcomp/field/algnum.v
+++ b/mathcomp/field/algnum.v
@@ -439,7 +439,7 @@ have nu_inj n y: nu (Sinj (ext n) y) = Sinj (ext n) (Saut (ext n) y).
   rewrite /nu; case: (mem_ext _ _ _); move: _.+1 => n1 y1 Dy /=.
   without loss /subnK Dn1: n n1 y y1 Dy / (n <= n1)%N.
     by move=> IH; case/orP: (leq_total n n1) => /IH => [/(_ y) | /(_ y1)]->.
-  elim: {n}(_ - n)%N {-1}n => [|k IHk] n in Dn1 y Dy *.
+  move: (n1 - n)%N => k in Dn1; elim: k => [|k IHk] in n Dn1 y Dy *.
     by move: y1 Dy; rewrite -Dn1 => y1  /fmorph_inj ->.
   rewrite addSnnS in Dn1; move/IHk: Dn1 => /=.
   case: (unpickle _) => [z|] /=; last exact.

--- a/mathcomp/field/closed_field.v
+++ b/mathcomp/field/closed_field.v
@@ -878,10 +878,11 @@ have Kclosed: GRing.ClosedField.axiom Kfield.
     apply/eqP; rewrite EtoKeq0 (eq_map_poly (toEleS _ _ _ _)) map_poly_comp Dpj.
     rewrite -rootE -[pj]minXpE ?ext1root // -Dpj size_map_poly.
     by rewrite size_addl ?size_polyXn ltnS ?size_opp ?size_poly.
-  rewrite {w}/pj; elim: {-9}j lemj => // k IHk lemSk.
-  move: lemSk (lemSk); rewrite {1}leq_eqVlt ltnS => /predU1P[<- | lemk] lemSk.
-    rewrite {k IHk lemSk}(eq_map_poly (toEeq m _)) map_poly_id //= /incEp.
-    by rewrite codeK eqxx pickleK.
+  rewrite {w}/pj; set j0 := (j in tagged (E_ _) j).
+  elim: {+}j lemj => // k IHk lemSk; rewrite {}/j0 in IHk *.
+  have:= lemSk; rewrite leq_eqVlt ltnS => /predU1P[Dm | lemk].
+    rewrite -{}Dm in lemSk *; rewrite {k IHk lemSk}(eq_map_poly (toEeq m _)).
+    by rewrite map_poly_id //= /incEp codeK eqxx pickleK.
   rewrite (eq_map_poly (toEleS _ _ _ _)) map_poly_comp {}IHk //= /incEp codeK.
   by rewrite -if_neg neq_ltn lemk.
 suffices{Kclosed} algF_K: {FtoK : {rmorphism F -> Kfield} | integralRange FtoK}.

--- a/mathcomp/field/cyclotomic.v
+++ b/mathcomp/field/cyclotomic.v
@@ -149,7 +149,7 @@ Qed.
 Lemma Cintr_Cyclotomic n z :
   n.-primitive_root z -> pZtoC 'Phi_n = cyclotomic z n.
 Proof.
-elim: {n}_.+1 {-2}n z (ltnSn n) => // m IHm n z0 le_mn prim_z0.
+elim/ltn_ind: n z => n IHn z0 prim_z0.
 rewrite /'Phi_n; case: (C_prim_root_exists _) => z /=.
 have n_gt0 := prim_order_gt0 prim_z0; rewrite prednK // => prim_z.
 have [uDn _ inDn] := divisors_correct n_gt0.
@@ -159,8 +159,7 @@ have defXn1: cyclotomic z n * pZtoC q = 'X^n - 1.
   rewrite (prod_cyclotomic prim_z) (big_rem n) ?inDn //=.
   rewrite divnn n_gt0 rmorph_prod /=; congr (_ * _).
   apply: eq_big_seq => d; rewrite mem_rem_uniq ?inE //= inDn => /andP[n'd ddvn].
-  rewrite -IHm ?dvdn_prim_root // -ltnS (leq_ltn_trans _ le_mn) //.
-  by rewrite ltn_neqAle n'd dvdn_leq.
+  by rewrite -IHn ?dvdn_prim_root // ltn_neqAle n'd dvdn_leq.
 have mapXn1 (R1 R2 : ringType) (f : {rmorphism R1 -> R2}):
   map_poly f ('X^n - 1) = 'X^n - 1.
 - by rewrite rmorphB /= rmorph1 map_polyXn.
@@ -263,8 +262,7 @@ have co_fg (R : idomainType): n%:R != 0 :> R -> @coprimep R (intrp f) (intrp g).
 suffices fzk0: root (pZtoC f) zk.
   have [] // := negP (coprimep_root (co_fg _ _) fzk0).
   by rewrite pnatr_eq0 -lt0n.
-move: gzk0 cokn; rewrite {zk}Dzk; elim: {k}_.+1 {-2}k (ltnSn k) => // m IHm k.
-rewrite ltnS => lekm gzk0 cokn.
+move: gzk0 cokn; rewrite {zk}Dzk; elim/ltn_ind: k => k IHk gzk0 cokn.
 have [|k_gt1] := leqP k 1; last have [p p_pr /dvdnP[k1 Dk]] := pdivP k_gt1.
   rewrite -[leq k 1](mem_iota 0 2) !inE => /pred2P[k0 | ->]; last first.
     by rewrite -Df dv_pf.
@@ -287,8 +285,8 @@ suffices: coprimep (pZtoC f) (pZtoC (g \Po 'X^p)).
   rewrite -exprM -Dk [_ == 0]gzk0 implybF => /negP[].
   have: root pz (z ^+ k1).
     by rewrite root_cyclotomic // prim_root_exp_coprime.
-  rewrite -Dpz -Dfg rmorphM rootM => /orP[] //= /IHm-> //.
-  rewrite (leq_trans _ lekm) // -[k1]muln1 Dk ltn_pmul2l ?prime_gt1 //.
+  rewrite -Dpz -Dfg rmorphM rootM => /orP[] //= /IHk-> //.
+  rewrite -[k1]muln1 Dk ltn_pmul2l ?prime_gt1 //.
   by have:= ltnW k_gt1; rewrite Dk muln_gt0 => /andP[].
 suffices: coprimep f (g \Po 'X^p).
   case/Bezout_coprimepP=> [[u v]]; rewrite -size_poly_eq1.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -555,8 +555,8 @@ Qed.
 
 Lemma Fadjoin_sum_direct : directv sumKx.
 Proof.
-rewrite directvE /=; case Dn: {-2}n (leqnn n) => // [m] {Dn}.
-elim: m => [|m IHm] ltm1n; rewrite ?big_ord1 // !(big_ord_recr m.+1) /=.
+rewrite directvE /=; case: (ubnPgeq n) (isT : n > 0) => -[//|m] ltmn _.
+elim: m ltmn => [|m IHm] ltm1n; rewrite ?big_ord1 // !(big_ord_recr m.+1) /=.
 do [move/(_ (ltnW ltm1n))/eqP; set S := (\sum_i _)%VS] in IHm *.
 rewrite -IHm dimv_add_leqif; apply/subvP=> z; rewrite memv_cap => /andP[Sz].
 case/memv_cosetP=> y Ky Dz; rewrite memv0 Dz mulf_eq0 expf_eq0 /=.

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -561,7 +561,7 @@ have [[p F0p splitLp] [autL DautL]] := (splittingFieldP, enum_AEnd).
 suffices{K} autL_px q: q != 0 -> q %| q1 -> size q > 1 -> has (fx_root q) autL.
   set q := minPoly K x; have: q \is monic := monic_minPoly K x.
   have: q %| q1 by rewrite minPolyS // sub1v.
-  elim: {q}_.+1 {-2}q (ltnSn (size q)) => // d IHd q leqd q_dv_q1 mon_q.
+  have [d] := ubnP (size q); elim: d q => // d IHd q leqd q_dv_q1 mon_q.
   have nz_q: q != 0 := monic_neq0 mon_q.
   have [|q_gt1|q_1] := ltngtP (size q) 1; last first; last by rewrite polySpred.
     by exists nil; rewrite big_nil -eqp_monic ?monic1 // -size_poly_eq1 q_1.
@@ -571,7 +571,7 @@ suffices{K} autL_px q: q != 0 -> q %| q1 -> size q > 1 -> has (fx_root q) autL.
   have q2_dv_q1: q2 %| q1 by rewrite (dvdp_trans _ q_dv_q1) // Dq dvdp_mulr.
   rewrite Dq; have [r /eqP->] := IHd q2 leqd q2_dv_q1 mon_q2.
   by exists (f x :: r); rewrite big_cons mulrC.
-elim: {q}_.+1 {-2}q (ltnSn (size q)) => // d IHd q leqd nz_q q_dv_q1 q_gt1.
+have [d] := ubnP (size q); elim: d q => // d IHd q leqd nz_q q_dv_q1 q_gt1.
 without loss{d leqd IHd nz_q q_gt1} irr_q: q q_dv_q1 / irreducible_poly q.
   move=> IHq; apply: wlog_neg => not_autLx_q; apply: IHq => //.
   split=> // q2 q2_neq1 q2_dv_q; rewrite -dvdp_size_eqp // eqn_leq dvdp_leq //=.
@@ -645,9 +645,10 @@ have [f homLf fxz]: exists2 f : 'End(Lz), kHom 1 imL f & f (inLz x) = z.
 pose f1 := (inLz^-1 \o f \o inLz)%VF; have /kHomP[fM fFid] := homLf.
 have Df1 u: inLz (f1 u) = f (inLz u).
   rewrite !comp_lfunE limg_lfunVK //= -[limg _]/(asval imL).
-  have [r def_pz defLz] := splitLpz.
-  have []: all (mem r) r /\ inLz u \in imL by split; first apply/allP.
-  rewrite -{1}defLz; elim/last_ind: {-1}r {u}(inLz u) => [|r1 y IHr1] u.
+  have [r def_pz defLz] := splitLpz; set r1 := r.
+  have: inLz u \in <<1 & r1>>%VS by rewrite defLz.
+  have: all (mem r) r1 by apply/allP.
+  elim/last_ind: r1 {u}(inLz u) => [|r1 y IHr1] u.
     by rewrite Fadjoin_nil => _ Fu; rewrite fFid // (subvP (sub1v _)).
   rewrite all_rcons adjoin_rcons => /andP[rr1 ry] /Fadjoin_polyP[pu r1pu ->].
   rewrite (kHom_horner homLf) -defLz; last exact: seqv_sub_adjoin; last first.
@@ -1353,7 +1354,7 @@ Lemma gal_independent_contra E (P : pred (gal_of E)) (c_ : gal_of E -> L) x :
     P x -> c_ x != 0 ->
   exists2 a, a \in E & \sum_(y | P y) c_ y * y a != 0.
 Proof.
-elim: {P}_.+1 c_ x {-2}P (ltnSn #|P|) => // n IHn c_ x P lePn Px nz_cx.
+have [n] := ubnP #|P|; elim: n c_ x P => // n IHn c_ x P lePn Px nz_cx.
 rewrite ltnS (cardD1x Px) in lePn; move/IHn: lePn => {n IHn}/=IH_P.
 have [/eqfun_inP c_Px'_0 | ] := boolP [forall (y | P y && (y != x)), c_ y == 0].
   exists 1; rewrite ?mem1v // (bigD1 x Px) /= rmorph1 mulr1.

--- a/mathcomp/field/separable.v
+++ b/mathcomp/field/separable.v
@@ -482,9 +482,9 @@ Lemma extendDerivation_horner p :
   extendDerivation K p.[x] = (map_poly D p).[x] + p^`().[x] * Dx K.
 Proof.
 move=> Kp sepKx; have:= separable_root_der; rewrite {}sepKx /= => nz_pKx'x.
-rewrite {-1}(divp_eq p (minPoly K x)) lfunE /= Fadjoin_poly_mod // raddfD /=.
-rewrite {1}(Derivation_mul_poly derD) ?divp_polyOver ?minPolyOver //.
-rewrite derivD derivM !{1}hornerD !{1}hornerM minPolyxx !{1}mulr0 !{1}add0r.
+rewrite [in RHS](divp_eq p (minPoly K x)) lfunE /= Fadjoin_poly_mod ?raddfD //=.
+rewrite (Derivation_mul_poly derD) ?divp_polyOver ?minPolyOver //.
+rewrite derivM !{1}hornerD !{1}hornerM minPolyxx !{1}mulr0 !{1}add0r.
 rewrite mulrDl addrA [_ + (_ * _ * _)]addrC {2}/Dx -mulrA -/Dx.
 by rewrite [_ / _]mulrC (mulVKf nz_pKx'x) mulrN addKr.
 Qed.
@@ -528,12 +528,14 @@ have DK_0: (K <= lker D)%VS.
   apply/subvP=> v Kv; rewrite memv_ker lfunE /= Fadjoin_polyC //.
   by rewrite derivC horner0.
 have Dder: Derivation <<K; x>> D.
-  apply/allP=> u /vbasis_mem Kx_u; apply/allP=> v /vbasis_mem Kx_v.
-  rewrite !lfunE /= -{-2}(Fadjoin_poly_eq Kx_u) -{-3}(Fadjoin_poly_eq Kx_v).
+  apply/allP=> u /vbasis_mem Kx_u; apply/allP=> v /vbasis_mem Kx_v; apply/eqP.
+  rewrite !lfunE /=; set Px := Fadjoin_poly K x.
+  set Px_u := Px u; rewrite -(Fadjoin_poly_eq Kx_u) -/Px -/Px_u.
+  set Px_v := Px v; rewrite -(Fadjoin_poly_eq Kx_v) -/Px -/Px_v.
   rewrite -!hornerM -hornerD -derivM.
-  rewrite Fadjoin_poly_mod ?rpredM ?Fadjoin_polyOver //.
-  rewrite {2}(divp_eq (_ * _) (minPoly K x)) derivD derivM pKx'_0 mulr0 addr0.
-  by rewrite hornerD hornerM minPolyxx mulr0 add0r.
+  rewrite /Px Fadjoin_poly_mod ?rpredM ?Fadjoin_polyOver //.
+  rewrite [in RHS](divp_eq (Px_u * Px_v) (minPoly K x)) derivD derivM.
+  by rewrite pKx'_0 mulr0 addr0 hornerD hornerM minPolyxx mulr0 add0r.
 have{Dder DK_0}: x \in lker D by apply: subvP Kx_x; apply: derKx_0.
 apply: contraLR => K'x; rewrite memv_ker lfunE /= Fadjoin_polyX //.
 by rewrite derivX hornerC oner_eq0.

--- a/mathcomp/fingroup/fingroup.v
+++ b/mathcomp/fingroup/fingroup.v
@@ -2163,7 +2163,7 @@ case: (pickP (fun i : 'I_N => B ^+ i.+1 \subset B ^+ i)) => [n fixBn | no_fix].
   elim: {2}(n : nat) => [|m IHm]; first by rewrite mulg1.
   by apply: subset_trans fixBn; rewrite !expgSr mulgA mulSg.
 suffices: N < #|B ^+ N| by rewrite ltnNge max_card.
-elim: {-2}N (leqnn N) => [|n IHn] lt_nN; first by rewrite cards1.
+have [] := ubnPgeq N; elim=> [|n IHn] lt_nN; first by rewrite cards1.
 apply: leq_ltn_trans (IHn (ltnW lt_nN)) (proper_card _).
 by rewrite /proper (no_fix (Ordinal lt_nN)) expgS mulUg mul1g subsetUl.
 Qed.

--- a/mathcomp/fingroup/gproduct.v
+++ b/mathcomp/fingroup/gproduct.v
@@ -591,8 +591,8 @@ Proof.
 apply: (iffP eqP) => [defG i j Pi Pj neq_ij | cHH].
   rewrite (bigD1 j) // (bigD1 i) /= ?cprodA in defG; last exact/andP.
   by case/cprodP: defG => [[K _ /cprodP[//]]].
-set Q := P; have: subpred Q P by [].
-elim: {Q}_.+1 {-2}Q (ltnSn #|Q|) => // n IHn Q leQn sQP.
+set Q := P; have sQP: subpred Q P by []; have [n leQn] := ubnP #|Q|.
+elim: n => // n IHn in (Q) leQn sQP *.
 have [i Qi | Q0] := pickP Q; last by rewrite !big_pred0.
 rewrite (cardD1x Qi) add1n ltnS !(bigD1 i Qi) /= in leQn *.
 rewrite {}IHn {n leQn}// => [|j /andP[/sQP //]].
@@ -620,7 +620,7 @@ transitivity (\prod_(j <- rot n r2) x j).
   rewrite Dr2 !big_cons in defG Ax *; have [[_ G1 _ defG1] _ _] := cprodP defG.
   rewrite (IHr r3 G1) //; first by case/allP/andP: Ax => _ /allP.
   by rewrite -(perm_cons i) -Dr2 perm_sym perm_rot perm_sym.
-rewrite -{-2}(cat_take_drop n r2) in eq_r12 *.
+rewrite -(cat_take_drop n r2) [in LHS]cat_take_drop in eq_r12 *.
 rewrite (perm_big _ eq_r12) !big_cat /= !(big_nth i) !big_mkord in defG *.
 have /cprodP[[G1 G2 defG1 defG2] _ /centsP-> //] := defG.
   rewrite defG2 -(bigcprodW defG2) mem_prodg // => k _; apply: Ax.
@@ -763,8 +763,8 @@ Proof.
 apply: (iffP eqP) => [defG i Pi | dxG].
   rewrite !(bigD1 i Pi) /= in defG; have [[_ G' _ defG'] _ _ _] := dprodP defG.
   by apply/dprodYP; rewrite -defG defG' bigprodGE (bigdprodWY defG').
-set Q := P; have: subpred Q P by [].
-elim: {Q}_.+1 {-2}Q (ltnSn #|Q|) => // n IHn Q leQn sQP.
+set Q := P; have sQP: subpred Q P by []; have [n leQn] := ubnP #|Q|.
+elim: n => // n IHn in (Q) leQn sQP *.
 have [i Qi | Q0] := pickP Q; last by rewrite !big_pred0.
 rewrite (cardD1x Qi) add1n ltnS !(bigD1 i Qi) /= in leQn *.
 rewrite {}IHn {n leQn}// => [|j /andP[/sQP //]].
@@ -820,8 +820,8 @@ Lemma bigcprod_coprime_dprod (I : finType) (P : pred I) (A : I -> {set gT}) G :
     (forall i j, P i -> P j -> i != j -> coprime #|A i| #|A j|) ->
   \big[dprod/1]_(i | P i) A i = G.
 Proof.
-move=> defG coA; set Q := P in defG *; have: subpred Q P by [].
-elim: {Q}_.+1 {-2}Q (ltnSn #|Q|) => // m IHm Q leQm in G defG * => sQP.
+move=> defG coA; set Q := P in defG *; have sQP: subpred Q P by [].
+have [m leQm] := ubnP #|Q|; elim: m => // m IHm in (Q) leQm G defG sQP *.
 have [i Qi | Q0] := pickP Q; last by rewrite !big_pred0 in defG *.
 move: defG; rewrite !(bigD1 i Qi) /= => /cprodP[[Hi Gi defAi defGi] <-].
 rewrite defAi defGi => cHGi.

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -465,18 +465,18 @@ Arguments dpair {eT}.
 Lemma prod_tpermP s :
   {ts : seq (T * T) | s = \prod_(t <- ts) tperm t.1 t.2 & all dpair ts}.
 Proof.
-elim: {s}_.+1 {-2}s (ltnSn #|[pred x | s x != x]|) => // n IHn s.
-rewrite ltnS => le_s_n; case: (pickP (fun x => s x != x)) => [x s_x | s_id].
-  have [|ts def_s ne_ts] := IHn (tperm x (s^-1 x) * s).
-    rewrite (cardD1 x) !inE s_x in le_s_n; apply: leq_ltn_trans le_s_n.
-    apply: subset_leq_card; apply/subsetP=> y.
-    rewrite !inE permM permE /= -(canF_eq (permK _)).
-    have [-> | ne_yx] := altP (y =P x); first by rewrite permKV eqxx.
-    by case: (s y =P x) => // -> _; rewrite eq_sym.
+have [n] := ubnP #|[pred x | s x != x]|; elim: n s => // n IHn s /ltnSE-le_s_n.
+case: (pickP (fun x => s x != x)) => [x s_x | s_id]; last first.
+  exists nil; rewrite // big_nil; apply/permP=> x.
+  by apply/eqP/idPn; rewrite perm1 s_id.
+have [|ts def_s ne_ts] := IHn (tperm x (s^-1 x) * s); last first.
   exists ((x, s^-1 x) :: ts); last by rewrite /= -(canF_eq (permK _)) s_x.
   by rewrite big_cons -def_s mulgA tperm2 mul1g.
-exists nil; rewrite // big_nil; apply/permP=> x.
-by apply/eqP/idPn; rewrite perm1 s_id.
+rewrite (cardD1 x) !inE s_x in le_s_n; apply: leq_ltn_trans le_s_n.
+apply: subset_leq_card; apply/subsetP=> y.
+rewrite !inE permM permE /= -(canF_eq (permK _)).
+have [-> | ne_yx] := altP (y =P x); first by rewrite permKV eqxx.
+by case: (s y =P x) => // -> _; rewrite eq_sym.
 Qed.
 
 Lemma odd_perm_prod ts :

--- a/mathcomp/solvable/extraspecial.v
+++ b/mathcomp/solvable/extraspecial.v
@@ -420,7 +420,7 @@ have iC1U (U : {group gT}) x:
   by rewrite -norm_joinEl ?cardSg ?join_subG ?(subset_trans sUG).
 have oCG (U : {group gT}):
   Z \subset U -> U \subset G -> #|'C_G(U)| = (p * #|G : U|)%N.
-- elim: {U}_.+1 {-2}U (ltnSn #|U|) => // m IHm U leUm sZU sUG.
+- have [m] := ubnP #|U|; elim: m U => // m IHm U leUm sZU sUG.
   have [<- | neZU] := eqVneq Z U.
     by rewrite -oZ Lagrange // (setIidPl _) // centsC subsetIr.
   have{neZU} [x Gx not_cUx]: exists2 x, x \in G & x \notin 'C(U).

--- a/mathcomp/solvable/extremal.v
+++ b/mathcomp/solvable/extremal.v
@@ -575,9 +575,9 @@ suffices{k k_gt0 le_k_n2} defGn2: <[x ^+ p]> \x <[y]> = 'Ohm_(n.-2)(G).
   rewrite -subSn // -subSS def_n1 def_n => -> /=; rewrite subnSK // subn2.
   by apply/eqP; rewrite eqEsubset OhmS ?Ohm_sub //= -{1}Ohm_id OhmS ?Ohm_leq.
 rewrite dprodEY //=; last by apply/trivgP; rewrite -tiXY setSI ?cycleX.
-apply/eqP; rewrite eqEsubset join_subG !cycle_subG /= {-2}(OhmE _ pG) -/r.
-rewrite def_n (subsetP (Ohm_leq G (ltn0Sn _))) // mem_gen /=; last first.
-  by rewrite !inE -order_dvdn oxp groupX /=.
+apply/eqP; rewrite eqEsubset join_subG !cycle_subG /= [in y \in _]def_n.
+rewrite (subsetP (Ohm_leq G (ltn0Sn _)) y) //= (OhmE _ pG) -/r.
+rewrite mem_gen /=; last by rewrite !inE -order_dvdn oxp groupX /=.
 rewrite gen_subG /= cent_joinEr // -defXY; apply/subsetP=> uv; case/setIP.
 case/imset2P=> u v Xu Yv ->{uv}; rewrite /r inE def_n expnS expgM.
 case/lcosetP: (XYp u v Xu Yv) => _ /cycleP[j ->] ->.
@@ -786,8 +786,8 @@ have defK: K = [set w].
   apply/eqP; rewrite eqEsubset sub1set Kw andbT subDset setUC.
   apply/subsetP=> uivj; have: uivj \in B by rewrite inE.
   rewrite -{1}defB => /imset2P[_ _ /cycleP[i ->] /cycleP[j ->] ->] {uivj}.
-  rewrite !inE sqrB -{-1}[j]odd_double_half.
-  case: (odd j); rewrite -order_dvdn ?ov // ou -def2r -mul2n dvdn_pmul2l //.
+  rewrite !inE sqrB; set b := odd j; rewrite -[j]odd_double_half -/b.
+  case: b; rewrite -order_dvdn ?ov // ou -def2r -mul2n dvdn_pmul2l //.
   case/dvdnP=> k ->{i}; apply/orP.
   rewrite add0n -[j./2]odd_double_half addnC doubleD -!muln2 -mulnA.
   rewrite -(expg_mod_order v) ov modnMDl; case: (odd _); last first.

--- a/mathcomp/solvable/gseries.v
+++ b/mathcomp/solvable/gseries.v
@@ -116,7 +116,7 @@ Lemma subnormalP H G :
   reflect (exists2 s, normal.-series H s & last H s = G) (H <|<| G).
 Proof.
 apply: (iffP andP) => [[sHG snHG] | [s Hsn <-{G}]].
-  elim: {G}#|G| {-2}G sHG snHG => [|m IHm] G sHG.
+  move: #|G| snHG => m; elim: m => [|m IHm] in G sHG *.
     by exists [::]; last by apply/eqP; rewrite eq_sym.
   rewrite iterSr => /IHm[|s Hsn defG].
     by rewrite sub_gen // class_supportEr (bigD1 1) //= conjsg1 subsetUl.
@@ -125,10 +125,10 @@ apply: (iffP andP) => [[sHG snHG] | [s Hsn <-{G}]].
   by rewrite norms_gen ?class_support_norm.
 set f := fun _ => <<_>>; have idf: iter _ f H == H.
   by elim=> //= m IHm; rewrite (eqP IHm) /f class_support_id genGid.
-elim: {s}(size s) {-2}s (eqxx (size s)) Hsn => [[] //= | m IHm s].
-case/lastP: s => // s G; rewrite size_rcons last_rcons -cats1 cat_path /=.
-set K := last H s => def_m /and3P[Hsn /andP[sKG nKG] _].
-have:= sKG; rewrite subEproper; case/predU1P=> [<-|prKG]; first exact: IHm.
+have [m] := ubnP (size s); elim: m s Hsn => // m IHm /lastP[//|s G].
+rewrite size_rcons last_rcons rcons_path /= ltnS.
+set K := last H s => /andP[Hsn /andP[sKG nKG]] lt_s_m.
+have:= sKG; rewrite subEproper => /predU1P[<-|prKG]; first exact: IHm.
 pose L := [group of f G].
 have sHK: H \subset K by case/IHm: Hsn.
 have sLK: L \subset K by rewrite gen_subG class_support_sub_norm.
@@ -136,7 +136,8 @@ rewrite -(subnK (proper_card (sub_proper_trans sLK prKG))) iter_add iterSr.
 have defH: H = setIgr L H by rewrite -sub_setIgr ?sub_gen ?sub_class_support.
 have: normal.-series H (map (setIgr L) s) by rewrite defH path_setIgr.
 case/IHm=> [|_]; first by rewrite size_map.
-by rewrite {1 2}defH last_map (subset_trans sHK) //= (setIidPr sLK) => /eqP->.
+rewrite [in last _]defH last_map (subset_trans sHK) //=.
+by rewrite (setIidPr sLK) => /eqP->.
 Qed.
 
 Lemma subnormal_refl G : G <|<| G.
@@ -513,7 +514,7 @@ Qed.
 Lemma chief_series_exists H G :
   H <| G -> {s | (G.-chief).-series 1%G s & last 1%G s = H}.
 Proof.
-elim: {H}_.+1 {-2}H (ltnSn #|H|) => // m IHm U leUm nsUG.
+have [m] := ubnP #|H|; elim: m H => // m IHm U leUm nsUG.
 have [-> | ntU] := eqVneq U 1%G; first by exists [::].
 have [V maxV]: {V : {group gT} | maxnormal V U G}.
   by apply: ex_maxgroup; exists 1%G; rewrite proper1G ntU norms1.

--- a/mathcomp/solvable/hall.v
+++ b/mathcomp/solvable/hall.v
@@ -31,8 +31,8 @@ Implicit Type gT : finGroupType.
 Theorem SchurZassenhaus_split gT (G H : {group gT}) :
   Hall G H -> H <| G -> [splits G, over H].
 Proof.
-move: {2}_.+1 (ltnSn #|G|) => n; elim: n => // n IHn in gT G H *.
-rewrite ltnS => Gn hallH nsHG; have [sHG nHG] := andP nsHG.
+have [n] := ubnP #|G|; elim: n => // n IHn in gT G H * => /ltnSE-Gn hallH nsHG.
+have [sHG nHG] := andP nsHG.
 have [-> | [p pr_p pH]] := trivgVpdiv H.
   by apply/splitsP; exists G; rewrite inE -subG1 subsetIl mul1g eqxx.
 have [P sylP] := Sylow_exists p H.
@@ -102,8 +102,9 @@ Theorem SchurZassenhaus_trans_sol gT (H K K1 : {group gT}) :
     coprime #|H| #|K| -> #|K1| = #|K| ->
   exists2 x, x \in H & K1 :=: K :^ x.
 Proof.
-move: {2}_.+1 (ltnSn #|H|) => n; elim: n => // n IHn in gT H K K1 *.
-rewrite ltnS => leHn solH nHK; have [-> | ] := eqsVneq H 1.
+have [n] := ubnP #|H|.
+elim: n => // n IHn in gT H K K1 * => /ltnSE-leHn solH nHK.
+have [-> | ] := eqsVneq H 1.
   rewrite mul1g => sK1K _ eqK1K; exists 1; first exact: set11.
   by apply/eqP; rewrite conjsg1 eqEcard sK1K eqK1K /=.
 pose G := (H <*> K)%G.
@@ -150,9 +151,8 @@ Lemma SchurZassenhaus_trans_actsol gT (G A B : {group gT}) :
     coprime #|G| #|A| -> #|A| = #|B| ->
   exists2 x, x \in G & B :=: A :^ x.
 Proof.
-set AG := A <*> G; move: {2}_.+1 (ltnSn #|AG|) => n.
-elim: n => // n IHn in gT A B G AG *.
-rewrite ltnS => leAn solA nGA sB_AG coGA oAB.
+set AG := A <*> G; have [n] := ubnP #|AG|.
+elim: n => // n IHn in gT A B G AG * => /ltnSE-leAn solA nGA sB_AG coGA oAB.
 have [A1 | ntA] := eqsVneq A 1.
   by exists 1; rewrite // conjsg1 A1 (@card1_trivg _ B) // -oAB A1 cards1.
 have [M [sMA nsMA ntM]] := solvable_norm_abelem solA (normal_refl A) ntA.
@@ -218,8 +218,7 @@ Lemma Hall_exists_subJ pi gT (G : {group gT}) :
                 & forall K : {group gT}, K \subset G -> pi.-group K ->
                   exists2 x, x \in G & K \subset H :^ x.
 Proof.
-move: {2}_.+1 (ltnSn #|G|) => n.
-elim: n gT G => // n IHn gT G; rewrite ltnS => leGn solG.
+have [n] := ubnP #|G|; elim: n gT G => // n IHn gT G /ltnSE-leGn solG.
 have [-> | ntG] := eqsVneq G 1.
   exists 1%G => [|_ /trivGP-> _]; last by exists 1; rewrite ?set11 ?sub1G.
   by rewrite pHallE sub1G cards1 part_p'nat.
@@ -581,8 +580,8 @@ Proposition coprime_Hall_subset pi (gT : finGroupType) (A G X : {group gT}) :
     X \subset G -> pi.-group X -> A \subset 'N(X) ->
   exists H : {group gT}, [/\ pi.-Hall(G) H, A \subset 'N(H) & X \subset H].
 Proof.
-move: {2}_.+1 (ltnSn #|G|) => n.
-elim: n => // n IHn in gT A G X * => leGn nGA coGA solG sXG piX nXA.
+have [n] := ubnP #|G|.
+elim: n => // n IHn in gT A G X * => /ltnSE-leGn nGA coGA solG sXG piX nXA.
 have [G1 | ntG] := eqsVneq G 1.
   case: (coprime_Hall_exists pi nGA) => // H hallH nHA.
   by exists H; split; rewrite // (subset_trans sXG) // G1 sub1G.

--- a/mathcomp/solvable/jordanholder.v
+++ b/mathcomp/solvable/jordanholder.v
@@ -174,8 +174,7 @@ Qed.
 Lemma JordanHolderUniqueness (G : gTg) (s1 s2 : seq gTg) :
   comps G s1 -> comps G s2 -> perm_eq (mkfactors G s1) (mkfactors G s2).
 Proof.
-elim: {G}#|G| {-2}G (leqnn #|G|) => [|n Hi] G cG in s1 s2 * => cs1 cs2.
-  by rewrite leqNgt cardG_gt0 in cG.
+have [n] := ubnP #|G|; elim: n G => // n Hi G in s1 s2 * => /ltnSE-cG cs1 cs2.
 have [G1 | ntG] := boolP (G :==: 1).
   have -> : s1 = [::] by apply/eqP; rewrite -(trivg_comps cs1).
   have -> : s2 = [::] by apply/eqP; rewrite -(trivg_comps cs2).
@@ -188,10 +187,10 @@ case es2: s2 cs2 => [|N2 st2] cs2 {s1 es1}.
   by move: (trivg_comps cs2); rewrite eqxx; move/negP:ntG.
 case/andP: cs1 => /= lst1; case/andP=> maxN_1 pst1.
 case/andP: cs2 => /= lst2; case/andP=> maxN_2 pst2.
-have cN1 : #|N1| <= n.
-  by rewrite -ltnS (leq_trans _ cG) ?proper_card ?(maxnormal_proper maxN_1).
-have cN2 : #|N2| <= n.
-  by rewrite -ltnS (leq_trans _ cG) ?proper_card ?(maxnormal_proper maxN_2).
+have cN1 : #|N1| < n.
+  by rewrite (leq_trans _ cG) ?proper_card ?(maxnormal_proper maxN_1).
+have cN2 : #|N2| < n.
+  by rewrite (leq_trans _ cG) ?proper_card ?(maxnormal_proper maxN_2).
 case: (N1 =P N2) {s2 es2} => [eN12 |].
   by rewrite eN12 /= perm_cons Hi // /comps ?lst2 //= -eN12 lst1.
 move/eqP; rewrite -val_eqE /=; move/eqP=> neN12.
@@ -588,8 +587,7 @@ Lemma StrongJordanHolderUniqueness (G : {group rT}) (s1 s2 : seq {group rT}) :
     G \subset D -> acomps to G s1 -> acomps to G s2 -> 
   perm_eq (mkfactors G s1) (mkfactors G s2).
 Proof.
-elim: {G} #|G| {-2}G (leqnn #|G|) => [|n Hi] G cG in s1 s2 * => hsD cs1 cs2.
-  by rewrite leqNgt cardG_gt0 in cG.
+have [n] := ubnP #|G|; elim: n G => // n Hi G in s1 s2 * => cG hsD cs1 cs2.
 case/orP: (orbN (G :==: 1)) => [tG | ntG].
   have -> : s1 = [::] by apply/eqP; rewrite -(trivg_acomps cs1).
   have -> : s2 = [::] by apply/eqP; rewrite -(trivg_acomps cs2).
@@ -608,10 +606,10 @@ have sN1D : N1 \subset D.
   by apply: subset_trans hsD; apply: maxainv_sub maxN_1.
 have sN2D : N2 \subset D.
   by apply: subset_trans hsD; apply: maxainv_sub maxN_2.
-have cN1 : #|N1| <= n.
-  by rewrite -ltnS (leq_trans _ cG) ?proper_card ?(maxainv_proper maxN_1).
-have cN2 : #|N2| <= n.
-  by rewrite -ltnS (leq_trans _ cG) ?proper_card ?(maxainv_proper maxN_2).
+have cN1 : #|N1| < n.
+  by rewrite -ltnS (leq_trans _ cG) ?ltnS ?proper_card ?(maxainv_proper maxN_1).
+have cN2 : #|N2| < n.
+  by rewrite -ltnS (leq_trans _ cG) ?ltnS ?proper_card ?(maxainv_proper maxN_2).
 case: (N1 =P N2) {s2 es2} => [eN12 |].
   by rewrite eN12 /= perm_cons Hi // /acomps ?lst2 //= -eN12 lst1.
 move/eqP; rewrite -val_eqE /=; move/eqP=> neN12.

--- a/mathcomp/solvable/maximal.v
+++ b/mathcomp/solvable/maximal.v
@@ -993,7 +993,7 @@ Lemma card_subcent_extraspecial U :
   U \subset G -> #|'C_G(U)| = (#|'Z(G) :&: U| * #|G : U|)%N.
 Proof.
 move=> sUG; rewrite setIAC (setIidPr sUG).
-elim: {U}_.+1 {-2}U (ltnSn #|U|) sUG => // m IHm U leUm sUG.
+have [m leUm] := ubnP #|U|; elim: m => // m IHm in U leUm sUG *.
 have [cUG | not_cUG]:= orP (orbN (G \subset 'C(U))).
   by rewrite !(setIidPl _) ?Lagrange // centsC.
 have{not_cUG} [x Gx not_cUx] := subsetPn not_cUG.
@@ -1183,7 +1183,7 @@ Theorem extraspecial_structure S : p.-group S -> extraspecial S ->
   {Es | all (fun E => (#|E| == p ^ 3)%N && ('Z(E) == 'Z(S))) Es
       & \big[cprod/1%g]_(E <- Es) E \* 'Z(S) = S}.
 Proof.
-elim: {S}_.+1 {-2}S (ltnSn #|S|) => // m IHm S leSm pS esS.
+have [m] := ubnP #|S|; elim: m S => // m IHm S leSm pS esS.
 have [x Z'x]: {x | x \in S :\: 'Z(S)}.
   apply/sigW/set0Pn; rewrite -subset0 subDset setU0.
   apply: contra (extraspecial_nonabelian esS) => sSZ.
@@ -1210,11 +1210,11 @@ Let oZ := card_center_extraspecial pS esS.
 (* This is Aschbacher (23.10)(2). *)
 Lemma card_extraspecial : {n | n > 0 & #|S| = (p ^ n.*2.+1)%N}.
 Proof.
-exists (logn p #|S|)./2.
+set T := S; exists (logn p #|T|)./2.
   rewrite half_gt0 ltnW // -(leq_exp2l _ _ (prime_gt1 p_pr)) -card_pgroup //.
   exact: min_card_extraspecial.
-have [Es] := extraspecial_structure pS esS.
-elim: Es {3 4 5}S => [_ _ <-| E s IHs T] /=.
+have [Es] := extraspecial_structure pS esS; rewrite -[in RHS]/T.
+elim: Es T => [_ _ <-| E s IHs T] /=.
   by rewrite big_nil cprod1g oZ (pfactorK 1).
 rewrite -andbA big_cons -cprodA; case/and3P; move/eqP=> oEp3; move/eqP=> defZE.
 move/IHs=> {IHs}IHs; case/cprodP=> [[_ U _ defU]]; rewrite defU => defT cEU.
@@ -1233,8 +1233,8 @@ have [Es] := extraspecial_structure pS esS.
 elim: Es S oZ => [T _ _ <-| E s IHs T oZT] /=.
   rewrite big_nil cprod1g (center_idP (center_abelian T)).
   by apply/Aut_sub_fullP=> // g injg gZ; exists g.
-rewrite -andbA big_cons -cprodA; case/and3P; move/eqP=> oE; move/eqP=> defZE.
-move=> es_s; case/cprodP=> [[_ U _ defU]]; rewrite defU => defT cEU.
+rewrite -andbA big_cons -cprodA => /and3P[/eqP-oE /eqP-defZE es_s].
+case/cprodP=> -[_ U _ defU]; rewrite defU => defT cEU.
 have sUT: U \subset T by rewrite -defT mulG_subr.
 have sZU: 'Z(T) \subset U.
   by case/cprodP: defU => [[V _ -> _] <- _]; apply: mulG_subr.

--- a/mathcomp/solvable/nilpotent.v
+++ b/mathcomp/solvable/nilpotent.v
@@ -238,8 +238,8 @@ apply/idP/mapP=> {s}/= [nilG | [n _ Ln1]]; last first.
   rewrite -subG1 {}Ln1; elim: n => // n IHn.
   by rewrite (subset_trans sHR) ?commSg.
 pose m := #|G|.-1; exists m; first by rewrite mem_iota /= prednK.
-rewrite ['L__(G)]card_le1_trivg //= -(subnn m).
-elim: {-2}m => [|n]; [by rewrite subn0 prednK | rewrite lcnSn subnS].
+set n := m; rewrite ['L__(G)]card_le1_trivg //= -(subnn m) -[m in _ - m]/n.
+elim: n => [|n]; [by rewrite subn0 prednK | rewrite lcnSn subnS].
 case: (eqsVneq 'L_n.+1(G) 1) => [-> | ntLn]; first by rewrite comm1G cards1.
 case: (m - n) => [|m' /= IHn]; first by rewrite leqNgt cardG_gt1 ntLn.
 rewrite -ltnS (leq_trans (proper_card _) IHn) //.
@@ -464,8 +464,8 @@ Qed.
 
 Lemma ucn_lcnP n G : ('L_n.+1(G) == 1) = ('Z_n(G) == G).
 Proof.
-rewrite !eqEsubset sub1G ucn_sub /= andbT -(ucn0 G).
-elim: {1 3}n 0 (addn0 n) => [j <- //|i IHi j].
+rewrite !eqEsubset sub1G ucn_sub /= andbT -(ucn0 G); set i := (n in LHS).
+have: i + 0 = n by [rewrite addn0]; elim: i 0 => [j <- //|i IHi j].
 rewrite addSnnS => /IHi <- {IHi}; rewrite ucnSn lcnSn.
 rewrite -sub_morphim_pre ?gFsub_trans ?gFnorm_trans // subsetI.
 by rewrite morphimS ?gFsub // quotient_cents2 ?gFsub_trans ?gFnorm_trans.
@@ -611,8 +611,8 @@ Qed.
 
 Lemma nilpotent_subnormal G H : nilpotent G -> H \subset G -> H <|<| G.
 Proof.
-move=> nilG; elim: {H}_.+1 {-2}H (ltnSn (#|G| - #|H|)) => // m IHm H.
-rewrite ltnS => leGHm sHG.
+move=> nilG; have [m] := ubnP (#|G| - #|H|).
+elim: m H => // m IHm H /ltnSE-leGHm sHG.
 have [->|] := eqVproper sHG; first exact: subnormal_refl.
 move/(nilpotent_proper_norm nilG); set K := 'N_G(H) => prHK.
 have snHK: H <|<| K by rewrite normal_subnormal ?normalSG.

--- a/mathcomp/solvable/pgroup.v
+++ b/mathcomp/solvable/pgroup.v
@@ -623,8 +623,8 @@ Proof. by rewrite /psubgroup sub1G pgroup1. Qed.
 
 Lemma Cauchy p G : prime p -> p %| #|G| -> {x | x \in G & #[x] = p}.
 Proof.
-move=> p_pr; elim: {G}_.+1 {-2}G (ltnSn #|G|) => // n IHn G.
-rewrite ltnS => leGn pG; pose xpG := [pred x in G | #[x] == p].
+move=> p_pr; have [n] := ubnP #|G|; elim: n G => // n IHn G /ltnSE-leGn pG.
+pose xpG := [pred x in G | #[x] == p].
 have [x /andP[Gx /eqP] | no_x] := pickP xpG; first by exists x.
 have{pG n leGn IHn} pZ: p %| #|'C_G(G)|.
   suffices /dvdn_addl <-:  p %| #|G :\: 'C(G)| by rewrite cardsID.

--- a/mathcomp/solvable/sylow.v
+++ b/mathcomp/solvable/sylow.v
@@ -514,7 +514,7 @@ Qed.
 
 Lemma nil_Zgroup_cyclic G : Zgroup G -> nilpotent G -> cyclic G.
 Proof.
-elim: {G}_.+1 {-2}G (ltnSn #|G|) => // n IHn G; rewrite ltnS => leGn ZgG nilG.
+have [n] := ubnP #|G|; elim: n G => // n IHn G /ltnSE-leGn ZgG nilG.
 have [->|[p pr_p pG]] := trivgVpdiv G; first by rewrite -cycle1 cycle_cyclic.
 have /dprodP[_ defG Cpp' _] := nilpotent_pcoreC p nilG.
 have /cyclicP[x def_p]: cyclic 'O_p(G).
@@ -567,9 +567,8 @@ Theorem Baer_Suzuki x G :
     x \in G -> (forall y, y \in G -> p.-group <<[set x; x ^ y]>>) ->
   x \in 'O_p(G).
 Proof.
-elim: {G}_.+1 {-2}G x (ltnSn #|G|) => // n IHn G x; rewrite ltnS.
-set E := x ^: G => leGn Gx pE.
-have{pE} pE: {in E &, forall x1 x2, p.-group <<[set x1; x2]>>}.
+have [n] := ubnP #|G|; elim: n G x => // n IHn G x /ltnSE-leGn Gx pE.
+set E := x ^: G; have{pE} pE: {in E &, forall x1 x2, p.-group <<[set x1; x2]>>}.
   move=> _ _ /imsetP[y1 Gy1 ->] /imsetP[y2 Gy2 ->].
   rewrite -(mulgKV y1 y2) conjgM -2!conjg_set1 -conjUg genJ pgroupJ.
   by rewrite pE // groupMl ?groupV.

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1392,10 +1392,10 @@ Lemma partition_big (I J : finType) (P : pred I) p (Q : pred J) F :
 Proof.
 move=> Qp; transitivity (\big[*%M/1]_(i | P i && Q (p i)) F i).
   by apply: eq_bigl => i; case Pi: (P i); rewrite // Qp.
-elim: {Q Qp}_.+1 {-2}Q (ltnSn #|Q|) => // n IHn Q.
-case: (pickP Q) => [j Qj | Q0 _]; last first.
+have [n leQn] := ubnP #|Q|; elim: n => // n IHn in Q {Qp} leQn *.
+case: (pickP Q) => [j Qj | Q0]; last first.
   by rewrite !big_pred0 // => i; rewrite Q0 andbF.
-rewrite ltnS (cardD1x j Qj) (bigD1 j) //; move/IHn=> {n IHn} <-.
+rewrite (bigD1 j) // -IHn; last by rewrite ltnS (cardD1x j Qj) in leQn.
 rewrite (bigID (fun i => p i == j)); congr (_ * _); apply: eq_bigl => i.
   by case: eqP => [-> | _]; rewrite !(Qj, simpm).
 by rewrite andbA.
@@ -1408,14 +1408,13 @@ Lemma reindex_onto (I J : finType) (h : J -> I) h' (P : pred I) F :
   \big[*%M/1]_(i | P i) F i =
     \big[*%M/1]_(j | P (h j) && (h' (h j) == j)) F (h j).
 Proof.
-move=> h'K; elim: {P}_.+1 {-3}P h'K (ltnSn #|P|) => //= n IHn P h'K.
-case: (pickP P) => [i Pi | P0 _]; last first.
+move=> h'K; have [n lePn] := ubnP #|P|; elim: n => // n IHn in P h'K lePn *.
+case: (pickP P) => [i Pi | P0]; last first.
   by rewrite !big_pred0 // => j; rewrite P0.
-rewrite ltnS (cardD1x i Pi); move/IHn {n IHn} => IH.
 rewrite (bigD1 i Pi) (bigD1 (h' i)) h'K ?Pi ?eq_refl //=; congr (_ * _).
-rewrite {}IH => [|j]; [apply: eq_bigl => j | by case/andP; auto].
-rewrite andbC -andbA (andbCA (P _)); case: eqP => //= hK; congr (_ && ~~ _).
-by apply/eqP/eqP=> [<-|->] //; rewrite h'K.
+rewrite {}IHn => [|j /andP[]|]; [|by auto | by rewrite (cardD1x i) in lePn]. 
+apply: eq_bigl => j; rewrite andbC -andbA (andbCA (P _)); case: eqP => //= hK.
+by congr (_ && ~~ _); apply/eqP/eqP=> [<-|->] //; rewrite h'K.
 Qed.
 Arguments reindex_onto [I J] h h' [P F].
 

--- a/mathcomp/ssreflect/binomial.v
+++ b/mathcomp/ssreflect/binomial.v
@@ -508,13 +508,13 @@ suffices [le_i_ti le_ti_ni]: i <= tnth t i /\ tnth t i <= i + n.
   by rewrite /sub_mn inordK ?subnKC // ltnS leq_subLR.
 pose y0 := tnth t i; rewrite (tnth_nth y0) -(nth_map _ (val i)) ?size_tuple //.
 case def_e: (map _ _) => [|x e] /=; first by rewrite nth_nil ?leq_addr.
-rewrite def_e in inc_t; split.
-  case: {-2}i; rewrite /= -{1}(size_tuple t) -(size_map val) def_e.
-  elim=> //= j IHj lt_j_t; apply: leq_trans (pathP (val i) inc_t _ lt_j_t).
-  by rewrite ltnS IHj 1?ltnW.
+set nth_i := nth (i : nat); rewrite def_e in inc_t; split.
+  have: i < size (x :: e) by rewrite -def_e size_map size_tuple ltn_ord.
+  elim: (val i) => //= j IHj lt_j_e.
+  by apply: leq_trans (pathP (val i) inc_t _ lt_j_e); rewrite ltnS IHj 1?ltnW.
 move: (_ - _) (subnK (valP i)) => k /=.
-elim: k {-2}(val i) => /= [|k IHk] j def_m; rewrite -ltnS -addSn.
-  by rewrite [j.+1]def_m -def_e (nth_map y0) ?ltn_ord // size_tuple -def_m.
+elim: k (val i) => /= [|k IHk] j; rewrite -ltnS -addSn ?add0n => def_m.
+  by rewrite def_m -def_e /nth_i (nth_map y0) ?ltn_ord // size_tuple -def_m.
 rewrite (leq_trans _ (IHk _ _)) -1?addSnnS //; apply: (pathP _ inc_t).
 rewrite -ltnS (leq_trans (leq_addl k _)) // -addSnnS def_m.
 by rewrite -(size_tuple t) -(size_map val) def_e.

--- a/mathcomp/ssreflect/choice.v
+++ b/mathcomp/ssreflect/choice.v
@@ -90,11 +90,12 @@ Qed.
 Lemma codeK : cancel code decode.
 Proof.
 elim=> //= v s IHs; rewrite -[_ * _]prednK ?muln_gt0 ?expn_gt0 //=.
-rewrite -{3}[v]addn0; elim: v {1 4}0 => [|v IHv {IHs}] q.
-  rewrite mul1n /= -{1}addnn -{4}IHs; move: (_ s) {IHs} => n.
-  by elim: {1 3}n => //=; case: n.
+set two := 2; rewrite -[v in RHS]addn0; elim: v 0 => [|v IHv {IHs}] q.
+  rewrite mul1n add0n /= -{}[in RHS]IHs; case: (code s) => // u; pose n := u.+1.
+  by transitivity [rec q, n + u.+1, n.*2]; [rewrite addnn | elim: n => //=].
 rewrite expnS -mulnA mul2n -{1}addnn -[_ * _]prednK ?muln_gt0 ?expn_gt0 //.
-by rewrite doubleS addSn /= addSnnS; elim: {-2}_.-1 => //=.
+set u := _.-1 in IHv *; set n := u; rewrite [in u1 in _ + u1]/n.
+by rewrite [in RHS]addSnnS -{}IHv; elim: n.
 Qed.
 
 Lemma ltn_code s : all (fun j => j < code s) s.

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1406,7 +1406,7 @@ Definition perm_eq s1 s2 :=
 Lemma permP s1 s2 : reflect (count^~ s1 =1 count^~ s2) (perm_eq s1 s2).
 Proof.
 apply: (iffP allP) => /= [eq_cnt1 a | eq_cnt x _]; last exact/eqP.
-elim: {a}_.+1 {-2}a (ltnSn (count a (s1 ++ s2))) => // n IHn a le_an.
+have [n le_an] := ubnP (count a (s1 ++ s2)); elim: n => // n IHn in a le_an *. 
 have [/eqP|] := posnP (count a (s1 ++ s2)).
   by rewrite count_cat addn_eq0; do 2!case: eqP => // ->.
 rewrite -has_count => /hasP[x s12x a_x]; pose a' := predD1 a x.

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -400,6 +400,51 @@ Proof. by move=> lt_mn /ltnW; apply: leq_trans. Qed.
 Lemma leq_total m n : (m <= n) || (m >= n).
 Proof. by rewrite -implyNb -ltnNge; apply/implyP; apply: ltnW. Qed.
 
+(* Helper lemmas to support generalized induction over a nat measure.         *)
+(* The idiom for a proof by induction over a measure Mxy : nat involving      *)
+(* variables x, y, ... (e.g., size x + size y) is                             *)
+(*   have [m leMn] := ubnP Mxy; elim: n => // n IHn in x y ... leMn ... *.    *)
+(* after which the current goal (possibly modified by generalizations in the  *)
+(* in ... part) can be proven with the extra context assumptions              *)
+(*  n : nat                                                                   *)
+(*  IHn : forall x y ..., Mxy < n -> ... -> the_initial_goal                  *)
+(*  leMn : Mxy < n.+1                                                         *)
+(* This is preferable to the legacy idiom relying on numerical occurrence     *)
+(* selection, which is fragile if there can be multiple occurrences of x, y,  *)
+(* ... in the measure expression Mxy (e.g., in #|y| with x : finType and      *)
+(* y : {set x}).                                                              *)
+(*  The leMn statement is convertible to Mxy <= n; if it is necessary to      *)
+(* have _exactly_ leMn : Mxy <= n, the ltnSE helper lemma may be used as      *)
+(* follows                                                                    *)
+(*   have [m] := ubnP Mxy; elim: n => // n IHn in x y ... * => /ltnSE-leMn.   *)
+(*  We also provide alternative helper lemmas for proofs where the upper      *)
+(* bound appears in the goal, and we assume nonstrict (in)equality.           *)
+(* In either case the proof will have to dispatch an Mxy = 0 case.            *)
+(*  have [m defM] := ubnPleq Mxy; elim: n => [|n IHn] in x y ... defM ... *.  *)
+(* yields two subgoals, in which Mxy has been replaced by 0 and n.+1,         *)
+(* with the extra assumption defM : Mxy <= 0 / Mxy <= n.+1, respectively.     *)
+(* The second goal also has the inductive assumption                          *)
+(*   IHn : forall x y ..., Mxy <= n -> ... -> the_initial_goal[n / Mxy].      *)
+(* Using ubnPgeq or ubnPeq instead of ubnPleq yields assumptions with         *)
+(* Mxy >= 0/n.+1 or Mxy == 0/n.+1 instead of Mxy <= 0/n.+1, respectively.     *)
+(* These introduce a different kind of induction; for example ubnPgeq M lets  *)
+(* us remember that n < M throughout the induction.                           *)
+(*   Finally, the ltn_ind lemma provides a generalized induction view for a   *)
+(* property of a single integer (i.e., the case Mxy := x).                    *)
+Lemma ubnP m : {n | m < n}.             Proof. by exists m.+1. Qed.
+Lemma ltnSE m n : m < n.+1 -> m <= n.   Proof. by []. Qed.
+Variant ubn_leq_spec m : nat -> Type := UbnLeq n of m <= n : ubn_leq_spec m n.
+Variant ubn_geq_spec m : nat -> Type := UbnGeq n of m >= n : ubn_geq_spec m n.
+Variant ubn_eq_spec m : nat -> Type := UbnEq n of m == n : ubn_eq_spec m n.
+Lemma ubnPleq m : ubn_leq_spec m m.    Proof. by []. Qed.
+Lemma ubnPgeq m : ubn_geq_spec m m.    Proof. by []. Qed.
+Lemma ubnPeq m : ubn_eq_spec m m.      Proof. by []. Qed.
+Lemma ltn_ind P : (forall n, (forall m, m < n -> P m) -> P n) -> forall n, P n.
+Proof.
+move=> accP M; have [n leMn] := ubnP M; elim: n => // n IHn in M leMn *.
+by apply/accP=> p /leq_trans/(_ leMn)/IHn.
+Qed.
+
 (* Link to the legacy comparison predicates. *)
 
 Lemma leP m n : reflect (m <= n)%coq_nat (m <= n).
@@ -412,15 +457,14 @@ Arguments leP {m n}.
 
 Lemma le_irrelevance m n le_mn1 le_mn2 : le_mn1 = le_mn2 :> (m <= n)%coq_nat.
 Proof.
-elim: {n}n.+1 {-1}n (erefl n.+1) => // n IHn _ [<-] in le_mn1 le_mn2 *.
-pose def_n2 := erefl n; transitivity (eq_ind _ _ le_mn2 _ def_n2) => //.
-move def_n1: {1 4 5 7}n le_mn1 le_mn2 def_n2 => n1 le_mn1.
-case: n1 / le_mn1 def_n1 => [|n1 le_mn1] def_n1 [|n2 le_mn2] def_n2.
-- by rewrite [def_n2]eq_axiomK.
-- by move/leP: (le_mn2); rewrite -{1}def_n2 ltnn.
-- by move/leP: (le_mn1); rewrite {1}def_n2 ltnn.
-case: def_n2 (def_n2) => ->{n2} def_n2 in le_mn2 *.
-by rewrite [def_n2]eq_axiomK /=; congr le_S; apply: IHn.
+elim/ltn_ind: n => n IHn in le_mn1 le_mn2 *; set n1 := n in le_mn1 *.
+pose def_n : n = n1 := erefl n; transitivity (eq_ind _ _ le_mn2 _ def_n) => //.
+case: n1 / le_mn1 le_mn2 => [|n1 le_mn1] {n}[|n le_mn2] in (def_n) IHn *.
+- by rewrite [def_n]eq_axiomK.
+- by case/leP/idPn: (le_mn2); rewrite -def_n ltnn.
+- by case/leP/idPn: (le_mn1); rewrite def_n ltnn.
+case: def_n (def_n) => <-{n1} def_n in le_mn1 *.
+by rewrite [def_n]eq_axiomK /=; congr le_S; apply: IHn.
 Qed.
 
 Lemma ltP m n : reflect (m < n)%coq_nat (m < n).
@@ -1675,7 +1719,7 @@ Definition bin_of_nat n0 := if n0 is n.+1 then Npos (pos_of_nat n n) else 0%num.
 Lemma bin_of_natK : cancel bin_of_nat nat_of_bin.
 Proof.
 have sub2nn n : n.*2 - n = n by rewrite -addnn addKn.
-case=> //= n; rewrite -{3}[n]sub2nn.
+case=> //= n; rewrite -[n in RHS]sub2nn.
 by elim: n {2 4}n => // m IHm [|[|n]] //=; rewrite IHm // natTrecE sub2nn.
 Qed.
 


### PR DESCRIPTION
Replace the legacy generalised induction idiom with a more robust one
that does not rely on the `{-2}` numerical occurrence selector, using
either new helper lemmas `ubnP`, `ltnSE`, `ubnPleq`, `ubnPgeq`, `ubnPeq`, or a specific `nat`
induction principle `ltn_ind`.
   This change anticipates an expected evolution of `fintype` to integrate `finmap`. It is likely that the new definition of the `#|A|` notation will hide multiple occurrences of `A`, which will break the `{-2}` induction idiom. Client libraries should update before the 1.11 release.

Fixes #422 