### PR TITLE
[ci] add missing "except:" rules to fix the nightly build on GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,6 +82,8 @@ make-coq-latest:
 .opam-build-once:
   extends: .opam-build
   except:
+    - tags
+    - merge_requests
     - schedules
   
 coq-8.7:
@@ -144,6 +146,9 @@ coq-dev:
     - make -j "${NJOBS}"
     - make install
   except:
+    - tags
+    - merge_requests
+    - schedules
     - /^experiment\/order$/
     - /^pr-(270|388|402|419|446)$/
 
@@ -219,6 +224,9 @@ ci-fourcolor-dev-270:
     - make -j "${NJOBS}"
     - make install
   except:
+    - tags
+    - merge_requests
+    - schedules
     - /^experiment\/order$/
     - /^pr-(270|388|402|419|446)$/
 


### PR DESCRIPTION
##### Motivation for this change

It appears adding an `except:` rule in a GitLab CI job that `extends:` another one *overwrites* the `except` rules, which means some `except` conditions are missing − so we were getting too many jobs in the `master` scheduled pipeline that deploys `mathcomp/mathcomp-dev` every night (cf. screenshot below).

![2019-12-15_01-09-01_Screenshot_too-many-jobs-in-scheduled-pipeline](https://user-images.githubusercontent.com/10367254/70856283-2bcfda00-1ed9-11ea-921b-e2d8a1d380ed.png)

##### Things done/to do

- [x] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- [x] ~added corresponding documentation in the headers~
- [ ] I propose to update the [wiki](https://github.com/math-comp/math-comp/wiki/How-to-add-overlays-for-PRs) with a link to this PR once it is merged (given that this issue is partly related to overlay jobs)

<!-- leave this note as a reminder to reviewers -->

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.