### PR TITLE
take advantage of opam variables and their default values

### DIFF
--- a/coq-mathcomp-algebra.opam
+++ b/coq-mathcomp-algebra.opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "coq-mathcomp-algebra"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
@@ -10,7 +9,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/algebra" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/algebra" "install" ]
-depends: [ "coq-mathcomp-fingroup" { = "dev" } ]
+depends: [ "coq-mathcomp-fingroup" { = version } ]
 
 tags: [ "keyword:algebra" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.algebra" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-character.opam
+++ b/coq-mathcomp-character.opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "coq-mathcomp-character"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
@@ -10,7 +9,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/character" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/character" "install" ]
-depends: [ "coq-mathcomp-field" { = "dev" } ]
+depends: [ "coq-mathcomp-field" { = version } ]
 
 tags: [ "keyword:algebra" "keyword:character" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.character" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-field.opam
+++ b/coq-mathcomp-field.opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "coq-mathcomp-field"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
@@ -10,7 +9,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/field" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/field" "install" ]
-depends: [ "coq-mathcomp-solvable" { = "dev" } ]
+depends: [ "coq-mathcomp-solvable" { = version } ]
 
 tags: [ "keyword:algebra" "keyword:field" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.field" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-fingroup.opam
+++ b/coq-mathcomp-fingroup.opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "coq-mathcomp-fingroup"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
@@ -10,7 +9,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/fingroup" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/fingroup" "install" ]
-depends: [ "coq-mathcomp-ssreflect" { = "dev" } ]
+depends: [ "coq-mathcomp-ssreflect" { = version } ]
 
 tags: [ "keyword:finite groups" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.fingroup" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-solvable.opam
+++ b/coq-mathcomp-solvable.opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "coq-mathcomp-solvable"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
@@ -10,7 +9,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/solvable" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/solvable"  "install" ]
-depends: [ "coq-mathcomp-algebra" { = "dev" } ]
+depends: [ "coq-mathcomp-algebra" { = version } ]
 
 tags: [ "keyword:finite groups" "keyword:Feit Thompson theorem" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.solvable" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "coq-mathcomp-ssreflect"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 

--- a/etc/utils/packager
+++ b/etc/utils/packager
@@ -72,8 +72,7 @@ do pkgdir="$PKGPREFIX/coq-mathcomp-$pkg/coq-mathcomp-$pkg.$VERSION"
    if [ $VERSION == "dev" ]
    then cp $GITROOT/coq-mathcomp-$pkg.opam $pkgdir/opam
    else git show "$BRANCH:coq-mathcomp-$pkg.opam" > $pkgdir/opam
-        sed -r "/^version/s?dev?$VERSION?" -i $pkgdir/opam
-        sed -r "/^depends.*coq-mathcomp.*/s?dev?$VERSION?" -i $pkgdir/opam
+        sed -r "/^version/d" -i $pkgdir/opam
    fi
    echo "" >> $pkgdir/opam
    echo "url {" >> $pkgdir/opam


### PR DESCRIPTION
##### Motivation for this change

<!-- please explain your reason for doing this change -->
When proposing new packages to opam-coq-archive for release 1.10.0, maintainers of this archive suggested that we remove 'name: ' and 'version: ' lines from the opam files, because these are variables that can receive a default value, fixed by the name of the file or the name of directory above.  Similarly, the fact that several `coq-mathcomp-*` share the same version can be carried around using the `version` variable.  These modifications lead to changes in the `etc/utils/packager` script.

The code touched by this pull-request is relevant to developers who want to work with the development version of math-comp and opam using the opam files found in the git root directory and to future release managers.

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
