### PR TITLE
Add *.vos and *.vok to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.d
 *.vo
 *.vio
+*.vos
+*.vok
 *.cm*
 *~
 *.glob


### PR DESCRIPTION
##### Motivation for this change

These interface files have been introduced by coq/coq#8642.

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
