### PR TITLE
Fix the doc-clean target of Makefile

### DIFF
--- a/mathcomp/Makefile.common
+++ b/mathcomp/Makefile.common
@@ -146,4 +146,4 @@ doc: __always__ Makefile.coq
 	cp ../etc/artwork/coqdoc.css _build_doc/htmldoc
 
 doc-clean:
-	rm -r _build_doc/
+	rm -rf _build_doc/


### PR DESCRIPTION
##### Motivation for this change

`make clean` fails if the doc has not been generated: https://github.com/math-comp/math-comp/pull/428#issuecomment-559650506.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
