### PR TITLE
Refactoring and linting proofs especially in polydiv.v

### DIFF
--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -161,7 +161,7 @@ Lemma zmod1gE : 1%g = 0 :> U.            Proof. by []. Qed.
 Lemma zmodVgE x : x^-1%g = - x.          Proof. by []. Qed.
 Lemma zmodMgE x y : (x * y)%g = x + y.   Proof. by []. Qed.
 Lemma zmodXgE n x : (x ^+ n)%g = x *+ n. Proof. by []. Qed.
-Lemma zmod_mulgC x y : commute x y.      Proof. exact: GRing.addrC. Qed.
+Lemma zmod_mulgC x y : commute x y.      Proof. exact: addrC. Qed.
 Lemma zmod_abelian (A : {set U}) : abelian A.
 Proof. by apply/centsP=> x _ y _; apply: zmod_mulgC. Qed.
 
@@ -524,17 +524,17 @@ Canonical unit_subFinType := Eval hnf in [subFinType of uT].
 
 Definition unit1 := Unit phR (@GRing.unitr1 _).
 Lemma unit_inv_proof u : (val u)^-1 \is a GRing.unit.
-Proof. by rewrite GRing.unitrV ?(valP u). Qed.
+Proof. by rewrite unitrV ?(valP u). Qed.
 Definition unit_inv u := Unit phR (unit_inv_proof u).
 Lemma unit_mul_proof u v : val u * val v \is a GRing.unit.
-Proof. by rewrite (GRing.unitrMr _ (valP u)) ?(valP v). Qed.
+Proof. by rewrite (unitrMr _ (valP u)) ?(valP v). Qed.
 Definition unit_mul u v := Unit phR (unit_mul_proof u v).
 Lemma unit_muluA : associative unit_mul.
-Proof. by move=> u v w; apply: val_inj; apply: GRing.mulrA. Qed.
+Proof. by move=> u v w; apply/val_inj/mulrA. Qed.
 Lemma unit_mul1u : left_id unit1 unit_mul.
-Proof. by move=> u; apply: val_inj; apply: GRing.mul1r. Qed.
+Proof. by move=> u; apply/val_inj/mul1r. Qed.
 Lemma unit_mulVu : left_inverse unit1 unit_inv unit_mul.
-Proof. by move=> u; apply: val_inj; apply: GRing.mulVr (valP u). Qed.
+Proof. by move=> u; apply/val_inj/(mulVr (valP u)). Qed.
 
 Definition unit_GroupMixin := FinGroup.Mixin unit_muluA unit_mul1u unit_mulVu.
 Canonical unit_baseFinGroupType :=
@@ -551,12 +551,12 @@ Definition unit_act x u := x * val u.
 Lemma unit_actE x u : unit_act x u = x * val u. Proof. by []. Qed.
 
 Canonical unit_action :=
-  @TotalAction _ _ unit_act (@GRing.mulr1 _) (fun _ _ _ => GRing.mulrA _ _ _).
+  @TotalAction _ _ unit_act (@mulr1 _) (fun _ _ _ => mulrA _ _ _).
 Lemma unit_is_groupAction : @is_groupAction _ R setT setT unit_action.
 Proof.
 move=> u _ /=; rewrite inE; apply/andP; split.
   by apply/subsetP=> x _; rewrite inE.
-by apply/morphicP=> x y _ _; rewrite !actpermE /= [_ u]GRing.mulrDl.
+by apply/morphicP=> x y _ _; rewrite !actpermE /= [_ u]mulrDl.
 Qed.
 Canonical unit_groupAction := GroupAction unit_is_groupAction.
 

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -164,7 +164,7 @@ Proof. by case: m => n; rewrite (modNz_nat, modz_nat) ?modn1. Qed.
 Lemma divz1 m : (m %/ 1)%Z = m. Proof. by rewrite -{1}[m]mulr1 mulzK. Qed.
 
 Lemma divzz d : (d %/ d)%Z = (d != 0).
