### PR TITLE
Remove CI overlay for PR #270

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,8 +149,6 @@ coq-dev:
     - tags
     - merge_requests
     - schedules
-    - /^experiment\/order$/
-    - /^pr-(270|388|402|419|446)$/
 
 ci-fourcolor-8.7:
   extends: .ci-fourcolor
@@ -177,42 +175,6 @@ ci-fourcolor-dev:
   variables:
     COQ_VERSION: "dev"
 
-.ci-fourcolor-270:
-  extends: .ci
-  variables:
-    CONTRIB_URL: "https://github.com/pi8027/fourcolor.git"
-    CONTRIB_VERSION: fix-mathcomp-270
-  script:
-    - make -j "${NJOBS}"
-    - make install
-  only:
-    - /^experiment\/order$/
-    - /^pr-(270|388|402|419|446)$/
-
-ci-fourcolor-8.7-270:
-  extends: .ci-fourcolor-270
-  variables:
-    COQ_VERSION: "8.7"
-
-ci-fourcolor-8.8-270:
-  extends: .ci-fourcolor-270
-  variables:
-    COQ_VERSION: "8.8"
-
-ci-fourcolor-8.9-270:
-  extends: .ci-fourcolor-270
-  variables:
-    COQ_VERSION: "8.9"
-
-ci-fourcolor-8.10-270:
-  extends: .ci-fourcolor-270
-  variables:
-    COQ_VERSION: "8.10"
-
-ci-fourcolor-dev-270:
-  extends: .ci-fourcolor-270
-  variables:
-    COQ_VERSION: "dev"
 
 # The Odd Order Theorem
 .ci-odd-order:
@@ -227,8 +189,6 @@ ci-fourcolor-dev-270:
     - tags
     - merge_requests
     - schedules
-    - /^experiment\/order$/
-    - /^pr-(270|388|402|419|446)$/
 
 ci-odd-order-8.7:
   extends: .ci-odd-order
@@ -252,43 +212,6 @@ ci-odd-order-8.10:
 
 ci-odd-order-dev:
   extends: .ci-odd-order
-  variables:
-    COQ_VERSION: "dev"
-
-.ci-odd-order-270:
-  extends: .ci
-  variables:
-    CONTRIB_URL: "https://github.com/pi8027/odd-order.git"
-    CONTRIB_VERSION: fix-mathcomp-270
-  script:
-    - make -j "${NJOBS}"
-    - make install
-  only:
-    - /^experiment\/order$/
-    - /^pr-(270|388|402|419|446)$/
-
-ci-odd-order-8.7-270:
- extends: .ci-odd-order-270
- variables:
-   COQ_VERSION: "8.7"
-
-ci-odd-order-8.8-270:
- extends: .ci-odd-order-270
- variables:
-   COQ_VERSION: "8.8"
-
-ci-odd-order-8.9-270:
- extends: .ci-odd-order-270
- variables:
-   COQ_VERSION: "8.9"
-
-ci-odd-order-8.10-270:
- extends: .ci-odd-order-270
- variables:
-   COQ_VERSION: "8.10"
-
-ci-odd-order-dev-270:
-  extends: .ci-odd-order-270
   variables:
     COQ_VERSION: "dev"
 
@@ -347,7 +270,7 @@ ci-bigenough-8.9:
   variables:
     COQ_VERSION: "8.9"
 
-ci-bigenough-8.9:
+ci-bigenough-8.10:
   extends: .ci-bigenough
   variables:
     COQ_VERSION: "8.10"


### PR DESCRIPTION
##### Motivation for this change

This PR removes the CI overlay for PR #270 and fixes `ci-bigenough-8.10`.

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
