### PR TITLE
The compatibility module in ssrnum should now be for version 1.10

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,7 +145,7 @@ coq-dev:
     - make install
   except:
     - /^experiment\/order$/
-    - /^pr-(270|388|402|419)$/
+    - /^pr-(270|388|402|419|446)$/
 
 ci-fourcolor-8.7:
   extends: .ci-fourcolor
@@ -182,7 +182,7 @@ ci-fourcolor-dev:
     - make install
   only:
     - /^experiment\/order$/
-    - /^pr-(270|388|402|419)$/
+    - /^pr-(270|388|402|419|446)$/
 
 ci-fourcolor-8.7-270:
   extends: .ci-fourcolor-270
@@ -193,6 +193,16 @@ ci-fourcolor-8.8-270:
   extends: .ci-fourcolor-270
   variables:
     COQ_VERSION: "8.8"
+
+ci-fourcolor-8.9-270:
+  extends: .ci-fourcolor-270
+  variables:
+    COQ_VERSION: "8.9"
+
+ci-fourcolor-8.10-270:
+  extends: .ci-fourcolor-270
+  variables:
+    COQ_VERSION: "8.10"
 
 ci-fourcolor-dev-270:
   extends: .ci-fourcolor-270
@@ -210,7 +220,7 @@ ci-fourcolor-dev-270:
     - make install
   except:
     - /^experiment\/order$/
-    - /^pr-(270|388|402|419)$/
+    - /^pr-(270|388|402|419|446)$/
 
 ci-odd-order-8.7:
   extends: .ci-odd-order
@@ -247,7 +257,7 @@ ci-odd-order-dev:
     - make install
   only:
     - /^experiment\/order$/
-    - /^pr-(270|388|402|419)$/
+    - /^pr-(270|388|402|419|446)$/
 
 ci-odd-order-8.7-270:
  extends: .ci-odd-order-270
@@ -258,6 +268,16 @@ ci-odd-order-8.8-270:
  extends: .ci-odd-order-270
  variables:
    COQ_VERSION: "8.8"
+
+ci-odd-order-8.9-270:
+ extends: .ci-odd-order-270
+ variables:
+   COQ_VERSION: "8.9"
+
+ci-odd-order-8.10-270:
+ extends: .ci-odd-order-270
+ variables:
+   COQ_VERSION: "8.10"
 
 ci-odd-order-dev-270:
   extends: .ci-odd-order-270

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -86,10 +86,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `ler_norm_sum`, `ler_norm_sub`, `ler_dist_add`, `ler_sub_norm_add`,
     `ler_sub_dist`, `ler_dist_dist`, `ler_dist_norm_add`, `ler_nnorml`,
     `ltr_nnorml`, `lter_nnormr`.
-  + The compatibility layer for the version 1.9 is provided as the
-    `ssrnum.mc_1_9` module. One may compile proofs compatible with the version
-    1.9 in newer versions by using the `mc_1_9.Num` module instead of the `Num`
-    module. However, instances of the number structures may require changes.
+  + The compatibility layer for the version 1.10 is provided as the
+    `ssrnum.mc_1_10` module. One may compile proofs compatible with the version
+    1.10 in newer versions by using the `mc_1_10.Num` module instead of the
+    `Num` module. However, instances of the number structures may require
+    changes.
 
 ### Renamed
 

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -26,7 +26,7 @@ From mathcomp Require Import ssralg poly.
 (*   normedZmodType R                                                         *)
 (*                  == interface for a normed Zmodule structure indexed by    *)
 (*                     numDomainType R.                                       *)
-(*   NormedZmodType R T m                                                  *)
+(*   NormedZmodType R T m                                                     *)
 (*                  == pack the normed Zmodule mixin into a normedZmodType.   *)
 (*                     The carrier T must have an integral domain structure.  *)
 (*   [normedZmodType R of T for S]                                            *)
@@ -5039,7 +5039,7 @@ Export Num.RealLeMixin.Exports Num.RealLtMixin.Exports.
 Notation ImaginaryMixin := Num.ClosedField.ImaginaryMixin.
 
 (* compatibility module *)
-Module mc_1_9.
+Module mc_1_10.
 Module Num.
 (* If you failed to process the next line in the PG or the CoqIDE, replace    *)
 (* all the "ssrnum.Num" with "Top.Num" in this module to process them, and    *)
@@ -5617,4 +5617,4 @@ Notation "[ 'arg' 'maxr_' ( i > i0 ) F ]" := [arg maxr_(i > i0 | true) F]
    format "[ 'arg'  'maxr_' ( i  >  i0 ) F ]") : form_scope.
 
 End Num.
-End mc_1_9.
+End mc_1_10.


### PR DESCRIPTION
##### Motivation for this change

This addresses https://github.com/math-comp/math-comp/pull/270#discussion_r353195738. @CohenCyril 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
