### PR TITLE
Fix hint declarations to specify the database explicitly

### DIFF
--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -2257,7 +2257,7 @@ suff iter_big k : k <= n.+1 -> k <= #|iter k F set0|.
 elim: k => [|k IHk] k_lt //=; apply: (leq_ltn_trans (IHk (ltnW k_lt))).
 by rewrite proper_card// properEneq// subset_iterS neq_iter.
 Qed.
-Hint Resolve fixsetK.
+Hint Resolve fixsetK : core.
 
 Lemma minset_fix : minset [pred X | F X == X] fixset.
 Proof.
@@ -2338,7 +2338,7 @@ Hypothesis (F_mono : {homo F : X Y / X \subset Y}).
 Definition funsetC X := ~: (F (~: X)).
 Lemma funsetC_mono : {homo funsetC : X Y / X \subset Y}.
 Proof. by move=> *; rewrite subCset setCK F_mono// subCset setCK. Qed.
-Hint Resolve funsetC_mono.
+Hint Resolve funsetC_mono : core.
 
 Definition cofixset := ~: fixset funsetC.
 


### PR DESCRIPTION
##### Motivation for this change

Adding/removing hints to/from the `core` hint database implicitly has been deprecated in Coq 8.10.

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
