### PR TITLE
Big enum

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -36,9 +36,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `eq_enum_rank_in`, `enum_rank_in_inj`, `lshift_inj`, and
   `rshift_inj`.
 
-- Bigop theorems: `big_rmcond`, `bigD1_seq`,
+- Bigop theorems: `index_enum_uniq`, `big_rmcond`, `bigD1_seq`,
   `big_enum_val_cond`, `big_enum_rank_cond`,
-  `big_enum_val`, `big_enum_rank`, `big_set`.
+  `big_enum_val`, `big_enum_rank`, `big_set`,
+  `big_enumP`, `big_enum_cond`, `big_enum`
 
 - Arithmetic theorems in ssrnat and div:
   - some trivial results in ssrnat: `ltn_predL`, `ltn_predRL`,
@@ -101,7 +102,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replaced the legacy generalised induction idiom with a more robust one
 that does not rely on the `{-2}` numerical occurrence selector, using
 new `ssrnat` helper lemmas `ltn_ind`, `ubnP`, `ubnPleq`,  ...., (see above). The new idiom is documented in `ssrnat`.
-   This change anticipates an expected evolution of `fintype` to integrate `finmap`. It is likely that the new definition of the `#|A|` notation will hide multiple occurrences of `A`, which will break the `{-2}` induction idiom. Client libraries should update before the 1.11 release.
+   This change anticipates an expected evolution of `fintype` to integrate `finmap`. It is likely that the new definition of the `#|A|` notation will hide multiple occurrences of `A`, which will break the `{-2}` induction idiom. Client libraries should update before the 1.11 release (see [PR #434](https://github.com/math-comp/math-comp/pull/434) for examples).
+   
+ - Replaced the use of the accidental convertibility between `enum A` and 
+   `filter A (index_enum T)` with more explicit lemmas `big_enumP`, `big_enum`, `big_enum_cond`, `big_image` added to the `bigop` library, and deprecated the `filter_index_enum` lemma that states the corresponding equality. Both convertibility and equality may no longer hold in future `mathcomp` releases when sets over `finType`s are generalised to finite sets over `choiceType`s, so client libraries should stop relying on this identity. File `bigop.v` has some boilerplate to help with the port; also see [PR #441](https://github.com/math-comp/math-comp/pull/441) for examples.
+   
+ - Restricted `big_image`, `big_image_cond`, `big_image_id` and `big_image_cond_id`
+ to `bigop`s over _abelian_ monoids, anticipating the change in the definition of `enum`. This may introduce some incompatibilities - non-abelian instances should be dealt with a combination of `big_map` and `big_enumP`.
    
 - `eqVneq` lemma is changed from `{x = y} + {x != y}` to
   `eq_xor_neq x y (y == x) (x == y)`, on which a case analysis performs

--- a/mathcomp/algebra/mxalgebra.v
+++ b/mathcomp/algebra/mxalgebra.v
@@ -2091,7 +2091,7 @@ Lemma mxdirect_delta n f : {in P &, injective f} ->
 Proof.
 pose fP := image f P => Uf; have UfP: uniq fP by apply/dinjectiveP.
 suffices /mxdirectP : mxdirect (\sum_i <<delta_mx 0 i : 'rV[F]_n>>).
-  rewrite /= !(bigID [mem fP] predT) -!big_uniq //= !big_map !big_filter.
+  rewrite /= !(bigID [mem fP] predT) -!big_uniq //= !big_map !big_enum.
   by move/mxdirectP; rewrite mxdirect_addsE => /andP[].
 apply/mxdirectP=> /=; transitivity (mxrank (1%:M : 'M[F]_n)).
   apply/eqmx_rank; rewrite submx1 mx1_sum_delta summx_sub_sums // => i _.

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -307,16 +307,16 @@ Implicit Types p q : {poly R}.
 Definition char_poly_mx := 'X%:M - map_mx (@polyC R) A.
 Definition char_poly := \det char_poly_mx.
 
-Let diagA := [seq A i i | i : 'I_n].
+Let diagA := [seq A i i | i <- index_enum _ & true].
 Let size_diagA : size diagA = n.
-Proof. by rewrite size_image card_ord. Qed.
+Proof. by rewrite -[n]card_ord size_map; have [e _ _ []] := big_enumP. Qed.
 
 Let split_diagA :
   exists2 q, \prod_(x <- diagA) ('X - x%:P) + q = char_poly & size q <= n.-1.
 Proof.
 rewrite [char_poly](bigD1 1%g) //=; set q := \sum_(s | _) _; exists q.
-  congr (_ + _); rewrite odd_perm1 mul1r big_map enumT; apply: eq_bigr => i _.
-  by rewrite !mxE perm1 eqxx.
+  congr (_ + _); rewrite odd_perm1 mul1r big_map big_filter /=.
+  by apply: eq_bigr => i _; rewrite !mxE perm1 eqxx.
 apply: leq_trans {q}(size_sum _ _ _) _; apply/bigmax_leqP=> s nt_s.
 have{nt_s} [i nfix_i]: exists i, s i != i.
   apply/existsP; rewrite -negb_forall; apply: contra nt_s => s_1.
@@ -329,7 +329,7 @@ apply: leq_trans (_ : #|[pred j | s j == j]|.+1 <= n.-1).
     by rewrite -subn1 -addnS leq_subLR addnA leq_add.
   rewrite !mxE eq_sym !inE; case: (s j == j); first by rewrite polyseqXsubC.
   by rewrite sub0r size_opp size_polyC leq_b1.
-rewrite -{8}[n]card_ord -(cardC (pred2 (s i) i)) card2 nfix_i !ltnS.
+rewrite -[n in n.-1]card_ord -(cardC (pred2 (s i) i)) card2 nfix_i !ltnS.
 apply: subset_leq_card; apply/subsetP=> j; move/(_ =P j)=> fix_j.
 rewrite !inE -{1}fix_j (inj_eq perm_inj) orbb.
 by apply: contraNneq nfix_i => <-; rewrite fix_j.
@@ -354,7 +354,7 @@ Proof.
 move=> n_gt0; have [q <- lt_q_n] := split_diagA; set p := \prod_(x <- _) _.
 rewrite coefD {q lt_q_n}(nth_default 0 lt_q_n) addr0.
 have{n_gt0} ->: p`_n.-1 = ('X * p)`_n by rewrite coefXM eqn0Ngt n_gt0.
-have ->: \tr A = \sum_(x <- diagA) x by rewrite big_map enumT.
+have ->: \tr A = \sum_(x <- diagA) x by rewrite big_map big_filter.
 rewrite -size_diagA {}/p; elim: diagA => [|x d IHd].
   by rewrite !big_nil mulr1 coefX oppr0.
 rewrite !big_cons coefXM mulrBl coefB IHd opprD addrC; congr (- _ + _).

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -922,7 +922,10 @@ by rewrite size_XsubC.
 Qed.
 
 Lemma size_exp_XsubC n a : size (('X - a%:P) ^+ n) = n.+1.
-Proof. by rewrite -[n]card_ord -prodr_const size_prod_XsubC cardE enumT. Qed.
+Proof.
+rewrite -[n]card_ord -prodr_const -big_filter size_prod_XsubC.
+by have [e _ _ [_ ->]] := big_enumP.
+Qed.
 
 (* Some facts about regular elements. *)
 

--- a/mathcomp/algebra/vector.v
+++ b/mathcomp/algebra/vector.v
@@ -1879,7 +1879,7 @@ Variable (K : fieldType) (vT : vectType K).
 Lemma sumv_pi_sum (I : finType) (P : pred I) Vs v (V : {vspace vT})
                   (defV : V = (\sum_(i | P i) Vs i)%VS) :
   v \in V -> \sum_(i | P i) sumv_pi_for defV i v = v :> vT.
-Proof. by apply: sumv_pi_uniq_sum; apply: enum_uniq. Qed.
+Proof. by apply: sumv_pi_uniq_sum; have [e _ []] := big_enumP. Qed.
 
 Lemma sumv_pi_nat_sum m n (P : pred nat) Vs v (V : {vspace vT})
                       (defV : V = (\sum_(m <= i < n | P i) Vs i)%VS) :

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -528,8 +528,7 @@ Qed.
 Lemma cfun_on_sum A :
   'CF(G, A) = (\sum_(xG in classes G | xG \subset A) <['1_xG]>)%VS.
 Proof.
-rewrite ['CF(G, A)]span_def big_map big_filter.
-by apply: eq_bigl => xG; rewrite !inE.
+by rewrite ['CF(G, A)]span_def big_image; apply: eq_bigl => xG; rewrite !inE.
 Qed.
 
 Lemma cfun_onP A phi :
@@ -2047,15 +2046,14 @@ Lemma cfBigdprodEi i (phi : 'CF(A i)) x :
     P i -> (forall j, P j -> x j \in A j) ->
   cfBigdprodi phi (\prod_(j | P j) x j)%g = phi (x i).
 Proof.
-set r := enum P => Pi /forall_inP; have r_i: i \in r by rewrite mem_enum.
-have:= bigdprodWcp defG; rewrite -big_andE -!(big_filter _ P) filter_index_enum.
-rewrite -/r big_all => defGr /allP Ax.
-rewrite (perm_bigcprod defGr Ax (perm_to_rem r_i)) big_cons cfDprodEl ?Pi //.
-- by rewrite cfRes_id.
-- by rewrite Ax.
-rewrite big_seq group_prod // => j; rewrite mem_rem_uniq ?enum_uniq //.
-case/andP=> i'j /= r_j; apply/mem_gen/bigcupP; exists j; last exact: Ax.
-by rewrite -[P j](mem_enum P) r_j.
+have [r big_r [Ur mem_r] _] := big_enumP P => Pi AxP.
+have:= bigdprodWcp defG; rewrite -!big_r => defGr.
+have{AxP} [r_i Axr]: i \in r /\ {in r, forall j, x j \in A j}.
+  by split=> [|j]; rewrite mem_r // => /AxP.
+rewrite (perm_bigcprod defGr Axr (perm_to_rem r_i)) big_cons.
+rewrite cfDprodEl ?Pi ?cfRes_id ?Axr // big_seq group_prod // => j.
+rewrite mem_rem_uniq // => /andP[i'j /= r_j].
+by apply/mem_gen/bigcupP; exists j; [rewrite -mem_r r_j | apply: Axr].
 Qed.
 
 Lemma cfBigdprodi_iso i : P i -> isometry (@cfBigdprodi i).

--- a/mathcomp/character/inertia.v
+++ b/mathcomp/character/inertia.v
@@ -481,7 +481,7 @@ Lemma reindex_cfclass R idx (op : Monoid.com_law idx) (F : 'CF(H) -> R) i :
   \big[op/idx]_(chi <- ('chi_i ^: G)%CF) F chi
      = \big[op/idx]_(j | 'chi_j \in ('chi_i ^: G)%CF) F 'chi_j.
 Proof.
-move/im_cfclass_Iirr/(perm_big _) <-; rewrite big_map big_filter /=.
+move/im_cfclass_Iirr/(perm_big _) <-; rewrite big_image /=.
 by apply: eq_bigl => j; rewrite cfclass_IirrE.
 Qed.
 
@@ -1174,7 +1174,7 @@ have [inj_Mphi | /injectivePn[i [j i'j eq_mm_ij]]] := boolP (injectiveb mmLth).
   rewrite ['Ind phi]cfun_sum_cfdot sum_cfunE (bigID (mem (codom mmLth))) /=.
   rewrite ler_paddr ?sumr_ge0 // => [i _|].
     by rewrite char1_ge0 ?rpredZ_Cnat ?Cnat_cfdot_char ?cfInd_char ?irr_char.
-  rewrite -big_uniq //= big_map big_filter -sumr_const ler_sum // => i _.
+  rewrite -big_uniq //= big_image -sumr_const ler_sum // => i _.
   rewrite cfunE -[in rhs in _ <= rhs](cfRes1 L) -cfdot_Res_r mmLthL cfRes1.
   by rewrite DthL cfdotZr rmorph_nat cfnorm_irr mulr1.
 constructor 2; exists e; first by exists p0.

--- a/mathcomp/character/integral_char.v
+++ b/mathcomp/character/integral_char.v
@@ -56,7 +56,7 @@ have Q_Xn1: ('X^n - 1 : {poly Qn}) \is a polyOver 1%AS.
 have splitXn1: splittingFieldFor 1 ('X^n - 1) {:Qn}.
   pose r := codom (fun i : 'I_n => w ^+ i).
   have Dr: 'X^n - 1 = \prod_(y <- r) ('X - y%:P).
-    by rewrite -(factor_Xn_sub_1 prim_w) big_mkord big_map enumT.
+    by rewrite -(factor_Xn_sub_1 prim_w) big_mkord big_image.
   exists r; first by rewrite -Dr eqpxx.
   apply/eqP; rewrite eqEsubv subvf -genQn adjoin_seqSr //; apply/allP=> /=.
   by rewrite andbT -root_prod_XsubC -Dr; apply/unity_rootP/prim_expr_order.
@@ -657,7 +657,7 @@ have Qpi1: pi1 \in Crat.
     have /vlineP[q ->] := mem_galNorm galQn (memvf a).
     by rewrite rmorphZ_num rmorph1 mulr1 Crat_rat.
   rewrite /galNorm rmorph_prod -/calG imItoQ big_imset //=.
-  rewrite /pi1 -(eq_bigl _ _ imItoS) -big_uniq // big_map big_filter /=.
+  rewrite /pi1 -(eq_bigl _ _ imItoS) -big_uniq // big_image /=.
   apply: eq_bigr => k _; have [nuC DnuC] := gQnC (ItoQ k); rewrite DnuC Da.
   have [r ->] := char_sum_irr Nchi; rewrite !sum_cfunE rmorph_sum.
   apply: eq_bigr => i _; have /QnGg[b Db] := irr_char i.

--- a/mathcomp/character/vcharacter.v
+++ b/mathcomp/character/vcharacter.v
@@ -464,7 +464,7 @@ Proof.
 move=> Zphi def_n lt_n_4.
 pose S := [seq '[phi, 'chi_i] *: 'chi_i | i in irr_constt phi].
 have def_phi: phi = \sum_(xi <- S) xi.
-  rewrite big_map /= big_filter big_mkcond {1}[phi]cfun_sum_cfdot.
+  rewrite big_image big_mkcond {1}[phi]cfun_sum_cfdot.
   by apply: eq_bigr => i _; rewrite if_neg; case: eqP => // ->; rewrite scale0r.
 have orthS: orthonormal S.
   apply/orthonormalP; split=> [|_ _ /mapP[i phi_i ->] /mapP[j _ ->]].

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -216,7 +216,8 @@ have FpxF q: Fpx (q ^ FtoL) = root (q ^ FtoL) x.
 pose p_ (I : {set 'I_n}) := \prod_(i <- enum I) ('X - (r`_i)%:P).
 have{px0 Dp} /ex_minset[I /minsetP[/andP[FpI pIx0] minI]]: exists I, Fpx (p_ I).
   exists setT; suffices ->: p_ setT = p ^ FtoL by rewrite FpxF.
-  by rewrite Dp (big_nth 0) big_mkord /p_ (eq_enum (in_set _)) big_filter.
+  rewrite Dp (big_nth 0) big_mkord /p_ big_enum /=.
+  by apply/eq_bigl=> i; rewrite inE.
 have{p} [p DpI]: {p | p_ I = p ^ FtoL}.
   exists (p_ I ^ (fun y => if isF y is left Fy then sval (sig_eqW Fy) else 0)).
   rewrite -map_poly_comp map_poly_id // => y /(allP FpI) /=.

--- a/mathcomp/field/cyclotomic.v
+++ b/mathcomp/field/cyclotomic.v
@@ -39,8 +39,9 @@ Proof. exact: monic_prod_XsubC. Qed.
 
 Lemma size_cyclotomic z n : size (cyclotomic z n) = (totient n).+1.
 Proof.
-rewrite /cyclotomic -big_filter filter_index_enum size_prod_XsubC; congr _.+1.
-rewrite -cardE -sum1_card totient_count_coprime -big_mkcond big_mkord.
+rewrite /cyclotomic -big_filter size_prod_XsubC; congr _.+1.
+case: big_enumP => _ _ _ [_ ->].
+rewrite totient_count_coprime -big_mkcond big_mkord -sum1_card.
 by apply: eq_bigl => k; rewrite coprime_sym.
 Qed.
 
@@ -63,14 +64,13 @@ Let n_gt0 := prim_order_gt0 prim_z.
 
 Lemma root_cyclotomic x : root (cyclotomic z n) x = n.-primitive_root x.
 Proof.
-rewrite /cyclotomic -big_filter filter_index_enum.
-rewrite -(big_map _ xpredT (fun y => 'X - y%:P)) root_prod_XsubC.
+transitivity (x \in [seq z ^+ i | i : 'I_n in [pred i : 'I_n | coprime i n]]).
+  by rewrite -root_prod_XsubC big_image.
 apply/imageP/idP=> [[k co_k_n ->] | prim_x].
   by rewrite prim_root_exp_coprime.
 have [k Dx] := prim_rootP prim_z (prim_expr_order prim_x).
-exists (Ordinal (ltn_pmod k n_gt0)) => /=.
-  by rewrite unfold_in /= coprime_modl -(prim_root_exp_coprime k prim_z) -Dx.
-by rewrite prim_expr_mod.
+exists (Ordinal (ltn_pmod k n_gt0)) => /=; last by rewrite prim_expr_mod.
+by rewrite inE coprime_modl -(prim_root_exp_coprime k prim_z) -Dx.
 Qed.
 
 Lemma prod_cyclotomic :
@@ -212,9 +212,7 @@ Proof.
 have [-> | n_gt0] := posnP n; first by rewrite Cyclotomic0 polyseq1.
 have [z prim_z] := C_prim_root_exists n_gt0.
 rewrite -(size_map_inj_poly (can_inj intCK)) //.
-rewrite (Cintr_Cyclotomic prim_z) -[_ n]big_filter filter_index_enum.
-rewrite size_prod_XsubC -cardE totient_count_coprime big_mkord -big_mkcond /=.
-by rewrite (eq_card (fun _ => coprime_sym _ _)) sum1_card.
+by rewrite (Cintr_Cyclotomic prim_z) size_cyclotomic.
 Qed.
 
 Lemma minCpoly_cyclotomic n z :
@@ -252,8 +250,8 @@ have [zk gzk0]: exists zk, root (pZtoC g) zk.
   by exists rg`_0; rewrite Dg root_prod_XsubC mem_nth.
 have [k cokn Dzk]: exists2 k, coprime k n & zk = z ^+ k.
   have: root pz zk by rewrite -Dpz -Dfg rmorphM rootM gzk0 orbT.
-  rewrite -[pz]big_filter -(big_map _ xpredT (fun a => 'X - a%:P)).
-  by rewrite root_prod_XsubC => /imageP[k]; exists k.
+  rewrite -[pz](big_image _ _ _ (fun r => 'X - r%:P)) root_prod_XsubC.
+  by case/imageP=> k; exists k.
 have co_fg (R : idomainType): n%:R != 0 :> R -> @coprimep R (intrp f) (intrp g).
   move=> nz_n; have: separable_poly (intrp ('X^n - 1) : {poly R}).
     by rewrite rmorphB rmorph1 /= map_polyXn separable_Xn_sub_1.

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -99,7 +99,7 @@ set n := #|F|; set oppX := - 'X; set pF := LHS.
 have le_oppX_n: size oppX <= n by rewrite size_opp size_polyX finRing_gt1.
 have: size pF = (size (enum F)).+1 by rewrite -cardE size_addl size_polyXn.
 move/all_roots_prod_XsubC->; last by rewrite uniq_rootsE enum_uniq.
-  by rewrite enumT lead_coefDl ?size_polyXn // lead_coefXn scale1r.
+  by rewrite big_enum lead_coefDl ?size_polyXn // lead_coefXn scale1r.
 by apply/allP=> x _; rewrite rootE !hornerE hornerXn expf_card subrr.
 Qed.
 
@@ -186,7 +186,7 @@ Canonical fieldExt_finFieldType fT := [finFieldType of fT].
 Lemma finField_splittingField_axiom fT : SplittingField.axiom fT.
 Proof.
 exists ('X^#|fT| - 'X); first by rewrite rpredB 1?rpredX ?polyOverX.
-exists (enum fT); first by rewrite enumT finField_genPoly eqpxx.
+exists (enum fT); first by rewrite big_enum finField_genPoly eqpxx.
 by apply/vspaceP=> x; rewrite memvf seqv_sub_adjoin ?mem_enum.
 Qed.
 
@@ -363,9 +363,10 @@ without loss {K} ->: K / K = 1%AS.
   by move=> IH_K; apply: galoisS (IH_K _ (erefl _)); rewrite sub1v subvf.
 apply/splitting_galoisField; pose finL := FinFieldExtType L.
 exists ('X^#|finL| - 'X); split; first by rewrite rpredB 1?rpredX ?polyOverX.
-  rewrite (finField_genPoly finL) -big_filter.
+  rewrite (finField_genPoly finL) -big_enum /=.
   by rewrite separable_prod_XsubC ?(enum_uniq finL).
-exists (enum finL); first by rewrite enumT (finField_genPoly finL) eqpxx.
+exists (enum finL).
+  by rewrite (@big_enum _ _ _ _ finL) (finField_genPoly finL) eqpxx.
 by apply/vspaceP=> x; rewrite memvf seqv_sub_adjoin ?(mem_enum finL).
 Qed.
 
@@ -390,7 +391,7 @@ have idfP x: reflect (f x = x) (x \in 1%VS).
     rewrite /q rmorphB /= map_polyXn map_polyX.
     by rewrite rootE !(hornerE, hornerXn) [x ^+ _]xFx subrr.
   have{q} ->: q = \prod_(z <- [seq b%:A | b : F]) ('X - z%:P).
-    rewrite /q finField_genPoly rmorph_prod big_map enumT.
+    rewrite /q finField_genPoly rmorph_prod big_image /=.
     by apply: eq_bigr => b _; rewrite rmorphB /= map_polyX map_polyC.
   by rewrite root_prod_XsubC => /mapP[a]; exists a.
 have fM: rmorphism f.

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -448,14 +448,15 @@ pose mkf (z : L) := 'X - z%:P.
 exists (\prod_i \prod_(j < \dim {:L} | j < size (r i)) mkf (r i)`_j).
   apply: rpred_prod => i _; rewrite big_ord_narrow /= /r; case: sigW => rs /=.
   by rewrite (big_nth 0) big_mkord => /eqP <- {rs}; apply: minPolyOver.
-rewrite pair_big_dep /= -big_filter filter_index_enum -(big_map _ xpredT mkf).
+rewrite pair_big_dep /= -big_filter -(big_map _ xpredT mkf).
 set rF := map _ _; exists rF; first exact: eqpxx.
 apply/eqP; rewrite eqEsubv subvf -(span_basis (vbasisP {:L})).
 apply/span_subvP=> _ /tnthP[i ->]; set x := tnth _ i.
 have /tnthP[j ->]: x \in in_tuple (r i).
   by rewrite -root_prod_XsubC /r; case: sigW => _ /=/eqP<-; apply: root_minPoly.
-apply/seqv_sub_adjoin/imageP; rewrite (tnth_nth 0) /in_mem/=.
-by exists (i, widen_ord (sz_r i) j) => /=.
+apply/seqv_sub_adjoin/mapP; rewrite (tnth_nth 0).
+exists (i, widen_ord (sz_r i) j) => //.
+by rewrite mem_filter /= ltn_ord mem_index_enum.
 Qed.
 
 Fact regular_splittingAxiom F : SplittingField.axiom (regular_fieldExtType F).

--- a/mathcomp/ssreflect/binomial.v
+++ b/mathcomp/ssreflect/binomial.v
@@ -386,8 +386,8 @@ rewrite -card_uniq_tuples.
 have bijFF: {on (_ : pred _), bijective (@Finfun D T)}.
   by exists fgraph => x _; [apply: FinfunK | apply: fgraphK].
 rewrite -(on_card_preimset (bijFF _)); apply: eq_card => /= t.
-rewrite !inE -(big_andE predT) -big_filter big_all -all_map.
-by rewrite -[injectiveb _]/(uniq _) [map _ _]codom_ffun FinfunK.
+rewrite !inE -(big_andE predT) -big_image /= big_all.
+by rewrite -[t in RHS]FinfunK -codom_ffun.
 Qed.
 
 Lemma card_inj_ffuns D T :


### PR DESCRIPTION
Added lemmas `big_enum_cond`, `big_enum` and `big_enumP` to handle more
explicitly big ops iterating over explicit enumerations in a `finType`.
The previous practice was to rely on the convertibility between
`enum A` and `filter A (index_enum T)`, sometimes explicitly via the
`filter_index_enum` equality, more often than not implicitly.
Both are likely to fail after the integration of `finmap`, as the
`choiceType` theory can’t guarantee that the order in selected
enumerations is consistent.
For this reason `big_enum` and the related (but currently unused)
`big_image` lemmas are restricted to the abelian case. The `big_enumP`
lemma can be used to handle enumerations in the non-abelian case, as
explained in the `bigop.v` internal documentation.
The Changelog entry enjoins clients to stop relying on either
`filter_index_enum` and convertibility (though this PR still provides
both), and warns about the restriction of the `big_image` lemma set to
the abelian case, as it it a possible source of incompatibility.