### PR TITLE
Add FCSL-PCM library to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -373,6 +373,26 @@ ci-finmap-dev:
   variables:
     COQ_VERSION: "dev"
 
+# The FCSL-PCM library
+.ci-fcsl-pcm:
+  extends: .ci
+  variables:
+    CONTRIB_URL: "https://github.com/imdea-software/fcsl-pcm.git"
+    CONTRIB_VERSION: master
+  script:
+    - opam pin add -n -k path coq-fcsl-pcm .
+    - opam install -y -v -j "${NJOBS}" coq-fcsl-pcm
+
+ci-fcsl-pcm-8.10:
+  extends: .ci-fcsl-pcm
+  variables:
+    COQ_VERSION: "8.10"
+
+ci-fcsl-pcm-dev:
+  extends: .ci-fcsl-pcm
+  variables:
+    COQ_VERSION: "dev"
+
 ################
 ### deploy stage
 ################


### PR DESCRIPTION
##### Motivation for this change

FCSL-PCM is in Coq's CI and relying on Mathcomp, so this will prevent breaking Coq's CI, see
https://github.com/imdea-software/fcsl-pcm/issues/17.
The `master` branch of FCSL-PCM only supports Coq 8.10 and Coq's `master` branch.

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