-Proof. by have [-> // | d_nz] := altP eqP; rewrite -{1}[d]mul1r mulzK. Qed.
+Proof. by have [-> // | d_nz] := eqVneq; rewrite -{1}[d]mul1r mulzK. Qed.
 
 Lemma ltz_pmod m d : d > 0 -> (m %% d)%Z < d.
 Proof.
@@ -453,7 +453,7 @@ Proof. by move=> dv_n; rewrite addrC divzDl // addrC. Qed.
 
 Lemma Qint_dvdz (m d : int) : (d %| m)%Z -> ((m%:~R / d%:~R : rat) \is a Qint).
 Proof.
-case/dvdzP=> z ->; rewrite rmorphM /=; case: (altP (d =P 0)) => [->|dn0].
+case/dvdzP=> z ->; rewrite rmorphM /=; have [->|dn0] := eqVneq d 0.
   by rewrite mulr0 mul0r.
 by rewrite mulfK ?intr_eq0 // rpred_int.
 Qed.
@@ -564,7 +564,7 @@ Variant egcdz_spec m n : int * int -> Type :=
 
 Lemma egcdzP m n : egcdz_spec m n (egcdz m n).
 Proof.
-rewrite /egcdz; have [-> | m_nz] := altP eqP.
+rewrite /egcdz; have [-> | m_nz] := eqVneq.
   by split; [rewrite -abszEsign gcd0z | rewrite coprimezE absz_sign].
 have m_gt0 : (`|m| > 0)%N by rewrite absz_gt0.
 case: egcdnP (coprime_egcdn `|n| m_gt0) => //= u v Duv _ co_uv; split.
@@ -706,7 +706,7 @@ Qed.
 Lemma dvdz_contents a p : (a %| zcontents p)%Z = (p \is a polyOver (dvdz a)).
 Proof.
 rewrite dvdzE abszM absz_sg lead_coef_eq0.
-have [-> | nz_p] := altP eqP; first by rewrite mul0n dvdn0 rpred0.
+have [-> | nz_p] := eqVneq; first by rewrite mul0n dvdn0 rpred0.
 rewrite mul1n; apply/dvdn_biggcdP/(all_nthP 0)=> a_dv_p i ltip /=.
   exact: (a_dv_p (Ordinal ltip)).
 exact: a_dv_p.
@@ -751,14 +751,14 @@ Qed.
 
 Lemma sgz_lead_primitive p : sgz (lead_coef (zprimitive p)) = (p != 0).
 Proof.
-have [-> | nz_p] := altP eqP; first by rewrite zprimitive0 lead_coef0.
+have [-> | nz_p] := eqVneq; first by rewrite zprimitive0 lead_coef0.
 apply: (@mulfI _ (sgz (zcontents p))); first by rewrite sgz_eq0 zcontents_eq0.
 by rewrite -sgzM mulr1 -lead_coefZ -zpolyEprim sgz_contents.
 Qed.
 
 Lemma zcontents_primitive p : zcontents (zprimitive p) = (p != 0).
 Proof.
-have [-> | nz_p] := altP eqP; first by rewrite zprimitive0 zcontents0.
+have [-> | nz_p] := eqVneq; first by rewrite zprimitive0 zcontents0.
 apply: (@mulfI _ (zcontents p)); first by rewrite zcontents_eq0.
 by rewrite mulr1 -zcontentsZ -zpolyEprim.
 Qed.

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -1197,7 +1197,7 @@ Definition nz_row m n (A : 'M_(m, n)) :=
 Lemma nz_row_eq0 m n (A : 'M_(m, n)) : (nz_row A == 0) = (A == 0).
 Proof.
 rewrite /nz_row; symmetry; case: pickP => [i /= nzAi | Ai0].
-  by rewrite (negbTE nzAi); apply: contraTF nzAi => /eqP->; rewrite row0 eqxx.
+  by rewrite (negPf nzAi); apply: contraTF nzAi => /eqP->; rewrite row0 eqxx.
 by rewrite eqxx; apply/eqP/row_matrixP=> i; move/eqP: (Ai0 i) ->; rewrite row0.
 Qed.
 
@@ -1289,7 +1289,7 @@ Lemma matrix_sum_delta A :
 Proof.
 apply/matrixP=> i j.
 rewrite summxE (bigD1 i) // summxE (bigD1 j) //= !mxE !eqxx mulr1.
-rewrite !big1 ?addr0 //= => [i' | j']; rewrite eq_sym => /negbTE diff.
+rewrite !big1 ?addr0 //= => [i' | j']; rewrite eq_sym => /negPf diff.
   by rewrite summxE big1 // => j' _; rewrite !mxE diff mulr0.
 by rewrite !mxE eqxx diff mulr0.
 Qed.
@@ -1406,7 +1406,7 @@ Lemma diag_mx_sum_delta n (d : 'rV_n) :
 Proof.
 apply/matrixP=> i j; rewrite summxE (bigD1 i) //= !mxE eqxx /=.
 rewrite eq_sym mulr_natr big1 ?addr0 // => i' ne_i'i.
-by rewrite !mxE eq_sym (negbTE ne_i'i) mulr0.
+by rewrite !mxE eq_sym (negPf ne_i'i) mulr0.
 Qed.
 
 (* Scalar matrix : a diagonal matrix with a constant on the diagonal *)
@@ -1563,7 +1563,7 @@ Qed.
 Lemma rowE m n i (A : 'M_(m, n)) : row i A = delta_mx 0 i *m A.
 Proof.
 apply/rowP=> j; rewrite !mxE (bigD1 i) //= mxE !eqxx mul1r.
-by rewrite big1 ?addr0 // => i' ne_i'i; rewrite mxE /= (negbTE ne_i'i) mul0r.
+by rewrite big1 ?addr0 // => i' ne_i'i; rewrite mxE /= (negPf ne_i'i) mul0r.
 Qed.
 
 Lemma row_mul m n p (i : 'I_m) A (B : 'M_(n, p)) :
@@ -1581,7 +1581,7 @@ Lemma mul_delta_mx_cond m n p (j1 j2 : 'I_n) (i1 : 'I_m) (k2 : 'I_p) :
 Proof.
 apply/matrixP=> i k; rewrite !mxE (bigD1 j1) //=.
 rewrite mulmxnE !mxE !eqxx andbT -natrM -mulrnA !mulnb !andbA andbAC.
-by rewrite big1 ?addr0 // => j; rewrite !mxE andbC -natrM; move/negbTE->.
+by rewrite big1 ?addr0 // => j; rewrite !mxE andbC -natrM; move/negPf->.
 Qed.
 
 Lemma mul_delta_mx m n p (j : 'I_n) (i : 'I_m) (k : 'I_p) :
@@ -1590,20 +1590,20 @@ Proof. by rewrite mul_delta_mx_cond eqxx. Qed.
 
 Lemma mul_delta_mx_0 m n p (j1 j2 : 'I_n) (i1 : 'I_m) (k2 : 'I_p) :
   j1 != j2 -> delta_mx i1 j1 *m delta_mx j2 k2 = 0.
-Proof. by rewrite mul_delta_mx_cond => /negbTE->. Qed.
+Proof. by rewrite mul_delta_mx_cond => /negPf->. Qed.
 
 Lemma mul_diag_mx m n d (A : 'M_(m, n)) :
   diag_mx d *m A = \matrix_(i, j) (d 0 i * A i j).
 Proof.
 apply/matrixP=> i j; rewrite !mxE (bigD1 i) //= mxE eqxx big1 ?addr0 // => i'.
-by rewrite mxE eq_sym mulrnAl => /negbTE->.
+by rewrite mxE eq_sym mulrnAl => /negPf->.
 Qed.
 
 Lemma mul_mx_diag m n (A : 'M_(m, n)) d :
   A *m diag_mx d = \matrix_(i, j) (A i j * d 0 j).
 Proof.
 apply/matrixP=> i j; rewrite !mxE (bigD1 j) //= mxE eqxx big1 ?addr0 // => i'.
-by rewrite mxE eq_sym mulrnAr; move/negbTE->.
+by rewrite mxE eq_sym mulrnAr; move/negPf->.
 Qed.
 
 Lemma mulmx_diag n (d e : 'rV_n) :
@@ -1761,7 +1761,7 @@ have [le_n_i | lt_i_n] := leqP n i.
   by rewrite -pid_mx_minh !mxE leq_min ltnNge le_n_i andbF mul0r.
 rewrite (bigD1 (Ordinal lt_i_n)) //= big1 ?addr0 => [|j].
   by rewrite !mxE eqxx /= -natrM mulnb andbCA.
-by rewrite -val_eqE /= !mxE eq_sym -natrM => /negbTE->.
+by rewrite -val_eqE /= !mxE eq_sym -natrM => /negPf->.
 Qed.
 
 Lemma pid_mx_id m n p r :
@@ -2309,7 +2309,7 @@ Proof.
 rewrite [\det _](bigD1 s) //= big1 => [|i _]; last by rewrite /= !mxE eqxx.
 rewrite mulr1 big1 ?addr0 => //= t Dst.
 case: (pickP (fun i => s i != t i)) => [i ist | Est].
-  by rewrite (bigD1 i) // mulrCA /= !mxE (negbTE ist) mul0r.
+  by rewrite (bigD1 i) // mulrCA /= !mxE (negPf ist) mul0r.
 by case/eqP: Dst; apply/permP => i; move/eqP: (Est i).
 Qed.
 
@@ -2368,9 +2368,9 @@ Proof.
 rewrite /(\det _) (bigD1 1%g) //= addrC big1 => [|p p1].
   by rewrite add0r odd_perm1 mul1r; apply: eq_bigr => i; rewrite perm1 mxE eqxx.
 have{p1}: ~~ perm_on set0 p.
-  apply: contra p1; move/subsetP=> p1; apply/eqP; apply/permP=> i.
-  by rewrite perm1; apply/eqP; apply/idPn; move/p1; rewrite inE.
-case/subsetPn=> i; rewrite !inE eq_sym; move/negbTE=> p_i _.
+  apply: contra p1; move/subsetP=> p1; apply/eqP/permP=> i.
+  by rewrite perm1; apply/eqP/idPn; move/p1; rewrite inE.
+case/subsetPn=> i; rewrite !inE eq_sym; move/negPf=> p_i _.
 by rewrite (bigD1 i) //= mulrCA mxE p_i mul0r.
 Qed.
 
@@ -2441,13 +2441,13 @@ Proof. by apply/matrixP=> i j; rewrite !mxE cofactorZ. Qed.
 (* Cramer Rule : adjugate on the left *)
 Lemma mul_mx_adj n (A : 'M[R]_n) : A *m \adj A = (\det A)%:M.
 Proof.
-apply/matrixP=> i1 i2; rewrite !mxE; case Di: (i1 == i2).
-  rewrite (eqP Di) (expand_det_row _ i2) //=.
+apply/matrixP=> i1 i2; rewrite !mxE; have [->|Di] := eqVneq.
+  rewrite (expand_det_row _ i2) //=.
   by apply: eq_bigr => j _; congr (_ * _); rewrite mxE.
 pose B := \matrix_(i, j) (if i == i2 then A i1 j else A i j).
-have EBi12: B i1 =1 B i2 by move=> j; rewrite /= !mxE Di eq_refl.
-rewrite -[_ *+ _](determinant_alternate (negbT Di) EBi12) (expand_det_row _ i2).
-apply: eq_bigr => j _; rewrite !mxE eq_refl; congr (_ * (_ * _)).
+have EBi12: B i1 =1 B i2 by move=> j; rewrite /= !mxE eqxx (negPf Di).
+rewrite -[_ *+ _](determinant_alternate Di EBi12) (expand_det_row _ i2).
+apply: eq_bigr => j _; rewrite !mxE eqxx; congr (_ * (_ * _)).
 apply: eq_bigr => s _; congr (_ * _); apply: eq_bigr => i _.
 by rewrite !mxE eq_sym -if_neg neq_lift.
 Qed.
@@ -2488,7 +2488,7 @@ elim: n1 => [|n1 IHn1] in Aul Aur *.
   by do 2![rewrite !mxE; case: splitP => [[]|k] //=; move/val_inj=> <- {k}].
 rewrite (expand_det_col _ (lshift n2 0)) big_split_ord /=.
 rewrite addrC big1 1?simp => [|i _]; last by rewrite block_mxEdl mxE simp.
-rewrite (expand_det_col _ 0) big_distrl /=; apply eq_bigr=> i _.
+rewrite (expand_det_col _ 0) big_distrl /=; apply: eq_bigr=> i _.
 rewrite block_mxEul -!mulrA; do 2!congr (_ * _).
 by rewrite col'_col_mx !col'Kl raddf0 row'Ku row'_row_mx IHn1.
 Qed.

--- a/mathcomp/algebra/mxalgebra.v
+++ b/mathcomp/algebra/mxalgebra.v
@@ -637,7 +637,7 @@ Lemma rowV0P m n (A : 'M_(m, n)) :
 Proof.
 rewrite -[A == 0]negbK; case: rowV0Pn => IH.
   by right; case: IH => v svA nzv IH; case/eqP: nzv; apply: IH.
-by left=> v svA; apply/eqP; apply/idPn=> nzv; case: IH; exists v.
+by left=> v svA; apply/eqP/idPn=> nzv; case: IH; exists v.
 Qed.
 
 Lemma submx_full m1 m2 n (A : 'M_(m1, n)) (B : 'M_(m2, n)) :
@@ -687,8 +687,7 @@ Proof. exact: row_free_unit. Qed.
 Lemma mxrank_unit n (A : 'M_n) : A \in unitmx -> \rank A = n.
 Proof. by rewrite -row_full_unit => /eqnP. Qed.
 
-Lemma mxrank1 n : \rank (1%:M : 'M_n) = n.
-Proof. by apply: mxrank_unit; apply: unitmx1. Qed.
+Lemma mxrank1 n : \rank (1%:M : 'M_n) = n. Proof. exact: mxrank_unit. Qed.
 
 Lemma mxrank_delta m n i j : \rank (delta_mx i j : 'M_(m, n)) = 1%N.
 Proof.
@@ -799,7 +798,7 @@ Qed.
 
 Lemma eq_row_base m n (A : 'M_(m, n)) : (row_base A :=: A)%MS.
 Proof.
-apply/eqmxP; apply/andP; split; apply/submxP.
+apply/eqmxP/andP; split; apply/submxP.
   exists (pid_mx (\rank A) *m invmx (col_ebase A)).
   by rewrite -{8}[A]mulmx_ebase !mulmxA mulmxKV // pid_mx_id.
 exists (col_ebase A *m pid_mx (\rank A)).
@@ -857,7 +856,7 @@ by rewrite qidmx_eq1 row_full_unit unitmx1 => /eqP.
 Qed.
 
 Lemma genmx_id m n (A : 'M_(m, n)) : (<<<<A>>>> = <<A>>)%MS.
-Proof. by apply: eq_genmx; apply: genmxE. Qed.
+Proof. exact/eq_genmx/genmxE. Qed.
 
 Lemma row_base_free m n (A : 'M_(m, n)) : row_free (row_base A).
 Proof. by apply/eqnP; rewrite eq_row_base. Qed.
@@ -1229,8 +1228,8 @@ Proof.
 rewrite /equivmx qidmx_eq1 /qidmx /capmx_witness.
 rewrite -sub1mx; case s1A: (1%:M <= A)%MS => /=; last first.
   rewrite !genmxE submx_refl /= -negb_add; apply: contra {s1A}(negbT s1A).
-  case: eqP => [<- _| _]; first by rewrite genmxE.
-  by case: eqP A => //= -> A; move/eqP->; rewrite pid_mx_1.
+  have [<- | _] := eqP; first by rewrite genmxE.
+  by case: eqP A => //= -> A /eqP ->; rewrite pid_mx_1.
 case: (m =P n) => [-> | ne_mn] in A s1A *.
   by rewrite conform_mx_id submx_refl pid_mx_1 eqxx.
 by rewrite nonconform_mx ?submx1 ?s1A ?eqxx //; case: eqP.
@@ -1395,7 +1394,7 @@ rewrite (capmxC A B) capmxC; wlog idA: m1 m3 A C / qidmx A.
   apply: capmx_norm_eq; first by rewrite !qidmx_cap andbAC.
   by apply/andP; split; rewrite !sub_capmx andbAC -!sub_capmx.
 rewrite -!(capmxC A) [in @capmx m1]unlock idA capmx_nop_id.
-have [eqBC |] :=eqVneq (qidmx B) (qidmx C).
+have [eqBC|] := eqVneq (qidmx B) (qidmx C).
   rewrite (@capmx_eq_norm n) ?capmx_nopP // capmx_eq_norm //.
   by apply: capmx_norm_eq; rewrite ?qidmx_cap ?capmxS ?capmx_nopP.
 by rewrite !unlock capmx_nopP capmx_nop_id; do 2?case: (qidmx _) => //.
@@ -2206,7 +2205,7 @@ rewrite (card_GL _ (ltn0Sn n.-1)) card_ord Fp_cast // big_add1 /=.
 pose p'gt0 m := m > 0 /\ logn p m = 0%N.
 suffices [Pgt0 p'P]: p'gt0 (\prod_(0 <= i < n.-1.+1) (p ^ i.+1 - 1))%N.
   by rewrite lognM // p'P pfactorK // addn0; case n.
-apply big_ind => [|m1 m2 [m10 p'm1] [m20]|i _]; rewrite {}/p'gt0 ?logn1 //.
+apply: big_ind => [|m1 m2 [m10 p'm1] [m20]|i _]; rewrite {}/p'gt0 ?logn1 //.
   by rewrite muln_gt0 m10 lognM ?p'm1.
 rewrite lognE -if_neg subn_gt0 p_pr /= -{1 2}(exp1n i.+1) ltn_exp2r // p_gt1.
 by rewrite dvdn_subr ?dvdn_exp // gtnNdvd.
@@ -2243,7 +2242,7 @@ Lemma memmx_eqP m1 m2 n (R1 : 'A_(m1, n)) (R2 : 'A_(m2, n)) :
   reflect (forall A, (A \in R1) = (A \in R2)) (R1 == R2)%MS.
 Proof.
 apply: (iffP eqmxP) => [eqR12 A | eqR12]; first by rewrite eqR12.
-by apply/eqmxP; apply/rV_eqP=> vA; rewrite -(vec_mxK vA) eqR12.
+by apply/eqmxP/rV_eqP=> vA; rewrite -(vec_mxK vA) eqR12.
 Qed.
 Arguments memmx_eqP {m1 m2 n R1 R2}.
 
@@ -2360,7 +2359,7 @@ Arguments mulsmxP {m1 m2 n A R1 R2}.
 Lemma mulsmxA m1 m2 m3 n (R1 : 'A_(m1, n)) (R2 : 'A_(m2, n)) (R3 : 'A_(m3, n)) :
   (R1 * (R2 * R3) = R1 * R2 * R3)%MS.
 Proof.
-rewrite -(genmx_muls (_ * _)%MS) -genmx_muls; apply/genmxP; apply/andP; split.
+rewrite -(genmx_muls (_ * _)%MS) -genmx_muls; apply/genmxP/andP; split.
   apply/mulsmx_subP=> A1 A23 R_A1; case/mulsmxP=> A2 R_A2 [A3 R_A3 ->{A23}].
   by rewrite !linear_sum summx_sub //= => i _; rewrite mulmxA !mem_mulsmx.
 apply/mulsmx_subP=> _ A3 /mulsmxP[A1 R_A1 [A2 R_A2 ->]] R_A3.

--- a/mathcomp/algebra/polydiv.v
+++ b/mathcomp/algebra/polydiv.v
@@ -115,7 +115,7 @@ Variable R : ringType.
 Implicit Types d p q r : {poly R}.
 
 (* Pseudo division, defined on an arbitrary ring *)
-Definition redivp_rec (q : {poly R})  :=
+Definition redivp_rec (q : {poly R}) :=
   let sq := size q in
   let cq := lead_coef q in
    fix loop (k : nat) (qq r : {poly R})(n : nat) {struct n} :=
@@ -146,54 +146,48 @@ rewrite /rdivp unlock; case: ifP => // Hp; rewrite /redivp_rec !size_poly0.
 by rewrite polySpred ?Hp.
 Qed.
 
-Lemma rdivp0 p : rdivp p 0 = 0.
-Proof. by rewrite /rdivp unlock eqxx. Qed.
+Lemma rdivp0 p : rdivp p 0 = 0. Proof. by rewrite /rdivp unlock eqxx. Qed.
 
 Lemma rdivp_small p q : size p < size q -> rdivp p q = 0.
 Proof.
 rewrite /rdivp unlock; have [-> | _ ltpq] := eqP; first by rewrite size_poly0.
-by case: (size p) => [|s]; rewrite /=  ltpq.
+by case: (size p) => [|s]; rewrite /= ltpq.
 Qed.
 
 Lemma leq_rdivp p q : size (rdivp p q) <= size p.
 Proof.
 have [/rdivp_small->|] := ltnP (size p) (size q); first by rewrite size_poly0.
 rewrite /rdivp /rmodp /rscalp unlock.
-case q0: (q == 0) => /=; first by rewrite size_poly0.
+have [->|q0] //= := eqVneq q 0.
 have: size (0 : {poly R}) <= size p by rewrite size_poly0.
-move: (leqnn (size p)); move: {2 3 4 6}(size p) => A.
+move: {2 3 4 6}(size p) (leqnn (size p)) => A.
 elim: (size p) 0%N (0 : {poly R}) {1 3 4}p (leqnn (size p)) => [|n ihn] k q1 r.
-  by  move/size_poly_leq0P->; rewrite /= size_poly0 lt0n size_poly_eq0 q0.
+  by move/size_poly_leq0P->; rewrite /= size_poly0 size_poly_gt0 q0.
 move=> /= hrn hr hq1 hq; case: ltnP => //= hqr.
-have sq: 0 < size q by rewrite size_poly_gt0 q0.
+have sq: 0 < size q by rewrite size_poly_gt0.
 have sr: 0 < size r by apply: leq_trans sq hqr.
 apply: ihn => //.
 - apply/leq_sizeP => j hnj.
   rewrite coefB -scalerAl coefZ coefXnM ltn_subRL ltnNge.
-  have hj : (size r).-1 <= j.
-    by apply: leq_trans hnj; move: hrn; rewrite -{1}(prednK sr) ltnS.
-  rewrite polySpred -?size_poly_gt0 // (leq_ltn_trans hj) /=; last first.
-    by rewrite -{1}(add0n j) ltn_add2r.
-  move: (hj); rewrite leq_eqVlt; case/orP.
-    move/eqP<-; rewrite (@polySpred _ q) ?q0 // subSS coefMC.
-    rewrite subKn; first by rewrite lead_coefE subrr.
-    by rewrite -ltnS -!polySpred // ?q0 -?size_poly_gt0.
-  move=> {hj} hj; move: (hj); rewrite prednK // coefMC; move/leq_sizeP=> -> //.
-  suff: size q <= j - (size r - size q).
-    by rewrite mul0r sub0r; move/leq_sizeP=> -> //; rewrite mulr0 oppr0.
-  rewrite subnBA // addnC -(prednK sq) -(prednK sr) addSn subSS.
-  by rewrite -addnBA ?(ltnW hj) // -{1}[_.-1]addn0 ltn_add2l subn_gt0.
+  have hj : (size r).-1 <= j by apply: leq_trans hnj; rewrite -ltnS prednK.
+  rewrite [r in r <= _]polySpred -?size_poly_gt0 // coefMC.
+  rewrite (leq_ltn_trans hj) /=; last by rewrite -add1n leq_add2r.
+  move: hj; rewrite leq_eqVlt prednK // => /predU1P [<- | hj].
+    by rewrite -subn1 subnAC subKn // !subn1 !lead_coefE subrr.
+  have/leq_sizeP-> //: size q <= j - (size r - size q).
+    by rewrite subnBA // leq_psubRL // leq_add2r.
+  by move/leq_sizeP: (hj) => -> //; rewrite mul0r mulr0 subr0.
 - apply: leq_trans (size_add _ _) _; rewrite geq_max; apply/andP; split.
     apply: leq_trans (size_mul_leq _ _) _.
     by rewrite size_polyC lead_coef_eq0 q0 /= addn1.
   rewrite size_opp; apply: leq_trans (size_mul_leq _ _) _.
-  apply: leq_trans hr; rewrite -subn1 leq_subLR -{2}(subnK hqr) addnA leq_add2r.
-  by rewrite add1n -(@size_polyXn R) size_scale_leq.
+  apply: leq_trans hr; rewrite -subn1 leq_subLR -[in (1 + _)%N](subnK hqr).
+  by rewrite addnA leq_add2r add1n -(@size_polyXn R) size_scale_leq.
 apply: leq_trans (size_add _ _) _; rewrite geq_max; apply/andP; split.
   apply: leq_trans (size_mul_leq _ _) _.
   by rewrite size_polyC lead_coef_eq0 q0 /= addnS addn0.
-apply: leq_trans (size_scale_leq _ _) _; rewrite size_polyXn.
-by rewrite -subSn // leq_subLR -add1n leq_add.
+apply: leq_trans (size_scale_leq _ _) _.
+by rewrite size_polyXn -subSn // leq_subLR -add1n leq_add.
 Qed.
 
 Lemma rmod0p p : rmodp 0 p = 0.
@@ -202,43 +196,32 @@ rewrite /rmodp unlock; case: ifP => // Hp; rewrite /redivp_rec !size_poly0.
 by rewrite polySpred ?Hp.
 Qed.
 
-Lemma rmodp0 p : rmodp p 0 = p.
-Proof. by rewrite /rmodp unlock eqxx. Qed.
+Lemma rmodp0 p : rmodp p 0 = p. Proof. by rewrite /rmodp unlock eqxx. Qed.
 
 Lemma rscalp_small p q : size p < size q -> rscalp p q = 0%N.
 Proof.
-rewrite /rscalp unlock; case: eqP => Eq // spq.
+rewrite /rscalp unlock; case: eqP => _ // spq.
 by case sp: (size p) => [| s] /=; rewrite spq.
 Qed.
 
 Lemma ltn_rmodp p q : (size (rmodp p q) < size q) = (q != 0).
 Proof.
-rewrite /rdivp /rmodp /rscalp unlock; case q0 : (q == 0).
-  by rewrite (eqP q0) /= size_poly0 ltn0.
+rewrite /rdivp /rmodp /rscalp unlock; have [->|q0] := eqVneq q 0.
+  by rewrite /= size_poly0 ltn0.
 elim: (size p) 0%N 0 {1 3}p (leqnn (size p)) => [|n ihn] k q1 r.
-  rewrite leqn0 size_poly_eq0; move/eqP->; rewrite /= size_poly0 /= lt0n.
-  by rewrite size_poly_eq0 q0 /= size_poly0 lt0n size_poly_eq0 q0.
-move=> hr /=; case: (@ltnP (size r) _) => //= hsrq; rewrite ihn //.
-apply/leq_sizeP => j hnj; rewrite coefB.
-have sr: 0 < size r.
-  by apply: leq_trans hsrq; apply: neq0_lt0n; rewrite size_poly_eq0.
-have sq: 0 < size q by rewrite size_poly_gt0 q0.
-have hj : (size r).-1 <= j.
-  by apply: leq_trans hnj; move: hr; rewrite -{1}(prednK sr) ltnS.
-rewrite -scalerAl !coefZ coefXnM ltn_subRL ltnNge; move: (sr).
-move/prednK => {1}<-.
-have -> /= : (size r).-1 < size q + j.
-  apply: (@leq_trans ((size q) + (size r).-1)); last by rewrite leq_add2l.
-  by rewrite -{1}[_.-1]add0n ltn_add2r.
-move: (hj); rewrite leq_eqVlt; case/orP.
-  move/eqP<-; rewrite -{1}(prednK sq) -{3}(prednK sr) subSS.
-  rewrite subKn; first by rewrite coefMC !lead_coefE subrr.
-  by move: hsrq; rewrite -{1}(prednK sq) -{1}(prednK sr) ltnS.
-move=> {hj} hj; move: (hj); rewrite prednK // coefMC; move/leq_sizeP=> -> //.
-suff: size q <= j - (size r - size q).
-   by rewrite mul0r sub0r; move/leq_sizeP=> -> //; rewrite mulr0 oppr0.
-rewrite subnBA // addnC -(prednK sq) -(prednK sr) addSn subSS.
-by rewrite -addnBA ?(ltnW hj) // -{1}[_.-1]addn0 ltn_add2l subn_gt0.
+  move/size_poly_leq0P->.
+  by rewrite /= size_poly0 size_poly_gt0 q0 size_poly0 size_poly_gt0.
+move=> hr /=; case: (ltnP (size r)) => // hsrq; apply/ihn/leq_sizeP => j hnj.
+rewrite coefB -scalerAl !coefZ coefXnM coefMC ltn_subRL ltnNge.
+have sq: 0 < size q by rewrite size_poly_gt0.
+have sr: 0 < size r by apply: leq_trans hsrq.
+have hj: (size r).-1 <= j by apply: leq_trans hnj; rewrite -ltnS prednK.
+move: (leq_add sq hj); rewrite add1n prednK // => -> /=.
+move: hj; rewrite leq_eqVlt prednK // => /predU1P [<- | hj].
+  by rewrite -predn_sub subKn // !lead_coefE subrr.
+have/leq_sizeP -> //: size q <= j - (size r - size q).
+  by rewrite subnBA // leq_subRL ?leq_add2r // (leq_trans hj) // leq_addr.
+by move/leq_sizeP: hj => -> //; rewrite mul0r mulr0 subr0.
 Qed.
 
 Lemma ltn_rmodpN0 p q : q != 0 -> size (rmodp p q) < size q.
@@ -246,69 +229,61 @@ Proof. by rewrite ltn_rmodp. Qed.
 
 Lemma rmodp1 p : rmodp p 1 = 0.
 Proof.
-case p0: (p == 0); first by rewrite (eqP p0) rmod0p.
-apply/eqP; rewrite -size_poly_eq0.
-by have := (ltn_rmodp p 1); rewrite size_polyC !oner_neq0 ltnS leqn0.
+apply/eqP; have := ltn_rmodp p 1.
+by rewrite !oner_neq0 -size_poly_eq0 size_poly1 ltnS leqn0.
 Qed.
 
 Lemma rmodp_small p q : size p < size q -> rmodp p q = p.
 Proof.
-rewrite /rmodp unlock; case: eqP => Eq; first by rewrite Eq size_poly0.
+rewrite /rmodp unlock; have [->|_] := eqP; first by rewrite size_poly0.
 by case sp: (size p) => [| s] Hs /=; rewrite sp Hs /=.
 Qed.
 
-Lemma leq_rmodp m d : size (rmodp m d)  <= size m.
+Lemma leq_rmodp m d : size (rmodp m d) <= size m.
 Proof.
 case: (ltnP (size m) (size d)) => [|h]; first by move/rmodp_small->.
-case d0: (d == 0); first by rewrite (eqP d0) rmodp0.
-by apply: leq_trans h; apply: ltnW; rewrite ltn_rmodp d0.
+have [->|d0] := eqVneq d 0; first by rewrite rmodp0.
+by apply: leq_trans h; apply: ltnW; rewrite ltn_rmodp.
 Qed.
 
 Lemma rmodpC p c : c != 0 -> rmodp p c%:P = 0.
 Proof.
-move=> Hc; apply/eqP; rewrite -size_poly_eq0 -leqn0 -ltnS.
+move=> Hc; apply/eqP; rewrite -size_poly_leq0 -ltnS.
 have -> : 1%N = nat_of_bool (c != 0) by rewrite Hc.
 by rewrite -size_polyC ltn_rmodp polyC_eq0.
 Qed.
 
-Lemma rdvdp0 d : rdvdp d 0.
-Proof. by rewrite /rdvdp rmod0p. Qed.
+Lemma rdvdp0 d : rdvdp d 0. Proof. by rewrite /rdvdp rmod0p. Qed.
 
-Lemma rdvd0p n : (rdvdp 0 n) = (n == 0).
-Proof. by rewrite /rdvdp rmodp0. Qed.
+Lemma rdvd0p n : rdvdp 0 n = (n == 0). Proof. by rewrite /rdvdp rmodp0. Qed.
 
 Lemma rdvd0pP n : reflect (n = 0) (rdvdp 0 n).
-Proof. by  apply: (iffP idP); rewrite rdvd0p; move/eqP. Qed.
+Proof. by apply: (iffP idP); rewrite rdvd0p; move/eqP. Qed.
 
 Lemma rdvdpN0 p q : rdvdp p q -> q != 0 -> p != 0.
-Proof. by move=> pq hq; apply: contraL pq => /eqP ->; rewrite rdvd0p. Qed.
+Proof. by move=> pq hq; apply: contraTneq pq => ->; rewrite rdvd0p. Qed.
 
-Lemma rdvdp1 d : (rdvdp d 1) = ((size d) == 1%N).
+Lemma rdvdp1 d : rdvdp d 1 = (size d == 1%N).
 Proof.
-rewrite /rdvdp; case d0: (d == 0).
-  by rewrite (eqP d0) rmodp0 size_poly0 (negPf (@oner_neq0 _)).
-have:= (size_poly_eq0 d); rewrite d0; move/negbT; rewrite -lt0n.
-rewrite leq_eqVlt; case/orP => hd; last first.
-  by rewrite rmodp_small ?size_poly1 // oner_eq0 -(subnKC hd).
-rewrite eq_sym in hd; rewrite hd; have [c cn0 ->] := size_poly1P _ hd.
+rewrite /rdvdp; have [->|] := eqVneq d 0.
+  by rewrite rmodp0 size_poly0 (negPf (oner_neq0 _)).
+rewrite -size_poly_leq0 -ltnS; case: ltngtP => // [|/eqP] hd _.
+  by rewrite rmodp_small ?size_poly1 // oner_eq0.
+have [c cn0 ->] := size_poly1P _ hd.
 rewrite /rmodp unlock -size_poly_eq0 size_poly1 /= size_poly1 size_polyC cn0 /=.
 by rewrite polyC_eq0 (negPf cn0) !lead_coefC !scale1r subrr !size_poly0.
 Qed.
 
-Lemma rdvd1p m : rdvdp 1 m.
-Proof. by rewrite /rdvdp rmodp1. Qed.
+Lemma rdvd1p m : rdvdp 1 m. Proof. by rewrite /rdvdp rmodp1. Qed.
 
 Lemma Nrdvdp_small (n d : {poly R}) :
-  n != 0 -> size n < size d -> (rdvdp d n) = false.
-Proof.
-by move=> nn0 hs; rewrite /rdvdp; rewrite (rmodp_small hs); apply: negPf.
-Qed.
+  n != 0 -> size n < size d -> rdvdp d n = false.
+Proof. by move=> nn0 hs; rewrite /rdvdp (rmodp_small hs); apply: negPf. Qed.
 
 Lemma rmodp_eq0P p q : reflect (rmodp p q = 0) (rdvdp q p).
 Proof. exact: (iffP eqP). Qed.
 
-Lemma rmodp_eq0 p q : rdvdp q p -> rmodp p q = 0.
-Proof. by move/rmodp_eq0P. Qed.
+Lemma rmodp_eq0 p q : rdvdp q p -> rmodp p q = 0. Proof. exact: rmodp_eq0P. Qed.
 
 Lemma rdvdp_leq p q : rdvdp p q -> q != 0 -> size p <= size q.
 Proof. by move=> dvd_pq; rewrite leqNgt; apply: contra => /rmodp_small <-. Qed.
@@ -331,8 +306,8 @@ Qed.
 
 Lemma rgcdp0 : right_id 0 rgcdp.
 Proof.
-move=> p; have:= rgcd0p p; rewrite /rgcdp size_poly0 size_poly_gt0 if_neg.
-by case: ifP => /= p0; rewrite ?(eqxx, p0) // (eqP p0).
+move=> p; have:= rgcd0p p; rewrite /rgcdp size_poly0 size_poly_gt0.
+by case: eqVneq => p0; rewrite ?(eqxx, p0) //= eqxx.
 Qed.
 
 Lemma rgcdpE p q :
@@ -346,38 +321,30 @@ pose rgcdp_rec := fix rgcdp_rec (n : nat) (pp qq : {poly R}) {struct n} :=
 have Irec: forall m n p q, size q <= m -> size q <= n
       -> size q < size p -> rgcdp_rec m p q = rgcdp_rec n p q.
   + elim=> [|m Hrec] [|n] //= p1 q1.
-    - rewrite leqn0 size_poly_eq0; move/eqP=> -> _.
-      rewrite size_poly0 size_poly_gt0 rmodp0 => nzp.
-      by rewrite (negPf nzp); case: n => [|n] /=; rewrite rmod0p eqxx.
-    - rewrite leqn0 size_poly_eq0 => _; move/eqP=> ->.
-      rewrite size_poly0 size_poly_gt0 rmodp0 => nzp.
-      by rewrite (negPf nzp); case: m {Hrec} => [|m] /=; rewrite rmod0p eqxx.
-  case: ifP => Epq Sm Sn Sq //; rewrite ?Epq //.
-  case: (eqVneq q1 0) => [->|nzq].
+    - move/size_poly_leq0P=> -> _; rewrite size_poly0 size_poly_gt0 rmodp0.
+      by move/negPf->; case: n => [|n] /=; rewrite rmod0p eqxx.
+    - move=> _ /size_poly_leq0P ->; rewrite size_poly0 size_poly_gt0 rmodp0.
+      by move/negPf->; case: m {Hrec} => [|m] /=; rewrite rmod0p eqxx.
+  case: eqVneq => Epq Sm Sn Sq //; have [->|nzq] := eqVneq q1 0.
     by case: n m {Sm Sn Hrec} => [|m] [|n] //=; rewrite rmod0p eqxx.
   apply: Hrec; last by rewrite ltn_rmodp.
     by rewrite -ltnS (leq_trans _ Sm) // ltn_rmodp.
   by rewrite -ltnS (leq_trans _ Sn) // ltn_rmodp.
-case: (eqVneq p 0) => [-> | nzp].
+have [->|nzp] := eqVneq p 0.
   by rewrite rmod0p rmodp0 rgcd0p rgcdp0 if_same.
-case: (eqVneq q 0) => [-> | nzq].
+have [->|nzq] := eqVneq q 0.
   by rewrite rmod0p rmodp0 rgcd0p rgcdp0 if_same.
-rewrite /rgcdp -/rgcdp_rec.
-case: ltnP; rewrite (negPf nzp, negPf nzq) //=.
-  move=> ltpq; rewrite ltn_rmodp (negPf nzp) //=.
-  rewrite -(ltn_predK ltpq) /=; case: eqP => [->|].
+rewrite /rgcdp -/rgcdp_rec !ltn_rmodp (negPf nzp) (negPf nzq) /=.
+have [ltpq|leqp] := ltnP; rewrite !(negPf nzp, negPf nzq) //= polySpred //=.
+  have [->|nzqp] := eqVneq.
     by case: (size p) => [|[|s]]; rewrite /= rmodp0 (negPf nzp) // rmod0p eqxx.
-  move/eqP=> nzqp; rewrite (negPf nzp).
   apply: Irec => //; last by rewrite ltn_rmodp.
-    by rewrite -ltnS (ltn_predK ltpq) (leq_trans _ ltpq) ?leqW // ltn_rmodp.
+    by rewrite -ltnS -polySpred // (leq_trans _ ltpq) ?leqW // ltn_rmodp.
   by rewrite ltnW // ltn_rmodp.
-move=> leqp; rewrite ltn_rmodp (negPf nzq) //=.
-have p_gt0: size p > 0 by rewrite size_poly_gt0.
-rewrite -(prednK p_gt0) /=; case: eqP => [->|].
+have [->|nzpq] := eqVneq.
   by case: (size q) => [|[|s]]; rewrite /= rmodp0 (negPf nzq) // rmod0p eqxx.
-move/eqP=> nzpq; rewrite (negPf nzq).
 apply: Irec => //; last by rewrite ltn_rmodp.
-  by rewrite -ltnS (prednK p_gt0) (leq_trans _ leqp) // ltn_rmodp.
+  by rewrite -ltnS -polySpred // (leq_trans _ leqp) // ltn_rmodp.
 by rewrite ltnW // ltn_rmodp.
 Qed.
 
@@ -388,38 +355,35 @@ Variant comm_redivp_spec m d : nat * {poly R} * {poly R} -> Type :=
 
 Lemma comm_redivpP m d : comm_redivp_spec m d (redivp m d).
 Proof.
-rewrite unlock; case: (altP (d =P 0))=> [->| Hd].
+rewrite unlock; have [->|Hd] := eqVneq d 0.
   by constructor; rewrite !(simp, eqxx).
 have: GRing.comm d (lead_coef d)%:P -> m * (lead_coef d ^+ 0)%:P = 0 * d + m.
   by rewrite !simp.
-elim: (size m) 0%N 0 {1 4 6}m (leqnn (size m))=>
-   [|n IHn] k q r Hr /=.
-  have{Hr} ->: r = 0 by apply/eqP; rewrite -size_poly_eq0; move: Hr; case: size.
+elim: (size m) 0%N 0 {1 4 6}m (leqnn (size m)) => [|n IHn] k q r Hr /=.
+  move/size_poly_leq0P: Hr ->.
   suff hsd: size (0: {poly R}) < size d by rewrite hsd => /= ?; constructor.
-  by rewrite size_polyC eqxx (polySpred Hd).
-case: ltP=> Hlt Heq; first by constructor=> // _; apply/ltP.
-apply: IHn=> [|Cda]; last first.
+  by rewrite size_poly0 size_poly_gt0.
+case: ltnP => Hlt Heq; first by constructor.
+apply/IHn=> [|Cda]; last first.
   rewrite mulrDl addrAC -addrA subrK exprSr polyC_mul mulrA Heq //.
   by rewrite mulrDl -mulrA Cda mulrA.
-apply/leq_sizeP => j Hj.
-rewrite coefD coefN coefMC -scalerAl coefZ coefXnM.
-move/ltP: Hlt; rewrite -leqNgt=> Hlt.
+apply/leq_sizeP => j Hj; rewrite coefB coefMC -scalerAl coefZ coefXnM.
+rewrite ltn_subRL ltnNge (leq_trans Hr) /=; last first.
+  by apply: leq_ltn_trans Hj _; rewrite -add1n leq_add2r size_poly_gt0.
 move: Hj; rewrite leq_eqVlt; case/predU1P => [<-{j} | Hj]; last first.
-  rewrite nth_default ?(leq_trans Hqq) // ?simp; last by apply: (leq_trans Hr).
-  rewrite nth_default; first by rewrite if_same !simp oppr0.
+  rewrite !nth_default ?simp ?oppr0 ?(leq_trans Hr) //.
   by rewrite -{1}(subKn Hlt) leq_sub2r // (leq_trans Hr).
 move: Hr; rewrite leq_eqVlt ltnS; case/predU1P=> Hqq; last first.
-  rewrite !nth_default ?if_same ?simp ?oppr0 //.
-  by rewrite -{1}(subKn Hlt) leq_sub2r // (leq_trans Hqq).
-rewrite {2}/lead_coef Hqq polySpred // subSS ltnNge leq_subr /=.
-by rewrite subKn ?addrN // -subn1 leq_subLR add1n -Hqq.
+  by rewrite !nth_default ?simp ?oppr0 // -{1}(subKn Hlt) leq_sub2r.
+rewrite /lead_coef Hqq polySpred // subSS subKn ?addrN //.
+by rewrite -subn1 leq_subLR add1n -Hqq.
 Qed.
 
 Lemma rmodpp p : GRing.comm p (lead_coef p)%:P -> rmodp p p = 0.
 Proof.
-move=> hC; rewrite /rmodp unlock; case: ifP => hp /=; first by rewrite (eqP hp).
-move: (hp); rewrite -size_poly_eq0 /redivp_rec; case sp: (size p)=> [|n] // _.
-rewrite mul0r sp ltnn add0r subnn expr0 hC alg_polyC subrr.
+move=> hC; rewrite /rmodp unlock; have [-> //|] := eqVneq.
+rewrite -size_poly_eq0 /redivp_rec; case sp: (size p)=> [|n] // _.
+rewrite sp ltnn subnn expr0 hC alg_polyC !simp subrr.
 by case: n sp => [|n] sp; rewrite size_polyC /= eqxx.
 Qed.
 
@@ -459,18 +423,17 @@ Lemma redivp_eq q r :
     let c := (lead_coef d ^+ k)%:P in
   redivp (q * d + r) d = (k, q * c, r * c).
 Proof.
-move=> lt_rd; case: comm_redivpP=> k q1 r1; move/(_ Cdl)=> Heq.
-have: d != 0 by case: (size d) lt_rd (size_poly_eq0 d) => // n _ <-.
-move=> dn0; move/(_ dn0)=> Hs.
+move=> lt_rd; case: comm_redivpP=> k q1 r1 /(_ Cdl) Heq.
+have dn0: d != 0 by case: (size d) lt_rd (size_poly_eq0 d) => // n _ <-.
+move=> /(_ dn0) Hs.
 have eC : q * d * (lead_coef d ^+ k)%:P = q * (lead_coef d ^+ k)%:P * d.
-  by rewrite -mulrA polyC_exp (GRing.commrX k Cdl) mulrA.
+  by rewrite -mulrA polyC_exp (commrX k Cdl) mulrA.
 suff e1 : q1 = q * (lead_coef d ^+ k)%:P.
-  congr (_, _, _) => //=; move/eqP: Heq; rewrite [_ + r1]addrC.
-  rewrite -subr_eq; move/eqP<-; rewrite e1 mulrDl addrAC -{2}(add0r (r * _)).
-  by rewrite eC subrr add0r.
+  congr (_, _, _) => //=; move/eqP: Heq.
+  by rewrite [_ + r1]addrC -subr_eq e1 mulrDl addrAC eC subrr add0r; move/eqP.
 have : (q1 - q * (lead_coef d ^+ k)%:P) * d = r * (lead_coef d ^+ k)%:P - r1.
   apply: (@addIr _ r1); rewrite subrK.
-  apply: (@addrI _  ((q * (lead_coef d ^+ k)%:P) * d)).
+  apply: (@addrI _ ((q * (lead_coef d ^+ k)%:P) * d)).
   by rewrite mulrDl mulNr !addrA [_ + (q1 * d)]addrC addrK -eC -mulrDl.
 move/eqP; rewrite -[_ == _ - _]subr_eq0 rreg_div0 //.
   by case/andP; rewrite subr_eq0; move/eqP.
@@ -496,15 +459,14 @@ have Hnq0 := rreg_lead0 Rreg; set lq := lead_coef d.
 pose v := rscalp p d; pose m := maxn v k.
 rewrite /rdvdp -(rreg_polyMC_eq0 _ (@rregX _ _ (m - v) Rreg)).
 suff:
- ((rdivp p d) * (lq ^+ (m - v))%:P  - q1 * (lq ^+ (m - k))%:P) * d +
-  (rmodp p d) * (lq ^+ (m - v))%:P  == 0.
+ ((rdivp p d) * (lq ^+ (m - v))%:P - q1 * (lq ^+ (m - k))%:P) * d +
+  (rmodp p d) * (lq ^+ (m - v))%:P == 0.
   rewrite rreg_div0 //; first by case/andP.
-  by rewrite rreg_size ?ltn_rmodp //; apply rregX.
-rewrite mulrDl addrAC mulNr -!mulrA  polyC_exp -(GRing.commrX (m-v) Cdl).
+  by rewrite rreg_size ?ltn_rmodp //; exact: rregX.
+rewrite mulrDl addrAC mulNr -!mulrA polyC_exp -(commrX (m-v) Cdl).
 rewrite -polyC_exp mulrA -mulrDl -rdivp_eq // [(_ ^+ (m - k))%:P]polyC_exp.
-rewrite -(GRing.commrX (m-k) Cdl) -polyC_exp mulrA -he -!mulrA -!polyC_mul.
-rewrite -/v -!exprD addnC subnK ?leq_maxl //.
-by rewrite addnC subnK ?subrr ?leq_maxr.
+rewrite -(commrX (m-k) Cdl) -polyC_exp mulrA -he -!mulrA -!polyC_mul -/v.
+by rewrite -!exprD addnC subnK ?leq_maxl // addnC subnK ?subrr ?leq_maxr.
 Qed.
 
 Variant rdvdp_spec p q : {poly R} -> bool -> Type :=
@@ -523,27 +485,23 @@ Qed.
 Lemma rdvdp_mull p : rdvdp d (p * d).
 Proof. by apply: (@eq_rdvdp 0%N p); rewrite expr0 mulr1. Qed.
 
-Lemma rmodp_mull p : rmodp (p * d) d = 0.
-Proof.
-case: (d =P 0)=> Hd; first by rewrite Hd simp rmod0p.
-by apply/eqP; apply: rdvdp_mull.
-Qed.
+Lemma rmodp_mull p : rmodp (p * d) d = 0. Proof. exact/eqP/rdvdp_mull. Qed.
 
 Lemma rmodpp : rmodp d d = 0.
-Proof. by rewrite -{1}(mul1r d) rmodp_mull. Qed.
+Proof. by rewrite -[d in rmodp d _]mul1r rmodp_mull. Qed.
 
 Lemma rdivpp : rdivp d d = (lead_coef d ^+ rscalp d d)%:P.
+Proof.
 have dn0 : d != 0 by rewrite -lead_coef_eq0 rreg_neq0.
 move: (rdivp_eq d); rewrite rmodpp addr0.
 suff ->: GRing.comm d (lead_coef d ^+ rscalp d d)%:P by move/(rreg_lead Rreg)->.
 by rewrite polyC_exp; apply: commrX.
 Qed.
 
-Lemma rdvdpp : rdvdp d d.
-Proof. by apply/eqP; apply: rmodpp. Qed.
+Lemma rdvdpp : rdvdp d d. Proof. exact/eqP/rmodpp. Qed.
 
-Lemma rdivpK p : rdvdp d p -> 
-  (rdivp p d) * d = p * (lead_coef d ^+ rscalp p d)%:P.
+Lemma rdivpK p : rdvdp d p ->
+  rdivp p d * d = p * (lead_coef d ^+ rscalp p d)%:P.
 Proof. by rewrite rdivp_eq /rdvdp; move/eqP->; rewrite addr0. Qed.
 
 End ComRegDivisor.
@@ -565,18 +523,17 @@ Implicit Types p q r : {poly R}.
 Variable d : {poly R}.
 Hypothesis mond : d \is monic.
 
-Lemma redivp_eq q r :  size r < size d ->
+Lemma redivp_eq q r : size r < size d ->
   let k := (redivp (q * d + r) d).1.1 in
   redivp (q * d + r) d = (k, q, r).
 Proof.
-case: (monic_comreg mond)=> Hc Hr; move/(redivp_eq Hc Hr q).
+case: (monic_comreg mond)=> Hc Hr /(redivp_eq Hc Hr q).
 by rewrite (eqP mond) => -> /=; rewrite expr1n !mulr1.
 Qed.
 
-Lemma rdivp_eq p :
-  p = (rdivp p d) * d + (rmodp p d).
+Lemma rdivp_eq p : p = rdivp p d * d + rmodp p d.
 Proof.
-rewrite -rdivp_eq; rewrite (eqP mond); last exact: commr1.
+rewrite -rdivp_eq (eqP mond); last exact: commr1.
 by rewrite expr1n mulr1.
 Qed.
 
@@ -585,31 +542,28 @@ Proof.
 by case: (monic_comreg mond) => hc hr; rewrite rdivpp // (eqP mond) expr1n.
 Qed.
 
-Lemma rdivp_addl_mul_small q r :
-  size r < size d -> rdivp (q * d + r) d = q.
+Lemma rdivp_addl_mul_small q r : size r < size d -> rdivp (q * d + r) d = q.
 Proof.
 by move=> Hd; case: (monic_comreg mond)=> Hc Hr; rewrite /rdivp redivp_eq.
 Qed.
 
 Lemma rdivp_addl_mul q r : rdivp (q * d + r) d = q + rdivp r d.
 Proof.
-case: (monic_comreg mond)=> Hc Hr; rewrite {1}(rdivp_eq r) addrA.
+case: (monic_comreg mond)=> Hc Hr; rewrite [r in _ * _ + r]rdivp_eq addrA.
 by rewrite -mulrDl rdivp_addl_mul_small // ltn_rmodp monic_neq0.
 Qed.
 
-Lemma rdivp_addl q r :
-  rdvdp d q -> rdivp (q + r) d = rdivp q d + rdivp r d.
+Lemma rdivp_addl q r : rdvdp d q -> rdivp (q + r) d = rdivp q d + rdivp r d.
 Proof.
-case: (monic_comreg mond)=> Hc Hr; rewrite {1}(rdivp_eq r) addrA.
-rewrite {2}(rdivp_eq q); move/rmodp_eq0P->; rewrite addr0.
-by rewrite -mulrDl rdivp_addl_mul_small // ltn_rmodp monic_neq0.
+case: (monic_comreg mond)=> Hc Hr; rewrite [r in q + r]rdivp_eq addrA.
+rewrite [q in q + _ + _]rdivp_eq; move/rmodp_eq0P->.
+by rewrite addr0 -mulrDl rdivp_addl_mul_small // ltn_rmodp monic_neq0.
 Qed.
 
-Lemma rdivp_addr q r :
-  rdvdp d r -> rdivp (q + r) d = rdivp q d + rdivp r d.
+Lemma rdivp_addr q r : rdvdp d r -> rdivp (q + r) d = rdivp q d + rdivp r d.
 Proof. by rewrite addrC; move/rdivp_addl->; rewrite addrC. Qed.
 
-Lemma rdivp_mull p  : rdivp (p * d) d = p.
+Lemma rdivp_mull p : rdivp (p * d) d = p.
 Proof. by rewrite -[p * d]addr0 rdivp_addl_mul rdiv0p addr0. Qed.
 
 Lemma rmodp_mull p : rmodp (p * d) d = 0.
@@ -622,26 +576,21 @@ Proof.
 by apply: rmodpp; rewrite (eqP mond); [apply: commr1 | apply: rreg1].
 Qed.
 
-Lemma rmodp_addl_mul_small q r :
-  size r < size d -> rmodp (q * d + r) d = r.
+Lemma rmodp_addl_mul_small q r : size r < size d -> rmodp (q * d + r) d = r.
 Proof.
 by move=> Hd; case: (monic_comreg mond)=> Hc Hr; rewrite /rmodp redivp_eq.
 Qed.
 
 Lemma rmodp_add p q : rmodp (p + q) d = rmodp p d + rmodp q d.
 Proof.
-rewrite {1}(rdivp_eq p) {1}(rdivp_eq q).
-rewrite addrCA 2!addrA -mulrDl (addrC (rdivp q d)) -addrA.
+rewrite [p in LHS]rdivp_eq [q in LHS]rdivp_eq addrACA -mulrDl.
 rewrite rmodp_addl_mul_small //; apply: (leq_ltn_trans (size_add _ _)).
 by rewrite gtn_max !ltn_rmodp // monic_neq0.
 Qed.
 
 Lemma rmodp_mulmr p q : rmodp (p * (rmodp q d)) d = rmodp (p * q) d.
 Proof.
-have -> : rmodp q d = q - (rdivp q d) * d.
-  by rewrite {2}(rdivp_eq q) addrAC subrr add0r.
-rewrite mulrDr rmodp_add -mulNr mulrA.
-by rewrite -{2}[rmodp _ _]addr0; congr (_ + _); apply: rmodp_mull.
+by rewrite [q in RHS]rdivp_eq mulrDr rmodp_add mulrA rmodp_mull add0r.
 Qed.
 
 Lemma rdvdpp : rdvdp d d.
@@ -666,14 +615,12 @@ Qed.
 
 Lemma rdvdpP p : reflect (exists qq, p = qq * d) (rdvdp d p).
 Proof.
-case: (monic_comreg mond)=> Hc Hr; apply: (iffP idP).
-  case: rdvdp_eqP=> // k qq; rewrite (eqP mond) expr1n mulr1 => -> _.
-  by exists qq.
-by case=> [qq]; move/eq_rdvdp.
+case: (monic_comreg mond)=> Hc Hr; apply: (iffP idP) => [|[qq] /eq_rdvdp //].
+by case: rdvdp_eqP=> // k qq; rewrite (eqP mond) expr1n mulr1 => ->; exists qq.
 Qed.
 
 Lemma rdivpK p : rdvdp d p -> (rdivp p d) * d = p.
-Proof. by move=> dvddp; rewrite {2}[p]rdivp_eq rmodp_eq0 ?addr0. Qed.
+Proof. by move=> dvddp; rewrite [RHS]rdivp_eq rmodp_eq0 ?addr0. Qed.
 
 End MonicDivisor.
 End RingMonic.
@@ -690,20 +637,18 @@ Variable R : ringType.
 Implicit Types d p q r : {poly R}.
 
 Lemma rdivp1 p : rdivp p 1 = p.
-Proof. by rewrite -{1}(mulr1 p) rdivp_mull // monic1. Qed.
+Proof. by rewrite -[p in LHS]mulr1 rdivp_mull // monic1. Qed.
 
 Lemma rdvdp_XsubCl p x : rdvdp ('X - x%:P) p = root p x.
 Proof.
-have [HcX Hr] := (monic_comreg (monicXsubC x)).
-apply/rmodp_eq0P/factor_theorem; last first.
-  by case=> p1 ->; apply: rmodp_mull; apply: monicXsubC.
+have [HcX Hr] := monic_comreg (monicXsubC x).
+apply/rmodp_eq0P/factor_theorem => [|[p1 ->]]; last exact/rmodp_mull/monicXsubC.
 move=> e0; exists (rdivp p ('X - x%:P)).
-by rewrite {1}(rdivp_eq (monicXsubC x) p) e0 addr0.
+by rewrite [LHS](rdivp_eq (monicXsubC x)) e0 addr0.
 Qed.
 
 Lemma polyXsubCP p x : reflect (p.[x] = 0) (rdvdp ('X - x%:P) p).
 Proof. by apply: (iffP idP); rewrite rdvdp_XsubCl; move/rootP. Qed.
-
 
 Lemma root_factor_theorem p x : root p x = (rdvdp ('X - x%:P) p).
 Proof. by rewrite rdvdp_XsubCl. Qed.
@@ -729,7 +674,6 @@ Variant redivp_spec (m d : {poly R}) : nat * {poly R} * {poly R} -> Type :=
     (lead_coef d ^+ k) *: m = q * d + r &
    (d != 0 -> size r < size d) : redivp_spec m d (k, q, r).
 
-
 Lemma redivpP m d : redivp_spec m d (redivp m d).
 Proof.
 rewrite redivp_def; constructor; last by move=> dn0; rewrite ltn_rmodp.
@@ -737,22 +681,23 @@ by rewrite -mul_polyC mulrC rdivp_eq //= /GRing.comm mulrC.
 Qed.
 
 Lemma rdivp_eq d p :
-  (lead_coef d ^+ (rscalp p d)) *: p = (rdivp p d) * d + (rmodp p d).
+  (lead_coef d ^+ rscalp p d) *: p = rdivp p d * d + rmodp p d.
 Proof.
 by rewrite /rdivp /rmodp /rscalp; case: redivpP=> k q1 r1 Hc _; apply: Hc.
 Qed.
 
 Lemma rdvdp_eqP d p : rdvdp_spec p d (rmodp p d) (rdvdp d p).
 Proof.
-case hdvd: (rdvdp d p); last by apply: RdvdpN; move/rmodp_eq0P/eqP: hdvd.
+case hdvd: (rdvdp d p); last by move/rmodp_eq0P/eqP/RdvdpN: hdvd.
 move/rmodp_eq0P: (hdvd)->; apply: (@Rdvdp _ _ _ (rscalp p d) (rdivp p d)).
 by rewrite mulrC mul_polyC rdivp_eq; move/rmodp_eq0P: (hdvd)->; rewrite addr0.
 Qed.
 
 Lemma rdvdp_eq q p :
-  (rdvdp q p) = ((lead_coef q) ^+ (rscalp p q) *: p == (rdivp p q) * q).
-apply/rmodp_eq0P/eqP; rewrite rdivp_eq; first by move->; rewrite addr0.
-by move/eqP; rewrite eq_sym addrC -subr_eq subrr; move/eqP->.
+  rdvdp q p = (lead_coef q ^+ rscalp p q *: p == rdivp p q * q).
+Proof.
+rewrite rdivp_eq; apply/rmodp_eq0P/eqP => [->|/eqP]; first by rewrite addr0.
+by rewrite eq_sym addrC -subr_eq subrr; move/eqP<-.
 Qed.
 
 End CommutativeRingPseudoDivision.
@@ -769,10 +714,9 @@ Variable R : unitRingType.
 Implicit Type p q r d : {poly R}.
 
 Lemma uniq_roots_rdvdp p rs :
-  all (root p) rs -> uniq_roots rs ->
-  rdvdp (\prod_(z <- rs) ('X - z%:P)) p.
+  all (root p) rs -> uniq_roots rs -> rdvdp (\prod_(z <- rs) ('X - z%:P)) p.
 Proof.
-move=> rrs; case/(uniq_roots_prod_XsubC rrs)=> q ->.
+move=> rrs /(uniq_roots_prod_XsubC rrs) [q ->].
 exact/RingMonic.rdvdp_mull/monic_prod_XsubC.
 Qed.
 
@@ -802,8 +746,7 @@ Definition divp p q := ((edivp p q).1).2.
 Definition modp p q := (edivp p q).2.
 Definition scalp p q := ((edivp p q).1).1.
 Definition dvdp p q := modp q p == 0.
-Definition eqp p q :=  (dvdp p q) && (dvdp q p).
-
+Definition eqp p q := (dvdp p q) && (dvdp q p).
 
 End IDomainPseudoDivisionDefs.
 
@@ -822,46 +765,39 @@ Section WeakTheoryForIDomainPseudoDivision.
 Variable R : idomainType.
 Implicit Type p q r d : {poly R}.
 
-
 Lemma edivp_def p q : edivp p q = (scalp p q, divp p q, modp p q).
 Proof. by rewrite /scalp /divp /modp; case: (edivp p q) => [[]] /=. Qed.
 
-Lemma edivp_redivp p q : (lead_coef q \in GRing.unit) = false ->
+Lemma edivp_redivp p q : lead_coef q \in GRing.unit = false ->
   edivp p q = redivp p q.
 Proof. by move=> hu; rewrite unlock hu; case: (redivp p q) => [[? ?] ?]. Qed.
 
 Lemma divpE p q :
   p %/ q = if lead_coef q \in GRing.unit
-    then (lead_coef q)^-(rscalp p q) *: (rdivp p q)
+    then lead_coef q ^- rscalp p q *: rdivp p q
     else rdivp p q.
-Proof.
-by case ulcq: (lead_coef q \in GRing.unit); rewrite /divp unlock redivp_def ulcq.
-Qed.
+Proof. by case: ifP; rewrite /divp unlock redivp_def => ->. Qed.
 
 Lemma modpE p q :
   p %% q = if lead_coef q \in GRing.unit
-    then (lead_coef q)^-(rscalp p q) *: (rmodp p q)
+    then lead_coef q ^- rscalp p q *: (rmodp p q)
     else rmodp p q.
-Proof.
-by case ulcq: (lead_coef q \in GRing.unit); rewrite /modp unlock redivp_def ulcq.
-Qed.
+Proof. by case: ifP; rewrite /modp unlock redivp_def => ->. Qed.
 
 Lemma scalpE p q :
   scalp p q = if lead_coef q \in GRing.unit then 0%N else rscalp p q.
-Proof.
-by case h: (lead_coef q \in GRing.unit); rewrite /scalp unlock redivp_def h.
-Qed.
+Proof. by case: ifP; rewrite /scalp unlock redivp_def => ->. Qed.
 
 Lemma dvdpE p q : p %| q = rdvdp p q.
 Proof.
 rewrite /dvdp modpE /rdvdp; case ulcq: (lead_coef p \in GRing.unit)=> //.
-rewrite -[_ *: _ == 0]size_poly_eq0 size_scale ?size_poly_eq0 //.
+rewrite -[in LHS]size_poly_eq0 size_scale ?size_poly_eq0 //.
 by rewrite invr_eq0 expf_neq0 //; apply: contraTneq ulcq => ->; rewrite unitr0.
 Qed.
 
 Lemma lc_expn_scalp_neq0 p q : lead_coef q ^+ scalp p q != 0.
 Proof.
-case: (eqVneq q 0) => [->|nzq]; last by rewrite expf_neq0 ?lead_coef_eq0.
+have [->|nzq] := eqVneq q 0; last by rewrite expf_neq0 ?lead_coef_eq0.
 by rewrite /scalp 2!unlock /= eqxx lead_coef0 unitr0 /= oner_neq0.
 Qed.
 
@@ -899,46 +835,33 @@ Lemma edivp_eq d q r : size r < size d -> lead_coef d \in GRing.unit ->
 Proof.
 have hC : GRing.comm d (lead_coef d)%:P by apply: mulrC.
 move=> hsrd hu; rewrite unlock hu; case et: (redivp _ _) => [[s qq] rr].
-have cdn0 : lead_coef d != 0.
-  by move: hu; case d0: (lead_coef d == 0) => //; rewrite (eqP d0) unitr0.
-move: (et); rewrite RingComRreg.redivp_eq //; last by apply/rregP.
-rewrite et /=; case=> e1 e2; rewrite -!mul_polyC -!exprVn !polyC_exp.
-suff h x y: x * (lead_coef d ^+ s)%:P = y -> ((lead_coef d)^-1)%:P ^+ s * y = x.
-  by congr (_, _, _); apply: h.
-have hn0 : (lead_coef d)%:P ^+ s != 0 by apply: expf_neq0; rewrite polyC_eq0.
-move=> hh; apply: (mulfI hn0); rewrite mulrA -exprMn -polyC_mul divrr //.
-by rewrite expr1n mul1r -polyC_exp mulrC; apply: sym_eq.
+have cdn0 : lead_coef d != 0 by case: eqP hu => //= ->; rewrite unitr0.
+move: (et); rewrite RingComRreg.redivp_eq //; last exact/rregP.
+rewrite et /= mulrC (mulrC r) !mul_polyC; case=> <- <-.
+by rewrite !scalerA mulVr ?scale1r // unitrX.
 Qed.
 
-Lemma divp_eq  p q :
-    (lead_coef q ^+ (scalp p q)) *: p = (p %/ q) * q + (p %% q).
+Lemma divp_eq p q : (lead_coef q ^+ scalp p q) *: p = (p %/ q) * q + (p %% q).
 Proof.
 rewrite divpE modpE scalpE.
 case uq: (lead_coef q \in GRing.unit); last by rewrite rdivp_eq.
-rewrite expr0 scale1r; case: (altP (q =P 0)) => [-> | qn0].
-  rewrite mulr0 add0r lead_coef0 rmodp0 /rscalp unlock eqxx expr0 invr1.
-  by rewrite scale1r.
-have hn0 : (lead_coef q ^+ rscalp p q)%:P != 0.
-  by rewrite polyC_eq0 expf_neq0 // lead_coef_eq0.
-apply: (mulfI hn0).
-rewrite -scalerAl -scalerDr !mul_polyC scalerA mulrV ?unitrX //.
-by rewrite scale1r rdivp_eq.
+rewrite expr0 scale1r; have [->|qn0] := eqVneq q 0.
+  by rewrite lead_coef0 expr0n /rscalp unlock eqxx invr1 !scale1r rmodp0 !simp.
+by rewrite -scalerAl -scalerDr -rdivp_eq scalerA mulVr (scale1r, unitrX).
 Qed.
 
-
-Lemma dvdp_eq q p :
-  (q %| p) = ((lead_coef q) ^+ (scalp p q) *: p == (p %/ q) * q).
+Lemma dvdp_eq q p : (q %| p) = (lead_coef q ^+ scalp p q *: p == (p %/ q) * q).
 Proof.
 rewrite dvdpE rdvdp_eq scalpE divpE; case: ifP => ulcq //.
-rewrite expr0 scale1r; apply/eqP/eqP.
-  by rewrite -scalerAl; move<-; rewrite scalerA mulVr ?scale1r // unitrX.
-by move=> {2}->; rewrite scalerAl scalerA mulrV ?scale1r // unitrX.
+rewrite expr0 scale1r -scalerAl; apply/eqP/eqP => [<- | {2}->].
+  by rewrite scalerA mulVr ?scale1r // unitrX.
+by rewrite scalerA mulrV ?scale1r // unitrX.
 Qed.
 
-Lemma divpK d p : d %| p -> p %/ d * d = ((lead_coef d) ^+ (scalp p d)) *: p.
+Lemma divpK d p : d %| p -> p %/ d * d = (lead_coef d ^+ scalp p d) *: p.
 Proof. by rewrite dvdp_eq; move/eqP->. Qed.
 
-Lemma divpKC d p : d %| p -> d * (p %/ d) = ((lead_coef d) ^+ (scalp p d)) *: p.
+Lemma divpKC d p : d %| p -> d * (p %/ d) = (lead_coef d ^+ scalp p d) *: p.
 Proof. by move=> ?; rewrite mulrC divpK. Qed.
 
 Lemma dvdpP q p :
@@ -948,37 +871,32 @@ rewrite dvdp_eq; apply: (iffP eqP) => [e | [[c qq] cn0 e]].
   by exists (lead_coef q ^+ scalp p q, p %/ q) => //=.
 apply/eqP; rewrite -dvdp_eq dvdpE.
 have Ecc: c%:P != 0 by rewrite polyC_eq0.
-case: (eqVneq p 0) => [->|nz_p]; first by rewrite rdvdp0.
-pose p1 : {poly R} := lead_coef q ^+ rscalp p q  *: qq - c *: (rdivp p q).
-have E1: c *: (rmodp p q) = p1 * q.
-  rewrite mulrDl {1}mulNr -scalerAl -e scalerA mulrC -scalerA -scalerAl.
+have [->|nz_p] := eqVneq p 0; first by rewrite rdvdp0.
+pose p1 : {poly R} := lead_coef q ^+ rscalp p q *: qq - c *: (rdivp p q).
+have E1: c *: rmodp p q = p1 * q.
+  rewrite mulrDl mulNr -scalerAl -e scalerA mulrC -scalerA -scalerAl.
   by rewrite -scalerBr rdivp_eq addrC addKr.
-rewrite /dvdp; apply/idPn=> m_nz.
-have: p1 * q != 0 by rewrite -E1 -mul_polyC mulf_neq0 // -/(dvdp q p) dvdpE.
-rewrite mulf_eq0; case/norP=> p1_nz q_nz; have:= ltn_rmodp p q.
-rewrite q_nz -(size_scale _ cn0) E1 size_mul //.
-by rewrite polySpred // ltnNge leq_addl.
+suff: p1 * q == 0 by rewrite -E1 -mul_polyC mulf_eq0 (negPf Ecc).
+rewrite mulf_eq0; apply/norP; case=> p1_nz q_nz; have:= ltn_rmodp p q.
+by rewrite q_nz -(size_scale _ cn0) E1 size_mul // polySpred // ltnNge leq_addl.
 Qed.
 
-Lemma mulpK p q : q != 0 ->
-  p * q %/ q = lead_coef q ^+ scalp (p * q) q *: p.
+Lemma mulpK p q : q != 0 -> p * q %/ q = lead_coef q ^+ scalp (p * q) q *: p.
 Proof.
-move=> qn0; move/rregP: (qn0); apply; rewrite -scalerAl divp_eq.
+move=> qn0; apply: (rregP qn0); rewrite -scalerAl divp_eq.
 suff -> : (p * q) %% q = 0 by rewrite addr0.
 rewrite modpE RingComRreg.rmodp_mull ?scaler0 ?if_same //.
   by red; rewrite mulrC.
 by apply/rregP; rewrite lead_coef_eq0.
 Qed.
 
-Lemma mulKp p q : q != 0 ->
-  q * p %/ q = lead_coef q ^+ scalp (p * q) q *: p.
+Lemma mulKp p q : q != 0 -> q * p %/ q = lead_coef q ^+ scalp (p * q) q *: p.
 Proof. by move=> nzq; rewrite mulrC; apply: mulpK. Qed.
 
 Lemma divpp p : p != 0 -> p %/ p = (lead_coef p ^+ scalp p p)%:P.
 Proof.
-move=> np0; have := (divp_eq p p).
-suff -> : p %% p = 0.
-  by rewrite addr0; move/eqP; rewrite -mul_polyC (inj_eq (mulIf np0)); move/eqP.
+move=> np0; have := divp_eq p p.
+suff -> : p %% p = 0 by rewrite addr0 -mul_polyC; move/(mulIf np0).
 rewrite modpE Ring.rmodpp; last by red; rewrite mulrC.
 by rewrite scaler0 if_same.
 Qed.
@@ -1009,10 +927,9 @@ Qed.
 
 Lemma leq_divp p q : (size (p %/ q) <= size p).
 Proof.
-rewrite /divp unlock redivp_def /=; case: ifP=> /=; rewrite ?leq_rdivp //.
-move=> ulcq; rewrite size_scale ?leq_rdivp //.
-rewrite -exprVn expf_neq0 // invr_eq0.
-by move: ulcq; case lcq0: (lead_coef q == 0) => //; rewrite (eqP lcq0) unitr0.
+rewrite /divp unlock redivp_def /=; case: ifP => ulcq; rewrite ?leq_rdivp //=.
+rewrite size_scale ?leq_rdivp // -exprVn expf_neq0 // invr_eq0.
+by case: eqP ulcq => // ->; rewrite unitr0.
 Qed.
 
 Lemma div0p p : 0 %/ p = 0.
@@ -1062,42 +979,37 @@ Qed.
 
 Lemma modp_mull p q : (p * q) %% q = 0.
 Proof.
-case: (altP (q =P 0)) => [-> | nq0]; first by rewrite modp0 mulr0.
-have rlcq :  (GRing.rreg (lead_coef q)) by apply/rregP; rewrite lead_coef_eq0.
-have hC :  GRing.comm q (lead_coef q)%:P by red; rewrite mulrC.
+have [-> | nq0] := eqVneq q 0; first by rewrite modp0 mulr0.
+have rlcq : GRing.rreg (lead_coef q) by apply/rregP; rewrite lead_coef_eq0.
+have hC : GRing.comm q (lead_coef q)%:P by red; rewrite mulrC.
 by rewrite modpE; case: ifP => ulcq; rewrite RingComRreg.rmodp_mull // scaler0.
 Qed.
 
-Lemma modp_mulr d p : (d * p) %% d = 0.
-Proof. by rewrite mulrC modp_mull. Qed.
+Lemma modp_mulr d p : (d * p) %% d = 0. Proof. by rewrite mulrC modp_mull. Qed.
 
 Lemma modpp d : d %% d = 0.
-Proof. by rewrite -{1}(mul1r d) modp_mull. Qed.
+Proof. by rewrite -[d in d %% _]mul1r modp_mull. Qed.
 
 Lemma ltn_modp p q : (size (p %% q) < size q) = (q != 0).
 Proof.
-rewrite /modp unlock redivp_def /=; case: ifP=> /=; rewrite ?ltn_rmodp //.
-move=> ulcq; rewrite size_scale ?ltn_rmodp //.
-rewrite -exprVn expf_neq0 // invr_eq0.
-by move: ulcq; case lcq0: (lead_coef q == 0) => //; rewrite (eqP lcq0) unitr0.
+rewrite /modp unlock redivp_def /=; case: ifP=> ulcq; rewrite ?ltn_rmodp //=.
+rewrite size_scale ?ltn_rmodp // -exprVn expf_neq0 // invr_eq0.
+by case: eqP ulcq => // ->; rewrite unitr0.
 Qed.
 
 Lemma ltn_divpl d q p : d != 0 ->
    (size (q %/ d) < size p) = (size q < size (p * d)).
 Proof.
-move=> dn0; have sd : size d > 0 by rewrite size_poly_gt0 dn0.
+move=> dn0.
 have: (lead_coef d) ^+ (scalp q d) != 0 by apply: lc_expn_scalp_neq0.
-move/size_scale; move/(_ q)<-; rewrite divp_eq; case quo0 : (q %/ d == 0).
-  rewrite (eqP quo0) mul0r add0r size_poly0.
-  case p0 : (p == 0); first by rewrite (eqP p0) mul0r size_poly0 ltnn ltn0.
-  have sp : size p > 0 by rewrite size_poly_gt0 p0.
-  rewrite /= size_mul ?p0 // sp; apply: sym_eq; move/prednK:(sp)<-.
-  by rewrite addSn /= ltn_addl // ltn_modp.
+move/(size_scale q)<-; rewrite divp_eq; have [->|quo0] := eqVneq (q %/ d) 0.
+  rewrite mul0r add0r size_poly0 size_poly_gt0.
+  have [->|pn0] := eqVneq p 0; first by rewrite mul0r size_poly0 ltn0.
+  by rewrite size_mul // (polySpred pn0) addSn ltn_addl // ltn_modp.
 rewrite size_addl; last first.
-  rewrite size_mul ?quo0 //; move/negbT: quo0; rewrite -size_poly_gt0.
-  by move/prednK<-; rewrite addSn /= ltn_addl // ltn_modp.
-case: (altP (p =P 0)) => [-> | pn0]; first by rewrite mul0r size_poly0 !ltn0.
-by rewrite !size_mul ?quo0 //; move/prednK: sd<-; rewrite !addnS ltn_add2r.
+  by rewrite size_mul // (polySpred quo0) addSn /= ltn_addl // ltn_modp.
+have [->|pn0] := eqVneq p 0; first by rewrite mul0r size_poly0 !ltn0.
+by rewrite !size_mul ?quo0 // (polySpred dn0) !addnS ltn_add2r.
 Qed.
 
 Lemma leq_divpr d p q : d != 0 ->
@@ -1106,33 +1018,26 @@ Proof. by move=> dn0; rewrite leqNgt ltn_divpl // -leqNgt. Qed.
 
 Lemma divpN0 d p : d != 0 -> (p %/ d != 0) = (size d <= size p).
 Proof.
-move=> dn0; rewrite -{2}(mul1r d) -leq_divpr // size_polyC oner_eq0 /=.
-by rewrite size_poly_gt0.
+move=> dn0.
+by rewrite -[d in RHS]mul1r -leq_divpr // size_polyC oner_eq0 size_poly_gt0.
 Qed.
 
-Lemma size_divp p q : q != 0 -> size (p %/ q) = ((size p) - (size q).-1)%N.
+Lemma size_divp p q : q != 0 -> size (p %/ q) = (size p - (size q).-1)%N.
 Proof.
 move=> nq0; case: (leqP (size q) (size p)) => sqp; last first.
   move: (sqp); rewrite -{1}(ltn_predK sqp) ltnS -subn_eq0 divp_small //.
   by move/eqP->; rewrite size_poly0.
-move: (nq0); rewrite -size_poly_gt0 => lt0sq.
-move: (sqp); move/(leq_trans lt0sq) => lt0sp.
-move: (lt0sp); rewrite size_poly_gt0=> p0.
-move: (divp_eq p q); move/(congr1 (size \o (@polyseq R)))=> /=.
+have np0 : p != 0.
+  by rewrite -size_poly_gt0; apply: leq_trans sqp; rewrite size_poly_gt0.
+have /= := congr1 (size \o @polyseq R) (divp_eq p q).
 rewrite size_scale; last by rewrite expf_eq0 lead_coef_eq0 (negPf nq0) andbF.
-case: (eqVneq (p %/ q) 0) => [-> | qq0].
+have [->|qq0] := eqVneq (p %/ q) 0.
   by rewrite mul0r add0r=> es; move: nq0; rewrite -(ltn_modp p) -es ltnNge sqp.
-move/negP:(qq0); move/negP; rewrite -size_poly_gt0 => lt0qq.
 rewrite size_addl.
-  rewrite size_mul ?qq0 // => ->.
-  apply/eqP; rewrite -(eqn_add2r ((size q).-1)).
-  rewrite subnK; first by rewrite -subn1 addnBA // subn1.
-  rewrite /leq -(subnDl 1%N) !add1n prednK // (@ltn_predK (size q)) //.
-    by rewrite addnC subnDA subnn sub0n.
-  by rewrite -[size q]add0n ltn_add2r.
+  by move->; apply/eqP; rewrite size_mul // (polySpred nq0) addnS /= addnK.
 rewrite size_mul ?qq0 //.
-move: nq0; rewrite -(ltn_modp p); move/leq_trans; apply; move/prednK: lt0qq<-.
-by rewrite addSn /= leq_addl.
+move: nq0; rewrite -(ltn_modp p); move/leq_trans; apply.
+by rewrite (polySpred qq0) addSn /= leq_addl.
 Qed.
 
 Lemma ltn_modpN0 p q : q != 0 -> size (p %% q) < size q.
@@ -1140,39 +1045,36 @@ Proof. by rewrite ltn_modp. Qed.
 
 Lemma modp_mod p q : (p %% q) %% q = p %% q.
 Proof.
-by case: (eqVneq q 0) => [-> | qn0]; rewrite ?modp0 // modp_small ?ltn_modp.
+by have [->|qn0] := eqVneq q 0; rewrite ?modp0 // modp_small ?ltn_modp.
 Qed.
 
-Lemma leq_modp m d : size (m %% d)  <= size m.
+Lemma leq_modp m d : size (m %% d) <= size m.
 Proof.
 rewrite /modp unlock redivp_def /=; case: ifP; rewrite ?leq_rmodp //.
 move=> ud; rewrite size_scale ?leq_rmodp // invr_eq0 expf_neq0 //.
 by apply: contraTneq ud => ->; rewrite unitr0.
 Qed.
 
-Lemma dvdp0 d : d %| 0.
-Proof. by rewrite /dvdp mod0p. Qed.
+Lemma dvdp0 d : d %| 0. Proof. by rewrite /dvdp mod0p. Qed.
 
 Hint Resolve dvdp0 : core.
 
-Lemma dvd0p p : (0 %| p) = (p == 0).
-Proof. by rewrite /dvdp modp0. Qed.
+Lemma dvd0p p : (0 %| p) = (p == 0). Proof. by rewrite /dvdp modp0. Qed.
 
 Lemma dvd0pP p : reflect (p = 0) (0 %| p).
 Proof. by apply: (iffP idP); rewrite dvd0p; move/eqP. Qed.
 
 Lemma dvdpN0 p q : p %| q -> q != 0 -> p != 0.
-Proof. by move=> pq hq; apply: contraL pq=> /eqP ->; rewrite dvd0p. Qed.
+Proof. by move=> pq hq; apply: contraTneq pq => ->; rewrite dvd0p. Qed.
 
-Lemma dvdp1 d : (d %| 1) = ((size d) == 1%N).
+Lemma dvdp1 d : (d %| 1) = (size d == 1%N).
 Proof.
 rewrite /dvdp modpE; case ud: (lead_coef d \in GRing.unit); last exact: rdvdp1.
 rewrite -size_poly_eq0 size_scale; first by rewrite size_poly_eq0 -rdvdp1.
 by rewrite invr_eq0 expf_neq0 //; apply: contraTneq ud => ->; rewrite unitr0.
 Qed.
 
-Lemma dvd1p m : 1 %| m.
-Proof. by rewrite /dvdp modp1. Qed.
+Lemma dvd1p m : 1 %| m. Proof. by rewrite /dvdp modp1. Qed.
 
 Lemma gtNdvdp p q : p != 0 -> size p < size q -> (q %| p) = false.
 Proof.
@@ -1182,57 +1084,52 @@ Qed.
 Lemma modp_eq0P p q : reflect (p %% q = 0) (q %| p).
 Proof. exact: (iffP eqP). Qed.
 
-Lemma modp_eq0 p q : (q %| p) -> p %% q = 0.
-Proof. by move/modp_eq0P. Qed.
+Lemma modp_eq0 p q : (q %| p) -> p %% q = 0. Proof. exact: modp_eq0P. Qed.
 
 Lemma leq_divpl d p q :
   d %| p -> (size (p %/ d) <= size q) = (size p <= size (q * d)).
 Proof.
-case: (eqVneq d 0) => [-> | nd0].
-  by move/dvd0pP->; rewrite divp0 size_poly0 !leq0n.
-move=> hd; rewrite leq_eqVlt ltn_divpl // (leq_eqVlt (size p)).
+case: (eqVneq d 0) => [-> /dvd0pP -> | nd0 hd].
+  by rewrite divp0 size_poly0 !leq0n.
+rewrite leq_eqVlt ltn_divpl // (leq_eqVlt (size p)).
 case lhs: (size p < size (q * d)); rewrite ?orbT ?orbF //.
 have: (lead_coef d) ^+ (scalp p d) != 0 by rewrite expf_neq0 // lead_coef_eq0.
-move/size_scale; move/(_ p)<-; rewrite divp_eq.
-move/modp_eq0P: hd->; rewrite addr0; case: (altP (p %/ d =P 0))=> [-> | quon0].
-  rewrite mul0r size_poly0 eq_sym (eq_sym 0%N) size_poly_eq0.
-  case: (altP (q =P 0)) => [-> | nq0]; first by rewrite mul0r size_poly0 eqxx.
-  by rewrite size_poly_eq0 mulf_eq0 (negPf nq0) (negPf nd0).
-case: (altP (q =P 0)) => [-> | nq0].
+move/(size_scale p)<-; rewrite divp_eq; move/modp_eq0P: hd->; rewrite addr0.
+have [-> | quon0] := eqVneq (p %/ d) 0.
+  rewrite mul0r size_poly0 2!(eq_sym 0%N) !size_poly_eq0.
+  by rewrite mulf_eq0 (negPf nd0) orbF.
+have [-> | nq0] := eqVneq q 0.
   by rewrite mul0r size_poly0 !size_poly_eq0 mulf_eq0 (negPf nd0) orbF.
-rewrite !size_mul //; move: nd0; rewrite -size_poly_gt0; move/prednK<-.
-by rewrite !addnS /= eqn_add2r.
+by rewrite !size_mul // (polySpred nd0) !addnS /= eqn_add2r.
 Qed.
 
 Lemma dvdp_leq p q : q != 0 -> p %| q -> size p <= size q.
-move=> nq0 /modp_eq0P => rpq; case: (ltnP (size p) (size q)).
-   by move/ltnW->.
-rewrite leq_eqVlt; case/orP; first by move/eqP->.
-by move/modp_small; rewrite rpq => h; move: nq0; rewrite h eqxx.
+Proof.
+move=> nq0 /modp_eq0P.
+by case: ltngtP => // /modp_small -> /eqP; rewrite (negPf nq0).
 Qed.
 
 Lemma eq_dvdp c quo q p : c != 0 -> c *: p = quo * q -> q %| p.
 Proof.
 move=> cn0; case: (eqVneq p 0) => [->|nz_quo def_quo] //.
-pose p1 : {poly R} := lead_coef q ^+ scalp p q  *: quo - c *: (p %/ q).
+pose p1 : {poly R} := lead_coef q ^+ scalp p q *: quo - c *: (p %/ q).
 have E1: c *: (p %% q) = p1 * q.
-  rewrite mulrDl {1}mulNr-scalerAl -def_quo scalerA mulrC -scalerA.
+  rewrite mulrDl mulNr -scalerAl -def_quo scalerA mulrC -scalerA.
   by rewrite -scalerAl -scalerBr divp_eq addrAC subrr add0r.
 rewrite /dvdp; apply/idPn=> m_nz.
 have: p1 * q != 0 by rewrite -E1 -mul_polyC mulf_neq0 // polyC_eq0.
 rewrite mulf_eq0; case/norP=> p1_nz q_nz.
-have := (ltn_modp p q); rewrite q_nz -(size_scale (p %% q) cn0) E1.
+have := ltn_modp p q; rewrite q_nz -(size_scale (p %% q) cn0) E1.
 by rewrite size_mul // polySpred // ltnNge leq_addl.
 Qed.
 
-Lemma dvdpp d : d %| d.
-Proof. by rewrite /dvdp modpp. Qed.
+Lemma dvdpp d : d %| d. Proof. by rewrite /dvdp modpp. Qed.
 
 Hint Resolve dvdpp : core.
 
-Lemma divp_dvd p q : (p %| q) -> ((q %/ p) %| q).
+Lemma divp_dvd p q : p %| q -> (q %/ p) %| q.
 Proof.
-case: (eqVneq p 0) => [-> | np0]; first by rewrite divp0.
+have [-> | np0] := eqVneq p 0; first by rewrite divp0.
 rewrite dvdp_eq => /eqP h.
 apply: (@eq_dvdp ((lead_coef p)^+ (scalp q p)) p); last by rewrite mulrC.
 by rewrite expf_neq0 // lead_coef_eq0.
@@ -1240,7 +1137,7 @@ Qed.
 
 Lemma dvdp_mull m d n : d %| n -> d %| m * n.
 Proof.
-case: (eqVneq d 0) => [-> |dn0]; first by move/dvd0pP->; rewrite mulr0 dvdpp.
+case: (eqVneq d 0) => [-> /dvd0pP -> | dn0]; first by rewrite mulr0 dvdpp.
 rewrite dvdp_eq => /eqP e.
 apply: (@eq_dvdp (lead_coef d ^+ scalp n d) (m * (n %/ d))).
   by rewrite expf_neq0 // lead_coef_eq0.
@@ -1254,8 +1151,8 @@ Hint Resolve dvdp_mull dvdp_mulr : core.
 
 Lemma dvdp_mul d1 d2 m1 m2 : d1 %| m1 -> d2 %| m2 -> d1 * d2 %| m1 * m2.
 Proof.
-case: (eqVneq d1 0) => [-> |d1n0]; first by move/dvd0pP->; rewrite !mul0r dvdpp.
-case: (eqVneq d2 0) => [-> |d2n0]; first by move=> _ /dvd0pP ->; rewrite !mulr0.
+case: (eqVneq d1 0) => [-> /dvd0pP -> | d1n0]; first by rewrite !mul0r dvdpp.
+case: (eqVneq d2 0) => [-> _ /dvd0pP -> | d2n0]; first by rewrite !mulr0.
 rewrite dvdp_eq; set c1 := _ ^+ _; set q1 := _ %/ _; move/eqP=> Hq1.
 rewrite dvdp_eq; set c2 := _ ^+ _; set q2 := _ %/ _; move/eqP=> Hq2.
 apply: (@eq_dvdp (c1 * c2) (q1 * q2)).
@@ -1266,7 +1163,7 @@ Qed.
 
 Lemma dvdp_addr m d n : d %| m -> (d %| m + n) = (d %| n).
 Proof.
-case: (altP (d =P 0)) => [-> | dn0]; first by move/dvd0pP->; rewrite add0r.
+case: (eqVneq d 0) => [-> /dvd0pP -> | dn0]; first by rewrite add0r.
 rewrite dvdp_eq; set c1 := _ ^+ _; set q1 := _ %/ _; move/eqP=> Eq1.
 apply/idP/idP; rewrite dvdp_eq; set c2 := _ ^+ _; set q2 := _ %/ _.
   have sn0 : c1 * c2 != 0.
@@ -1277,7 +1174,7 @@ apply/idP/idP; rewrite dvdp_eq; set c2 := _ ^+ _; set q2 := _ %/ _.
 have sn0 : c1 * c2 != 0.
   by rewrite !mulf_neq0 // expf_eq0 lead_coef_eq0 (negPf dn0) andbF.
 move/eqP=> Eq2; apply: (@eq_dvdp _ (c1 *: q2 + c2 *: q1) _ _ sn0).
-by  rewrite mulrDl -!scalerAl -Eq1 -Eq2 !scalerA mulrC addrC scalerDr.
+by rewrite mulrDl -!scalerAl -Eq1 -Eq2 !scalerA mulrC addrC scalerDr.
 Qed.
 
 Lemma dvdp_addl n d m : d %| n -> (d %| m + n) = (d %| m).
@@ -1286,27 +1183,27 @@ Proof. by rewrite addrC; apply: dvdp_addr. Qed.
 Lemma dvdp_add d m n : d %| m -> d %| n -> d %| m + n.
 Proof. by move/dvdp_addr->. Qed.
 
-Lemma dvdp_add_eq  d m n : d %| m + n -> (d %| m) = (d %| n).
+Lemma dvdp_add_eq d m n : d %| m + n -> (d %| m) = (d %| n).
 Proof. by move=> ?; apply/idP/idP; [move/dvdp_addr <-| move/dvdp_addl <-]. Qed.
 
 Lemma dvdp_subr d m n : d %| m -> (d %| m - n) = (d %| n).
-Proof. by move=> ?; apply dvdp_add_eq; rewrite -addrA addNr simp. Qed.
+Proof. by move=> ?; apply: dvdp_add_eq; rewrite -addrA addNr simp. Qed.
 
-Lemma dvdp_subl  d m n : d %| n -> (d %| m - n) = (d %| m).
+Lemma dvdp_subl d m n : d %| n -> (d %| m - n) = (d %| m).
 Proof. by move/dvdp_addl<-; rewrite subrK. Qed.
 
-Lemma dvdp_sub  d m n : d %| m -> d %| n -> d %| m - n.
-Proof.  by move=> *; rewrite dvdp_subl. Qed.
+Lemma dvdp_sub d m n : d %| m -> d %| n -> d %| m - n.
+Proof. by move=> *; rewrite dvdp_subl. Qed.
 
 Lemma dvdp_mod d n m : d %| n -> (d %| m) = (d %| m %% n).
 Proof.
-case: (altP (n =P 0)) => [-> | nn0]; first by rewrite modp0.
-case: (altP (d =P 0)) => [-> | dn0]; first by move/dvd0pP->; rewrite modp0.
+have [-> | nn0] := eqVneq n 0; first by rewrite modp0.
+case: (eqVneq d 0) => [-> /dvd0pP -> | dn0]; first by rewrite modp0.
 rewrite dvdp_eq; set c1 := _ ^+ _; set q1 := _ %/ _; move/eqP=> Eq1.
 apply/idP/idP; rewrite dvdp_eq; set c2 := _ ^+ _; set q2 := _ %/ _.
   have sn0 : c1 * c2 != 0.
    by rewrite !mulf_neq0 // expf_eq0 lead_coef_eq0 (negPf dn0) andbF.
-  pose quo :=  (c1 * lead_coef n ^+ scalp m n) *: q2 - c2 *: (m %/ n) * q1.
+  pose quo := (c1 * lead_coef n ^+ scalp m n) *: q2 - c2 *: (m %/ n) * q1.
   move/eqP=> Eq2; apply: (@eq_dvdp _ quo _ _ sn0).
   rewrite mulrDl mulNr -!scalerAl -!mulrA -Eq1 -Eq2 -scalerAr !scalerA.
   rewrite mulrC [_ * c2]mulrC mulrA -[((_ * _) * _) *: _]scalerA -scalerBr.
@@ -1314,7 +1211,7 @@ apply/idP/idP; rewrite dvdp_eq; set c2 := _ ^+ _; set q2 := _ %/ _.
 have sn0 : c1 * c2 * lead_coef n ^+ scalp m n != 0.
   rewrite !mulf_neq0 // expf_eq0 lead_coef_eq0 ?(negPf dn0) ?andbF //.
   by rewrite (negPf nn0) andbF.
-move/eqP=> Eq2; apply: (@eq_dvdp _ (c2 *: (m  %/ n) * q1 + c1 *: q2) _ _ sn0).
+move/eqP=> Eq2; apply: (@eq_dvdp _ (c2 *: (m %/ n) * q1 + c1 *: q2) _ _ sn0).
 rewrite -scalerA divp_eq scalerDr -!scalerA Eq2 scalerAl scalerAr Eq1.
 by rewrite scalerAl mulrDl mulrA.
 Qed.
@@ -1322,35 +1219,32 @@ Qed.
 Lemma dvdp_trans : transitive (@dvdp R).
 Proof.
 move=> n d m.
-case: (altP (d =P 0)) => [-> | dn0]; first by move/dvd0pP->.
-case: (altP (n =P 0)) => [-> | nn0]; first by move=> _ /dvd0pP ->.
+case: (eqVneq d 0) => [-> /dvd0pP -> // | dn0].
+case: (eqVneq n 0) => [-> _ /dvd0pP -> // | nn0].
 rewrite dvdp_eq; set c1 := _ ^+ _; set q1 := _ %/ _; move/eqP=> Hq1.
 rewrite dvdp_eq; set c2 := _ ^+ _; set q2 := _ %/ _; move/eqP=> Hq2.
 have sn0 : c1 * c2 != 0 by rewrite mulf_neq0 // expf_neq0 // lead_coef_eq0.
 by apply: (@eq_dvdp _ (q2 * q1) _ _ sn0); rewrite -scalerA Hq2 scalerAr Hq1 mulrA.
 Qed.
 
-Lemma dvdp_mulIl p q : p %| p * q.
-Proof. by apply: dvdp_mulr; apply: dvdpp. Qed.
+Lemma dvdp_mulIl p q : p %| p * q. Proof. exact/dvdp_mulr/dvdpp. Qed.
 
-Lemma dvdp_mulIr p q : q %| p * q.
-Proof. by apply: dvdp_mull; apply: dvdpp. Qed.
+Lemma dvdp_mulIr p q : q %| p * q. Proof. exact/dvdp_mull/dvdpp. Qed.
 
 Lemma dvdp_mul2r r p q : r != 0 -> (p * r %| q * r) = (p %| q).
 Proof.
 move=> nzr.
-case: (eqVneq p 0) => [-> | pn0].
+have [-> | pn0] := eqVneq p 0.
   by rewrite mul0r !dvd0p mulf_eq0 (negPf nzr) orbF.
-case: (eqVneq q 0) => [-> | qn0]; first by rewrite mul0r !dvdp0.
+have [-> | qn0] := eqVneq q 0; first by rewrite mul0r !dvdp0.
 apply/idP/idP; last by move=> ?; rewrite dvdp_mul ?dvdpp.
 rewrite dvdp_eq; set c := _ ^+ _; set x := _ %/ _; move/eqP=> Hx.
-apply: (@eq_dvdp c x).
-  by rewrite expf_neq0 // lead_coef_eq0 mulf_neq0.
-by apply: (GRing.mulIf nzr); rewrite -GRing.mulrA -GRing.scalerAl.
+apply: (@eq_dvdp c x); first by rewrite expf_neq0 // lead_coef_eq0 mulf_neq0.
+by apply: (mulIf nzr); rewrite -mulrA -scalerAl.
 Qed.
 
 Lemma dvdp_mul2l r p q: r != 0 -> (r * p %| r * q) = (p %| q).
-Proof. by rewrite ![r * _]GRing.mulrC; apply: dvdp_mul2r. Qed.
+Proof. by rewrite ![r * _]mulrC; apply: dvdp_mul2r. Qed.
 
 Lemma ltn_divpr d p q :
   d %| q -> (size p < size (q %/ d)) = (size (p * d) < size q).
@@ -1360,11 +1254,9 @@ Lemma dvdp_exp d k p : 0 < k -> d %| p -> d %| (p ^+ k).
 Proof. by case: k => // k _ d_dv_m; rewrite exprS dvdp_mulr. Qed.
 
 Lemma dvdp_exp2l d k l : k <= l -> d ^+ k %| d ^+ l.
-Proof.
-by move/subnK <-; rewrite exprD dvdp_mull // ?lead_coef_exp ?unitrX.
-Qed.
+Proof. by move/subnK <-; rewrite exprD dvdp_mull // ?lead_coef_exp ?unitrX. Qed.
 
-Lemma dvdp_Pexp2l  d k l : 1 < size d -> (d ^+ k %| d ^+ l) = (k <= l).
+Lemma dvdp_Pexp2l d k l : 1 < size d -> (d ^+ k %| d ^+ l) = (k <= l).
 Proof.
 move=> sd; case: leqP => [|gt_n_m]; first exact: dvdp_exp2l.
 have dn0 : d != 0 by rewrite -size_poly_gt0; apply: ltn_trans sd.
@@ -1375,7 +1267,7 @@ Qed.
 
 Lemma dvdp_exp2r p q k : p %| q -> p ^+ k %| q ^+ k.
 Proof.
-case: (eqVneq p 0) => [-> | pn0]; first by move/dvd0pP->.
+case: (eqVneq p 0) => [-> /dvd0pP -> // | pn0].
 rewrite dvdp_eq; set c := _ ^+ _; set t := _ %/ _; move/eqP=> e.
 apply: (@eq_dvdp (c ^+ k) (t ^+ k)); first by rewrite !expf_neq0 ?lead_coef_eq0.
 by rewrite -exprMn -exprZn; congr (_ ^+ k).
@@ -1384,17 +1276,10 @@ Qed.
 Lemma dvdp_exp_sub p q k l: p != 0 ->
   (p ^+ k %| q * p ^+ l) = (p ^+ (k - l) %| q).
 Proof.
-move=> pn0; case: (leqP k l)=> hkl.
+move=> pn0; case: (leqP k l)=> [|/ltnW] hkl.
   move: (hkl); rewrite -subn_eq0; move/eqP->; rewrite expr0 dvd1p.
-  apply: dvdp_mull; case: (ltnP 1%N (size p)) => sp.
-    by rewrite dvdp_Pexp2l.
-  move: sp; case esp: (size p) => [|sp].
-    by move/eqP: esp; rewrite size_poly_eq0 (negPf pn0).
-  rewrite ltnS leqn0; move/eqP=> sp0; move/eqP: esp; rewrite sp0.
-  by case/size_poly1P => c cn0 ->; move/subnK: hkl<-; rewrite exprD dvdp_mulIr.
-rewrite -{1}[k](@subnK l) 1?ltnW// exprD dvdp_mul2r//.
-elim: l {hkl}=> [|l ihl]; first by rewrite expr0 oner_eq0.
-by rewrite exprS mulf_neq0.
+  exact/dvdp_mull/dvdp_exp2l.
+by rewrite -[in LHS](subnK hkl) exprD dvdp_mul2r // expf_eq0 (negPf pn0) andbF.
 Qed.
 
 Lemma dvdp_XsubCl p x : ('X - x%:P) %| p = root p x.
@@ -1417,12 +1302,11 @@ move=> rrs; case/(uniq_roots_prod_XsubC rrs)=> q ->.
 by apply: dvdp_mull; rewrite // (eqP (monic_prod_XsubC _)) unitr1.
 Qed.
 
-
-Lemma root_bigmul : forall x (ps : seq {poly R}),
+Lemma root_bigmul x (ps : seq {poly R}) :
   ~~root (\big[*%R/1]_(p <- ps) p) x = all (fun p => ~~ root p x) ps.
 Proof.
-move=> x; elim; first by rewrite big_nil root1.
-by move=> p ps ihp; rewrite big_cons /= rootM negb_or ihp.
+elim: ps => [|p ps ihp]; first by rewrite big_nil root1.
+by rewrite big_cons /= rootM negb_or ihp.
 Qed.
 
 Lemma eqpP m n :
@@ -1432,11 +1316,11 @@ Proof.
 apply: (iffP idP) => [| [[c1 c2]/andP[nz_c1 nz_c2 eq_cmn]]]; last first.
   rewrite /eqp (@eq_dvdp c2 c1%:P) -?eq_cmn ?mul_polyC // (@eq_dvdp c1 c2%:P) //.
   by rewrite eq_cmn mul_polyC.
-case: (eqVneq m 0) => [-> | m_nz].
-  by case/andP => /dvd0pP -> _; exists (1, 1); rewrite ?scaler0 // oner_eq0.
-case: (eqVneq n 0) => [-> | n_nz].
-  by case/andP => _ /dvd0pP ->; exists (1, 1); rewrite ?scaler0 // oner_eq0.
-case/andP; rewrite !dvdp_eq; set c1 := _ ^+ _; set c2 := _ ^+ _.
+case: (eqVneq m 0) => [-> /andP [/dvd0pP -> _] | m_nz].
+  by exists (1, 1); rewrite ?scaler0 // oner_eq0.
+case: (eqVneq n 0) => [-> /andP [_ /dvd0pP ->] | n_nz /andP []].
+  by exists (1, 1); rewrite ?scaler0 // oner_eq0.
+rewrite !dvdp_eq; set c1 := _ ^+ _; set c2 := _ ^+ _.
 set q1 := _ %/ _; set q2 := _ %/ _; move/eqP => Hq1 /eqP Hq2;
 have Hc1 : c1 != 0 by rewrite expf_eq0 lead_coef_eq0 negb_and m_nz orbT.
 have Hc2 : c2 != 0 by rewrite expf_eq0 lead_coef_eq0 negb_and n_nz orbT.
@@ -1448,7 +1332,7 @@ rewrite mulf_eq0; case/norP=> nz_q1 nz_q2.
 have: size q2 <= 1%N.
   have:= size_mul nz_q1 nz_q2; rewrite def_q12 size_polyC mulf_neq0 //=.
   by rewrite polySpred // => ->; rewrite leq_addl.
-rewrite leq_eqVlt ltnS leqn0 size_poly_eq0 (negPf nz_q2) orbF.
+rewrite leq_eqVlt ltnS size_poly_leq0 (negPf nz_q2) orbF.
 case/size_poly1P=> c cn0 cqe; exists (c2, c); first by rewrite Hc2.
 by rewrite Hq2 -mul_polyC -cqe.
 Qed.
@@ -1458,12 +1342,10 @@ Proof.
 move=> /eqpP [[c1 c2] /= /andP [nz_c1 nz_c2]] eq.
 have/(congr1 lead_coef) := eq; rewrite !lead_coefZ.
 move=> eqC; apply/(@mulfI _ c2%:P); rewrite ?polyC_eq0 //.
-rewrite !mul_polyC scalerA -eqC mulrC -scalerA eq.
-by rewrite !scalerA mulrC.
+by rewrite !mul_polyC scalerA -eqC mulrC -scalerA eq !scalerA mulrC.
 Qed.
 
-Lemma eqpxx : reflexive (@eqp R).
-Proof. by move=> p; rewrite /eqp dvdpp. Qed.
+Lemma eqpxx : reflexive (@eqp R). Proof. by move=> p; rewrite /eqp dvdpp. Qed.
 
 Hint Resolve eqpxx : core.
 
@@ -1478,23 +1360,22 @@ Qed.
 
 Lemma eqp_ltrans : left_transitive (@eqp R).
 Proof.
-move=> p q r pq.
-by apply/idP/idP=> e; apply: eqp_trans e; rewrite // eqp_sym.
+by move=> p q r pq; apply/idP/idP; apply: eqp_trans; rewrite // eqp_sym.
 Qed.
 
 Lemma eqp_rtrans : right_transitive (@eqp R).
 Proof. by move=> x y xy z; rewrite eqp_sym (eqp_ltrans xy) eqp_sym. Qed.
 
-Lemma eqp0 : forall p, (p %= 0) = (p == 0).
+Lemma eqp0 p : (p %= 0) = (p == 0).
 Proof.
-move=> p; case: eqP; move/eqP=> Ep; first by rewrite (eqP Ep) eqpxx.
-by apply/negP; case/andP=> _; rewrite /dvdp modp0 (negPf Ep).
+have [->|Ep] := eqVneq; first by rewrite ?eqpxx.
+by apply/negP => /andP [_]; rewrite /dvdp modp0 (negPf Ep).
 Qed.
 
 Lemma eqp01 : 0 %= (1 : {poly R}) = false.
 Proof.
-case abs : (0 %= 1) => //; case/eqpP: abs=> [[c1 c2]] /andP [c1n0 c2n0] /=.
-by rewrite scaler0 alg_polyC; move/eqP; rewrite eq_sym polyC_eq0 (negbTE c2n0).
+case: eqpP => // -[[c1 c2]] /andP [c1n0 c2n0] /= /esym /eqP.
+by rewrite scaler0 alg_polyC polyC_eq0 (negPf c2n0).
 Qed.
 
 Lemma eqp_scale p c : c != 0 -> c *: p %= p.
@@ -1505,9 +1386,8 @@ Qed.
 
 Lemma eqp_size p q : p %= q -> size p = size q.
 Proof.
-case: (q =P 0); move/eqP => Eq; first by rewrite (eqP Eq) eqp0; move/eqP->.
-rewrite eqp_sym; case: (p =P 0); move/eqP => Ep.
-  by rewrite (eqP Ep) eqp0; move/eqP->.
+have [->|Eq] := eqVneq q 0; first by rewrite eqp0; move/eqP->.
+rewrite eqp_sym; have [->|Ep] := eqVneq p 0; first by rewrite eqp0; move/eqP->.
 by case/andP => Dp Dq; apply: anti_leq; rewrite !dvdp_leq.
 Qed.
 
@@ -1515,7 +1395,7 @@ Lemma size_poly_eq1 p : (size p == 1%N) = (p %= 1).
 Proof.
 apply/size_poly1P/idP=> [[c cn0 ep] |].
   by apply/eqpP; exists (1, c); rewrite ?oner_eq0 // alg_polyC scale1r.
-by move/eqp_size; rewrite size_poly1; move/eqP; move/size_poly1P.
+by move/eqp_size; rewrite size_poly1; move/eqP/size_poly1P.
 Qed.
 
 Lemma polyXsubC_eqp1 (x : R) : ('X - x%:P %= 1) = false.
@@ -1525,11 +1405,9 @@ Lemma dvdp_eqp1 p q : p %| q -> q %= 1 -> p %= 1.
 Proof.
 move=> dpq hq.
 have sizeq : size q == 1%N by rewrite size_poly_eq1.
-have n0q : q != 0.
-  by case abs: (q == 0) => //; move: hq; rewrite (eqP abs) eqp01.
-rewrite -size_poly_eq1 eqn_leq -{1}(eqP sizeq) dvdp_leq //=.
-case p0 : (size p == 0%N); last by rewrite neq0_lt0n.
-by move: dpq; rewrite size_poly_eq0 in p0; rewrite (eqP p0) dvd0p (negbTE n0q).
+have n0q : q != 0 by case: eqP hq => // ->; rewrite eqp01.
+rewrite -size_poly_eq1 eqn_leq -{1}(eqP sizeq) dvdp_leq //= size_poly_gt0.
+by apply/eqP => p0; move: dpq n0q; rewrite p0 dvd0p => ->.
 Qed.
 
 Lemma eqp_dvdr q p d: p %= q -> d %| p = (d %| q).
@@ -1546,10 +1424,10 @@ by rewrite /eqp; case/andP=> dd' d'd dp; apply: (dvdp_trans d'd).
 Qed.
 
 Lemma dvdp_scaler c m n : c != 0 -> m %| c *: n = (m %| n).
-Proof. by move=> cn0; apply: eqp_dvdr; apply: eqp_scale. Qed.
+Proof. by move=> cn0; exact/eqp_dvdr/eqp_scale. Qed.
 
 Lemma dvdp_scalel c m n : c != 0 -> (c *: m %| n) = (m %| n).
-Proof. by move=> cn0; apply: eqp_dvdl; apply: eqp_scale. Qed.
+Proof. by move=> cn0; exact/eqp_dvdl/eqp_scale. Qed.
 
 Lemma dvdp_opp d p : d %| (- p) = (d %| p).
 Proof. by apply: eqp_dvdr; rewrite -scaleN1r eqp_scale ?oppr_eq0 ?oner_eq0. Qed.
@@ -1560,16 +1438,16 @@ Proof. by move=> nz_r; rewrite /eqp !dvdp_mul2r. Qed.
 Lemma eqp_mul2l r p q: r != 0 -> (r * p %= r * q) = (p %= q).
 Proof. by move=> nz_r; rewrite /eqp !dvdp_mul2l. Qed.
 
-Lemma eqp_mull r p q: (q %= r) -> (p * q %= p * r).
+Lemma eqp_mull r p q: q %= r -> p * q %= p * r.
 Proof.
 case/eqpP=> [[c d]] /andP [c0 d0 e]; apply/eqpP; exists (c, d); rewrite ?c0 //.
 by rewrite scalerAr e -scalerAr.
 Qed.
 
-Lemma eqp_mulr q p r : (p %= q) -> (p * r %= q * r).
+Lemma eqp_mulr q p r : p %= q -> p * r %= q * r.
 Proof. by move=> epq; rewrite ![_ * r]mulrC eqp_mull. Qed.
 
-Lemma eqp_exp  p q k : p %= q -> p ^+ k %= q ^+ k.
+Lemma eqp_exp p q k : p %= q -> p ^+ k %= q ^+ k.
 Proof.
 move=> pq; elim: k=> [|k ihk]; first by rewrite !expr0 eqpxx.
 by rewrite !exprS (@eqp_trans (q * p ^+ k)) // (eqp_mulr, eqp_mull).
@@ -1578,8 +1456,8 @@ Qed.
 Lemma polyC_eqp1 (c : R) : (c%:P %= 1) = (c != 0).
 Proof.
 apply/eqpP/idP => [[[x y]] |nc0] /=.
-  case c0: (c == 0); rewrite // alg_polyC (eqP c0) scaler0.
-  by case/andP=> _ /=; move/negbTE<-; move/eqP; rewrite eq_sym polyC_eq0.
+  case: (eqVneq c) => [->|] //= /andP [_] /negPf <- /eqP.
+  by rewrite alg_polyC scaler0 eq_sym polyC_eq0.
 exists (1, c); first by rewrite nc0 /= oner_neq0.
 by rewrite alg_polyC scale1r.
 Qed.
@@ -1590,14 +1468,13 @@ Proof. by move/eqp_dvdl->; rewrite dvd1p. Qed.
 Lemma dvdp_size_eqp p q : p %| q -> size p == size q = (p %= q).
 Proof.
 move=> pq; apply/idP/idP; last by move/eqp_size->.
-case (q =P 0)=> [->|]; [|move/eqP => Hq].
-  by rewrite size_poly0 size_poly_eq0; move/eqP->; rewrite eqpxx.
-case (p =P 0)=> [->|]; [|move/eqP => Hp].
-  by rewrite size_poly0 eq_sym size_poly_eq0; move/eqP->; rewrite eqpxx.
+have [->|Hq] := eqVneq q 0; first by rewrite size_poly0 size_poly_eq0 eqp0.
+have [->|Hp] := eqVneq p 0.
+  by rewrite size_poly0 eq_sym size_poly_eq0 eqp_sym eqp0.
 move: pq; rewrite dvdp_eq; set c := _ ^+ _; set x := _ %/ _; move/eqP=> eqpq.
-move: (eqpq); move/(congr1 (size \o (@polyseq R)))=> /=.
-have cn0 : c != 0 by  rewrite expf_neq0 // lead_coef_eq0.
-rewrite (@eqp_size _ q); last  by apply: eqp_scale.
+have /= := congr1 (size \o @polyseq R) eqpq.
+have cn0 : c != 0 by rewrite expf_neq0 // lead_coef_eq0.
+rewrite (@eqp_size _ q); last exact: eqp_scale.
 rewrite size_mul ?p0 // => [-> HH|]; last first.
   apply/eqP=> HH; move: eqpq; rewrite HH mul0r.
   by move/eqP; rewrite scale_poly_eq0 (negPf Hq) (negPf cn0).
@@ -1611,8 +1488,7 @@ Qed.
 Lemma eqp_root p q : p %= q -> root p =1 root q.
 Proof.
 move/eqpP=> [[c d]] /andP [c0 d0 e] x; move/negPf:c0=>c0; move/negPf:d0=>d0.
-rewrite rootE -[_==_]orFb -c0 -mulf_eq0 -hornerZ e hornerZ.
-by rewrite mulf_eq0 d0.
+by rewrite rootE -[_==_]orFb -c0 -mulf_eq0 -hornerZ e hornerZ mulf_eq0 d0.
 Qed.
 
 Lemma eqp_rmod_mod p q : rmodp p q %= modp p q.
@@ -1632,7 +1508,7 @@ Lemma dvd_eqp_divl d p q (dvd_dp : d %| q) (eq_pq : p %= q) :
   p %/ d %= q %/ d.
 Proof.
 case: (eqVneq q 0) eq_pq=> [->|q_neq0]; first by rewrite eqp0=> /eqP->.
-have d_neq0: d != 0 by apply: contraL dvd_dp=> /eqP->; rewrite dvd0p.
+have d_neq0: d != 0 by apply: contraTneq dvd_dp=> ->; rewrite dvd0p.
 move=> eq_pq; rewrite -(@eqp_mul2r d) // !divpK // ?(eqp_dvdr _ eq_pq) //.
 rewrite (eqp_ltrans (eqp_scale _ _)) ?lc_expn_scalp_neq0 //.
 by rewrite (eqp_rtrans (eqp_scale _ _)) ?lc_expn_scalp_neq0.
@@ -1659,7 +1535,7 @@ Qed.
 Lemma gcdp0 : right_id 0 gcdp.
 Proof.
 move=> p; have:= gcd0p p; rewrite /gcdp /gcdp_rec size_poly0 size_poly_gt0.
-by rewrite if_neg; case: ifP => /= p0; rewrite ?(eqxx, p0) // (eqP p0).
+by case: eqVneq => //= ->; rewrite eqxx.
 Qed.
 
 Lemma gcdpE p q :
@@ -1673,54 +1549,44 @@ pose gcdpE_rec := fix gcdpE_rec (n : nat) (pp qq : {poly R}) {struct n} :=
 have Irec: forall k l p q, size q <= k -> size q <= l
       -> size q < size p -> gcdpE_rec k p q = gcdpE_rec l p q.
 + elim=> [|m Hrec] [|n] //= p1 q1.
-  - rewrite leqn0 size_poly_eq0; move/eqP=> -> _.
-    rewrite size_poly0 size_poly_gt0 modp0 => nzp.
-    by rewrite (negPf nzp); case: n => [|n] /=; rewrite mod0p eqxx.
-  - rewrite leqn0 size_poly_eq0 => _; move/eqP=> ->.
-    rewrite size_poly0 size_poly_gt0 modp0 => nzp.
-    by rewrite (negPf nzp); case: m {Hrec} => [|m] /=; rewrite mod0p eqxx.
-  case: ifP => Epq Sm Sn Sq //; rewrite ?Epq //.
-  case: (eqVneq q1 0) => [->|nzq].
+  - move/size_poly_leq0P=> -> _; rewrite size_poly0 size_poly_gt0 modp0.
+    by move/negPf ->; case: n => [|n] /=; rewrite mod0p eqxx.
+  - move=> _ /size_poly_leq0P ->; rewrite size_poly0 size_poly_gt0 modp0.
+    by move/negPf ->; case: m {Hrec} => [|m] /=; rewrite mod0p eqxx.
+  case: eqP => Epq Sm Sn Sq //; have [->|nzq] := eqVneq q1 0.
     by case: n m {Sm Sn Hrec} => [|m] [|n] //=; rewrite mod0p eqxx.
   apply: Hrec; last by rewrite ltn_modp.
     by rewrite -ltnS (leq_trans _ Sm) // ltn_modp.
   by rewrite -ltnS (leq_trans _ Sn) // ltn_modp.
-case: (eqVneq p 0) => [-> | nzp].
-  by rewrite mod0p modp0 gcd0p gcdp0 if_same.
-case: (eqVneq q 0) => [-> | nzq].
-  by rewrite mod0p modp0 gcd0p gcdp0 if_same.
-rewrite /gcdp /gcdp_rec.
-case: ltnP; rewrite (negPf nzp, negPf nzq) //=.
-  move=> ltpq; rewrite ltn_modp (negPf nzp) //=.
-  rewrite -(ltn_predK ltpq) /=; case: eqP => [->|].
+have [->|nzp] := eqVneq p 0; first by rewrite mod0p modp0 gcd0p gcdp0 if_same.
+have [->|nzq] := eqVneq q 0; first by rewrite mod0p modp0 gcd0p gcdp0 if_same.
+rewrite /gcdp /gcdp_rec !ltn_modp !(negPf nzp, negPf nzq) /=.
+have [ltpq|leqp] := ltnP; rewrite !(negPf nzp, negPf nzq) /= polySpred //.
+  have [->|nzqp] := eqVneq.
     by case: (size p) => [|[|s]]; rewrite /= modp0 (negPf nzp) // mod0p eqxx.
-  move/eqP=> nzqp; rewrite (negPf nzp).
   apply: Irec => //; last by rewrite ltn_modp.
-    by rewrite -ltnS (ltn_predK ltpq) (leq_trans _ ltpq) ?leqW // ltn_modp.
+    by rewrite -ltnS -polySpred // (leq_trans _ ltpq) ?leqW // ltn_modp.
   by rewrite ltnW // ltn_modp.
-move=> leqp; rewrite ltn_modp (negPf nzq) //=.
-have p_gt0: size p > 0 by rewrite size_poly_gt0.
-rewrite -(prednK p_gt0) /=; case: eqP => [->|].
+case: eqVneq => [->|nzpq].
   by case: (size q) => [|[|s]]; rewrite /= modp0 (negPf nzq) // mod0p eqxx.
-move/eqP=> nzpq; rewrite (negPf nzq); apply: Irec => //; rewrite ?ltn_modp //.
-  by rewrite -ltnS (prednK p_gt0) (leq_trans _ leqp) // ltn_modp.
+apply: Irec => //; rewrite ?ltn_modp //.
+  by rewrite -ltnS -polySpred // (leq_trans _ leqp) // ltn_modp.
 by rewrite ltnW // ltn_modp.
 Qed.
 
 Lemma size_gcd1p p : size (gcdp 1 p) = 1%N.
 Proof.
-rewrite gcdpE size_polyC oner_eq0 /= modp1; case: ltnP.
+rewrite gcdpE size_polyC oner_eq0 /= modp1; have [|/size1_polyC ->] := ltnP.
   by rewrite gcd0p size_polyC oner_eq0.
-move/size1_polyC=> e; rewrite e.
-case p00: (p`_0 == 0); first by rewrite (eqP p00) modp0 gcdp0 size_poly1.
-by rewrite modpC ?p00 // gcd0p size_polyC p00.
+have [->|p00] := eqVneq p`_0 0; first by rewrite modp0 gcdp0 size_poly1.
+by rewrite modpC // gcd0p size_polyC p00.
 Qed.
 
 Lemma size_gcdp1 p : size (gcdp p 1) = 1%N.
-rewrite gcdpE size_polyC oner_eq0 /= modp1; case: ltnP; last first.
-  by rewrite gcd0p size_polyC oner_eq0.
-rewrite ltnS leqn0 size_poly_eq0; move/eqP->; rewrite gcdp0 modp0 size_polyC.
-by rewrite oner_eq0.
+Proof.
+rewrite gcdpE size_polyC oner_eq0 /= modp1 ltnS; case: leqP.
+  by move/size_poly_leq0P->; rewrite gcdp0 modp0 size_polyC oner_eq0.
+by rewrite gcd0p size_polyC oner_eq0.
 Qed.
 
 Lemma gcdpp : idempotent gcdp.
@@ -1740,11 +1606,9 @@ suffices /IHr/andP[E1 E2]: minn (size q) (size (p %% q)) < r.
 by rewrite gtn_min orbC (leq_trans _ le_qr) ?ltn_modp.
 Qed.
 
-Lemma dvdp_gcdl p q : gcdp p q %| p.
-Proof. by case/andP: (dvdp_gcdlr p q). Qed.
+Lemma dvdp_gcdl p q : gcdp p q %| p. Proof. by case/andP: (dvdp_gcdlr p q). Qed.
 
-Lemma dvdp_gcdr p q :gcdp p q %| q.
-Proof. by case/andP: (dvdp_gcdlr p q). Qed.
+Lemma dvdp_gcdr p q :gcdp p q %| q. Proof. by case/andP: (dvdp_gcdlr p q). Qed.
 
 Lemma leq_gcdpl p q : p != 0 -> size (gcdp p q) <= size p.
 Proof. by move=> pn0; move: (dvdp_gcdl p q); apply: dvdp_leq. Qed.
@@ -1766,16 +1630,16 @@ apply: IHr => //; last by rewrite -(dvdp_mod _ dv_n).
 by rewrite gtn_min orbC (leq_trans _ le_r) ?ltn_modp.
 Qed.
 
-Lemma gcdpC : forall p q, gcdp p q %= gcdp q p.
-Proof. by move=> p q; rewrite /eqp !dvdp_gcd !dvdp_gcdl !dvdp_gcdr. Qed.
+Lemma gcdpC p q : gcdp p q %= gcdp q p.
+Proof. by rewrite /eqp !dvdp_gcd !dvdp_gcdl !dvdp_gcdr. Qed.
 
 Lemma gcd1p p : gcdp 1 p %= 1.
 Proof.
 rewrite -size_poly_eq1 gcdpE size_poly1; case: ltnP.
   by rewrite modp1 gcd0p size_poly1 eqxx.
 move/size1_polyC=> e; rewrite e.
-case p00: (p`_0 == 0); first by rewrite (eqP p00) modp0 gcdp0 size_poly1.
-by rewrite modpC ?p00 // gcd0p size_polyC p00.
+have [->|p00] := eqVneq p`_0 0; first by rewrite modp0 gcdp0 size_poly1.
+by rewrite modpC // gcd0p size_polyC p00.
 Qed.
 
 Lemma gcdp1 p : gcdp p 1 %= 1.
@@ -1784,25 +1648,25 @@ Proof. by rewrite (eqp_ltrans (gcdpC _ _)) gcd1p. Qed.
 Lemma gcdp_addl_mul p q r: gcdp r (p * r + q) %= gcdp r q.
 Proof.
 suff h m n d : gcdp d n %| gcdp d (m * d + n).
-  apply/andP; split => //; rewrite {2}(_: q = (-p) * r + (p * r + q)) ?H //.
-  by rewrite GRing.mulNr GRing.addKr.
+  apply/andP; split => //.
+  by rewrite {2}(_: q = (-p) * r + (p * r + q)) ?H // mulNr addKr.
 by rewrite dvdp_gcd dvdp_gcdl /= dvdp_addr ?dvdp_gcdr ?dvdp_mull ?dvdp_gcdl.
 Qed.
 
 Lemma gcdp_addl m n : gcdp m (m + n) %= gcdp m n.
-Proof. by rewrite -{2}(mul1r m) gcdp_addl_mul. Qed.
+Proof. by rewrite -[m in m + _]mul1r gcdp_addl_mul. Qed.
 
 Lemma gcdp_addr m n : gcdp m (n + m) %= gcdp m n.
 Proof. by rewrite addrC gcdp_addl. Qed.
 
 Lemma gcdp_mull m n : gcdp n (m * n) %= n.
 Proof.
-case: (eqVneq n 0) => [-> | nn0]; first by rewrite gcd0p mulr0 eqpxx.
-case: (eqVneq m 0) => [-> | mn0]; first by rewrite mul0r gcdp0 eqpxx.
-rewrite gcdpE modp_mull gcd0p size_mul //; case: ifP; first by rewrite eqpxx.
-rewrite (polySpred mn0) addSn /= -{1}[size n]add0n ltn_add2r; move/negbT.
-rewrite -ltnNge prednK ?size_poly_gt0 // leq_eqVlt ltnS leqn0 size_poly_eq0.
-rewrite (negPf mn0) orbF; case/size_poly1P=> c cn0 -> {mn0 m}; rewrite mul_polyC.
+have [-> | nn0] := eqVneq n 0; first by rewrite gcd0p mulr0 eqpxx.
+have [-> | mn0] := eqVneq m 0; first by rewrite mul0r gcdp0 eqpxx.
+rewrite gcdpE modp_mull gcd0p size_mul //; case: leqP; last by rewrite eqpxx.
+rewrite (polySpred mn0) addSn /= -[n in _ <= n]add0n leq_add2r -ltnS.
+rewrite -polySpred //= leq_eqVlt ltnS size_poly_leq0 (negPf mn0) orbF.
+case/size_poly1P=> c cn0 -> {mn0 m}; rewrite mul_polyC.
 suff -> : n %% (c *: n) = 0 by rewrite gcd0p; apply: eqp_scale.
 by apply/modp_eq0P; rewrite dvdp_scalel.
 Qed.
@@ -1826,21 +1690,21 @@ Qed.
 
 Lemma dvdp_gcd_idl m n : m %| n -> gcdp m n %= m.
 Proof.
-case: (eqVneq m 0) => [-> | mn0].
+have [-> | mn0] := eqVneq m 0.
   by rewrite dvd0p => /eqP ->; rewrite gcdp0 eqpxx.
-rewrite dvdp_eq; move/eqP; move/(f_equal (gcdp m)) => h.
-apply: eqp_trans (gcdp_mull (n %/ m) _); rewrite -h eqp_sym gcdp_scaler //.
-by rewrite expf_neq0 // lead_coef_eq0.
+rewrite dvdp_eq; move/eqP/(f_equal (gcdp m)) => h.
+apply: eqp_trans (gcdp_mull (n %/ m) _).
+by rewrite -h eqp_sym gcdp_scaler // expf_neq0 // lead_coef_eq0.
 Qed.
 
 Lemma dvdp_gcd_idr m n : n %| m -> gcdp m n %= n.
-Proof. by move/dvdp_gcd_idl => h; apply: eqp_trans h; apply: gcdpC. Qed.
+Proof. by move/dvdp_gcd_idl; exact/eqp_trans/gcdpC. Qed.
 
 Lemma gcdp_exp p k l : gcdp (p ^+ k) (p ^+ l) %= p ^+ minn k l.
 Proof.
 wlog leqmn: k l / k <= l.
   move=> hwlog; case: (leqP k l); first exact: hwlog.
-  by move/ltnW; rewrite minnC; move/hwlog=> h; apply: eqp_trans h; apply: gcdpC.
+  by move/ltnW; rewrite minnC; move/hwlog; apply/eqp_trans/gcdpC.
 rewrite (minn_idPl leqmn); move/subnK: leqmn<-; rewrite exprD.
 by apply: eqp_trans (gcdp_mull _ _) _; apply: eqpxx.
 Qed.
@@ -1859,7 +1723,8 @@ move=> eqr; rewrite /eqp !(dvdp_gcd, dvdp_gcdl, andbT) /=.
 by rewrite -(eqp_dvdr _ eqr) dvdp_gcdr (eqp_dvdr _ eqr) dvdp_gcdr.
 Qed.
 
-Lemma eqp_gcdl r p q :  p %= q -> gcdp p r %= gcdp q r.
+Lemma eqp_gcdl r p q : p %= q -> gcdp p r %= gcdp q r.
+Proof.
 move=> eqr; rewrite /eqp !(dvdp_gcd, dvdp_gcdr, andbT) /=.
 by rewrite -(eqp_dvdr _ eqr) dvdp_gcdl (eqp_dvdr _ eqr) dvdp_gcdl.
 Qed.
@@ -1872,34 +1737,33 @@ Qed.
 
 Lemma eqp_rgcd_gcd p q : rgcdp p q %= gcdp p q.
 Proof.
-move: (leqnn (minn (size p) (size q))); move: {2}(minn (size p) (size q)) => n.
+move: {2}(minn (size p) (size q)) (leqnn (minn (size p) (size q))) => n.
 elim: n p q => [p q|n ihn p q hs].
   rewrite leqn0 /minn; case: ltnP => _; rewrite size_poly_eq0; move/eqP->.
     by rewrite gcd0p rgcd0p eqpxx.
   by rewrite gcdp0 rgcdp0 eqpxx.
-case: (eqVneq p 0) => [-> | pn0]; first by rewrite gcd0p rgcd0p eqpxx.
-case: (eqVneq q 0) => [-> | qn0]; first by rewrite gcdp0 rgcdp0 eqpxx.
+have [-> | pn0] := eqVneq p 0; first by rewrite gcd0p rgcd0p eqpxx.
+have [-> | qn0] := eqVneq q 0; first by rewrite gcdp0 rgcdp0 eqpxx.
 rewrite gcdpE rgcdpE; case: ltnP => sp.
-  have e := (eqp_rmod_mod q p); move: (e); move/(eqp_gcdl p) => h.
-  apply: eqp_trans h; apply: ihn; rewrite (eqp_size e) geq_min.
-  by rewrite -ltnS (leq_trans _ hs) // (minn_idPl (ltnW _)) ?ltn_modp.
-have e := (eqp_rmod_mod p q); move: (e); move/(eqp_gcdl q) => h.
-apply: eqp_trans h; apply: ihn; rewrite (eqp_size e) geq_min.
-by rewrite -ltnS (leq_trans _ hs) // (minn_idPr _) ?ltn_modp.
+  have e := eqp_rmod_mod q p; apply/eqp_trans/ihn: (eqp_gcdl p e).
+  rewrite (eqp_size e) geq_min -ltnS (leq_trans _ hs) //.
+  by rewrite (minn_idPl (ltnW _)) ?ltn_modp.
+have e := eqp_rmod_mod p q; apply/eqp_trans/ihn: (eqp_gcdl q e).
+rewrite (eqp_size e) geq_min -ltnS (leq_trans _ hs) //.
+by rewrite (minn_idPr _) ?ltn_modp.
 Qed.
 
 Lemma gcdp_modr m n : gcdp m (n %% m) %= gcdp m n.
 Proof.
-case: (eqVneq m 0) => [-> | mn0]; first by rewrite modp0 eqpxx.
+have [-> | mn0] := eqVneq m 0; first by rewrite modp0 eqpxx.
 have : (lead_coef m) ^+ (scalp n m) != 0 by rewrite expf_neq0 // lead_coef_eq0.
-move/gcdp_scaler; move/(_ m n) => h; apply: eqp_trans h; rewrite divp_eq.
-by rewrite eqp_sym gcdp_addl_mul.
+move/(gcdp_scaler m n); apply/eqp_trans.
+by rewrite divp_eq eqp_sym gcdp_addl_mul.
 Qed.
 
 Lemma gcdp_modl m n : gcdp (m %% n) n %= gcdp m n.
 Proof.
-apply: eqp_trans (gcdpC _ _) _; apply: eqp_trans (gcdp_modr _ _) _.
-exact: gcdpC.
+apply: eqp_trans (gcdpC _ _); apply: eqp_trans (gcdp_modr _ _); exact: gcdpC.
 Qed.
 
 Lemma gcdp_def d m n :
@@ -1915,33 +1779,26 @@ Definition coprimep p q := size (gcdp p q) == 1%N.
 Lemma coprimep_size_gcd p q : coprimep p q -> size (gcdp p q) = 1%N.
 Proof. by rewrite /coprimep=> /eqP. Qed.
 
-Lemma coprimep_def p q : (coprimep p q) = (size (gcdp p q) == 1%N).
+Lemma coprimep_def p q : coprimep p q = (size (gcdp p q) == 1%N).
 Proof. done. Qed.
 
-Lemma coprimep_scalel c m n :
-  c != 0 -> coprimep (c *: m) n = coprimep m n.
+Lemma coprimep_scalel c m n : c != 0 -> coprimep (c *: m) n = coprimep m n.
 Proof. by move=> ?; rewrite !coprimep_def (eqp_size (gcdp_scalel _ _ _)). Qed.
 
-Lemma coprimep_scaler c m n:
-  c != 0 -> coprimep m (c *: n) = coprimep m n.
+Lemma coprimep_scaler c m n: c != 0 -> coprimep m (c *: n) = coprimep m n.
 Proof. by move=> ?; rewrite !coprimep_def (eqp_size (gcdp_scaler _ _ _)). Qed.
 
 Lemma coprimepp p : coprimep p p = (size p == 1%N).
 Proof. by rewrite coprimep_def gcdpp. Qed.
 
-Lemma gcdp_eqp1 p q : gcdp p q %= 1 = (coprimep p q).
+Lemma gcdp_eqp1 p q : gcdp p q %= 1 = coprimep p q.
 Proof. by rewrite coprimep_def size_poly_eq1. Qed.
 
 Lemma coprimep_sym p q : coprimep p q = coprimep q p.
-Proof.
-by rewrite -!gcdp_eqp1; apply: eqp_ltrans; rewrite gcdpC.
-Qed.
+Proof. by rewrite -!gcdp_eqp1; apply: eqp_ltrans; rewrite gcdpC. Qed.
 
 Lemma coprime1p p : coprimep 1 p.
-Proof.
-rewrite /coprimep -[1%N](size_poly1 R); apply/eqP; apply: eqp_size.
-exact: gcd1p.
-Qed.
+Proof. by rewrite /coprimep -[1%N](size_poly1 R); exact/eqP/eqp_size/gcd1p. Qed.
 
 Lemma coprimep1 p : coprimep p 1.
 Proof. by rewrite coprimep_sym; apply: coprime1p. Qed.
@@ -1956,12 +1813,10 @@ Proof. by rewrite coprimep_sym coprimep0. Qed.
 Lemma coprimepP p q :
  reflect (forall d, d %| p -> d %| q -> d %= 1) (coprimep p q).
 Proof.
-apply: (iffP idP)=> [|h].
-  rewrite /coprimep; move/eqP=> hs d dvddp dvddq.
-  have dvddg: d %| gcdp p q by rewrite dvdp_gcd dvddp dvddq.
-  by apply: (dvdp_eqp1 dvddg); rewrite -size_poly_eq1; apply/eqP.
-case/andP: (dvdp_gcdlr p q)=> h1 h2.
-by rewrite /coprimep size_poly_eq1; apply: h.
+rewrite /coprimep; apply: (iffP idP) => [/eqP hs d dvddp dvddq | h].
+  have/dvdp_eqp1: d %| gcdp p q by rewrite dvdp_gcd dvddp dvddq.
+  by rewrite -size_poly_eq1 hs; exact.
+by rewrite size_poly_eq1; case/andP: (dvdp_gcdlr p q); apply: h.
 Qed.
 
 Lemma coprimepPn p q : p != 0 ->
@@ -1969,43 +1824,35 @@ Lemma coprimepPn p q : p != 0 ->
 Proof.
 move=> p0; apply: (iffP idP).
   by rewrite -gcdp_eqp1=> ng1; exists (gcdp p q); rewrite dvdpp /=.
-case=> d; case/andP=> dg; apply: contra; rewrite -gcdp_eqp1=> g1.
+case=> d /andP [dg]; apply: contra; rewrite -gcdp_eqp1=> g1.
 by move: dg; rewrite (eqp_dvdr _ g1) dvdp1 size_poly_eq1.
 Qed.
 
 Lemma coprimep_dvdl q p r : r %| q -> coprimep p q -> coprimep p r.
 Proof.
-move=> rq cpq; apply/coprimepP=> d dp dr; move/coprimepP:cpq=> cpq'.
-by apply: cpq'; rewrite // (dvdp_trans dr).
+move=> rp /coprimepP cpq'; apply/coprimepP => d dp dr.
+exact/cpq'/(dvdp_trans dr).
 Qed.
 
-Lemma coprimep_dvdr  p q r :
-  r %| p -> coprimep p q -> coprimep r q.
+Lemma coprimep_dvdr p q r : r %| p -> coprimep p q -> coprimep r q.
 Proof.
-move=> rp; rewrite ![coprimep _ q]coprimep_sym.
-by move/coprimep_dvdl; apply.
+by move=> rp; rewrite ![coprimep _ q]coprimep_sym; apply/coprimep_dvdl.
 Qed.
-
 
 Lemma coprimep_modl p q : coprimep (p %% q) q = coprimep p q.
 Proof.
-symmetry; rewrite !coprimep_def.
-case: (ltnP (size p) (size q))=> hpq; first by rewrite modp_small.
-by rewrite gcdpE ltnNge hpq.
+rewrite !coprimep_def [in RHS]gcdpE.
+by case: ltnP => // hpq; rewrite modp_small // gcdpE hpq.
 Qed.
 
 Lemma coprimep_modr q p : coprimep q (p %% q) = coprimep q p.
 Proof. by rewrite ![coprimep q _]coprimep_sym coprimep_modl. Qed.
 
-Lemma rcoprimep_coprimep  q p : rcoprimep q p = coprimep q p.
-Proof.
-by rewrite /coprimep /rcoprimep; rewrite (eqp_size (eqp_rgcd_gcd _ _)).
-Qed.
+Lemma rcoprimep_coprimep q p : rcoprimep q p = coprimep q p.
+Proof. by rewrite /coprimep /rcoprimep (eqp_size (eqp_rgcd_gcd _ _)). Qed.
 
 Lemma eqp_coprimepr p q r : q %= r -> coprimep p q = coprimep p r.
-Proof.
-by rewrite -!gcdp_eqp1; move/(eqp_gcdr p) => h1; apply: (eqp_ltrans h1).
-Qed.
+Proof. by rewrite -!gcdp_eqp1; move/(eqp_gcdr p)/eqp_ltrans. Qed.
 
 Lemma eqp_coprimepl p q r : q %= r -> coprimep q p = coprimep r p.
 Proof. by rewrite !(coprimep_sym _ p); apply: eqp_coprimepr. Qed.
@@ -2023,17 +1870,16 @@ Definition egcdp p q :=
     else let e := egcdp_rec q p (size p) in (e.2, e.1).
 
 (* No provable egcd0p *)
-Lemma egcdp0 p : egcdp p 0 = (1, 0).
-Proof. by rewrite /egcdp size_poly0. Qed.
+Lemma egcdp0 p : egcdp p 0 = (1, 0). Proof. by rewrite /egcdp size_poly0. Qed.
 
 Lemma egcdp_recP : forall k p q, q != 0 -> size q <= k -> size q <= size p ->
   let e := (egcdp_rec p q k) in
     [/\ size e.1 <= size q, size e.2 <= size p & gcdp p q %= e.1 * p + e.2 * q].
 Proof.
-elim=> [|k ihk] p q /= qn0; first by rewrite leqn0 size_poly_eq0 (negPf qn0).
+elim=> [|k ihk] p q /= qn0; first by rewrite size_poly_leq0 (negPf qn0).
 move=> sqSn qsp; rewrite (negPf qn0).
 have sp : size p > 0 by apply: leq_trans qsp; rewrite size_poly_gt0.
-case: (eqVneq (p %% q) 0) => [r0 | rn0] /=.
+have [r0 | rn0] /= := eqVneq (p %%q) 0.
   rewrite r0 /egcdp_rec; case: k ihk sqSn => [|n] ihn sqSn /=.
     rewrite !scaler0 !mul0r subr0 add0r mul1r size_poly0 size_poly1.
     by rewrite dvdp_gcd_idr /dvdp ?r0.
@@ -2042,64 +1888,60 @@ case: (eqVneq (p %% q) 0) => [r0 | rn0] /=.
 have h1 : size (p %% q) <= k.
   by rewrite -ltnS; apply: leq_trans sqSn; rewrite ltn_modp.
 have h2 : size (p %% q) <= size q by rewrite ltnW // ltn_modp.
-have := (ihk q (p %% q) rn0 h1 h2).
+have := ihk q (p %% q) rn0 h1 h2.
 case: (egcdp_rec _ _)=> u v /= => [[ihn'1 ihn'2 ihn'3]].
 rewrite gcdpE ltnNge qsp //= (eqp_ltrans (gcdpC _ _)); split; last first.
 - apply: (eqp_trans ihn'3).
   rewrite mulrBl addrCA -scalerAl scalerAr -mulrA -mulrBr.
   by rewrite divp_eq addrAC subrr add0r eqpxx.
 - apply: (leq_trans (size_add _ _)).
-  case: (eqVneq v 0)=> [-> | vn0].
+  have [-> | vn0] := eqVneq v 0.
     rewrite mul0r size_opp size_poly0 maxn0; apply: leq_trans ihn'1 _.
     exact: leq_modp.
-  case: (eqVneq (p %/ q) 0)=> [-> | qqn0].
+  have [-> | qqn0] := eqVneq (p %/ q) 0.
     rewrite mulr0 size_opp size_poly0 maxn0; apply: leq_trans ihn'1 _.
     exact: leq_modp.
   rewrite geq_max (leq_trans ihn'1) ?leq_modp //= size_opp size_mul //.
-  move: (ihn'2); rewrite -(leq_add2r (size (p %/ q))).
-  have : size v + size (p %/ q) > 0 by rewrite addn_gt0 size_poly_gt0 vn0.
-  have : size q + size (p %/ q) > 0 by rewrite addn_gt0 size_poly_gt0 qn0.
-  do 2!move/prednK=> {1}<-; rewrite ltnS => h; apply: leq_trans h _.
-  rewrite size_divp // addnBA; last by apply: leq_trans qsp; apply: leq_pred.
-  rewrite addnC -addnBA ?leq_pred //; move: qn0; rewrite -size_poly_eq0 -lt0n.
-  by move/prednK=> {1}<-; rewrite subSnn addn1.
+  move: (ihn'2); rewrite (polySpred vn0) (polySpred qn0).
+  rewrite -(ltn_add2r (size (p %/ q))) !addSn /= ltnS; move/leq_trans; apply.
+  rewrite size_divp // addnBA ?addKn //.
+  by apply: leq_trans qsp; apply: leq_pred.
 - by rewrite size_scale // lc_expn_scalp_neq0.
 Qed.
 
-Lemma egcdpP p q : p != 0 ->  q != 0 -> forall (e := egcdp p q),
+Lemma egcdpP p q : p != 0 -> q != 0 -> forall (e := egcdp p q),
   [/\ size e.1 <= size q, size e.2 <= size p & gcdp p q %= e.1 * p + e.2 * q].
 Proof.
-move=> pn0 qn0; rewrite /egcdp; case: (leqP (size q) (size p)) => /= hp.
-  by apply: egcdp_recP.
-move/ltnW: hp => hp; case: (egcdp_recP pn0 (leqnn (size p)) hp) => h1 h2 h3.
-by split => //; rewrite (eqp_ltrans (gcdpC _ _)) addrC.
+rewrite /egcdp => pn0 qn0; case: (leqP (size q) (size p)) => /= [|/ltnW] hp.
+  exact: egcdp_recP.
+case: (egcdp_recP pn0 (leqnn (size p)) hp) => h1 h2 h3; split => //.
+by rewrite (eqp_ltrans (gcdpC _ _)) addrC.
 Qed.
 
 Lemma egcdpE p q (e := egcdp p q) : gcdp p q %= e.1 * p + e.2 * q.
 Proof.
 rewrite {}/e; have [-> /= | qn0] := eqVneq q 0.
   by rewrite gcdp0 egcdp0 mul1r mulr0 addr0.
-have [p0 | pn0] := eqVneq p 0; last by case: (egcdpP pn0 qn0).
-rewrite p0 gcd0p mulr0 add0r /egcdp size_poly0 leqn0 size_poly_eq0 (negPf qn0).
-by rewrite /= mul1r.
+have [-> | pn0] := eqVneq p 0; last by case: (egcdpP pn0 qn0).
+by rewrite gcd0p /egcdp size_poly0 size_poly_leq0 (negPf qn0) /= !simp.
 Qed.
 
 Lemma Bezoutp p q : exists u, u.1 * p + u.2 * q %= (gcdp p q).
 Proof.
-case: (eqVneq p 0) => [-> | pn0].
+have [-> | pn0] := eqVneq p 0.
   by rewrite gcd0p; exists (0, 1); rewrite mul0r mul1r add0r.
-case: (eqVneq q 0) => [-> | qn0].
+have [-> | qn0] := eqVneq q 0.
   by rewrite gcdp0; exists (1, 0); rewrite mul0r mul1r addr0.
 pose e := egcdp p q; exists e; rewrite eqp_sym.
 by case: (egcdpP pn0 qn0).
 Qed.
 
-Lemma Bezout_coprimepP : forall p q,
+Lemma Bezout_coprimepP p q :
   reflect (exists u, u.1 * p + u.2 * q %= 1) (coprimep p q).
 Proof.
-move=> p q; rewrite -gcdp_eqp1; apply: (iffP idP)=> [g1|].
+rewrite -gcdp_eqp1; apply: (iffP idP)=> [g1|].
   by case: (Bezoutp p q) => [[u v] Puv]; exists (u, v); apply: eqp_trans g1.
-case=> [[u v]]; rewrite eqp_sym=> Puv; rewrite /eqp  (eqp_dvdr _ Puv).
+case=> [[u v]]; rewrite eqp_sym=> Puv; rewrite /eqp (eqp_dvdr _ Puv).
 by rewrite dvdp_addr dvdp_mull ?dvdp_gcdl ?dvdp_gcdr //= dvd1p.
 Qed.
 
@@ -2109,15 +1951,15 @@ case/Bezout_coprimepP=> [[u v] euv] px0.
 move/eqpP: euv => [[c1 c2]] /andP /= [c1n0 c2n0 e].
 suffices: c1 * (v.[x] * q.[x]) != 0.
   by rewrite !mulf_eq0 !negb_or c1n0 /=; case/andP.
-move/(f_equal (fun t => horner t x)): e; rewrite /= !hornerZ hornerD.
+have := f_equal (horner^~ x) e; rewrite /= !hornerZ hornerD.
 by rewrite !hornerM (eqP px0) mulr0 add0r hornerC mulr1; move->.
 Qed.
 
 Lemma Gauss_dvdpl p q d: coprimep d q -> (d %| p * q) = (d %| p).
 Proof.
 move/Bezout_coprimepP=>[[u v] Puv]; apply/idP/idP; last exact: dvdp_mulr.
-move: Puv; move/(eqp_mull p); rewrite mulr1 mulrDr eqp_sym=> peq dpq.
-rewrite (eqp_dvdr _  peq) dvdp_addr; first by rewrite mulrA mulrAC dvdp_mulr.
+move/(eqp_mull p): Puv; rewrite mulr1 mulrDr eqp_sym=> peq dpq.
+rewrite (eqp_dvdr _ peq) dvdp_addr; first by rewrite mulrA mulrAC dvdp_mulr.
 by rewrite mulrA dvdp_mull ?dvdpp.
 Qed.
 
@@ -2127,17 +1969,17 @@ Proof. by rewrite mulrC; apply: Gauss_dvdpl. Qed.
 (* This could be simplified with the introduction of lcmp *)
 Lemma Gauss_dvdp m n p : coprimep m n -> (m * n %| p) = (m %| p) && (n %| p).
 Proof.
-case: (eqVneq m 0) => [-> | mn0].
+have [-> | mn0] := eqVneq m 0.
   by rewrite coprime0p => /eqp_dvdl->; rewrite !mul0r dvd0p dvd1p andbT.
-case: (eqVneq n 0) => [-> | nn0].
+have [-> | nn0] := eqVneq n 0.
   by rewrite coprimep0 => /eqp_dvdl->; rewrite !mulr0 dvd1p.
-move=> hc; apply/idP/idP.
-  move/Gauss_dvdpl: hc => <- h; move/(dvdp_mull m): (h); rewrite dvdp_mul2l //.
-  move->; move/(dvdp_mulr n): (h); rewrite dvdp_mul2r // andbT.
+move=> hc; apply/idP/idP => [mnmp | /andP [dmp dnp]].
+  move/Gauss_dvdpl: hc => <-; move: (dvdp_mull m mnmp); rewrite dvdp_mul2l //.
+  move->; move: (dvdp_mulr n mnmp); rewrite dvdp_mul2r // andbT.
   exact: dvdp_mulr.
-case/andP => dmp dnp; move: (dnp); rewrite dvdp_eq.
+move: (dnp); rewrite dvdp_eq.
 set c2 := _ ^+ _; set q2 := _ %/ _; move/eqP=> e2.
-have := (sym_eq (Gauss_dvdpl q2 hc)); rewrite -e2.
+have/esym := Gauss_dvdpl q2 hc; rewrite -e2.
 have -> : m %| c2 *: p by rewrite -mul_polyC dvdp_mull.
 rewrite dvdp_eq; set c3 := _ ^+ _; set q3 := _ %/ _; move/eqP=> e3.
 apply: (@eq_dvdp (c3 * c2) q3).
@@ -2195,7 +2037,7 @@ Proof. by rewrite !(coprimep_sym m); apply: coprimep_expl. Qed.
 
 Lemma gcdp_mul2l p q r : gcdp (p * q) (p * r) %= (p * gcdp q r).
 Proof.
-case: (eqVneq p 0)=> [->|hp]; first by rewrite !mul0r gcdp0 eqpxx.
+have [->|hp] := eqVneq p 0; first by rewrite !mul0r gcdp0 eqpxx.
 rewrite /eqp !dvdp_gcd !dvdp_mul2l // dvdp_gcdr dvdp_gcdl !andbT.
 move: (Bezoutp q r) => [[u v]] huv.
 rewrite eqp_sym in huv; rewrite (eqp_dvdr _ (eqp_mull _ huv)).
@@ -2203,25 +2045,23 @@ rewrite mulrDr ![p * (_ * _)]mulrCA.
 by apply: dvdp_add; rewrite dvdp_mull// (dvdp_gcdr, dvdp_gcdl).
 Qed.
 
-Lemma gcdp_mul2r q r p : gcdp (q * p) (r * p) %= (gcdp q r * p).
-Proof. by rewrite ![_ * p]GRing.mulrC gcdp_mul2l. Qed.
+Lemma gcdp_mul2r q r p : gcdp (q * p) (r * p) %= gcdp q r * p.
+Proof. by rewrite ![_ * p]mulrC gcdp_mul2l. Qed.
 
 Lemma mulp_gcdr p q r : r * (gcdp p q) %= gcdp (r * p) (r * q).
 Proof. by rewrite eqp_sym gcdp_mul2l. Qed.
 
 Lemma mulp_gcdl p q r : (gcdp p q) * r %= gcdp (p * r) (q * r).
-Proof. by  rewrite eqp_sym gcdp_mul2r. Qed.
+Proof. by rewrite eqp_sym gcdp_mul2r. Qed.
 
 Lemma coprimep_div_gcd p q : (p != 0) || (q != 0) ->
   coprimep (p %/ (gcdp p q)) (q %/ gcdp p q).
 Proof.
-move=> hpq.
-have gpq0: gcdp p q != 0 by rewrite gcdp_eq0 negb_and.
-rewrite -gcdp_eqp1 -(@eqp_mul2r (gcdp p q)) // mul1r.
+rewrite -negb_and -gcdp_eq0 -gcdp_eqp1 => gpq0.
+rewrite -(@eqp_mul2r (gcdp p q)) // mul1r (eqp_ltrans (mulp_gcdl _ _ _)).
 have: gcdp p q %| p by rewrite dvdp_gcdl.
 have: gcdp p q %| q by rewrite dvdp_gcdr.
-rewrite !dvdp_eq eq_sym; move/eqP=> hq; rewrite eq_sym; move/eqP=> hp.
-rewrite (eqp_ltrans (mulp_gcdl _ _ _)) hq hp.
+rewrite !dvdp_eq => /eqP <- /eqP <-.
 have lcn0 k : (lead_coef (gcdp p q)) ^+ k != 0.
   by rewrite expf_neq0 ?lead_coef_eq0.
 by apply: eqp_gcd; rewrite ?eqp_scale.
@@ -2240,7 +2080,7 @@ Qed.
 
 Lemma dvdp_div_eq0 p q : q %| p -> (p %/ q == 0) = (p == 0).
 Proof.
-move=> dvdp_qp; have [->|p_neq0] := altP (p =P 0); first by rewrite div0p eqxx.
+move=> dvdp_qp; have [->|p_neq0] := eqVneq p 0; first by rewrite div0p eqxx.
 rewrite divp_eq0 ltnNge dvdp_leq // (negPf p_neq0) orbF /=.
 by apply: contraTF dvdp_qp=> /eqP ->; rewrite dvd0p.
 Qed.
@@ -2250,6 +2090,7 @@ Lemma Bezout_coprimepPn p q : p != 0 -> q != 0 ->
     (0 < size uv.1 < size q) && (0 < size uv.2 < size p) &
       uv.1 * p = uv.2 * q)
     (~~ (coprimep p q)).
+Proof.
 move=> pn0 qn0; apply: (iffP idP); last first.
   case=> [[u v] /= /andP [/andP [ps1 s1] /andP [ps2 s2]] e].
   have: ~~(size (q * p) <= size (u * p)).
@@ -2257,49 +2098,46 @@ move=> pn0 qn0; apply: (iffP idP); last first.
     by rewrite ltn_add2r.
   apply: contra => ?; apply: dvdp_leq; rewrite ?mulf_neq0 // -?size_poly_gt0 //.
   by rewrite mulrC Gauss_dvdp // dvdp_mull // e dvdp_mull.
-rewrite coprimep_def neq_ltn.
-case/orP; first by rewrite ltnS leqn0 size_poly_eq0 gcdp_eq0 -[p == 0]negbK pn0.
+rewrite coprimep_def neq_ltn ltnS size_poly_leq0 gcdp_eq0.
+rewrite (negPf pn0) (negPf qn0) /=.
 case sg: (size (gcdp p q)) => [|n] //; case: n sg=> [|n] // sg _.
 move: (dvdp_gcdl p q); rewrite dvdp_eq; set c1 := _ ^+ _; move/eqP=> hu1.
 move: (dvdp_gcdr p q); rewrite dvdp_eq; set c2 := _ ^+ _; move/eqP=> hv1.
 exists (c1 *: (q %/ gcdp p q), c2 *: (p %/ gcdp p q)); last first.
-  by rewrite -!{1}scalerAl !scalerAr hu1 hv1 mulrCA.
-rewrite !{1}size_scale ?lc_expn_scalp_neq0 //= !size_poly_gt0 !divp_eq0.
+  by rewrite -!scalerAl !scalerAr hu1 hv1 mulrCA.
+rewrite !size_scale ?lc_expn_scalp_neq0 //= !size_poly_gt0 !divp_eq0.
 rewrite gcdp_eq0 !(negPf pn0) !(negPf qn0) /= -!leqNgt leq_gcdpl //.
 rewrite leq_gcdpr //= !ltn_divpl -?size_poly_eq0 ?sg //.
 rewrite !size_mul // -?size_poly_eq0 ?sg // ![(_ + n.+2)%N]addnS /=.
-by rewrite -{1}(addn0 (size p)) -{1}(addn0 (size q)) !ltn_add2l.
+by rewrite -!(addn1 (size _)) !leq_add2l.
 Qed.
 
 Lemma dvdp_pexp2r m n k : k > 0 -> (m ^+ k %| n ^+ k) = (m %| n).
 Proof.
 move=> k_gt0; apply/idP/idP; last exact: dvdp_exp2r.
-case: (eqVneq n 0) => [-> | nn0] //; case: (eqVneq m 0) => [-> | mn0].
+have [-> // | nn0] := eqVneq n 0; have [-> | mn0] := eqVneq m 0.
   move/prednK: k_gt0=> {1}<-; rewrite exprS mul0r //= !dvd0p expf_eq0.
   by case/andP=> _ ->.
-set d := gcdp m n; have := (dvdp_gcdr m n); rewrite -/d dvdp_eq.
+set d := gcdp m n; have := dvdp_gcdr m n; rewrite -/d dvdp_eq.
 set c1 := _ ^+ _; set n' := _ %/ _; move/eqP=> def_n.
-have := (dvdp_gcdl m n); rewrite -/d dvdp_eq.
+have := dvdp_gcdl m n; rewrite -/d dvdp_eq.
 set c2 := _ ^+ _; set m' := _ %/ _; move/eqP=> def_m.
 have dn0 : d != 0 by rewrite gcdp_eq0 negb_and nn0 orbT.
 have c1n0 : c1 != 0 by rewrite !expf_neq0 // lead_coef_eq0.
 have c2n0 : c2 != 0 by rewrite !expf_neq0 // lead_coef_eq0.
-rewrite -(@dvdp_scaler (c1 ^+ k)) ?expf_neq0 ?lead_coef_eq0 //.
 have c2k_n0 : c2 ^+ k != 0 by rewrite !expf_neq0 // lead_coef_eq0.
-rewrite -(@dvdp_scalel (c2 ^+k)) // -!exprZn def_m def_n !exprMn.
+rewrite -(@dvdp_scaler (c1 ^+ k)) ?expf_neq0 ?lead_coef_eq0 //.
+rewrite -(@dvdp_scalel (c2 ^+ k)) // -!exprZn def_m def_n !exprMn.
 rewrite dvdp_mul2r ?expf_neq0 //.
 have: coprimep (m' ^+ k) (n' ^+ k).
-  rewrite coprimep_pexpl // coprimep_pexpr //; apply: coprimep_div_gcd.
-  by rewrite nn0 orbT.
+  by rewrite coprimep_pexpl // coprimep_pexpr // coprimep_div_gcd ?mn0.
 move/coprimepP=> hc hd.
 have /size_poly1P [c cn0 em'] : size m' == 1%N.
-  case: (eqVneq m' 0) => [m'0 |m'_n0].
-    move/eqP: def_m; rewrite m'0 mul0r scale_poly_eq0.
-    by rewrite (negPf mn0) (negPf c2n0).
-  have := (hc _ (dvdpp _) hd); rewrite -size_poly_eq1.
+  case: (eqVneq m' 0) def_m => [-> /eqP | m'_n0 def_m].
+    by rewrite mul0r scale_poly_eq0 (negPf mn0) (negPf c2n0).
+  have := hc _ (dvdpp _) hd; rewrite -size_poly_eq1.
   rewrite polySpred; last by rewrite expf_eq0 negb_and m'_n0 orbT.
-  rewrite size_exp eqSS muln_eq0; move: k_gt0; rewrite lt0n; move/negPf->.
-  by rewrite orbF -{2}(@prednK (size m')) ?lt0n // size_poly_eq0.
+  by rewrite size_exp eqSS muln_eq0 orbC eqn0Ngt k_gt0 /= -eqSS -polySpred.
 rewrite -(@dvdp_scalel c2) // def_m em' mul_polyC dvdp_scalel //.
 by rewrite -(@dvdp_scaler c1) // def_n dvdp_mull.
 Qed.
@@ -2308,15 +2146,15 @@ Lemma root_gcd p q x : root (gcdp p q) x = root p x && root q x.
 Proof.
 rewrite /= !root_factor_theorem; apply/idP/andP=> [dg| [dp dq]].
   by split; apply: dvdp_trans dg _; rewrite ?(dvdp_gcdl, dvdp_gcdr).
-have:= (Bezoutp p q)=> [[[u v]]]; rewrite eqp_sym=> e.
+have:= Bezoutp p q => [[[u v]]]; rewrite eqp_sym=> e.
 by rewrite (eqp_dvdr _ e) dvdp_addl dvdp_mull.
 Qed.
 
-Lemma root_biggcd : forall x (ps : seq {poly R}),
+Lemma root_biggcd x (ps : seq {poly R}) :
   root (\big[gcdp/0]_(p <- ps) p) x = all (fun p => root p x) ps.
 Proof.
-move=> x; elim; first by rewrite big_nil root0.
-by move=> p ps ihp; rewrite big_cons /= root_gcd ihp.
+elim: ps => [|p ps ihp]; first by rewrite big_nil root0.
+by rewrite big_cons /= root_gcd ihp.
 Qed.
 
 (* "gdcop Q P" is the Greatest Divisor of P which is coprime to Q *)
@@ -2331,23 +2169,22 @@ Definition gdcop q p := gdcop_rec q p (size p).
 
 Variant gdcop_spec q p : {poly R} -> Type :=
   GdcopSpec r of (dvdp r p) & ((coprimep r q) || (p == 0))
-  & (forall d,  dvdp d p -> coprimep d q -> dvdp d r)
+  & (forall d, dvdp d p -> coprimep d q -> dvdp d r)
   : gdcop_spec q p r.
 
 Lemma gdcop0 q : gdcop q 0 = (q == 0)%:R.
-Proof. by  rewrite /gdcop size_poly0. Qed.
+Proof. by rewrite /gdcop size_poly0. Qed.
 
-Lemma gdcop_recP : forall q p k,
-  size p <= k -> gdcop_spec q p (gdcop_rec q p k).
+Lemma gdcop_recP q p k : size p <= k -> gdcop_spec q p (gdcop_rec q p k).
 Proof.
-move=> q p k; elim: k p => [p | k ihk p] /=.
-  rewrite leqn0 size_poly_eq0; move/eqP->.
-  case q0: (_ == _); split; rewrite ?coprime1p // ?eqxx ?orbT //.
-  by move=> d _; rewrite (eqP q0) coprimep0 dvdp1 size_poly_eq1.
+elim: k p => [p | k ihk p] /=.
+  move/size_poly_leq0P->.
+  have [->|q0] := eqVneq; split; rewrite ?coprime1p // ?eqxx ?orbT //.
+  by move=> d _; rewrite coprimep0 dvdp1 size_poly_eq1.
 move=> hs; case cop : (coprimep _ _); first by split; rewrite ?dvdpp ?cop.
-case (eqVneq p 0) => [-> | p0].
+have [-> | p0] := eqVneq p 0.
   by rewrite div0p; apply: ihk; rewrite size_poly0 leq0n.
-case: (eqVneq q 0) => [-> | q0].
+have [-> | q0] := eqVneq q 0.
   rewrite gcdp0 divpp ?p0 //= => {hs ihk}; case: k=> /=.
     rewrite eqxx; split; rewrite ?dvd1p ?coprimep0 ?eqpxx //=.
     by move=> d _; rewrite coprimep0 dvdp1 size_poly_eq1.
@@ -2359,26 +2196,24 @@ move: (dvdp_gcdl p q); rewrite dvdp_eq; move/eqP=> e.
 have sgp : size (gcdp p q) <= size p.
   by apply: dvdp_leq; rewrite ?gcdp_eq0 ?p0 ?q0 // dvdp_gcdl.
 have : p %/ gcdp p q != 0; last move/negPf=>p'n0.
-  move: (dvdp_mulIl (p %/ gcdp p q) (gcdp p q)); move/dvdpN0; apply; rewrite -e.
-  by rewrite scale_poly_eq0 negb_or lc_expn_scalp_neq0.
+  apply: dvdpN0 (dvdp_mulIl (p %/ gcdp p q) (gcdp p q)) _.
+  by rewrite -e scale_poly_eq0 negb_or lc_expn_scalp_neq0.
 have gn0 : gcdp p q != 0.
-  move: (dvdp_mulIr (p %/ gcdp p q) (gcdp p q)); move/dvdpN0; apply; rewrite -e.
-  by rewrite scale_poly_eq0 negb_or lc_expn_scalp_neq0.
+  apply: dvdpN0 (dvdp_mulIr (p %/ gcdp p q) (gcdp p q)) _.
+  by rewrite -e scale_poly_eq0 negb_or lc_expn_scalp_neq0.
 have sp' : size (p %/ (gcdp p q)) <= k.
-  rewrite size_divp ?sgp // leq_subLR (leq_trans hs)//.
-  rewrite -subn_gt0 addnK -subn1 ltn_subRL addn0 ltnNge leq_eqVlt.
-  by rewrite [_ == _]cop ltnS leqn0 size_poly_eq0 (negPf gn0).
+  rewrite size_divp ?sgp // leq_subLR (leq_trans hs) // -add1n leq_add2r -subn1.
+  by rewrite ltn_subRL add1n ltn_neqAle eq_sym [_ == _]cop size_poly_gt0 gn0.
 case (ihk _ sp')=> r' dr'p'; first rewrite p'n0 orbF=> cr'q maxr'.
 constructor=> //=; rewrite ?(negPf p0) ?orbF //.
   exact/(dvdp_trans dr'p')/divp_dvd/dvdp_gcdl.
 move=> d dp cdq; apply: maxr'; last by rewrite cdq.
 case dpq: (d %| gcdp p q).
-  move: (dpq); rewrite dvdp_gcd dp /= => dq; apply: dvdUp; move: cdq.
-  apply: contraLR=> nd1; apply/coprimepPn; last first.
+  move: (dpq); rewrite dvdp_gcd dp /= => dq; apply: dvdUp.
+  apply: contraLR cdq => nd1; apply/coprimepPn; last first.
     by exists d; rewrite dvdp_gcd dvdpp dq nd1.
-  move/negP: p0; move/negP; apply: contra=> d0; move: dp; rewrite (eqP d0).
-  by rewrite dvd0p.
-move: (dp); apply: contraLR=> ndp'.
+  by apply: contraNneq p0 => d0; move: dp; rewrite d0 dvd0p.
+apply: contraLR dp => ndp'.
 rewrite (@eqp_dvdr ((lead_coef (gcdp p q) ^+ scalp p (gcdp p q))*:p)).
   by rewrite e; rewrite Gauss_dvdpl //; apply: (coprimep_dvdl (dvdp_gcdr _ _)).
 by rewrite eqp_sym eqp_scale // lc_expn_scalp_neq0.
@@ -2393,24 +2228,23 @@ Proof. by move=> q_neq0; case: gdcopP=> d; rewrite (negPf q_neq0) orbF. Qed.
 Lemma size2_dvdp_gdco p q d : p != 0 -> size d = 2%N ->
   (d %| (gdcop q p)) = (d %| p) && ~~(d %| q).
 Proof.
-case: (eqVneq d 0) => [-> | dn0]; first by rewrite size_poly0.
+have [-> | dn0] := eqVneq d 0; first by rewrite size_poly0.
 move=> p0 sd; apply/idP/idP.
   case: gdcopP=> r rp crq maxr dr; move/negPf: (p0)=> p0f.
   rewrite (dvdp_trans dr) //=.
-  move: crq; apply: contraL=> dq; rewrite p0f orbF; apply/coprimepPn.
-    by move: p0; apply: contra=> r0; move: rp; rewrite (eqP r0) dvd0p.
+  apply: contraL crq => dq; rewrite p0f orbF; apply/coprimepPn.
+    by apply: contraNneq p0 => r0; move: rp; rewrite r0 dvd0p.
   by exists d; rewrite dvdp_gcd dr dq -size_poly_eq1 sd.
 case/andP=> dp dq; case: gdcopP=> r rp crq maxr; apply: maxr=> //.
 apply/coprimepP=> x xd xq.
 move: (dvdp_leq dn0 xd); rewrite leq_eqVlt sd; case/orP; last first.
-  rewrite ltnS leq_eqVlt; case/orP; first by rewrite -size_poly_eq1.
-  rewrite ltnS leqn0 size_poly_eq0; move/eqP=> x0; move: xd; rewrite x0 dvd0p.
-  by rewrite (negPf dn0).
+  rewrite ltnS leq_eqVlt ltnS size_poly_leq0 orbC.
+  case/predU1P => [x0|]; last by rewrite -size_poly_eq1.
+  by move: xd; rewrite x0 dvd0p (negPf dn0).
 by rewrite -sd dvdp_size_eqp //; move/(eqp_dvdl q); rewrite xq (negPf dq).
 Qed.
 
-Lemma dvdp_gdco p q : (gdcop p q) %| q.
-Proof. by case: gdcopP. Qed.
+Lemma dvdp_gdco p q : (gdcop p q) %| q. Proof. by case: gdcopP. Qed.
 
 Lemma root_gdco p q x : p != 0 -> root (gdcop q p) x = root p x && ~~(root q x).
 Proof.
@@ -2421,14 +2255,14 @@ Qed.
 
 Lemma dvdp_comp_poly r p q : (p %| q) -> (p \Po r) %| (q \Po r).
 Proof.
-case: (eqVneq p 0) => [-> | pn0].
+have [-> | pn0] := eqVneq p 0.
   by rewrite comp_poly0 !dvd0p; move/eqP->; rewrite comp_poly0.
 rewrite dvdp_eq; set c := _ ^+ _; set s := _ %/ _; move/eqP=> Hq.
 apply: (@eq_dvdp c (s \Po r)); first by rewrite expf_neq0 // lead_coef_eq0.
 by rewrite -comp_polyZ Hq comp_polyM.
 Qed.
 
-Lemma gcdp_comp_poly r p q : gcdp p q \Po r %=  gcdp (p \Po r) (q \Po r).
+Lemma gcdp_comp_poly r p q : gcdp p q \Po r %= gcdp (p \Po r) (q \Po r).
 Proof.
 apply/andP; split.
   by rewrite dvdp_gcd !dvdp_comp_poly ?dvdp_gcdl ?dvdp_gcdr.
@@ -2452,16 +2286,16 @@ Definition irreducible_poly p :=
   (size p > 1) * (forall q, size q != 1%N -> q %| p -> q %= p) : Prop.
 
 Lemma irredp_neq0 p : irreducible_poly p -> p != 0.
-Proof. by rewrite -size_poly_eq0 -lt0n => [[/ltnW]]. Qed.
+Proof. by rewrite -size_poly_gt0 => [[/ltnW]]. Qed.
 
 Definition apply_irredp p (irr_p : irreducible_poly p) := irr_p.2.
 Coercion apply_irredp : irreducible_poly >-> Funclass.
 
 Lemma modp_XsubC p c : p %% ('X - c%:P) = p.[c]%:P.
 Proof.
-have: root (p - p.[c]%:P) c by rewrite /root !hornerE subrr.
-case/factor_theorem=> q /(canRL (subrK _)) Dp; rewrite modpE /= lead_coefXsubC.
-rewrite GRing.unitr1 expr1n invr1 scale1r {1}Dp.
+have/factor_theorem [q /(canRL (subrK _)) Dp]: root (p - p.[c]%:P) c.
+  by rewrite /root !hornerE subrr.
+rewrite modpE /= lead_coefXsubC unitr1 expr1n invr1 scale1r [in LHS]Dp.
 rewrite RingMonic.rmodp_addl_mul_small // ?monicXsubC // size_XsubC size_polyC.
 by case: (p.[c] == 0).
 Qed.
@@ -2469,11 +2303,11 @@ Qed.
 Lemma coprimep_XsubC p c : coprimep p ('X - c%:P) = ~~ root p c.
 Proof.
 rewrite -coprimep_modl modp_XsubC /root -alg_polyC.
-have [-> | /coprimep_scalel->] := altP eqP; last exact: coprime1p.
+have [-> | /coprimep_scalel->] := eqVneq; last exact: coprime1p.
 by rewrite scale0r /coprimep gcd0p size_XsubC.
 Qed.
 
-Lemma coprimepX p : coprimep p 'X =  ~~ root p 0.
+Lemma coprimepX p : coprimep p 'X = ~~ root p 0.
 Proof. by rewrite -['X]subr0 coprimep_XsubC. Qed.
 
 Lemma eqp_monic : {in monic &, forall p q, (p %= q) = (p == q)}.
@@ -2482,9 +2316,8 @@ move=> p q monic_p monic_q; apply/idP/eqP=> [|-> //].
 case/eqpP=> [[a b] /= /andP[a_neq0 _] eq_pq].
 apply: (@mulfI _ a%:P); first by rewrite polyC_eq0.
 rewrite !mul_polyC eq_pq; congr (_ *: q); apply: (mulIf (oner_neq0 _)).
-by rewrite -{1}(monicP monic_q) -(monicP monic_p) -!lead_coefZ eq_pq.
+by rewrite -[in LHS](monicP monic_q) -(monicP monic_p) -!lead_coefZ eq_pq.
 Qed.
-
 
 Lemma dvdp_mul_XsubC p q c :
   (p %| ('X - c%:P) * q) = ((if root p c then p %/ ('X - c%:P) else p) %| q).
@@ -2557,7 +2390,7 @@ Proof. by rewrite modpE (eqP monq) unitr1 expr1n invr1 scale1r. Qed.
 Lemma scalpE p : scalp p q = 0%N.
 Proof. by rewrite scalpE (eqP monq) unitr1. Qed.
 
-Lemma divp_eq  p : p = (p %/ q) * q + (p %% q).
+Lemma divp_eq p : p = (p %/ q) * q + (p %% q).
 Proof. by rewrite -divp_eq (eqP monq) expr1n scale1r. Qed.
 
 Lemma divpp p : q %/ q = 1.
@@ -2575,8 +2408,7 @@ Qed.
 Lemma mulpK p : p * q %/ q = p.
 Proof. by rewrite mulpK ?monic_neq0 // (eqP monq) expr1n scale1r. Qed.
 
-Lemma mulKp p : q * p %/ q = p.
-Proof. by rewrite mulrC; apply: mulpK. Qed.
+Lemma mulKp p : q * p %/ q = p. Proof. by rewrite mulrC mulpK. Qed.
 
 End MonicDivisor.
 
@@ -2596,52 +2428,48 @@ Hypothesis ulcd : lead_coef d \in GRing.unit.
 Implicit Type p q r : {poly R}.
 
 Lemma divp_eq p : p = (p %/ d) * d + (p %% d).
-Proof. by have := (divp_eq p d); rewrite scalpE ulcd expr0 scale1r. Qed.
+Proof. by have := divp_eq p d; rewrite scalpE ulcd expr0 scale1r. Qed.
 
 Lemma edivpP p q r : p = q * d + r -> size r < size d ->
   q = (p %/ d) /\ r = p %% d.
 Proof.
-move=> ep srd; have := (divp_eq p); rewrite {1}ep.
+move=> ep srd; have := divp_eq p; rewrite [LHS]ep.
 move/eqP; rewrite -subr_eq -addrA addrC eq_sym -subr_eq -mulrBl; move/eqP.
 have lcdn0 : lead_coef d != 0 by apply: contraTneq ulcd => ->; rewrite unitr0.
-case abs: (p %/ d - q == 0).
-  move: abs; rewrite subr_eq0; move/eqP->; rewrite subrr mul0r; move/eqP.
-  by rewrite eq_sym subr_eq0; move/eqP->.
+have [-> /esym /eqP|abs] := eqVneq (p %/ d) q.
+  by rewrite subrr mul0r subr_eq0 => /eqP<-.
 have hleq : size d <= size ((p %/ d - q) * d).
   rewrite size_proper_mul; last first.
-    by rewrite mulf_eq0 (negPf lcdn0) orbF lead_coef_eq0 abs.
-  move: abs; rewrite -size_poly_eq0; move/negbT; rewrite -lt0n; move/prednK<-.
-  by rewrite addSn /= leq_addl.
+    by rewrite mulf_eq0 (negPf lcdn0) orbF lead_coef_eq0 subr_eq0.
+  by move: abs; rewrite -subr_eq0; move/polySpred->; rewrite addSn /= leq_addl.
 have hlt : size (r - p %% d) < size d.
-  apply: leq_ltn_trans (size_add _ _) _; rewrite size_opp.
-  by rewrite gtn_max srd ltn_modp /= -lead_coef_eq0.
-by move=> e; have:= (leq_trans hlt hleq); rewrite e ltnn.
+  apply: leq_ltn_trans (size_add _ _) _.
+  by rewrite gtn_max srd size_opp ltn_modp -lead_coef_eq0.
+by move=> e; have:= leq_trans hlt hleq; rewrite e ltnn.
 Qed.
 
-Lemma divpP p q r : p = q * d + r -> size r < size d ->
-  q = (p %/ d).
+Lemma divpP p q r : p = q * d + r -> size r < size d -> q = (p %/ d).
 Proof. by move/edivpP=> h; case/h. Qed.
 
-Lemma modpP p q r :  p = q * d + r -> size r < size d -> r = (p %% d).
+Lemma modpP p q r : p = q * d + r -> size r < size d -> r = (p %% d).
 Proof. by move/edivpP=> h; case/h. Qed.
 
 Lemma ulc_eqpP p q : lead_coef q \is a GRing.unit ->
   reflect (exists2 c : R, c != 0 & p = c *: q) (p %= q).
 Proof.
-  case: (altP (lead_coef q =P 0)) => [->|]; first by rewrite unitr0.
-  rewrite lead_coef_eq0 => nz_q ulcq; apply: (iffP idP).
-    case: (altP (p =P 0)) => [->|nz_p].
-      by rewrite eqp_sym eqp0 (negbTE nz_q).
-    move/eqp_eq=> eq; exists (lead_coef p / lead_coef q).
-      by rewrite mulf_neq0 // ?invr_eq0 lead_coef_eq0.
-    by apply/(scaler_injl ulcq); rewrite scalerA mulrCA divrr // mulr1.
-  by case=> c nz_c ->; apply/eqpP; exists (1, c); rewrite ?scale1r ?oner_eq0.
+have [->|] := eqVneq (lead_coef q) 0; first by rewrite unitr0.
+rewrite lead_coef_eq0 => nz_q ulcq; apply: (iffP idP).
+  have [->|nz_p] := eqVneq p 0; first by rewrite eqp_sym eqp0 (negPf nz_q).
+  move/eqp_eq=> eq; exists (lead_coef p / lead_coef q).
+    by rewrite mulf_neq0 // ?invr_eq0 lead_coef_eq0.
+  by apply/(scaler_injl ulcq); rewrite scalerA mulrCA divrr // mulr1.
+by case=> c nz_c ->; apply/eqpP; exists (1, c); rewrite ?scale1r ?oner_eq0.
 Qed.
 
 Lemma dvdp_eq p : (d %| p) = (p == p %/ d * d).
 Proof.
 apply/eqP/eqP=> [modp0 | ->]; last exact: modp_mull.
-by rewrite {1}(divp_eq p) modp0 addr0.
+by rewrite [p in LHS]divp_eq modp0 addr0.
 Qed.
 
 Lemma ucl_eqp_eq p q : lead_coef q \is a GRing.unit ->
@@ -2653,26 +2481,24 @@ Qed.
 
 Lemma modp_scalel c p : (c *: p) %% d = c *: (p %% d).
 Proof.
-case: (altP (c =P 0)) => [-> | cn0]; first by rewrite !scale0r mod0p.
+have [-> | cn0] := eqVneq c 0; first by rewrite !scale0r mod0p.
 have e : (c *: p) = (c *: (p %/ d)) * d + c *: (p %% d).
   by rewrite -scalerAl -scalerDr -divp_eq.
-have s: size (c *: (p %% d)) < size d.
-  rewrite -mul_polyC; apply: leq_ltn_trans (size_mul_leq _ _) _.
-  rewrite size_polyC cn0 addSn add0n /= ltn_modp.
-  by rewrite -lead_coef_eq0; apply: contraTneq ulcd => ->; rewrite unitr0.
-by case: (edivpP e s) => _ ->.
+suff s: size (c *: (p %% d)) < size d by case: (edivpP e s) => _ ->.
+rewrite -mul_polyC; apply: leq_ltn_trans (size_mul_leq _ _) _.
+rewrite size_polyC cn0 addSn add0n /= ltn_modp -lead_coef_eq0.
+by apply: contraTneq ulcd => ->; rewrite unitr0.
 Qed.
 
 Lemma divp_scalel c p : (c *: p) %/ d = c *: (p %/ d).
 Proof.
-case: (altP (c =P 0)) => [-> | cn0]; first by rewrite !scale0r div0p.
+have [-> | cn0] := eqVneq c 0; first by rewrite !scale0r div0p.
 have e : (c *: p) = (c *: (p %/ d)) * d + c *: (p %% d).
   by rewrite -scalerAl -scalerDr -divp_eq.
-have s: size (c *: (p %% d)) < size d.
-  rewrite -mul_polyC; apply: leq_ltn_trans (size_mul_leq _ _) _.
-  rewrite size_polyC cn0 addSn add0n /= ltn_modp.
-  by rewrite -lead_coef_eq0; apply: contraTneq ulcd => ->; rewrite unitr0.
-by case: (edivpP e s) => ->.
+suff s: size (c *: (p %% d)) < size d by case: (edivpP e s) => ->.
+rewrite -mul_polyC; apply: leq_ltn_trans (size_mul_leq _ _) _.
+rewrite size_polyC cn0 addSn add0n /= ltn_modp -lead_coef_eq0.
+by apply: contraTneq ulcd => ->; rewrite unitr0.
 Qed.
 
 Lemma eqp_modpl p q : p %= q -> (p %% d) %= (q %% d).
@@ -2683,52 +2509,41 @@ Qed.
 
 Lemma eqp_divl p q : p %= q -> (p %/ d) %= (q %/ d).
 Proof.
-case/eqpP=> [[c1 c2]] /andP /=  [c1n0 c2n0 e].
+case/eqpP=> [[c1 c2]] /andP /= [c1n0 c2n0 e].
 by apply/eqpP; exists (c1, c2); rewrite ?c1n0 // -!divp_scalel e.
 Qed.
 
 Lemma modp_opp p : (- p) %% d = - (p %% d).
-Proof.
-by rewrite -mulN1r -[- (_ %% _)]mulN1r -polyC_opp !mul_polyC modp_scalel.
-Qed.
+Proof. by rewrite -mulN1r -[RHS]mulN1r -polyC_opp !mul_polyC modp_scalel. Qed.
 
 Lemma divp_opp p : (- p) %/ d = - (p %/ d).
-Proof.
-by rewrite -mulN1r -[- (_ %/ _)]mulN1r -polyC_opp !mul_polyC divp_scalel.
-Qed.
+Proof. by rewrite -mulN1r -[RHS]mulN1r -polyC_opp !mul_polyC divp_scalel. Qed.
 
 Lemma modp_add p q : (p + q) %% d = p %% d + q %% d.
 Proof.
-have hs : size (p %% d + q %% d) < size d.
-  apply: leq_ltn_trans (size_add _ _) _.
-  rewrite gtn_max !ltn_modp andbb -lead_coef_eq0.
-  by apply: contraTneq ulcd => ->; rewrite unitr0.
-have he : (p + q) = (p %/ d + q %/ d) * d + (p %% d + q %% d).
-  rewrite {1}(divp_eq p) {1}(divp_eq q) addrAC addrA -mulrDl.
-  by rewrite [_ %% _ + _]addrC addrA.
-by case: (edivpP he hs).
+have/edivpP [] // : (p + q) = (p %/ d + q %/ d) * d + (p %% d + q %% d).
+  by rewrite mulrDl addrACA -!divp_eq.
+apply: leq_ltn_trans (size_add _ _) _.
+rewrite gtn_max !ltn_modp andbb -lead_coef_eq0.
+by apply: contraTneq ulcd => ->; rewrite unitr0.
 Qed.
 
 Lemma divp_add p q : (p + q) %/ d = p %/ d + q %/ d.
 Proof.
-have hs : size (p %% d + q %% d) < size d.
-  apply: leq_ltn_trans (size_add _ _) _.
-  rewrite gtn_max !ltn_modp andbb -lead_coef_eq0.
-  by apply: contraTneq ulcd => ->; rewrite unitr0.
-have he : (p + q) = (p %/ d + q %/ d) * d + (p %% d + q %% d).
-  rewrite {1}(divp_eq p) {1}(divp_eq q) addrAC addrA -mulrDl.
-  by rewrite [_ %% _ + _]addrC addrA.
-by case: (edivpP he hs).
+have/edivpP [] // : (p + q) = (p %/ d + q %/ d) * d + (p %% d + q %% d).
+  by rewrite mulrDl addrACA -!divp_eq.
+apply: leq_ltn_trans (size_add _ _) _.
+rewrite gtn_max !ltn_modp andbb -lead_coef_eq0.
+by apply: contraTneq ulcd => ->; rewrite unitr0.
 Qed.
 
 Lemma mulpK q : (q * d) %/ d = q.
 Proof.
-case/edivpP: (sym_eq (addr0 (q * d))); rewrite // size_poly0 size_poly_gt0.
+case/esym/edivpP: (addr0 (q * d)); rewrite // size_poly0 size_poly_gt0.
 by rewrite -lead_coef_eq0; apply: contraTneq ulcd => ->; rewrite unitr0.
 Qed.
 
-Lemma mulKp q : (d * q) %/ d = q.
-Proof. by rewrite mulrC; apply: mulpK. Qed.
+Lemma mulKp q : (d * q) %/ d = q. Proof. by rewrite mulrC; apply: mulpK. Qed.
 
 Lemma divp_addl_mul_small q r :
   size r < size d -> (q * d + r) %/ d = q.
@@ -2741,17 +2556,14 @@ Proof. by move=> srd; rewrite modp_add modp_mull add0r modp_small. Qed.
 Lemma divp_addl_mul q r : (q * d + r) %/ d = q + r %/ d.
 Proof. by rewrite divp_add mulpK. Qed.
 
-Lemma divpp : d %/ d = 1.
-Proof. by rewrite -{1}(mul1r d) mulpK. Qed.
+Lemma divpp : d %/ d = 1. Proof. by rewrite -[d in d %/ _]mul1r mulpK. Qed.
 
 Lemma leq_trunc_divp m : size (m %/ d * d) <= size m.
 Proof.
-have dn0 : d != 0.
-  by rewrite -lead_coef_eq0; apply: contraTneq ulcd => ->; rewrite unitr0.
-case q0 : (m %/ d == 0); first by rewrite (eqP q0) mul0r size_poly0 leq0n.
-rewrite {2}(divp_eq m) size_addl // size_mul ?q0 //; move/negbT: q0.
-rewrite -size_poly_gt0; move/prednK<-; rewrite addSn /=.
-by move: dn0; rewrite -(ltn_modp m); move/ltn_addl->.
+case: (eqVneq d 0) ulcd => [->|dn0 _]; first by rewrite lead_coef0 unitr0.
+have [->|q0] := eqVneq (m %/ d) 0; first by rewrite mul0r size_poly0 leq0n.
+rewrite {2}(divp_eq m) size_addl // size_mul // (polySpred q0) addSn /=.
+by rewrite ltn_addl // ltn_modp.
 Qed.
 
 Lemma dvdpP p : reflect (exists q, p = q * d) (d %| p).
@@ -2766,11 +2578,11 @@ Proof. by rewrite dvdp_eq; move/eqP. Qed.
 Lemma divpKC p : d %| p -> d * (p %/ d) = p.
 Proof. by move=> ?; rewrite mulrC divpK. Qed.
 
-Lemma dvdp_eq_div p q :  d %| p -> (q == p %/ d) = (q * d == p).
+Lemma dvdp_eq_div p q : d %| p -> (q == p %/ d) = (q * d == p).
 Proof.
 move/divpK=> {2}<-; apply/eqP/eqP; first by move->.
-suff dn0 : d != 0 by move/(mulIf dn0).
-by rewrite -lead_coef_eq0; apply: contraTneq ulcd => ->; rewrite unitr0.
+apply/mulIf; rewrite -lead_coef_eq0; apply: contraTneq ulcd => ->.
+by rewrite unitr0.
 Qed.
 
 Lemma dvdp_eq_mul p q : d %| p -> (p == q * d) = (p %/ d == q).
@@ -2790,11 +2602,7 @@ Lemma divp_mulCA p q : d %| p -> d %| q -> p * (q %/ d) = q * (p %/ d).
 Proof. by move=> hdp hdq; rewrite mulrC divp_mulAC // divp_mulA. Qed.
 
 Lemma modp_mul p q : (p * (q %% d)) %% d = (p * q) %% d.
-Proof.
-have -> : q %% d = q - q %/ d * d by rewrite {2}(divp_eq q) -addrA addrC subrK.
-rewrite mulrDr modp_add // -mulNr mulrA -{2}[_ %% _]addr0; congr (_ + _).
-by apply/eqP; apply: dvdp_mull; apply: dvdpp.
-Qed.
+Proof. by rewrite [q in RHS]divp_eq mulrDr modp_add mulrA modp_mull add0r. Qed.
 
 End UnitDivisor.
 
@@ -2807,16 +2615,12 @@ Hypothesis ulcd : lead_coef d \in GRing.unit.
 Implicit Types p q : {poly R}.
 
 Lemma expp_sub m n : n <= m -> (d ^+ (m - n))%N = d ^+ m %/ d ^+ n.
-Proof.
-by move/subnK=> {2}<-; rewrite exprD mulpK // lead_coef_exp unitrX.
-Qed.
+Proof. by move/subnK=> {2}<-; rewrite exprD mulpK // lead_coef_exp unitrX. Qed.
 
 Lemma divp_pmul2l p q : lead_coef q \in GRing.unit -> d * p %/ (d * q) = p %/ q.
 Proof.
-move=> uq.
-have udq: lead_coef (d * q) \in GRing.unit.
+move=> uq; rewrite {1}(divp_eq uq p) mulrDr mulrCA divp_addl_mul //; last first.
   by rewrite lead_coefM unitrM_comm ?ulcd //; red; rewrite mulrC.
-rewrite {1}(divp_eq uq p) mulrDr mulrCA divp_addl_mul //.
 have dn0 : d != 0.
   by rewrite -lead_coef_eq0; apply: contraTneq ulcd => ->; rewrite unitr0.
 have qn0 : q != 0.
@@ -2824,14 +2628,12 @@ have qn0 : q != 0.
 have dqn0 : d * q != 0 by rewrite mulf_eq0 negb_or dn0.
 suff : size (d * (p %% q)) < size (d * q).
   by rewrite ltnNge -divpN0 // negbK => /eqP ->; rewrite addr0.
-case: (altP ( (p %% q) =P 0)) => [-> | rn0].
+have [-> | rn0] := eqVneq (p %% q) 0.
   by rewrite mulr0 size_poly0 size_poly_gt0.
-rewrite !size_mul //; move: dn0; rewrite -size_poly_gt0.
-by move/prednK<-; rewrite !addSn /= ltn_add2l ltn_modp.
+by rewrite !size_mul // (polySpred dn0) !addSn /= ltn_add2l ltn_modp.
 Qed.
 
-Lemma divp_pmul2r p q :
-  lead_coef p \in GRing.unit ->  q * d %/ (p * d) = q %/ p.
+Lemma divp_pmul2r p q : lead_coef p \in GRing.unit -> q * d %/ (p * d) = q %/ p.
 Proof. by move=> uq; rewrite -!(mulrC d) divp_pmul2l. Qed.
 
 Lemma divp_divl r p q :
@@ -2839,14 +2641,14 @@ Lemma divp_divl r p q :
   q %/ p %/ r = q %/ (p * r).
 Proof.
 move=> ulcr ulcp.
-have e : q = (q %/ p %/ r) * (p * r) + ((q %/ p) %% r * p +  q %% p).
+have e : q = (q %/ p %/ r) * (p * r) + ((q %/ p) %% r * p + q %% p).
   by rewrite addrA (mulrC p) mulrA -mulrDl; rewrite -divp_eq //; apply: divp_eq.
 have pn0 : p != 0.
   by rewrite -lead_coef_eq0; apply: contraTneq ulcp => ->; rewrite unitr0.
 have rn0 : r != 0.
   by rewrite -lead_coef_eq0; apply: contraTneq ulcr => ->; rewrite unitr0.
-have s : size ((q %/ p) %% r * p +  q %% p) < size (p * r).
-  case: (altP ((q %/ p) %% r =P 0)) => [-> | qn0].
+have s : size ((q %/ p) %% r * p + q %% p) < size (p * r).
+  have [-> | qn0] := eqVneq ((q %/ p) %% r) 0.
     rewrite mul0r add0r size_mul // (polySpred rn0) addnS /=.
     by apply: leq_trans (leq_addr _ _); rewrite ltn_modp.
   rewrite size_addl mulrC.
@@ -2857,12 +2659,12 @@ case: (edivpP _ e s) => //; rewrite lead_coefM unitrM_comm ?ulcp //.
 by red; rewrite mulrC.
 Qed.
 
-Lemma divpAC p q : lead_coef p \in GRing.unit -> q %/ d %/ p =  q %/ p %/ d.
+Lemma divpAC p q : lead_coef p \in GRing.unit -> q %/ d %/ p = q %/ p %/ d.
 Proof. by move=> ulcp; rewrite !divp_divl // mulrC. Qed.
 
 Lemma modp_scaler c p : c \in GRing.unit -> p %% (c *: d) = (p %% d).
 Proof.
-move=> cn0; case: (eqVneq d 0) => [-> | dn0]; first by rewrite scaler0 !modp0.
+case: (eqVneq d 0) => [-> | dn0 cn0]; first by rewrite scaler0 !modp0.
 have e : p = (c^-1 *: (p %/ d)) * (c *: d) + (p %% d).
   by rewrite scalerCA scalerA mulVr // scale1r -(divp_eq ulcd).
 suff s : size (p %% d) < size (c *: d).
@@ -2872,8 +2674,7 @@ Qed.
 
 Lemma divp_scaler c p : c \in GRing.unit -> p %/ (c *: d) = c^-1 *: (p %/ d).
 Proof.
-move=> cn0; case: (eqVneq d 0) => [-> | dn0].
-   by rewrite scaler0 !divp0 scaler0.
+case: (eqVneq d 0) => [-> | dn0 cn0]; first by rewrite scaler0 !divp0 scaler0.
 have e : p = (c^-1 *: (p %/ d)) * (c *: d) + (p %% d).
   by rewrite scalerCA scalerA mulVr // scale1r -(divp_eq ulcd).
 suff s : size (p %% d) < size (c *: d).
@@ -2900,7 +2701,7 @@ Implicit Type p q r d : {poly F}.
 
 Lemma divp_eq p q : p = (p %/ q) * q + (p %% q).
 Proof.
-case: (eqVneq q 0) => [-> | qn0]; first by rewrite modp0 mulr0 add0r.
+have [-> | qn0] := eqVneq q 0; first by rewrite modp0 mulr0 add0r.
 by apply: IdomainUnit.divp_eq; rewrite unitfE lead_coef_eq0.
 Qed.
 
@@ -2915,20 +2716,18 @@ Lemma divpP p q d r : p = q * d + r -> size r < size d ->
   q = (p %/ d).
 Proof. by move/divp_modpP=> h; case/h. Qed.
 
-Lemma modpP p q d r :  p = q * d + r -> size r < size d -> r = (p %% d).
+Lemma modpP p q d r : p = q * d + r -> size r < size d -> r = (p %% d).
 Proof. by move/divp_modpP=> h; case/h. Qed.
 
 Lemma eqpfP p q : p %= q -> p = (lead_coef p / lead_coef q) *: q.
 Proof.
-have [->|nz_q] := altP (q =P 0).
-  by rewrite eqp0 => /eqP ->; rewrite scaler0.
-move/IdomainUnit.ucl_eqp_eq; apply; rewrite unitfE.
-by move: nz_q; rewrite -lead_coef_eq0 => nz_qT.
+have [->|nz_q] := eqVneq q 0; first by rewrite eqp0 scaler0 => /eqP ->.
+by apply/IdomainUnit.ucl_eqp_eq; rewrite unitfE lead_coef_eq0.
 Qed.
 
 Lemma dvdp_eq q p : (q %| p) = (p == p %/ q * q).
 Proof.
-case: (eqVneq q 0) => [-> | qn0]; first by rewrite dvd0p mulr0 eq_sym.
+have [-> | qn0] := eqVneq q 0; first by rewrite dvd0p mulr0 eq_sym.
 by apply: IdomainUnit.dvdp_eq; rewrite unitfE lead_coef_eq0.
 Qed.
 
@@ -2937,7 +2736,7 @@ Proof.
 apply: (iffP idP); last first.
   case=> c nz_c ->; apply/eqpP.
   by exists (1, c); rewrite ?scale1r ?oner_eq0.
-have [->|nz_q] := altP (q =P 0).
+have [->|nz_q] := eqVneq q 0.
   by rewrite eqp0=> /eqP ->; exists 1; rewrite ?scale1r ?oner_eq0.
 case/IdomainUnit.ulc_eqpP; first by rewrite unitfE lead_coef_eq0.
 by move=> c nz_c ->; exists c.
@@ -2945,7 +2744,7 @@ Qed.
 
 Lemma modp_scalel c p q : (c *: p) %% q = c *: (p %% q).
 Proof.
-case: (eqVneq q 0) => [-> | qn0]; first by rewrite !modp0.
+have [-> | qn0] := eqVneq q 0; first by rewrite !modp0.
 by apply: IdomainUnit.modp_scalel; rewrite unitfE lead_coef_eq0.
 Qed.
 
@@ -2957,13 +2756,13 @@ Proof. by rewrite mulrC; apply: mulpK. Qed.
 
 Lemma divp_scalel c p q : (c *: p) %/ q = c *: (p %/ q).
 Proof.
-case: (eqVneq q 0) => [-> | qn0]; first by rewrite !divp0 scaler0.
+have [-> | qn0] := eqVneq q 0; first by rewrite !divp0 scaler0.
 by apply: IdomainUnit.divp_scalel; rewrite unitfE lead_coef_eq0.
 Qed.
 
 Lemma modp_scaler c p d : c != 0 -> p %% (c *: d) = (p %% d).
 Proof.
-move=> cn0; case: (eqVneq d 0) => [-> | dn0]; first by rewrite scaler0 !modp0.
+case: (eqVneq d 0) => [-> | dn0 cn0]; first by rewrite scaler0 !modp0.
 have e : p = (c^-1 *: (p %/ d)) * (c *: d) + (p %% d).
   by rewrite scalerCA scalerA mulVf // scale1r -divp_eq.
 suff s : size (p %% d) < size (c *: d) by rewrite (modpP e s).
@@ -2972,8 +2771,7 @@ Qed.
 
 Lemma divp_scaler c p d : c != 0 -> p %/ (c *: d) = c^-1 *: (p %/ d).
 Proof.
-move=> cn0; case: (eqVneq d 0) => [-> | dn0].
-  by rewrite scaler0 !divp0 scaler0.
+case: (eqVneq d 0) => [-> | dn0 cn0]; first by rewrite scaler0 !divp0 scaler0.
 have e : p = (c^-1 *: (p %/ d)) * (c *: d) + (p %% d).
   by rewrite scalerCA scalerA mulVf // scale1r -divp_eq.
 suff s : size (p %% d) < size (c *: d) by rewrite (divpP e s).
@@ -3022,30 +2820,28 @@ Lemma eqp_gdcor p q r : q %= r -> gdcop p q %= gdcop p r.
 Proof.
 move=> eqr; rewrite /gdcop (eqp_size eqr).
 move: (size r)=> n; elim: n p q r eqr => [|n ihn] p q r; first by rewrite eqpxx.
-move=> eqr /=; rewrite (eqp_coprimepl p eqr); case: ifP => _ //; apply: ihn.
-by apply: eqp_div => //; apply: eqp_gcdl.
+move=> eqr /=; rewrite (eqp_coprimepl p eqr); case: ifP => _ //.
+exact/ihn/eqp_div/eqp_gcdl.
 Qed.
 
 Lemma eqp_gdcol p q r : q %= r -> gdcop q p %= gdcop r p.
 Proof.
 move=> eqr; rewrite /gdcop; move: (size p)=> n.
 elim: n p q r eqr {1 3}p (eqpxx p) => [|n ihn] p q r eqr s esp /=.
-  move: eqr; case: (eqVneq q 0)=> [-> | nq0 eqr] /=.
+  case: (eqVneq q 0) eqr => [-> | nq0 eqr] /=.
     by rewrite eqp_sym eqp0 => ->; rewrite eqpxx.
-  suff rn0 : r != 0 by rewrite (negPf rn0) eqpxx.
-  by apply: contraTneq eqr => ->; rewrite eqp0.
+  by case: (eqVneq r 0) eqr nq0 => [->|]; rewrite ?eqpxx // eqp0 => ->.
 rewrite (eqp_coprimepr _ eqr) (eqp_coprimepl _ esp); case: ifP=> _ //.
-by apply: ihn => //; apply: eqp_div => //; apply: eqp_gcd.
+exact/ihn/eqp_div/eqp_gcd.
 Qed.
 
 Lemma eqp_rgdco_gdco q p : rgdcop q p %= gdcop q p.
 Proof.
 rewrite /rgdcop /gdcop; move: (size p)=> n.
 elim: n p q {1 3}p {1 3}q (eqpxx p) (eqpxx q) => [|n ihn] p q s t /= sp tq.
-  move: tq; case: (eqVneq t 0)=> [-> | nt0 etq].
+  case: (eqVneq t 0) tq => [-> | nt0 etq].
     by rewrite eqp_sym eqp0 => ->; rewrite eqpxx.
-  suff qn0 : q != 0 by rewrite (negPf qn0) eqpxx.
-  by apply: contraTneq etq => ->; rewrite eqp0.
+  by case: (eqVneq q 0) etq nt0 => [->|]; rewrite ?eqpxx // eqp0 => ->.
 rewrite rcoprimep_coprimep (eqp_coprimepl t sp) (eqp_coprimepr p tq).
 case: ifP=> // _; apply: ihn => //; apply: eqp_trans (eqp_rdiv_div _ _) _.
 by apply: eqp_div => //; apply: eqp_trans (eqp_rgcd_gcd _ _) _; apply: eqp_gcd.
@@ -3053,19 +2849,19 @@ Qed.
 
 Lemma modp_opp p q : (- p) %% q = - (p %% q).
 Proof.
-case: (eqVneq q 0) => [-> | qn0]; first by rewrite !modp0.
+have [-> | qn0] := eqVneq q 0; first by rewrite !modp0.
 by apply: IdomainUnit.modp_opp; rewrite unitfE lead_coef_eq0.
 Qed.
 
 Lemma divp_opp p q : (- p) %/ q = - (p %/ q).
 Proof.
-case: (eqVneq q 0) => [-> | qn0]; first by rewrite !divp0 oppr0.
+have [-> | qn0] := eqVneq q 0; first by rewrite !divp0 oppr0.
 by apply: IdomainUnit.divp_opp; rewrite unitfE lead_coef_eq0.
 Qed.
 
 Lemma modp_add d p q : (p + q) %% d = p %% d + q %% d.
 Proof.
-case: (eqVneq d 0) => [-> | dn0]; first by rewrite !modp0.
+have [-> | dn0] := eqVneq d 0; first by rewrite !modp0.
 by apply: IdomainUnit.modp_add; rewrite unitfE lead_coef_eq0.
 Qed.
 
@@ -3074,7 +2870,7 @@ Proof. by apply/eqP; rewrite -addr_eq0 -modp_add addNr mod0p. Qed.
 
 Lemma divp_add d p q : (p + q) %/ d = p %/ d + q %/ d.
 Proof.
-case: (eqVneq d 0) => [-> | dn0]; first by rewrite !divp0 addr0.
+have [-> | dn0] := eqVneq d 0; first by rewrite !divp0 addr0.
 by apply: IdomainUnit.divp_add; rewrite unitfE lead_coef_eq0.
 Qed.
 
@@ -3099,20 +2895,20 @@ Qed.
 
 Lemma leq_trunc_divp d m : size (m %/ d * d) <= size m.
 Proof.
-case: (eqVneq d 0) => [-> | dn0]; first by rewrite mulr0 size_poly0.
+have [-> | dn0] := eqVneq d 0; first by rewrite mulr0 size_poly0.
 by apply: IdomainUnit.leq_trunc_divp; rewrite unitfE lead_coef_eq0.
 Qed.
 
 Lemma divpK d p : d %| p -> p %/ d * d = p.
 Proof.
-case: (eqVneq d 0) => [-> | dn0]; first by move/dvd0pP->; rewrite mulr0.
+case: (eqVneq d 0) => [-> /dvd0pP -> | dn0]; first by rewrite mulr0.
 by apply: IdomainUnit.divpK; rewrite unitfE lead_coef_eq0.
 Qed.
 
 Lemma divpKC d p : d %| p -> d * (p %/ d) = p.
 Proof. by move=> ?; rewrite mulrC divpK. Qed.
 
-Lemma dvdp_eq_div d p q :  d != 0 -> d %| p -> (q == p %/ d) = (q * d == p).
+Lemma dvdp_eq_div d p q : d != 0 -> d %| p -> (q == p %/ d) = (q * d == p).
 Proof.
 by move=> dn0; apply: IdomainUnit.dvdp_eq_div; rewrite unitfE lead_coef_eq0.
 Qed.
@@ -3122,7 +2918,7 @@ Proof. by move=> dn0 dv_d_p; rewrite eq_sym -dvdp_eq_div // eq_sym. Qed.
 
 Lemma divp_mulA d p q : d %| q -> p * (q %/ d) = p * q %/ d.
 Proof.
-case: (eqVneq d 0) => [-> | dn0]; first by move/dvd0pP->; rewrite !divp0 mulr0.
+case: (eqVneq d 0) => [-> /dvd0pP -> | dn0]; first by rewrite !divp0 mulr0.
 by apply: IdomainUnit.divp_mulA; rewrite unitfE lead_coef_eq0.
 Qed.
 
@@ -3140,43 +2936,42 @@ Proof.
 by move=> dn0 qn0; apply: IdomainUnit.divp_pmul2l; rewrite unitfE lead_coef_eq0.
 Qed.
 
-Lemma divp_pmul2r d p q : d != 0 -> p != 0 ->  q * d %/ (p * d) = q %/ p.
+Lemma divp_pmul2r d p q : d != 0 -> p != 0 -> q * d %/ (p * d) = q %/ p.
 Proof. by move=> dn0 qn0; rewrite -!(mulrC d) divp_pmul2l. Qed.
 
-Lemma divp_divl r p q :  q %/ p %/ r = q %/ (p * r).
+Lemma divp_divl r p q : q %/ p %/ r = q %/ (p * r).
 Proof.
-case: (eqVneq r 0) => [-> | rn0]; first by rewrite mulr0 !divp0.
-case: (eqVneq p 0) => [-> | pn0]; first by rewrite mul0r !divp0 div0p.
+have [-> | rn0] := eqVneq r 0; first by rewrite mulr0 !divp0.
+have [-> | pn0] := eqVneq p 0; first by rewrite mul0r !divp0 div0p.
 by apply: IdomainUnit.divp_divl; rewrite unitfE lead_coef_eq0.
 Qed.
 
-Lemma divpAC d p q : q %/ d %/ p =  q %/ p %/ d.
+Lemma divpAC d p q : q %/ d %/ p = q %/ p %/ d.
 Proof. by rewrite !divp_divl // mulrC. Qed.
 
 Lemma edivp_def p q : edivp p q = (0%N, p %/ q, p %% q).
 Proof.
 rewrite Idomain.edivp_def; congr (_, _, _); rewrite /scalp 2!unlock /=.
-case (eqVneq q 0) => [-> | qn0]; first by rewrite eqxx lead_coef0 unitr0.
-rewrite (negPf qn0) /= unitfE lead_coef_eq0 qn0 /=.
-by case: (redivp_rec _ _ _ _) => [[]].
+have [-> | qn0] := eqVneq; first by rewrite lead_coef0 unitr0.
+by rewrite unitfE lead_coef_eq0 qn0 /=; case: (redivp_rec _ _ _ _) => [[]].
 Qed.
 
 Lemma divpE p q : p %/ q = (lead_coef q)^-(rscalp p q) *: (rdivp p q).
 Proof.
-case: (eqVneq q 0) => [-> | qn0]; first by rewrite rdivp0 divp0 scaler0.
+have [-> | qn0] := eqVneq q 0; first by rewrite rdivp0 divp0 scaler0.
 by rewrite Idomain.divpE unitfE lead_coef_eq0 qn0.
 Qed.
 
 Lemma modpE p q : p %% q = (lead_coef q)^-(rscalp p q) *: (rmodp p q).
 Proof.
-case: (eqVneq q 0) => [-> | qn0].
+have [-> | qn0] := eqVneq q 0.
   by rewrite rmodp0 modp0 /rscalp unlock eqxx lead_coef0 expr0 invr1 scale1r.
 by rewrite Idomain.modpE unitfE lead_coef_eq0 qn0.
 Qed.
 
 Lemma scalpE p q : scalp p q = 0%N.
 Proof.
-case: (eqVneq q 0) => [-> | qn0]; first by rewrite scalp0.
+have [-> | qn0] := eqVneq q 0; first by rewrite scalp0.
 by rewrite Idomain.scalpE unitfE lead_coef_eq0 qn0.
 Qed.
 
@@ -3201,27 +2996,24 @@ Qed.
 
 Lemma modp_mul p q m : (p * (q %% m)) %% m = (p * q) %% m.
 Proof.
-have ->: q %% m = q - q %/ m * m by rewrite {2}(divp_eq q m) -addrA addrC subrK.
-rewrite mulrDr modp_add // -mulNr mulrA -{2}[_ %% _]addr0; congr (_ + _).
-by apply/eqP; apply: dvdp_mull; apply: dvdpp.
+by rewrite [in RHS](divp_eq q m) mulrDr modp_add mulrA modp_mull add0r.
 Qed.
 
 Lemma dvdpP p q : reflect (exists qq, p = qq * q) (q %| p).
 Proof.
-case: (eqVneq q 0)=> [-> | qn0]; last first.
+have [-> | qn0] := eqVneq q 0; last first.
   by apply: IdomainUnit.dvdpP; rewrite unitfE lead_coef_eq0.
-rewrite dvd0p.
-by apply: (iffP idP) => [/eqP->| [? ->]]; [exists 1|]; rewrite mulr0.
+by rewrite dvd0p; apply: (iffP eqP) => [->| [? ->]]; [exists 1|]; rewrite mulr0.
 Qed.
 
-Lemma Bezout_eq1_coprimepP : forall p q,
+Lemma Bezout_eq1_coprimepP p q :
   reflect (exists u, u.1 * p + u.2 * q = 1) (coprimep p q).
 Proof.
-move=> p q; apply: (iffP idP)=> [hpq|]; last first.
+apply: (iffP idP)=> [hpq|]; last first.
   by case=> [[u v]] /= e; apply/Bezout_coprimepP; exists (u, v); rewrite e eqpxx.
 case/Bezout_coprimepP: hpq => [[u v]] /=.
 case/eqpP=> [[c1 c2]] /andP /= [c1n0 c2n0] e.
-exists (c2^-1  *: (c1 *: u), c2^-1 *: (c1 *: v)); rewrite /=  -!scalerAl.
+exists (c2^-1 *: (c1 *: u), c2^-1 *: (c1 *: v)); rewrite /= -!scalerAl.
 by rewrite -!scalerDr e scalerA mulVf // scale1r.
 Qed.
 
@@ -3231,7 +3023,7 @@ rewrite /gdcop => nz_q; have [n hsp] := ubnPleq (size p).
 elim: n => [|n IHn] /= in p hsp *; first by rewrite (negPf nz_q) mul0r dvdp0.
 have [_ | ncop_pq] := ifPn; first by rewrite dvdp_mulr.
 have g_gt1: 1 < size (gcdp p q).
-  rewrite ltn_neqAle eq_sym ncop_pq lt0n size_poly_eq0 gcdp_eq0.
+  rewrite ltn_neqAle eq_sym ncop_pq size_poly_gt0 gcdp_eq0.
   by rewrite negb_and nz_q orbT.
 have [-> | nz_p] := eqVneq p 0.
   by rewrite div0p exprSr mulrA dvdp_mulr // IHn // size_poly0.
@@ -3282,7 +3074,7 @@ Proof.
 rewrite /rdivp /rscalp /rmodp !unlock map_poly_eq0 size_map_poly.
 have [// | q_nz] := ifPn; rewrite -(rmorph0 (map_poly_rmorphism f)) //.
 have [m _] := ubnPeq (size a); elim: m 0%N 0 a => [|m IHm] qq r a /=.
-  rewrite -!mul_polyC  !size_map_poly !lead_coef_map // -(map_polyXn f).
+  rewrite -!mul_polyC !size_map_poly !lead_coef_map // -(map_polyXn f).
   by rewrite -!(map_polyC f) -!rmorphM -rmorphB -rmorphD; case: (_ < _).
 rewrite -!mul_polyC !size_map_poly !lead_coef_map // -(map_polyXn f).
 by rewrite -!(map_polyC f) -!rmorphM -rmorphB -rmorphD /= IHm; case: (_ < _).
@@ -3302,7 +3094,7 @@ Implicit Type a b : {poly F}.
 Lemma edivp_map a b :
   edivp a^f b^f = (0%N, (a %/ b)^f, (a %% b)^f).
 Proof.
-case: (eqVneq b 0) => [-> | bn0].
+have [-> | bn0] := eqVneq b 0.
   rewrite (rmorph0 (map_poly_rmorphism f)) WeakIdomain.edivp_def !modp0 !divp0.
   by rewrite (rmorph0 (map_poly_rmorphism f)) scalp0.
 rewrite unlock redivp_map lead_coef_map rmorph_unit; last first.
@@ -3346,7 +3138,7 @@ Proof.
 wlog lt_p_q: p q / size p < size q.
   move=> IHpq; case: (ltnP (size p) (size q)) => [|le_q_p]; first exact: IHpq.
   rewrite gcdpE (gcdpE p^f) !size_map_poly ltnNge le_q_p /= -map_modp.
-  case: (eqVneq q 0) => [-> | q_nz]; first by rewrite rmorph0 !gcdp0.
+  have [-> | q_nz] := eqVneq q 0; first by rewrite rmorph0 !gcdp0.
   by rewrite IHpq ?ltn_modp.
 have [m le_q_m] := ubnP (size q); elim: m => // m IHm in p q lt_p_q le_q_m *.
 rewrite gcdpE (gcdpE p^f) !size_map_poly lt_p_q -map_modp.
@@ -3357,7 +3149,7 @@ Qed.
 Lemma coprimep_map p q : coprimep p^f q^f = coprimep p q.
 Proof. by rewrite -!gcdp_eqp1 -eqp_map rmorph1 gcdp_map. Qed.
 
-Lemma gdcop_rec_map p q n : (gdcop_rec p q n)^f = (gdcop_rec p^f q^f n).
+Lemma gdcop_rec_map p q n : (gdcop_rec p q n)^f = gdcop_rec p^f q^f n.
 Proof.
 elim: n p q => [|n IH] => /= p q.
   by rewrite map_poly_eq0; case: eqP; rewrite ?rmorph1 ?rmorph0.
@@ -3365,7 +3157,7 @@ rewrite /coprimep -gcdp_map size_map_poly.
 by case: eqP => Hq0 //; rewrite -map_divp -IH.
 Qed.
 
-Lemma gdcop_map p q : (gdcop p q)^f = (gdcop p^f q^f).
+Lemma gdcop_map p q : (gdcop p q)^f = gdcop p^f q^f.
 Proof. by rewrite /gdcop gdcop_rec_map !size_map_poly. Qed.
 
 End FieldMap.
@@ -3386,14 +3178,12 @@ Lemma root_coprimep (p q : {poly F}):
   (forall x, root p x -> q.[x] != 0) -> coprimep p q.
 Proof.
 move=> Ncmn; rewrite -gcdp_eqp1 -size_poly_eq1; apply/closed_rootP.
-by case=> r; rewrite root_gcd !rootE=> /andP [/Ncmn/negbTE->].
+by case=> r; rewrite root_gcd !rootE=> /andP [/Ncmn/negPf->].
 Qed.
 
 Lemma coprimepP (p q : {poly F}):
   reflect (forall x, root p x -> q.[x] != 0) (coprimep p q).
-Proof.
-  by apply: (iffP idP)=> [/coprimep_root|/root_coprimep].
-Qed.
+Proof. by apply: (iffP idP)=> [/coprimep_root|/root_coprimep]. Qed.
 
 End closed.
 

--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -79,10 +79,10 @@ Fact fracq_subproof : forall x : int * int,
   let d := if x.2 == 0 then 1 else (`|x.2| %/ gcdn `|x.1| `|x.2|)%:Z in
   (0 < d) && (coprime `|n| `|d|).
 Proof.
-move=> [m n] /=; case: (altP (n =P 0))=> [//|n0].
+move=> [m n] /=; have [//|n0] := eqVneq n 0.
 rewrite ltz_nat divn_gt0 ?gcdn_gt0 ?absz_gt0 ?n0 ?orbT //.
 rewrite dvdn_leq ?absz_gt0 ?dvdn_gcdr //= !abszM absz_sign mul1n.
-have [->|m0] := altP (m =P 0); first by rewrite div0n gcd0n divnn absz_gt0 n0.
+have [->|m0] := eqVneq m 0; first by rewrite div0n gcd0n divnn absz_gt0 n0.
 move: n0 m0; rewrite -!absz_gt0 absz_nat.
 move: `|_|%N `|_|%N => {m n} [|m] [|n] // _ _.
 rewrite /coprime -(@eqn_pmul2l (gcdn m.+1 n.+1)) ?gcdn_gt0 //.
@@ -142,7 +142,7 @@ Definition oneq := fracq (1, 1).
 Fact frac0q x : fracq (0, x) = zeroq.
 Proof.
 apply: val_inj; rewrite //= div0n !gcd0n !mulr0 !divnn.
-by have [//|x_neq0] := altP eqP; rewrite absz_gt0 x_neq0.
+by have [//|x_neq0] := eqVneq; rewrite absz_gt0 x_neq0.
 Qed.
 
 Fact fracq0  x : fracq (x, 0) = zeroq. Proof. exact/eqP. Qed.
@@ -174,7 +174,7 @@ Proof. by rewrite abszE normr_denq. Qed.
 Lemma rat_eq x y : (x == y) = (numq x * denq y == numq y * denq x).
 Proof.
 symmetry; rewrite rat_eqE andbC.
-have [->|] /= := altP (denq _ =P _); first by rewrite (inj_eq (mulIf _)).
+have [->|] /= := eqVneq (denq _); first by rewrite (inj_eq (mulIf _)).
 apply: contraNF => /eqP hxy; rewrite -absz_denq -[X in _ == X]absz_denq.
 rewrite eqz_nat /= eqn_dvd.
 rewrite -(@Gauss_dvdr _ `|numq x|) 1?coprime_sym ?coprime_num_den // andbC.
@@ -192,7 +192,7 @@ Qed.
 
 Fact fracq_eq0 x : (fracq x == zeroq) = (x.1 == 0) || (x.2 == 0).
 Proof.
-move: x=> [n d] /=; have [->|d0] := altP (d =P 0).
+move: x=> [n d] /=; have [->|d0] := eqVneq d 0.
   by rewrite fracq0 eqxx orbT.
 by rewrite orbF fracq_eq ?d0 //= mulr1 mul0r.
 Qed.
@@ -333,7 +333,7 @@ rewrite !(mulq_frac, invq_frac) ?denq_neq0 //.
 by apply/eqP; rewrite fracq_eq ?mulf_neq0 ?denq_neq0 //= mulr1 mul1r mulrC.
 Qed.
 
-Fact invq0 : invq 0 = 0. Proof. by apply/eqP. Qed.
+Fact invq0 : invq 0 = 0. Proof. exact/eqP. Qed.
 
 Definition RatFieldUnitMixin := FieldUnitMixin mulVq invq0.
 Canonical rat_unitRing :=
@@ -550,8 +550,8 @@ Qed.
 Lemma normr_num_div n d : `|numq (n%:~R / d%:~R)| = numq (`|n|%:~R / `|d|%:~R).
 Proof.
 rewrite (normrEsg n) (normrEsg d) !rmorphM /= invfM mulrACA !sgr_def.
-have [->|n_neq0] := altP eqP; first by rewrite mul0r mulr0.
-have [->|d_neq0] := altP eqP; first by rewrite invr0 !mulr0.
+have [->|n_neq0] := eqVneq; first by rewrite mul0r mulr0.
+have [->|d_neq0] := eqVneq; first by rewrite invr0 !mulr0.
 rewrite !intr_sign invr_sign -signr_addb numq_sign_mul -numq_div_lt0 //.
 by apply: (canRL (signrMK _)); rewrite mulz_sign_abs.
 Qed.
@@ -680,7 +680,7 @@ Canonical Qnat_semiringPred := SemiringPred Qnat_semiring_closed.
 End QnatPred.
 
 Lemma natq_div m n : n %| m -> (m %/ n)%:R = m%:R / n%:R :> rat.
-Proof. by apply: char0_natf_div; apply: char_num. Qed.
+Proof. exact/char0_natf_div/char_num. Qed.
 
 Section InRing.
 
@@ -814,7 +814,7 @@ Require setoid_ring.Field_theory setoid_ring.Field_tac.
 Lemma rat_field_theory :
   Field_theory.field_theory 0%Q 1%Q addq mulq subq oppq divq invq eq.
 Proof.
-split => //; first exact rat_ring_theory.
+split => //; first exact: rat_ring_theory.
 by move=> p /eqP p_neq0; rat_to_ring; rewrite mulVf.
 Qed.
 

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -1240,8 +1240,7 @@ Proof.
 by move=> reg_x; elim: n => [|n]; [apply: lreg1 | rewrite exprS; apply: lregM].
 Qed.
 
-Lemma lreg_sign n : lreg ((-1) ^+ n : R).
-Proof. by apply: lregX; apply: lregN; apply: lreg1. Qed.
+Lemma lreg_sign n : lreg ((-1) ^+ n : R). Proof. exact/lregX/lregN/lreg1. Qed.
 
 Lemma prodr_const (I : finType) (A : pred I) (x : R) :
   \prod_(i in A) x = x ^+ #|A|.
@@ -2554,7 +2553,7 @@ Lemma mulrAC : @right_commutative R R *%R. Proof. exact: mulmAC. Qed.
 Lemma mulrACA : @interchange R *%R *%R. Proof. exact: mulmACA. Qed.
 
 Lemma exprMn n : {morph (fun x => x ^+ n) : x y / x * y}.
-Proof. by move=> x y; apply: exprMn_comm; apply: mulrC. Qed.
+Proof. by move=> x y; exact/exprMn_comm/mulrC. Qed.
 
 Lemma prodrXl n I r (P : pred I) (F : I -> R) :
   \prod_(i <- r | P i) F i ^+ n = (\prod_(i <- r | P i) F i) ^+ n.
@@ -3413,7 +3412,7 @@ Variable R : comUnitRingType.
 Implicit Types x y : R.
 
 Lemma unitrM x y : (x * y \in unit) = (x \in unit) && (y \in unit).
-Proof. by apply: unitrM_comm; apply: mulrC. Qed.
+Proof. exact/unitrM_comm/mulrC. Qed.
 
 Lemma unitrPr x : reflect (exists y, x * y = 1) (x \in unit).
 Proof.
@@ -4501,7 +4500,7 @@ apply/existsP/idP=> [[p] | true_at_P].
   rewrite ((big_morph qev) true andb) //= big_andE /=.
   case/andP=> /forallP-eq_p_P.
   rewrite (@eq_pick _ _ P) => [|i]; first by case: pick.
-  by move/(_ i): eq_p_P => /=; case: (p i) => //=; move/negbTE.
+  by move/(_ i): eq_p_P => /=; case: (p i) => //= /negPf.
 exists [ffun i => P i] => /=; apply/andP; split.
   rewrite ((big_morph qev) true andb) //= big_andE /=.
   by apply/forallP=> i; rewrite /= ffunE; case Pi: (P i) => //=; apply: negbT.
@@ -4863,8 +4862,8 @@ Definition divfK := mulfVK.
 
 Lemma invfM : {morph @inv F : x y / x * y}.
 Proof.
-move=> x y; case: (eqVneq x 0) => [-> |nzx]; first by rewrite !(mul0r, invr0).
-case: (eqVneq y 0) => [-> |nzy]; first by rewrite !(mulr0, invr0).
+move=> x y; have [->|nzx] := eqVneq x 0; first by rewrite !(mul0r, invr0).
+have [->|nzy] := eqVneq y 0; first by rewrite !(mulr0, invr0).
 by rewrite mulrC invrM ?unitfE.
 Qed.
 
@@ -4877,7 +4876,7 @@ Proof. by move=> nz_x y; rewrite invf_div mulrC divfK. Qed.
 Lemma expfB_cond m n x : (x == 0) + n <= m -> x ^+ (m - n) = x ^+ m / x ^+ n.
 Proof.
 move/subnK=> <-; rewrite addnA addnK !exprD.
-have [-> | nz_x] := altP eqP; first by rewrite !mulr0 !mul0r.
+have [-> | nz_x] := eqVneq; first by rewrite !mulr0 !mul0r.
 by rewrite mulfK ?expf_neq0.
 Qed.
 
@@ -4922,7 +4921,7 @@ Variables (R : ringType) (f : {rmorphism F -> R}).
 
 Lemma fmorph_eq0 x : (f x == 0) = (x == 0).
 Proof.
-have [-> | nz_x] := altP (x =P _); first by rewrite rmorph0 eqxx.
+have [-> | nz_x] := eqVneq x; first by rewrite rmorph0 eqxx.
 apply/eqP; move/(congr1 ( *%R (f x^-1)))/eqP.
 by rewrite -rmorphM mulVf // mulr0 rmorph1 ?oner_eq0.
 Qed.
@@ -4947,7 +4946,7 @@ Variables (R : unitRingType) (f : {rmorphism F -> R}).
 
 Lemma fmorph_unit x : (f x \in unit) = (x != 0).
 Proof.
-have [-> |] := altP (x =P _); first by rewrite rmorph0 unitr0.
+have [-> |] := eqVneq x; first by rewrite rmorph0 unitr0.
 by rewrite -unitfE; apply: rmorph_unit.
 Qed.
 
@@ -4980,14 +4979,14 @@ Proof. by move=> nz_a; apply: can_inj (scalerK nz_a). Qed.
 
 Lemma scaler_eq0 a v : (a *: v == 0) = (a == 0) || (v == 0).
 Proof.
-have [-> | nz_a] := altP (a =P _); first by rewrite scale0r eqxx.
+have [-> | nz_a] := eqVneq a; first by rewrite scale0r eqxx.
 by rewrite (can2_eq (scalerK nz_a) (scalerKV nz_a)) scaler0.
 Qed.
 
 Lemma rpredZeq S (modS : submodPred S) (kS : keyed_pred modS) a v :
   (a *: v \in kS) = (a == 0) || (v \in kS).
 Proof.
-have [-> | nz_a] := altP eqP; first by rewrite scale0r rpred0.
+have [-> | nz_a] := eqVneq; first by rewrite scale0r rpred0.
 by apply/idP/idP; first rewrite -{2}(scalerK nz_a v); apply: rpredZ.
 Qed.
 
@@ -5204,7 +5203,7 @@ suffices or_wf fs : let ofs := foldr Or False fs in
 - apply: or_wf.
   suffices map_proj_wf bcs: let mbcs := map (proj n) bcs in
     all dnf_rterm bcs -> all (@qf_form _) mbcs && all (@rformula _) mbcs.
-    by apply: map_proj_wf; apply: qf_to_dnf_rterm.
+    by apply/map_proj_wf/qf_to_dnf_rterm.
   elim: bcs => [|bc bcs ihb] bcsr //= /andP[rbc rbcs].
   by rewrite andbAC andbA wf_proj //= andbC ihb.
 elim: fs => //= g gs ihg; rewrite -andbA => /and4P[-> qgs -> rgs] /=.

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -743,7 +743,7 @@ Lemma commrMz (x y : R) n : GRing.comm x y -> GRing.comm x (y *~ n).
 Proof. by rewrite /GRing.comm=> com_xy; rewrite mulrzAr mulrzAl com_xy. Qed.
 
 Lemma commr_int (x : R) n : GRing.comm x n%:~R.
-Proof. by apply: commrMz; apply: commr1. Qed.
+Proof. exact/commrMz/commr1. Qed.
 
 End Zintmul1rMorph.
 
@@ -1070,7 +1070,7 @@ Qed.
 Lemma exprzDr x (ux : x \is a GRing.unit) m n : x ^ (m + n) = x ^ m * x ^ n.
 Proof.
 move: n m; apply: wlog_le=> n m hnm.
-  by rewrite addrC hnm commrXz //; apply: commr_sym; apply: commrXz.
+  by rewrite addrC hnm commrXz //; exact/commr_sym/commrXz.
 case: (intP m) hnm=> {m} [|m|m]; rewrite ?mul1r ?add0r //;
  case: (intP n)=> {n} [|n|n _]; rewrite ?mulr1 ?addr0 //;
    do ?by rewrite exprzD_ss.
@@ -1115,14 +1115,11 @@ Proof. by rewrite exprz_pmulzl // exp1rz. Qed.
 
 Lemma exprzMzl x m n (ux : x \is a GRing.unit) (um : m%:~R \is a @GRing.unit R):
    (x *~ m) ^ n = (m%:~R ^ n) * x ^ n :> R.
-Proof.
-rewrite -[x *~ _]mulrzl exprMz_comm //.
-by apply: commr_sym; apply: commr_int.
-Qed.
+Proof. rewrite -[x *~ _]mulrzl exprMz_comm //; exact/commr_sym/commr_int. Qed.
 
 Lemma expNrz x n : (- x) ^ n = (-1) ^ n * x ^ n :> R.
 Proof.
-case: n=> [] n; rewrite ?NegzE; first by apply: exprNn.
+case: n=> [] n; rewrite ?NegzE; first exact: exprNn.
 by rewrite -!exprz_inv !invrN invr1; apply: exprNn.
 Qed.
 
@@ -1182,7 +1179,7 @@ Lemma expfz_n0addr x m n : m + n != 0 -> x ^ (m + n) = x ^ m * x ^ n.
 Proof.
 have [-> hmn|nx0 _] := eqVneq x 0; last exact: expfzDr.
 rewrite !exp0rz (negPf hmn).
-case: (altP (m =P 0)) hmn=> [->|]; rewrite (mul0r, mul1r) //.
+case: (eqVneq m 0) hmn => [->|]; rewrite (mul0r, mul1r) //.
 by rewrite add0r=> /negPf->.
 Qed.
 
@@ -1190,7 +1187,7 @@ Lemma expfzMl x y n : (x * y) ^ n = x ^ n * y ^ n.
 Proof.
 have [->|/negPf n0] := eqVneq n 0; first by rewrite !expr0z mulr1.
 case: (boolP ((x * y) == 0)); rewrite ?mulf_eq0.
-  by case/orP=> /eqP->; rewrite ?(mul0r, mulr0, exp0rz, n0).
+  by case/pred2P=> ->; rewrite ?(mul0r, mulr0, exp0rz, n0).
 by case/norP=> x0 y0; rewrite exprzMl ?unitfE.
 Qed.
 
@@ -1228,7 +1225,7 @@ Lemma ler_wniexpz2l x (x0 : 0 <= x) (x1 : x <= 1) :
 Proof.
 move=> [] m [] n; rewrite ?NegzE -!topredE /= ?oppr_cp0 ?ltz_nat // => _ _.
 rewrite ler_opp2 lez_nat -?invr_expz=> hmn; move: (x0).
-rewrite le0r=> /orP [/eqP->|lx0]; first by rewrite !exp0rz invr0.
+rewrite le0r=> /predU1P [->|lx0]; first by rewrite !exp0rz invr0.
 by rewrite lef_pinv -?topredE /= ?exprz_gt0 // ler_wiexpn2l.
 Qed.
 
@@ -1318,9 +1315,9 @@ Qed.
 
 Lemma pexpIrz n (n0 : n != 0) : {in >= 0 &, injective ((@exprz R)^~ n)}.
 Proof.
-move=> x y; rewrite ![_ \in _]le0r=> /orP [/eqP-> _ /eqP|hx].
+move=> x y; rewrite ![_ \in _]le0r=> /predU1P [-> _ /eqP|hx].
   by rewrite exp0rz ?(negPf n0) eq_sym expfz_eq0=> /andP [_ /eqP->].
-case/orP=> [/eqP-> /eqP|hy].
+case/predU1P=> [-> /eqP|hy].
   by rewrite exp0rz ?(negPf n0) expfz_eq0=> /andP [_ /eqP].
 move=> /(f_equal ( *%R^~ (y ^ (- n)))) /eqP.
 rewrite -expfzDr ?(gt_eqF hy) // subrr expr0z -exprz_inv -expfzMl.
@@ -1330,9 +1327,9 @@ Qed.
 
 Lemma nexpIrz n (n0 : n != 0) : {in <= 0 &, injective ((@exprz R)^~ n)}.
 Proof.
-move=> x y; rewrite ![_ \in _]le_eqVlt => /orP [/eqP -> _ /eqP|hx].
+move=> x y; rewrite ![_ \in _]le_eqVlt => /predU1P [-> _ /eqP|hx].
   by rewrite exp0rz ?(negPf n0) eq_sym expfz_eq0=> /andP [_ /eqP->].
-case/orP=> [/eqP -> /eqP|hy].
+case/predU1P=> [-> /eqP|hy].
   by rewrite exp0rz ?(negPf n0) expfz_eq0=> /andP [_ /eqP].
 move=> /(f_equal ( *%R^~ (y ^ (- n)))) /eqP.
 rewrite -expfzDr ?(lt_eqF hy) // subrr expr0z -exprz_inv -expfzMl.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -1774,7 +1774,7 @@ Lemma real_wlog_ltr P :
   forall a b : R, a \is real -> b \is real -> P a b.
 Proof.
 move=> rP sP hP; apply: real_wlog_ler=> // a b.
-rewrite le_eqVlt; case: eqVneq => [->|] //= _ lab; exact: hP.
+by rewrite le_eqVlt; case: eqVneq => [->|] //= _ /hP.
 Qed.
 
 (* Monotony of addition *)
@@ -5003,7 +5003,7 @@ Qed.
 
 Fact le_total : total (le m).
 Proof.
-move=> x y; rewrite !le_def; case: eqVneq => [->|] //=; rewrite -subr_eq0.
+move=> x y; rewrite !le_def; have [->|] //= := eqVneq; rewrite -subr_eq0.
 by move/(lt0_total m); rewrite -(sub_gt0 _ (x - y)) sub0r opprB !sub_gt0 orbC.
 Qed.
 

--- a/mathcomp/algebra/vector.v
+++ b/mathcomp/algebra/vector.v
@@ -205,7 +205,7 @@ by exists (fun r => sval (r2vP r)) => r; case: (r2vP r).
 Qed.
 Definition r2v := sval r2v_subproof.
 
-Lemma r2vK : cancel r2v v2r.   Proof. exact: (svalP r2v_subproof). Qed.
+Lemma r2vK : cancel r2v v2r.   Proof. exact: svalP r2v_subproof. Qed.
 Lemma r2v_inj : injective r2v. Proof. exact: can_inj r2vK. Qed.
 Lemma v2rK : cancel v2r r2v.   Proof. by have/bij_can_sym:= r2vK; apply. Qed.
 Lemma v2r_inj : injective v2r. Proof. exact: can_inj v2rK. Qed.
@@ -437,11 +437,11 @@ Canonical memv_addrPred U := AddrPred (memv_submod_closed U).
 Canonical memv_zmodPred U := ZmodPred (memv_submod_closed U).
 Canonical memv_submodPred U := SubmodPred (memv_submod_closed U).
 
-Lemma mem0v U : 0 \in U. Proof. exact : rpred0. Qed.
+Lemma mem0v U : 0 \in U. Proof. exact: rpred0. Qed.
 Lemma memvN U v : (- v \in U) = (v \in U). Proof. exact: rpredN. Qed.
-Lemma memvD U : {in U &, forall u v, u + v \in U}. Proof. exact : rpredD. Qed.
-Lemma memvB U : {in U &, forall u v, u - v \in U}. Proof. exact : rpredB. Qed.
-Lemma memvZ U k : {in U, forall v, k *: v \in U}. Proof. exact : rpredZ. Qed.
+Lemma memvD U : {in U &, forall u v, u + v \in U}. Proof. exact: rpredD. Qed.
+Lemma memvB U : {in U &, forall u v, u - v \in U}. Proof. exact: rpredB. Qed.
+Lemma memvZ U k : {in U, forall v, k *: v \in U}. Proof. exact: rpredZ. Qed.
 
 Lemma memv_suml I r (P : pred I) vs U :
   (forall i, P i -> vs i \in U) -> \sum_(i <- r | P i) vs i \in U.
@@ -900,7 +900,7 @@ have: \sum_(j | P j) [eta us with i |-> - v] j = 0.
   rewrite (bigD1 i) //= eqxx {1}Dv addrC -sumrB big1 // => j /andP[_ i'j].
   by rewrite (negPf i'j) subrr.
 move/dxU/(_ i Pi); rewrite /= eqxx -oppr_eq0 => -> // j Pj.
-by have [-> | i'j] := altP eqP; rewrite ?memvN // Uu ?Pj.
+by have [-> | i'j] := eqVneq; rewrite ?memvN // Uu ?Pj.
 Qed.
 
 Lemma directv_sum_unique {Us : I -> {vspace vT}} :
@@ -1170,7 +1170,7 @@ Qed.
 Lemma perm_basis X Y U : perm_eq X Y -> basis_of U X = basis_of U Y.
 Proof.
 move=> eqXY; congr ((_ == _) && _); last exact: perm_free.
-by apply/eq_span; apply: perm_mem.
+exact/eq_span/perm_mem.
 Qed.
 
 Lemma vbasisP U : basis_of U (vbasis U).
@@ -1182,7 +1182,7 @@ by rewrite row_base_free !eq_row_base submx_refl.
 Qed.
 
 Lemma vbasis_mem v U : v \in (vbasis U) -> v \in U.
-Proof. exact: (basis_mem (vbasisP _)). Qed.
+Proof. exact: basis_mem (vbasisP _). Qed.
 
 Lemma coord_vbasis v U :
   v \in U -> v = \sum_(i < \dim U) coord (vbasis U) i v *: (vbasis U)`_i.
@@ -1829,7 +1829,7 @@ Proof. by rewrite addv_pi2_id ?memv_pi2. Qed.
 
 Lemma addv_pi1_pi2 U V w :
   w \in (U + V)%VS -> addv_pi1 U V w + addv_pi2 U V w = w.
-Proof. by rewrite -addv_diff; apply: daddv_pi_add; apply: capv_diff. Qed.
+Proof. by rewrite -addv_diff; exact/daddv_pi_add/capv_diff. Qed.
 
 Section Sumv_Pi.
 
@@ -2044,4 +2044,3 @@ by apply/ffunP=> i; rewrite (lfunE (Linear lhsZ)) !ffunE sol_u.
 Qed.
 
 End Solver.
-

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -491,7 +491,7 @@ Proof. by rewrite cfunE cfuniE ?normal1 // inE mulr_natr. Qed.
 Lemma cfReprReg : cfRepr (regular_repr algCF G) = cfReg G.
 Proof.
 apply/cfun_inP=> x Gx; rewrite cfRegE.
-have [-> | ntx] := altP (x =P 1%g); first by rewrite cfRepr1.
+have [-> | ntx] := eqVneq x 1%g; first by rewrite cfRepr1.
 rewrite cfunE Gx [\tr _]big1 // => i _; rewrite 2!mxE /=.
 rewrite -(inj_eq enum_val_inj) gring_indexK ?groupM ?enum_valP //.
 by rewrite eq_mulVg1 mulKg (negbTE ntx).
@@ -714,7 +714,7 @@ Qed.
 
 Lemma xcfun_id i j : ('chi_i).['e_j]%CF = 'chi_i 1%g *+ (i == j).
 Proof.
-have [<-{j} | /xcfun_annihilate->//] := altP eqP; last exact: Wedderburn_id_mem.
+have [<-{j} | /xcfun_annihilate->//] := eqVneq; last exact: Wedderburn_id_mem.
 by rewrite -xcfunG // repr_mx1 -(xcfun_mul_id _ (envelop_mx1 _)) mulmx1.
 Qed.
 
@@ -1204,7 +1204,7 @@ transitivity (('chi_i).[e j *m aG y]%CF / 'chi_j 1%g).
   rewrite mulmx_suml raddf_sum big_distrl; apply: eq_bigr => x Gx /=.
   rewrite -scalemxAl xcfunZr -repr_mxM // xcfunG ?groupM // mulrAC mulrC.
   by congr (_ * _); rewrite mulrC mulKf ?irr1_neq0.
-rewrite mulr_natl mulrb; have [<-{j} | neq_ij] := altP eqP.
+rewrite mulr_natl mulrb; have [<-{j} | neq_ij] := eqVneq.
   by congr (_ / _); rewrite xcfun_mul_id ?envelop_mx_id ?xcfunG.
 rewrite (xcfun_annihilate neq_ij) ?mul0r //.
 case/andP: (Wedderburn_ideal (W j)) => _; apply: submx_trans.
@@ -1284,7 +1284,7 @@ transitivity ((#|'C_G[repr (y ^: G)]|%:R *: (X' *m X)) i_y i_x).
 rewrite mulmx1C // !mxE -!divg_index !(index_cent1, =^~ indexgI).
 rewrite (class_eqP (mem_repr y _)) ?class_refl // mulr_natr.
 rewrite (can_in_eq class_IirrK) ?mem_classes //.
-have [-> | not_yGx] := altP eqP; first by rewrite class_refl.
+have [-> | not_yGx] := eqVneq; first by rewrite class_refl.
 by rewrite [x \in _](contraNF _ not_yGx) // => /class_eqP->.
 Qed.
 
@@ -1450,7 +1450,7 @@ rewrite -!eq_scale_irr; apply/eqP/idP; last first.
   case/orP; first by case/andP=> /eqP-> /eqP->.
   case/orP=> /and3P[/eqP-> /eqP-> /eqP->]; first by rewrite addrC.
   by rewrite !scaleNr !addNr.
-have [-> /addrI/eqP-> // | /= ] := altP eqP.
+have [-> /addrI/eqP-> // | /=] := eqVneq.
 rewrite eq_scale_irr => /norP[/negP nz_a /negPf neq_ir].
 move/(congr1 (cfdotr 'chi__))/esym/eqP => /= eq_cfdot.
 move: {eq_cfdot}(eq_cfdot i) (eq_cfdot r); rewrite eq_sym !cfdotDl !cfdotZl.
@@ -2412,7 +2412,7 @@ Implicit Types G H : {group gT}.
 Lemma lin_irr_der1 G i :
    ('chi_i \is a linear_char) = (G^`(1)%g \subset cfker 'chi[G]_i).
 Proof.
-apply/idP/idP=> [|sG'K]; first by apply: lin_char_der1.
+apply/idP/idP=> [|sG'K]; first exact: lin_char_der1.
 have nsG'G: G^`(1) <| G := der_normal 1 G.
 rewrite qualifE irr_char -[i](quo_IirrK nsG'G) // mod_IirrE //=.
 by rewrite cfModE // morph1 lin_char1 //; apply/char_abelianP/der_abelian.
@@ -2832,8 +2832,7 @@ Proof.
 apply/eqP; rewrite eqEsubset; rewrite cfcenter_subset_center ?irr_char //.
 apply/subsetP=> _ /setIP[/morphimP[x /= _ Gx ->] cGx]; rewrite mem_quotient //=.
 rewrite -irrRepr cfker_repr cfcenter_repr inE Gx in cGx *.
-apply: mx_abs_irr_cent_scalar 'Chi_i _ _ _.
-  by apply: groupC; apply: socle_irr.
+apply: mx_abs_irr_cent_scalar 'Chi_i _ _ _; first exact/groupC/socle_irr.
 have nKG: G \subset 'N(rker 'Chi_i) by apply: rker_norm.
 (* GG -- locking here is critical to prevent Coq kernel divergence. *)
 apply/centgmxP=> y Gy; rewrite [eq]lock -2?(quo_repr_coset (subxx _) nKG) //.

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -943,7 +943,7 @@ Lemma cfCauchySchwarz phi psi :
   `|'[phi, psi]| ^+ 2 <= '[phi] * '[psi] ?= iff ~~ free (phi :: psi).
 Proof.
 rewrite free_cons span_seq1 seq1_free -negb_or negbK orbC.
-have [-> | nz_psi] /= := altP (psi =P 0).
+have [-> | nz_psi] /= := eqVneq psi 0.
   by apply/leifP; rewrite !cfdot0r normCK mul0r mulr0.
 without loss ophi: phi / '[phi, psi] = 0.
   move=> IHo; pose a := '[phi, psi] / '[psi]; pose phi1 := phi - a *: psi.
@@ -978,7 +978,7 @@ rewrite (mono_leif (ler_pmul2r _)) ?ltr0n //.
 have:= leif_trans (leif_Re_Creal '[phi, psi]) (cfCauchySchwarz_sqrt phi psi).
 congr (_ <= _ ?= iff _); apply: andb_id2r.
 rewrite free_cons span_seq1 seq1_free -negb_or negbK orbC.
-have [-> | nz_psi] := altP (psi =P 0); first by rewrite cfdot0r coord0.
+have [-> | nz_psi] := eqVneq psi 0; first by rewrite cfdot0r coord0.
 case/vlineP=> [x ->]; rewrite cfdotZl linearZ pmulr_lge0 ?cfnorm_gt0 //=.
 by rewrite (coord_free 0) ?seq1_free // eqxx mulr1.
 Qed.
@@ -1186,7 +1186,7 @@ rewrite orthonormalE; have [/= normS | not_normS] := allP; last first.
   by right=> [[_ o1S]]; case: not_normS => phi Sphi; rewrite /= o1S ?eqxx.
 apply: (iffP (pairwise_orthogonalP S)) => [] [uniqS oSS].
   split=> // [|phi psi]; first by case/andP: uniqS.
-  by have [-> _ /normS/eqP | /oSS] := altP eqP.
+  by have [-> _ /normS/eqP | /oSS] := eqVneq.
 split=> // [|phi psi Sphi Spsi /negbTE]; last by rewrite oSS // => ->.
 by rewrite /= (contra (normS _)) // cfdot0r eq_sym oner_eq0.
 Qed.
@@ -1497,7 +1497,7 @@ by rewrite -!cfMorphE // eq_phi.
 Qed.
 
 Lemma cfMorph_eq1 phi : (cfMorph phi == 1) = (phi == 1).
-Proof. by apply: rmorph_eq1; apply: cfMorph_inj. Qed.
+Proof. exact/rmorph_eq1/cfMorph_inj. Qed.
 
 Lemma cfker_morph phi : cfker (cfMorph phi) = G :&: f @*^-1 (cfker phi).
 Proof.
@@ -1526,7 +1526,7 @@ Lemma sub_morphim_cfker phi (A : {set aT}) :
 Proof. by move=> sAG; rewrite sub_cfker_morph ?sAG. Qed.
 
 Lemma cforder_morph phi : #[cfMorph phi]%CF = #[phi]%CF.
-Proof. by apply: cforder_inj_rmorph; apply: cfMorph_inj. Qed.
+Proof. exact/cforder_inj_rmorph/cfMorph_inj. Qed.
 
 End Main.
 
@@ -1607,7 +1607,7 @@ Qed.
 Lemma cfIsom_inj : injective (cfIsom isoGR). Proof. exact: can_inj cfIsomK. Qed.
 
 Lemma cfIsom_eq1 phi : (cfIsom isoGR phi == 1) = (phi == 1).
-Proof. by apply: rmorph_eq1; apply: cfIsom_inj. Qed.
+Proof. exact/rmorph_eq1/cfIsom_inj. Qed.
 
 Lemma cforder_isom phi : #[cfIsom isoGR phi]%CF = #[phi]%CF.
 Proof. exact: cforder_inj_rmorph cfIsom_inj. Qed.
@@ -1860,7 +1860,7 @@ by rewrite quotientK ?(subset_trans skerH) // -group_modr //= setIC tiKH mul1g.
 Qed.
 
 Lemma cforder_sdprod phi : #[cfSdprod phi]%CF = #[phi]%CF.
-Proof. by apply: cforder_inj_rmorph cfSdprod_inj. Qed.
+Proof. exact: cforder_inj_rmorph cfSdprod_inj. Qed.
 
 End SDproduct.
 

--- a/mathcomp/character/integral_char.v
+++ b/mathcomp/character/integral_char.v
@@ -67,7 +67,7 @@ exists (SplittingFieldType _ _ Qn_ax).
   apply: separable_Xn_sub_1; rewrite -(fmorph_eq0 QnC) rmorph_nat.
   by rewrite pnatr_eq0 -lt0n cardG_gt0.
 exists QnC => [// nuQn|].
-  by apply: (extend_algC_subfield_aut QnC [rmorphism of nuQn]).
+  exact: (extend_algC_subfield_aut QnC [rmorphism of nuQn]).
 rewrite span_seq1 in genQn.
 exists w => // hT H phi Nphi x x_dv_n.
 apply: sig_eqW; have [rH ->] := char_reprP Nphi.
@@ -372,7 +372,7 @@ Proof.
 move: {2}_.+1 (ltnSn #|G|) => n; elim: n => // n IHn in gT G *.
 rewrite ltnS => leGn piGle2; have [simpleG | ] := boolP (simple G); last first.
   rewrite negb_forall_in => /exists_inP[N sNG]; rewrite eq_sym.
-  have [-> | ] := altP (N =P G).
+  have [->|] := eqVneq N G.
     rewrite groupP /= genGid normG andbT eqb_id negbK => /eqP->.
     exact: solvable1.
   rewrite [N == G]eqEproper sNG eqbF_neg !negbK => ltNG /and3P[grN].

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -199,7 +199,7 @@ move=> linL; apply/eqP; rewrite eqEsubset sub_rowg_mx andbT.
 apply/subsetP=> v; rewrite inE genmxE => /submxP[u ->{v}].
 rewrite mulmx_sum_row group_prod // => i _.
 rewrite rowK; move: (enum_val i) (enum_valP i) => v Lv.
-case: (eqVneq (u 0 i) 0) => [->|]; first by rewrite scale0r group1.
+have [->|] := eqVneq (u 0 i) 0; first by rewrite scale0r group1.
 by rewrite -unitfE => aP; rewrite ((actsP linL) (FinRing.Unit _ aP)) ?inE.
 Qed.
 

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -1592,7 +1592,7 @@ Lemma mxsimple_exists m (U : 'M_(m, n)) :
 Proof.
 move=> modU nzU [] // simU; move: {2}_.+1 (ltnSn (\rank U)) => r leUr.
 elim: r => // r IHr in m U leUr modU nzU simU.
-have genU := genmxE U; apply simU; exists <<U>>%MS; last by rewrite genU.
+have genU := genmxE U; apply: (simU); exists <<U>>%MS; last by rewrite genU.
 apply/mxsimpleP; split; rewrite ?(eqmx_eq0 genU) ?(eqmx_module genU) //.
 case=> V; rewrite !genU=> /and4P[modV sVU nzV ltVU]; case: notF.
 apply: IHr nzV _ => // [|[W simW sWV]]; first exact: leq_trans ltVU _.
@@ -1891,7 +1891,7 @@ move=> modV redV [] // nssimV; have [r leVr] := ubnP (\rank V).
 elim: r => // r IHr in V leVr modV redV nssimV.
 have [V0 | nzV] := eqVneq V 0.
   by rewrite nssimV ?V0 //; apply: mxsemisimple0.
-apply (mxsimple_exists modV nzV) => [[U simU sUV]]; have [modU nzU _] := simU.
+apply: (mxsimple_exists modV nzV) => [[U simU sUV]]; have [modU nzU _] := simU.
 have [W modW defUW dxUW] := redV U modU sUV.
 have sWV: (W <= V)%MS by rewrite -defUW addsmxSr.
 apply: IHr (mx_reducibleS modW sWV redV) _ => // [|ssimW].
@@ -3492,8 +3492,7 @@ rewrite -defW; apply/sumsmx_subP=> j _; set x := x_ W j.
 have{Gx_} Gx: x \in G by rewrite Gx_.
 apply: submx_trans (submxMr _ sMU) _; apply: (mxmoduleP modU).
 rewrite inE -val_Clifford_act Gx //; set Wx := 'Cl%act W x.
-have [-> //= | neWxW] := eqVneq Wx W.
-case: (simM) => _ /negP[]; rewrite -submx0.
+case: (eqVneq Wx W) (simM) => [-> //=|] neWxW [_ /negP[]]; rewrite -submx0.
 rewrite (canF_eq (actKin 'Cl Gx)) in neWxW.
 rewrite -(component_mx_disjoint _ _ neWxW); try exact: socle_simple.
 rewrite sub_capmx {1}(submx_trans sMU sUW) val_Clifford_act ?groupV //.
@@ -5838,7 +5837,7 @@ have: mx_subseries (aG F) U /\ path ltmx 0 U by [].
 pose f : {rmorphism F0 -> F} := [rmorphism of idfun].
 elim: m F U f => [|m IHm] F U f [modU ltU].
   by rewrite addn0 (leq_trans (max_size_mx_series ltU)) ?rank_leq_row.
-rewrite addnS ltnNge -implybF; apply/implyP=> le_nG_Um; apply nosplit.
+rewrite addnS ltnNge -implybF; apply/implyP=> le_nG_Um; apply: nosplit.
 exists F => //; case=> [|n] rG irrG; first by case/mx_irrP: irrG.
 apply/idPn=> nabsG; pose cG := ('C(enveloping_algebra_mx rG))%MS.
 have{nabsG} [A]: exists2 A, (A \in cG)%MS & ~~ is_scalar_mx A.

--- a/mathcomp/field/algC.v
+++ b/mathcomp/field/algC.v
@@ -166,7 +166,7 @@ have normD x y : le (norm (x + y)) (norm x + norm y).
     have [-> | nz_u u_ge0 v_ge0] := eqVneq u 0; first by rewrite add0r.
     by have /andP[]: lt 0 (u + v) by rewrite sposDl // /lt nz_u.
   have le_sqr u v: conj u = u -> le 0 v -> le (u ^+ 2) (v ^+ 2) -> le u v.
-    move=> Ru v_ge0; have [-> // | nz_u] := eqVneq u 0.
+    case: (eqVneq u 0) => [-> //|nz_u Ru v_ge0].
     have [u_gt0 | u_le0 _] := boolP (lt 0 u).
       by rewrite leB (leB u) subr_sqr mulrC addrC; apply: sposM; apply: sposDl.
     rewrite leB posD // posE normN -addr_eq0; apply/eqP.
@@ -931,7 +931,7 @@ Qed.
 
 Lemma dvdCP x y : reflect (exists2 z, z \in Cint & y = z * x) (x %| y)%C.
 Proof.
-rewrite unfold_in; have [-> | nz_x] := altP eqP.
+rewrite unfold_in; have [-> | nz_x] := eqVneq.
   by apply: (iffP eqP) => [-> | [z _ ->]]; first exists 0; rewrite ?mulr0.
 apply: (iffP idP) => [Zyx | [z Zz ->]]; last by rewrite mulfK.
 by exists (y / x); rewrite ?divfK.
@@ -990,7 +990,7 @@ Canonical dvdC_zmodPred x := ZmodPred (dvdC_zmod x).
 Lemma dvdC_nat (p n : nat) : (p %| n)%C = (p %| n)%N.
 Proof.
 rewrite unfold_in CintEge0 ?divr_ge0 ?invr_ge0 ?ler0n // !pnatr_eq0.
-have [-> | nz_p] := altP eqP; first by rewrite dvd0n.
+have [-> | nz_p] := eqVneq; first by rewrite dvd0n.
 apply/CnatP/dvdnP=> [[q def_q] | [q ->]]; exists q.
   by apply/eqP; rewrite -eqC_nat natrM -def_q divfK ?pnatr_eq0.
 by rewrite [num in num / _]natrM mulfK ?pnatr_eq0.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -582,7 +582,7 @@ have add_Rroot xR p c: {yR | extendsR xR yR & has_Rroot xR p c -> root_in yR p}.
   pose abs v := if le 0 v then v else - v.
   have absN v: abs (- v) = abs v.
     rewrite /abs /le !(eq_sym 0) oppr_eq0 opprK posN.
-    have [-> | /posVneg/orP[v_gt0 | v_lt0]] := altP eqP; first by rewrite oppr0.
+    have [-> | /posVneg/orP[v_gt0 | v_lt0]] := eqVneq; first by rewrite oppr0.
       by rewrite v_gt0 /= -if_neg posNneg.
     by rewrite v_lt0 /= -if_neg -(opprK v) posN posNneg ?posN.
   have absE v: le 0 v -> abs v = v by rewrite /abs => ->.

--- a/mathcomp/field/algnum.v
+++ b/mathcomp/field/algnum.v
@@ -247,7 +247,7 @@ have: root (map_poly (nu \o QnC) (minPoly 1%AS x)) (nu (QnC x)).
   by rewrite fmorph_root root_minPoly.
 rewrite map_Qnum_poly ?minPolyOver // Hrs.
 rewrite [map_poly _ _](_:_ = \prod_(y <- map QnC rs) ('X - y%:P)); last first.
-  rewrite big_map rmorph_prod; apply eq_bigr => i _.
+  rewrite big_map rmorph_prod; apply: eq_bigr => i _.
   by rewrite rmorphB /= map_polyX map_polyC.
 rewrite root_prod_XsubC.
 by case/mapP => y _ ?; exists y.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -1311,7 +1311,7 @@ Definition subfx_poly_inv (q : {poly F}) : {poly F} :=
 Let subfx_poly_invE q : iotaPz (subfx_poly_inv q) = (iotaPz q)^-1.
 Proof.
 rewrite /subfx_poly_inv.
-have [-> | nzq] := altP eqP; first by rewrite rmorph0 invr0.
+have [-> | nzq] := eqVneq; first by rewrite rmorph0 invr0.
 rewrite [nth]lock -[_^-1]mul1r; apply: canRL (mulfK nzq) _; rewrite -rmorphM /=.
 have rz0: iotaPz (gdcop q p0) = 0.
   by apply/rootP; rewrite gdcop_map root_gdco ?map_poly_eq0 // p0z0 nzq.

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -132,7 +132,7 @@ Qed.
 Lemma kHom_inv K E f : kHom K E f -> {in E, {morph f : x / x^-1}}.
 Proof.
 case/kHomP=> fM idKf x Ex.
-case (eqVneq x 0) => [-> | nz_x]; first by rewrite linear0 invr0 linear0.
+have [-> | nz_x] := eqVneq x 0; first by rewrite linear0 invr0 linear0.
 have fxV: f x * f x^-1 = 1 by rewrite -fM ?rpredV ?divff // idKf ?mem1v.
 have Ufx: f x \is a GRing.unit by apply/unitrPr; exists (f x^-1).
 by apply: (mulrI Ufx); rewrite divrr.
@@ -1014,8 +1014,8 @@ Lemma galois_connection K E (A : {set gal_of E}):
   (K <= E)%VS -> (A \subset 'Gal(E / K)) = (K <= fixedField A)%VS.
 Proof.
 move=> sKE; apply/idP/idP => [/fixedFieldS | /(galS E)].
-  by apply: subv_trans; apply galois_connection_subv.
-by apply: subset_trans; apply: galois_connection_subset.
+  exact/subv_trans/galois_connection_subv.
+exact/subset_trans/galois_connection_subset.
 Qed.
 
 Definition galTrace U V a := \sum_(x in 'Gal(V / U)) (x a).
@@ -1047,7 +1047,7 @@ Qed.
 
 Lemma galNormX n : {morph galNorm U V : a / a ^+ n}.
 Proof.
-move=> a; elim: n => [|n IHn]; first by apply: galNorm1.
+move=> a; elim: n => [|n IHn]; first exact: galNorm1.
 by rewrite !exprS galNormM IHn.
 Qed.
 
@@ -1309,7 +1309,7 @@ Qed.
 Lemma galois_fixedField K E :
   reflect (fixedField 'Gal(E / K) = K) (galois K E).
 Proof.
-apply (iffP idP) => [/and3P[sKE /separableP sepKE nKE] | fixedKE].
+apply: (iffP idP) => [/and3P[sKE /separableP sepKE nKE] | fixedKE].
   apply/eqP; rewrite eqEsubv galois_connection_subv ?andbT //.
   apply/subvP=> a /mem_fixedFieldP[Ea fixEa]; rewrite -adjoin_deg_eq1.
   have [r /allP Er splitKa] := normalFieldP nKE a Ea.

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -475,7 +475,7 @@ have [|ts def_s ne_ts] := IHn (tperm x (s^-1 x) * s); last first.
 rewrite (cardD1 x) !inE s_x in le_s_n; apply: leq_ltn_trans le_s_n.
 apply: subset_leq_card; apply/subsetP=> y.
 rewrite !inE permM permE /= -(canF_eq (permK _)).
-have [-> | ne_yx] := altP (y =P x); first by rewrite permKV eqxx.
+have [-> | ne_yx] := eqVneq y x; first by rewrite permKV eqxx.
 by case: (s y =P x) => // -> _; rewrite eq_sym.
 Qed.
 

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -182,8 +182,8 @@ Qed.
 
 Lemma Mho_p_elt (p : nat) x : x \in A -> p.-elt x -> x ^+ (p ^ n) \in Mho.
 Proof.
-move=> Ax p_x; case: (eqVneq x 1) => [-> | ntx]; first by rewrite groupX.
-by apply: mem_gen; apply/imsetP; exists x; rewrite ?inE ?Ax (pdiv_p_elt p_x).
+move=> Ax p_x; have [-> | ntx] := eqVneq x 1; first by rewrite groupX.
+by apply/mem_gen/imsetP; exists x; rewrite ?inE ?Ax (pdiv_p_elt p_x).
 Qed.
 
 End Functors.
@@ -572,7 +572,7 @@ Lemma TIp1ElemP p A X Y :
 Proof.
 move=> EpX EpY; have p_pr := pnElem_prime EpX.
 have [oX oY] := (card_p1Elem EpX, card_p1Elem EpY).
-have [<- |] := altP eqP.
+have [<-|] := eqVneq.
   by right=> X1; rewrite -oX -(setIid X) X1 cards1 in p_pr.
 by rewrite eqEcard oX oY leqnn andbT; left; rewrite prime_TIg ?oX.
 Qed.
@@ -668,7 +668,7 @@ Proof.
 apply/setP=> E; rewrite inE in_setI; apply: andb_id2l => /pElemP[sEG abelE].
 apply/idP/nElemP=> [|[q]]; first by exists p; rewrite !inE sEG abelE.
 rewrite !inE -2!andbA => /and4P[_ /pgroupP qE _].
-case: (eqVneq E 1%G) => [-> | ]; first by rewrite cards1 !logn1.
+have [->|] := eqVneq E 1%G; first by rewrite cards1 !logn1.
 case/(pgroup_pdiv (abelem_pgroup abelE)) => p_pr pE _.
 by rewrite (eqnP (qE p p_pr pE)).
 Qed.
@@ -1166,7 +1166,7 @@ Qed.
 Lemma OhmE p G : p.-group G -> 'Ohm_n(G) = <<'Ldiv_(p ^ n)(G)>>.
 Proof.
 move=> pG; congr <<_>>; apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
-case: (eqVneq x 1) => [-> | ntx]; first by rewrite !expg1n.
+have [-> | ntx] := eqVneq x 1; first by rewrite !expg1n.
 by rewrite (pdiv_p_elt (mem_p_elt pG Gx)).
 Qed.
 
@@ -1468,9 +1468,8 @@ Lemma cyclic_pgroup_dprod_trivg p A B C :
 Proof.
 move=> pC cycC; case/cyclicP: cycC pC => x ->{C} pC defC.
 case/dprodP: defC => [] [G H -> ->{A B}] defC _ tiGH; rewrite -defC.
-case: (eqVneq <[x]> 1) => [|ntC].
-  move/trivgP; rewrite -defC mulG_subG => /andP[/trivgP-> _].
-  by rewrite mul1g; left.
+have [/trivgP | ntC] := eqVneq <[x]> 1.
+  by rewrite -defC mulG_subG => /andP[/trivgP-> _]; rewrite mul1g; left.
 have [pr_p _ _] := pgroup_pdiv pC ntC; pose K := 'Ohm_1(<[x]>).
 have prK : prime #|K| by rewrite (Ohm1_cyclic_pgroup_prime _ pC) ?cycle_cyclic.
 case: (prime_subgroupVti G prK) => [sKG |]; last first.
@@ -1842,7 +1841,7 @@ Qed.
 
 Lemma rank_cycle (x : gT) : 'r(<[x]>) = (x != 1).
 Proof.
-have [->|ntx] := altP (x =P 1); first by rewrite cycle1 rank1.
+have [->|ntx] := eqVneq x 1; first by rewrite cycle1 rank1.
 apply/eqP; rewrite eqn_leq rank_gt0 cycle_eq1 ntx andbT.
 by rewrite -grank_abelian ?cycle_abelian //= -(cards1 x) grank_min.
 Qed.
@@ -1948,7 +1947,7 @@ Qed.
 Lemma abelian_type_abelem p G : p.-abelem G -> abelian_type G = nseq 'r(G) p.
 Proof.
 move=> abelG; rewrite (abelian_type_homocyclic (abelem_homocyclic abelG)).
-case: (eqVneq G 1%G) => [-> | ntG]; first by rewrite rank1.
+have [-> | ntG] := eqVneq G 1%G; first by rewrite rank1.
 congr nseq; apply/eqP; rewrite eqn_dvd; have [pG _ ->] := and3P abelG.
 have [p_pr] := pgroup_pdiv pG ntG; case/Cauchy=> // x Gx <- _.
 exact: dvdn_exponent.

--- a/mathcomp/solvable/alt.v
+++ b/mathcomp/solvable/alt.v
@@ -258,9 +258,9 @@ case Hcard1: (#|H| == 1%N); move/eqP: Hcard1 => Hcard1.
   by left; apply: card1_trivg; rewrite Hcard1.
 right; case Hcard60: (#|H| == 60%N); move/eqP: Hcard60 => Hcard60.
   by apply/eqP; rewrite eqEcard Hcard60 F1 andbT; case/andP: Hnorm.
-have Hcard20: #|H| = 20; last clear Hcard1 Hcard60.
+have {Hcard1 Hcard60} Hcard20: #|H| = 20.
   have Hdiv: 20 %| #|H| by apply: FF => // HH; case Hcard1; rewrite HH cards1.
-  case H20: (#|H| == 20); first by apply/eqP.
+  case H20: (#|H| == 20); first exact/eqP.
   case: Hcard60; case/andP: Hnorm; move/cardSg; rewrite F1 => Hdiv1 _.
   by case/dvdnP: Hdiv H20 Hdiv1 => n ->; move: n; do 4!case=> //.
 have prime_5: prime 5 by [].
@@ -272,7 +272,7 @@ have nSyl5: #|'Syl_5(H)| = 1%N.
 case: (Sylow_exists 5 H) => S; case/pHallP=> sSH oS.
 have{oS} oS: #|S| = 5 by rewrite oS p_part Hcard20.
 suff: 20 %| #|S| by rewrite oS.
-apply FF => [|S1]; last by rewrite S1 cards1 in oS.
+apply: FF => [|S1]; last by rewrite S1 cards1 in oS.
 apply: char_normal_trans Hnorm; apply: lone_subgroup_char => // Q sQH isoQS.
 rewrite subEproper; apply/norP=> [[nQS _]]; move: nSyl5.
 rewrite (cardsD1 S) (cardsD1 Q) 4!{1}inE nQS !pHallE sQH sSH Hcard20 p_part.
@@ -362,8 +362,7 @@ Proof.
 have rgd_x p: rgd p x = x by rewrite permE /= insubF //= eqxx.
 have rfd_rgd p: rfd (rgd p) = p.
   apply/permP => [[z Hz]]; apply/val_eqP; rewrite !permE.
-  rewrite /= [rgd _ _]permE /= insubF eq_refl // permE /=.
-  by rewrite (@insubT _ (xpredC1 x) _ _ Hz).
+  by rewrite /= [rgd _ _]permE /= insubF eqxx // permE /= insubT.
 have sSd: 'C_('Alt_T)[x | 'P] \subset 'dom rfd.
   by apply/subsetP=> p; rewrite !inE /=; case/andP.
 apply/isogP; exists [morphism of restrm sSd rfd] => /=; last first.
@@ -449,7 +448,7 @@ have Hreg g z: g \in H -> g z = z -> g = 1.
   by rewrite memJ_norm ?(subsetP nH).
 clear K F8 F12 F13 Ksub F14.
 have Hcard: 5 < #|H|.
-  apply: (leq_trans oT); apply dvdn_leq; first by apply: cardG_gt0.
+  apply: (leq_trans oT); apply: dvdn_leq; first exact: cardG_gt0.
   by rewrite -cardsT (atrans_dvd F5).
 case Eh: (pred0b [predD1 H & 1]).
   by move: Hcard; rewrite /pred0b in Eh; rewrite (cardD1 1) group1 (eqP Eh).

--- a/mathcomp/solvable/cyclic.v
+++ b/mathcomp/solvable/cyclic.v
@@ -587,7 +587,7 @@ Variable u : {unit 'Z_#[a]}.
 Lemma injm_cyclem : 'injm (cyclem (val u) a).
 Proof.
 apply/subsetP=> x /setIdP[ax]; rewrite !inE -order_dvdn.
-case: (eqVneq a 1) => [a1 | nta]; first by rewrite a1 cycle1 inE in ax.
+have [a1 | nta] := eqVneq a 1; first by rewrite a1 cycle1 inE in ax.
 rewrite -order_eq1 -dvdn1; move/eqnP: (valP u) => /= <-.
 by rewrite dvdn_gcd {2}Zp_cast ?order_gt1 // order_dvdG.
 Qed.
@@ -616,7 +616,7 @@ Canonical Zp_unit_morphism := Morphism Zp_unitmM.
 
 Lemma injm_Zp_unitm : 'injm Zp_unitm.
 Proof.
-case: (eqVneq a 1) => [a1 | nta].
+have [a1 | nta] := eqVneq a 1.
   by rewrite subIset //= card_le1_trivg ?subxx // card_units_Zp a1 order1.
 apply/subsetP=> /= u /morphpreP[_ /set1P/= um1].
 have{um1}: Zp_unitm u a == Zp_unitm 1 a by rewrite um1 morph1.

--- a/mathcomp/solvable/frobenius.v
+++ b/mathcomp/solvable/frobenius.v
@@ -598,7 +598,7 @@ have partG: partition (gval K |: (H^# :^: K)) G.
   apply: Frobenius_partition; apply/andP; rewrite defG; split=> //.
   by apply/Frobenius_actionP; apply: HasFrobeniusAction FrobG.
 have{FrobG} [ffulG transG regG ntH [u Su defH]]:= FrobG.
-apply/setP=> x; rewrite !inE; have [-> | ntx] := altP eqP; first exact: group1.
+apply/setP=> x; rewrite !inE; have [-> | ntx] := eqVneq; first exact: group1.
 rewrite /= -(cover_partition partG) /cover.
 have neKHy y: gval K <> H^# :^ y.
   by move/setP/(_ 1); rewrite group1 conjD1g setD11.

--- a/mathcomp/solvable/sylow.v
+++ b/mathcomp/solvable/sylow.v
@@ -255,7 +255,7 @@ Qed.
 Lemma p2group_abelian P : p.-group P -> logn p #|P| <= 2 -> abelian P.
 Proof.
 move=> pP lePp2; pose Z := 'Z(P); have sZP: Z \subset P := center_sub P.
-case: (eqVneq Z 1); first by move/(trivg_center_pgroup pP)->; apply: abelian1.
+have [/(trivg_center_pgroup pP) ->|] := eqVneq Z 1; first exact: abelian1.
 case/(pgroup_pdiv (pgroupS sZP pP)) => p_pr _ [k oZ].
 apply: cyclic_center_factor_abelian.
 have [->|] := eqVneq (P / Z) 1; first exact: cyclic1.

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1480,7 +1480,7 @@ Proof.
 move=> h'K; have [n lePn] := ubnP #|P|; elim: n => // n IHn in P h'K lePn *.
 case: (pickP P) => [i Pi | P0]; last first.
   by rewrite !big_pred0 // => j; rewrite P0.
-rewrite (bigD1 i Pi) (bigD1 (h' i)) h'K ?Pi ?eq_refl //=; congr (_ * _).
+rewrite (bigD1 i Pi) (bigD1 (h' i)) h'K ?Pi ?eqxx //=; congr (_ * _).
 rewrite {}IHn => [|j /andP[]|]; [|by auto | by rewrite (cardD1x i) in lePn]. 
 apply: eq_bigl => j; rewrite andbC -andbA (andbCA (P _)); case: eqP => //= hK.
 by congr (_ && ~~ _); apply/eqP/eqP=> [<-|->] //; rewrite h'K.

--- a/mathcomp/ssreflect/binomial.v
+++ b/mathcomp/ssreflect/binomial.v
@@ -31,7 +31,7 @@ Qed.
 Lemma fact_prod n : n`! = \prod_(1 <= i < n.+1) i.
 Proof.
 elim: n => [|n IHn] //; first by rewrite big_nil.
-by apply sym_equal; rewrite factS IHn // !big_add1 big_nat_recr //= mulnC.
+by apply/esym; rewrite factS IHn // !big_add1 big_nat_recr //= mulnC.
 Qed.
 
 Lemma logn_fact p n : prime p -> logn p n`! = \sum_(1 <= k < n.+1) n %/ p ^ k.
@@ -114,7 +114,7 @@ rewrite [mFpM _ _]mFp1 (bigD1 Fpn1) -?mFpA -/mFpM; last first.
 rewrite (reindex_onto vFp vFp) -/mFpM => [|i]; last by do 3!case/andP; auto.
 rewrite (eq_bigl (xpredD1 ltv Fp0)) => [|i]; last first.
   rewrite andbC -!andbA -2!negb_or -vFpId orbC -leq_eqVlt.
-  rewrite andbA -ltnNge; symmetry; case: (altP eqP) => [->|ni0].
+  rewrite andbA -ltnNge; symmetry; have [->|ni0] := eqVneq.
     by case: eqP => // E; rewrite ?E !andbF.
   by rewrite vFpK //eqxx vFp0.
 rewrite -{2}[mFp]/mFpM -[mFpM _ _]big_split -/mFpM.

--- a/mathcomp/ssreflect/eqtype.v
+++ b/mathcomp/ssreflect/eqtype.v
@@ -916,9 +916,9 @@ Hypothesis aR'E : forall x y, aR' x y = (x != y) && (aR x y).
 Hypothesis rR'E : forall x y, rR' x y = (x != y) && (rR x y).
 
 Let aRE x y : aR x y = (x == y) || (aR' x y).
-Proof. by rewrite aR'E; case: (altP eqP) => //= ->; apply: aR_refl. Qed.
+Proof. by rewrite aR'E; case: eqVneq => //= ->; apply: aR_refl. Qed.
 Let rRE x y : rR x y = (x == y) || (rR' x y).
-Proof. by rewrite rR'E; case: (altP eqP) => //= ->; apply: rR_refl. Qed.
+Proof. by rewrite rR'E; case: eqVneq => //= ->; apply: rR_refl. Qed.
 
 Section InDom.
 Variable D : pred aT.
@@ -962,7 +962,7 @@ Lemma total_homo_mono_in : total aR ->
    {in D &, {mono f : x y / aR x y >-> rR x y}}.
 Proof.
 move=> aR_tot mf x y xD yD.
-have [->|neq_xy] := altP (x =P y); first by rewrite ?eqxx ?aR_refl ?rR_refl.
+have [->|neq_xy] := eqVneq x y; first by rewrite ?eqxx ?aR_refl ?rR_refl.
 have [xy|] := (boolP (aR x y)); first by rewrite rRE mf ?orbT// aR'E neq_xy.
 have /orP [->//|] := aR_tot x y.
 rewrite aRE eq_sym (negPf neq_xy) /= => /mf -/(_ yD xD).

--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -243,7 +243,7 @@ Lemma in_setT x : x \in setTfor (Phant T).
 Proof. by rewrite in_set. Qed.
 
 Lemma eqsVneq A B : eq_xor_neq A B (B == A) (A == B).
-Proof. by apply: eqVneq. Qed.
+Proof. exact: eqVneq. Qed.
 
 Lemma eq_finset (pA pB : pred T) : pA =1 pB -> finset pA = finset pB.
 Proof. by move=> eq_p; apply/setP => x; rewrite !(in_set, inE) eq_p. Qed.
@@ -862,7 +862,7 @@ Proof. by case/orP; apply: subset_trans; rewrite (subsetIl, subsetIr). Qed.
 
 Lemma subsetI A B C : (A \subset B :&: C) = (A \subset B) && (A \subset C).
 Proof.
-rewrite !(sameP setIidPl eqP) setIA; have [-> //| ] := altP (A :&: B =P A).
+rewrite !(sameP setIidPl eqP) setIA; have [-> //|] := eqVneq (A :&: B) A.
 by apply: contraNF => /eqP <-; rewrite -setIA -setIIl setIAC.
 Qed.
 
@@ -1428,7 +1428,7 @@ Proof.
 move=> injh; pose hA := mem (image h A).
 have [x0 Ax0 | A0] := pickP A; last first.
   by rewrite !big_pred0 // => x; apply/imsetP=> [[i]]; rewrite unfold_in A0.
-rewrite (eq_bigl hA) => [|j]; last by apply/imsetP/imageP.
+rewrite (eq_bigl hA) => [|j]; last exact/imsetP/imageP.
 pose h' j := if insub j : {? j | hA j} is Some u then iinv (svalP u) else x0.
 rewrite (reindex_onto h h') => [|j hAj]; rewrite {}/h'; last first.
   by rewrite (insubT hA hAj) f_iinv.

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -694,7 +694,7 @@ Lemma eq_subxx A B : A =i B -> A \subset B.
 Proof. by move/eq_subset->. Qed.
 
 Lemma subset_predT A : A \subset T.
-Proof. by apply/subsetP. Qed.
+Proof. exact/subsetP. Qed.
 
 Lemma predT_subset A : T \subset A -> forall x, x \in A.
 Proof. by move/subsetP=> allA x; apply: allA. Qed.
@@ -1240,7 +1240,7 @@ Lemma image_f A x : x \in A -> f x \in image f A.
 Proof. by move=> Ax; apply/imageP; exists x. Qed.
 
 Lemma codom_f x : f x \in codom f.
-Proof. by apply: image_f. Qed.
+Proof. exact: image_f. Qed.
 
 Lemma image_codom A : {subset image f A <= codom f}.
 Proof. by move=> _ /imageP[x _ ->]; apply: codom_f. Qed.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -2404,7 +2404,7 @@ Lemma comparable_ltgtP x y : x >=< y ->
   compare x y (y == x) (x == y) (x >= y) (x <= y) (x > y) (x < y).
 Proof.
 rewrite />=<%O !le_eqVlt [y == x]eq_sym.
-have := (altP (x =P y), (boolP (x < y), boolP (y < x))).
+have := (eqVneq x y, (boolP (x < y), boolP (y < x))).
 move=> [[->//|neq_xy /=] [[] xy [] //=]] ; do ?by rewrite ?ltxx; constructor.
   by rewrite ltxx in xy.
 by rewrite le_gtF // ltW.
@@ -3065,7 +3065,7 @@ Variant eq0_xor_gt0 x : bool -> bool -> Set :=
   | POsNotEq0 : 0 < x -> eq0_xor_gt0 x false true.
 
 Lemma posxP x : eq0_xor_gt0 x (x == 0) (0 < x).
-Proof. by rewrite lt0x; have [] := altP eqP; constructor; rewrite ?lt0x. Qed.
+Proof. by rewrite lt0x; have [] := eqVneq; constructor; rewrite ?lt0x. Qed.
 
 Canonical join_monoid := Monoid.Law (@joinA _ _) join0x joinx0.
 Canonical join_comoid := Monoid.ComLaw (@joinC _ _).
@@ -3430,7 +3430,7 @@ Proof. by rewrite subUx subxx join0x. Qed.
 
 Lemma disj_le x y : x `&` y == 0 -> x <= y = (x == 0).
 Proof.
-have [->|x_neq0] := altP (x =P 0); first by rewrite le0x.
+have [->|x_neq0] := eqVneq x 0; first by rewrite le0x.
 by apply: contraTF => lexy; rewrite (meet_idPl _).
 Qed.
 
@@ -3826,10 +3826,7 @@ Let T_total_porderType : porderType tt :=
   POrderType tt T (LtPOrderMixin (le_def m) (lt_irr m) (@lt_trans _ m)).
 
 Fact le_total : total (le m).
-Proof.
-move=> x y; rewrite !le_def (eq_sym y).
-by case: (altP eqP); last exact: lt_total.
-Qed.
+Proof. by move=> x y; rewrite !le_def; case: eqVneq; last exact: lt_total. Qed.
 
 Let T_total_distrLatticeType : distrLatticeType tt :=
   DistrLatticeType T_total_porderType

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -368,7 +368,7 @@ Proof.
 elim: s => [| h s]; first by case: ifP.
 rewrite mem2_cons => ->.
 do 2 rewrite inE (fun_if subseq) !if_arg !sub1seq /=.
-by case: eqVneq => [->|]; case: eqVneq.
+by have [->|] := eqVneq; case: eqVneq.
 Qed.
 
 Variant split2r x y : seq T -> Type :=
@@ -916,7 +916,7 @@ Let le_lex_transitive x sT : transitive (le_lex x sT).
 Proof.
 move=> ? ? ? /andP [xy /implyP xy'] /andP [yz /implyP yz'].
 rewrite /= (leT_tr xy yz) /=; apply/implyP => zx.
-by apply/ltn_trans: (xy' (leT_tr yz zx)) (yz' (leT_tr zx xy)).
+exact: ltn_trans (xy' (leT_tr yz zx)) (yz' (leT_tr zx xy)).
 Qed.
 
 Lemma filter_sort p s : filter p (sort leT s) = sort leT (filter p s).

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -429,7 +429,7 @@ Qed.
 Lemma set_set_nth s n1 y1 n2 y2 (s2 := set_nth s n2 y2) :
   set_nth (set_nth s n1 y1) n2 y2 = if n1 == n2 then s2 else set_nth s2 n1 y1.
 Proof.
-have [-> | ne_n12] := altP eqP.
+have [-> | ne_n12] := eqVneq.
   apply: eq_from_nth => [|i _]; first by rewrite !size_set_nth maxnA maxnn.
   by do 2!rewrite !nth_set_nth /=; case: eqP.
 apply: eq_from_nth => [|i _]; first by rewrite !size_set_nth maxnCA.
@@ -2239,7 +2239,7 @@ Lemma nth_index_map s x0 x :
   {in s &, injective f} -> x \in s -> nth x0 s (index (f x) (map f s)) = x.
 Proof.
 elim: s => //= y s IHs inj_f s_x; rewrite (inj_in_eq inj_f) ?mem_head //.
-move: s_x; rewrite inE; case: eqVneq => [-> | _] //=; apply: IHs.
+move: s_x; rewrite inE; have [-> // | _] := eqVneq; apply: IHs.
 by apply: sub_in2 inj_f => z; apply: predU1r.
 Qed.
 


### PR DESCRIPTION
##### Motivation for this change

This PR refactors several proofs especially in `polydiv.v` but does not change any definition and statements of theorems.
- Replace `altP eqP` and `altP (_ =P _)` with `eqVneq`:
  The improved `eqVneq` lemma (#351) is redesigned as a comparison predicate and introduces a hypothesis in the form of `x != y` in the second case. Thus, `case: (altP eqP)`, `case: (altP (x =P _))` and `case: (altP (x =P y))` idioms can be replaced with `case: eqVneq`, `case: (eqVneq x)` and `case: (eqVneq x y)` respectively. This replacement slightly simplifies and reduces proof scripts.
- Use `have [] :=` rather than `case:` if it is better.
- `by apply:` -> `exact:`.
- `apply/lem1; apply/lem2` or `apply: lem1; apply: lem2` -> `apply/lem1/lem2`.
- `move/lem1; move/lem2` -> `move/lem1/lem2`.
- Remove `GRing.` prefix if applicable.
- `negbTE` -> `negPf`, `eq_refl` -> `eqxx`, and `sym_equal` -> `esym`.

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
