### PR TITLE
treating deprecation warnings that appear with coq-8.10

### DIFF
--- a/mathcomp/Make
+++ b/mathcomp/Make
@@ -96,3 +96,4 @@ ssreflect/tuple.v
 -arg -w -arg -notation-overridden
 -arg -w -arg -duplicate-clear
 -arg -w -arg -ambiguous-paths
+-arg -w -arg -undeclared-scope

--- a/mathcomp/_CoqProject
+++ b/mathcomp/_CoqProject
@@ -5,3 +5,5 @@
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -notation-overridden
 -arg -w -arg -duplicate-clear
+-arg -w -arg -ambiguous-paths
+-arg -w -arg -undeclared-scope

--- a/mathcomp/algebra/mxalgebra.v
+++ b/mathcomp/algebra/mxalgebra.v
@@ -1999,7 +1999,7 @@ Arguments capmx_idPr {F n m1 m2 A B}.
 Arguments capmx_idPl {F n m1 m2 A B}.
 Arguments bigcapmx_inf [F I] i0 [P m n A_ B].
 Arguments sub_bigcapmxP {F I P m n A B_}.
-Arguments mxrank_injP {F m n} p [A f].
+Arguments mxrank_injP {F m n} p {A f}.
 Arguments mxdirectP {F n S}.
 Arguments mxdirect_addsP {F m1 m2 n A B}.
 Arguments mxdirect_sumsP {F I P n A_}.
@@ -2620,7 +2620,7 @@ Notation "''Z' ( R )" := (center_mx R) : matrix_set_scope.
 
 Arguments memmx_subP {F m1 m2 n R1 R2}.
 Arguments memmx_eqP {F m1 m2 n R1 R2}.
-Arguments memmx_addsP {F m1 m2 n} A [R1 R2].
+Arguments memmx_addsP {F m1 m2 n} A {R1 R2}.
 Arguments memmx_sumsP {F I P n A R_}.
 Arguments mulsmx_subP {F m1 m2 m n R1 R2 R}.
 Arguments mulsmxP {F m1 m2 n A R1 R2}.

--- a/mathcomp/fingroup/fingroup.v
+++ b/mathcomp/fingroup/fingroup.v
@@ -1839,8 +1839,8 @@ Arguments trivgP {gT G}.
 Arguments trivGP {gT G}.
 Arguments lcoset_eqP {gT G x y}.
 Arguments rcoset_eqP {gT G x y}.
-Arguments mulGidPl [gT G H].
-Arguments mulGidPr [gT G H].
+Arguments mulGidPl {gT G H}.
+Arguments mulGidPr {gT G H}.
 Arguments comm_group_setP {gT G H}.
 Arguments class_eqP {gT G x y}.
 Arguments repr_classesP {gT G xG}.

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1662,8 +1662,8 @@ Arguments big_enum_val [R idx op I A] F.
 Arguments big_enum_rank [R idx op I A x] xA F.
 Arguments pair_big_dep [R idx op I J].
 Arguments pair_big [R idx op I J].
-Arguments big_allpairs_dep [R idx op I1 I2 J h r1 r2 F].
-Arguments big_allpairs [R idx op I1 I2 r1 r2 F].
+Arguments big_allpairs_dep {R idx op I1 I2 J h r1 r2 F}.
+Arguments big_allpairs {R idx op I1 I2 r1 r2 F}.
 Arguments exchange_big_dep [R idx op I J rI rJ P Q] xQ [F].
 Arguments exchange_big_dep_nat [R idx op m1 n1 m2 n2 P Q] xQ [F].
 Arguments big_ord_recl [R idx op].


### PR DESCRIPTION
##### Motivation for this change

<!-- please explain your reason for doing this change -->
Remove deprecation warnings that became apparent at the time of the 1.10.0 release.
##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
