### PR TITLE
Non-distributive lattice structures

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -18,7 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Lemmas `eqEtupe`, `tnthS` and `tnth_nseq` in `tuple`
 
 - Ported `order.v` from the finmap library, which provides structures of ordered
-  sets (`porderType`, `distrLatticeType`, `orderType`, etc.) and its theory.
+  sets (`porderType`, `latticeType`, `distrLatticeType`, `orderType`, etc.) and
+  its theory.
 
 ### Changed
 

--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -573,6 +573,7 @@ Definition ratLeMixin : realLeMixin rat_idomainType :=
               (@le_rat_total 0) norm_ratN ge_rat0_norm lt_rat_def.
 
 Canonical rat_porderType := POrderType ring_display rat ratLeMixin.
+Canonical rat_latticeType := LatticeType rat ratLeMixin.
 Canonical rat_distrLatticeType := DistrLatticeType rat ratLeMixin.
 Canonical rat_orderType := OrderType rat le_rat_total.
 Canonical rat_numDomainType := NumDomainType rat ratLeMixin.

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -431,6 +431,7 @@ End intOrdered.
 End intOrdered.
 
 Canonical int_porderType := POrderType ring_display int intOrdered.Mixin.
+Canonical int_latticeType := LatticeType int intOrdered.Mixin.
 Canonical int_distrLatticeType := DistrLatticeType int intOrdered.Mixin.
 Canonical int_orderType := OrderType int intOrdered.lez_total.
 Canonical int_numDomainType := NumDomainType int intOrdered.Mixin.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -727,8 +727,11 @@ Section ClassDef.
 
 Record class_of R := Class {
   base   : NumDomain.class_of R;
+  nmixin_disp : unit;
+  nmixin : Order.Lattice.mixin_of (Order.POrder.Pack nmixin_disp base);
   lmixin_disp : unit;
-  lmixin : Order.DistrLattice.mixin_of (Order.POrder.Pack lmixin_disp base);
+  lmixin : Order.DistrLattice.mixin_of
+             (Order.Lattice.Pack lmixin_disp (Order.Lattice.Class nmixin));
   tmixin_disp : unit;
   tmixin : Order.Total.mixin_of
              (Order.DistrLattice.Pack
@@ -736,7 +739,10 @@ Record class_of R := Class {
 }.
 Local Coercion base : class_of >-> NumDomain.class_of.
 Local Coercion base2 T (c : class_of T) : Order.Total.class_of T :=
-  @Order.Total.Class _ (Order.DistrLattice.Class (@lmixin _ c)) _ (@tmixin _ c).
+  @Order.Total.Class
+    _ (@Order.DistrLattice.Class
+         _ (Order.Lattice.Class (@nmixin _ c)) _ (@lmixin _ c))
+    _ (@tmixin _ c).
 
 Structure type := Pack {sort; _ : class_of sort}.
 Local Coercion sort : type >-> Sortclass.
@@ -746,11 +752,13 @@ Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of xT).
 Definition pack :=
   fun bT b & phant_id (NumDomain.class bT) (b : NumDomain.class_of T) =>
-  fun mT ldisp l mdisp m &
+  fun mT ndisp n ldisp l mdisp m &
       phant_id (@Order.Total.class ring_display mT)
                (@Order.Total.Class
-                  T (@Order.DistrLattice.Class T b ldisp l) mdisp m) =>
-  Pack (@Class T b ldisp l mdisp  m).
+                  T (@Order.DistrLattice.Class
+                       T (@Order.Lattice.Class T b ndisp n) ldisp l)
+                  mdisp m) =>
+  Pack (@Class T b ndisp n ldisp l mdisp m).
 
 Definition eqType := @Equality.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
@@ -761,10 +769,25 @@ Definition unitRingType := @GRing.UnitRing.Pack cT xclass.
 Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
 Definition porderType := @Order.POrder.Pack ring_display cT xclass.
+Definition latticeType := @Order.Lattice.Pack ring_display cT xclass.
 Definition distrLatticeType := @Order.DistrLattice.Pack ring_display cT xclass.
 Definition orderType := @Order.Total.Pack ring_display cT xclass.
 Definition numDomainType := @NumDomain.Pack cT xclass.
 Definition normedZmodType := NormedZmodType numDomainType cT xclass.
+Definition zmod_latticeType := @Order.Lattice.Pack ring_display zmodType xclass.
+Definition ring_latticeType := @Order.Lattice.Pack ring_display ringType xclass.
+Definition comRing_latticeType :=
+  @Order.Lattice.Pack ring_display comRingType xclass.
+Definition unitRing_latticeType :=
+  @Order.Lattice.Pack ring_display unitRingType xclass.
+Definition comUnitRing_latticeType :=
+  @Order.Lattice.Pack ring_display comUnitRingType xclass.
+Definition idomain_latticeType :=
+  @Order.Lattice.Pack ring_display idomainType xclass.
+Definition normedZmod_latticeType :=
+  @Order.Lattice.Pack ring_display normedZmodType xclass.
+Definition numDomain_latticeType :=
+  @Order.Lattice.Pack ring_display numDomainType xclass.
 Definition zmod_distrLatticeType :=
   @Order.DistrLattice.Pack ring_display zmodType xclass.
 Definition ring_distrLatticeType :=
@@ -823,12 +846,22 @@ Coercion porderType : type >-> Order.POrder.type.
 Canonical porderType.
 Coercion numDomainType : type >-> NumDomain.type.
 Canonical numDomainType.
+Coercion latticeType : type >-> Order.Lattice.type.
+Canonical latticeType.
 Coercion distrLatticeType : type >-> Order.DistrLattice.type.
 Canonical distrLatticeType.
 Coercion orderType : type >-> Order.Total.type.
 Canonical orderType.
 Coercion normedZmodType : type >-> NormedZmodule.type.
 Canonical normedZmodType.
+Canonical zmod_latticeType.
+Canonical ring_latticeType.
+Canonical comRing_latticeType.
+Canonical unitRing_latticeType.
+Canonical comUnitRing_latticeType.
+Canonical idomain_latticeType.
+Canonical normedZmod_latticeType.
+Canonical numDomain_latticeType.
 Canonical zmod_distrLatticeType.
 Canonical ring_distrLatticeType.
 Canonical comRing_distrLatticeType.
@@ -846,7 +879,7 @@ Canonical idomain_orderType.
 Canonical normedZmod_orderType.
 Canonical numDomain_orderType.
 Notation realDomainType := type.
-Notation "[ 'realDomainType' 'of' T ]" := (@pack T _ _ id _ _ _ _ _ id)
+Notation "[ 'realDomainType' 'of' T ]" := (@pack T _ _ id _ _ _ _ _ _ _ id)
   (at level 0, format "[ 'realDomainType'  'of'  T ]") : form_scope.
 End Exports.
 
@@ -859,8 +892,11 @@ Section ClassDef.
 
 Record class_of R := Class {
   base  : NumField.class_of R;
+  nmixin_disp : unit;
+  nmixin : Order.Lattice.mixin_of (Order.POrder.Pack nmixin_disp base);
   lmixin_disp : unit;
-  lmixin : Order.DistrLattice.mixin_of (@Order.POrder.Pack lmixin_disp R base);
+  lmixin : Order.DistrLattice.mixin_of
+             (Order.Lattice.Pack lmixin_disp (Order.Lattice.Class nmixin));
   tmixin_disp : unit;
   tmixin : Order.Total.mixin_of
              (Order.DistrLattice.Pack
@@ -878,9 +914,10 @@ Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of xT).
 Definition pack :=
   fun bT (b : NumField.class_of T) & phant_id (NumField.class bT) b =>
-  fun mT ldisp l tdisp t & phant_id (RealDomain.class mT)
-                                    (@RealDomain.Class T b ldisp l tdisp t) =>
-  Pack (@Class T b ldisp l tdisp t).
+  fun mT ndisp n ldisp l tdisp t
+      & phant_id (RealDomain.class mT)
+                 (@RealDomain.Class T b ndisp n ldisp l tdisp t) =>
+  Pack (@Class T b ndisp n ldisp l tdisp t).
 
 Definition eqType := @Equality.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
@@ -892,16 +929,21 @@ Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
 Definition porderType := @Order.POrder.Pack ring_display cT xclass.
 Definition numDomainType := @NumDomain.Pack cT xclass.
+Definition latticeType := @Order.Lattice.Pack ring_display cT xclass.
 Definition distrLatticeType := @Order.DistrLattice.Pack ring_display cT xclass.
 Definition orderType := @Order.Total.Pack ring_display cT xclass.
 Definition realDomainType := @RealDomain.Pack cT xclass.
 Definition fieldType := @GRing.Field.Pack cT xclass.
 Definition numFieldType := @NumField.Pack cT xclass.
 Definition normedZmodType := NormedZmodType numDomainType cT xclass.
+Definition field_latticeType :=
+  @Order.Lattice.Pack ring_display fieldType xclass.
 Definition field_distrLatticeType :=
   @Order.DistrLattice.Pack ring_display fieldType xclass.
 Definition field_orderType := @Order.Total.Pack ring_display fieldType xclass.
 Definition field_realDomainType := @RealDomain.Pack fieldType xclass.
+Definition numField_latticeType :=
+  @Order.Lattice.Pack ring_display numFieldType xclass.
 Definition numField_distrLatticeType :=
   @Order.DistrLattice.Pack ring_display numFieldType xclass.
 Definition numField_orderType :=
@@ -935,6 +977,8 @@ Coercion porderType : type >-> Order.POrder.type.
 Canonical porderType.
 Coercion numDomainType : type >-> NumDomain.type.
 Canonical numDomainType.
+Coercion latticeType : type >-> Order.Lattice.type.
+Canonical latticeType.
 Coercion distrLatticeType : type >-> Order.DistrLattice.type.
 Canonical distrLatticeType.
 Coercion orderType : type >-> Order.Total.type.
@@ -947,14 +991,16 @@ Coercion numFieldType : type >-> NumField.type.
 Canonical numFieldType.
 Coercion normedZmodType : type >-> NormedZmodule.type.
 Canonical normedZmodType.
+Canonical field_latticeType.
 Canonical field_distrLatticeType.
 Canonical field_orderType.
 Canonical field_realDomainType.
+Canonical numField_latticeType.
 Canonical numField_distrLatticeType.
 Canonical numField_orderType.
 Canonical numField_realDomainType.
 Notation realFieldType := type.
-Notation "[ 'realFieldType' 'of' T ]" := (@pack T _ _ id _ _ _ _ _ id)
+Notation "[ 'realFieldType' 'of' T ]" := (@pack T _ _ id _ _ _ _ _ _ _ id)
   (at level 0, format "[ 'realFieldType'  'of'  T ]") : form_scope.
 End Exports.
 
@@ -989,9 +1035,10 @@ Definition unitRingType := @GRing.UnitRing.Pack cT xclass.
 Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
 Definition porderType := @Order.POrder.Pack ring_display cT xclass.
-Definition numDomainType := @NumDomain.Pack cT xclass.
+Definition latticeType := @Order.Lattice.Pack ring_display cT xclass.
 Definition distrLatticeType := @Order.DistrLattice.Pack ring_display cT xclass.
 Definition orderType := @Order.Total.Pack ring_display cT xclass.
+Definition numDomainType := @NumDomain.Pack cT xclass.
 Definition realDomainType := @RealDomain.Pack cT xclass.
 Definition fieldType := @GRing.Field.Pack cT xclass.
 Definition numFieldType := @NumField.Pack cT xclass.
@@ -1022,12 +1069,14 @@ Coercion idomainType : type >-> GRing.IntegralDomain.type.
 Canonical idomainType.
 Coercion porderType : type >-> Order.POrder.type.
 Canonical porderType.
-Coercion numDomainType : type >-> NumDomain.type.
-Canonical numDomainType.
+Coercion latticeType : type >-> Order.Lattice.type.
+Canonical latticeType.
 Coercion distrLatticeType : type >-> Order.DistrLattice.type.
 Canonical distrLatticeType.
 Coercion orderType : type >-> Order.Total.type.
 Canonical orderType.
+Coercion numDomainType : type >-> NumDomain.type.
+Canonical numDomainType.
 Coercion realDomainType : type >-> RealDomain.type.
 Canonical realDomainType.
 Coercion fieldType : type >-> GRing.Field.type.
@@ -1077,9 +1126,10 @@ Definition unitRingType := @GRing.UnitRing.Pack cT xclass.
 Definition comUnitRingType := @GRing.ComUnitRing.Pack cT xclass.
 Definition idomainType := @GRing.IntegralDomain.Pack cT xclass.
 Definition porderType := @Order.POrder.Pack ring_display cT xclass.
-Definition numDomainType := @NumDomain.Pack cT xclass.
+Definition latticeType := @Order.Lattice.Pack ring_display cT xclass.
 Definition distrLatticeType := @Order.DistrLattice.Pack ring_display cT xclass.
 Definition orderType := @Order.Total.Pack ring_display cT xclass.
+Definition numDomainType := @NumDomain.Pack cT xclass.
 Definition realDomainType := @RealDomain.Pack cT xclass.
 Definition fieldType := @GRing.Field.Pack cT xclass.
 Definition numFieldType := @NumField.Pack cT xclass.
@@ -1110,14 +1160,16 @@ Coercion idomainType : type >-> GRing.IntegralDomain.type.
 Canonical idomainType.
 Coercion porderType : type >-> Order.POrder.type.
 Canonical porderType.
-Coercion numDomainType : type >-> NumDomain.type.
-Canonical numDomainType.
-Coercion realDomainType : type >-> RealDomain.type.
-Canonical realDomainType.
+Coercion latticeType : type >-> Order.Lattice.type.
+Canonical latticeType.
 Coercion distrLatticeType : type >-> Order.DistrLattice.type.
 Canonical distrLatticeType.
 Coercion orderType : type >-> Order.Total.type.
 Canonical orderType.
+Coercion numDomainType : type >-> NumDomain.type.
+Canonical numDomainType.
+Coercion realDomainType : type >-> RealDomain.type.
+Canonical realDomainType.
 Coercion fieldType : type >-> GRing.Field.type.
 Canonical fieldType.
 Coercion numFieldType : type >-> NumField.type.
@@ -4773,17 +4825,17 @@ Qed.
 Lemma normrN x : `|- x| = `|x|.
 Proof. by rewrite -mulN1r normM -[RHS]mul1r normrN1. Qed.
 
-Definition lePOrderMixin : ltPOrderMixin R :=
+Definition ltPOrderMixin : ltPOrderMixin R :=
   LtPOrderMixin le_def' ltrr lt_trans.
 
 Definition normedZmodMixin :
-  @normed_mixin_of R R lePOrderMixin :=
-  @Num.NormedMixin _ _ lePOrderMixin (norm m)
+  @normed_mixin_of R R ltPOrderMixin :=
+  @Num.NormedMixin _ _ ltPOrderMixin (norm m)
                    (normD m) (@norm_eq0 m) normrMn normrN.
 
 Definition numDomainMixin :
-  @mixin_of R lePOrderMixin normedZmodMixin :=
-  @Num.Mixin _ lePOrderMixin normedZmodMixin (@addr_gt0 m)
+  @mixin_of R ltPOrderMixin normedZmodMixin :=
+  @Num.Mixin _ ltPOrderMixin normedZmodMixin (@addr_gt0 m)
              (@ger_total m) (@normM m) (@le_def m).
 
 End NumMixin.
@@ -4791,9 +4843,11 @@ End NumMixin.
 Module Exports.
 Notation numMixin := of_.
 Notation NumMixin := Mixin.
-Coercion lePOrderMixin : numMixin >-> ltPOrderMixin.
+Coercion ltPOrderMixin : numMixin >-> Order.LtPOrderMixin.of_.
 Coercion normedZmodMixin : numMixin >-> normed_mixin_of.
 Coercion numDomainMixin : numMixin >-> mixin_of.
+Definition NumDomainOfIdomain (T : idomainType) (m : of_ T) :=
+  NumDomainType (POrderType ring_display T m) m.
 End Exports.
 
 End NumMixin.
@@ -4811,14 +4865,17 @@ move=> x y; move: (real (x - y)).
 by rewrite unfold_in !ler_def subr0 add0r opprB orbC.
 Qed.
 
-Definition totalMixin :
-  Order.Total.mixin_of (DistrLatticeType R le_total) := le_total.
+Let R_distrLatticeType := DistrLatticeType (LatticeType R le_total) le_total.
+
+Definition totalMixin : Order.Total.mixin_of R_distrLatticeType := le_total.
 
 End RealMixin.
 
 Module Exports.
 Coercion le_total : real_axiom >-> totalPOrderMixin.
 Coercion totalMixin : real_axiom >-> totalOrderMixin.
+Definition RealDomainOfNumDomain (T : numDomainType) (m : real_axiom T) :=
+  [realDomainType of (OrderOfPOrder m)].
 End Exports.
 
 End RealMixin.
@@ -4910,9 +4967,14 @@ Notation realLeMixin := of_.
 Notation RealLeMixin := Mixin.
 Coercion numMixin : realLeMixin >-> NumMixin.of_.
 Coercion orderMixin : realLeMixin >-> totalPOrderMixin.
+Definition LeRealDomainOfIdomain (R : idomainType) (m : of_ R) :=
+  [realDomainType of @OrderOfPOrder _ (NumDomainOfIdomain m) m].
+Definition LeRealFieldOfField (R : fieldType) (m : of_ R) :=
+  [realFieldType of [numFieldType of LeRealDomainOfIdomain m]].
 End Exports.
 
 End RealLeMixin.
+Import RealLeMixin.Exports.
 
 Module RealLtMixin.
 Section RealLtMixin.
@@ -5021,9 +5083,14 @@ Notation realLtMixin := of_.
 Notation RealLtMixin := Mixin.
 Coercion numMixin : realLtMixin >-> NumMixin.of_.
 Coercion orderMixin : realLtMixin >-> totalPOrderMixin.
+Definition LtRealDomainOfIdomain (R : idomainType) (m : of_ R) :=
+  [realDomainType of @OrderOfPOrder _ (NumDomainOfIdomain m) m].
+Definition LtRealFieldOfField (R : fieldType) (m : of_ R) :=
+  [realFieldType of [numFieldType of LtRealDomainOfIdomain m]].
 End Exports.
 
 End RealLtMixin.
+Import RealLtMixin.Exports.
 
 End Num.
 

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -586,13 +586,8 @@ have add_Rroot xR p c: {yR | extendsR xR yR & has_Rroot xR p c -> root_in yR p}.
       by rewrite v_gt0 /= -if_neg posNneg.
     by rewrite v_lt0 /= -if_neg -(opprK v) posN posNneg ?posN.
   have absE v: le 0 v -> abs v = v by rewrite /abs => ->.
-  pose QyNum : realLtMixin (Q y) :=
-    RealLtMixin posD posM posNneg posB posVneg absN absE (rrefl _).
-  pose QyOrder :=
-    OrderType
-      (DistrLatticeType (POrderType ring_display (Q y) QyNum) QyNum) QyNum.
-  pose QyNumField := [numFieldType of NumDomainType QyOrder QyNum].
-  pose Ry := [realFieldType of [realDomainType of QyNumField]].
+  pose Ry := LtRealFieldOfField
+               (RealLtMixin posD posM posNneg posB posVneg absN absE (rrefl _)).
   have archiRy := @rat_algebraic_archimedean Ry _ alg_integral.
   by exists (ArchiFieldType Ry archiRy); apply: [rmorphism of idfun].
 have some_realC: realC.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -298,10 +298,11 @@ From mathcomp Require Import path fintype tuple bigop finset div prime.
 (* - totalOrderMixin == on a distrLatticeType T, totality of the order of T   *)
 (*                    := total (<=%O : rel T)                                 *)
 (*                   (can build: orderType)                                   *)
-(*    NB: this mixin is kept separate from totalPOrderMixin (even though it   *)
-(*        is convertible to it), in order to avoid ambiguous coercion paths.  *)
+(*    NB: the above three mixins are kept separate from each other (even      *)
+(*        though they are convertible), in order to avoid ambiguous coercion  *)
+(*        paths.                                                              *)
 (*                                                                            *)
-(* - distrLatticeMixin == on a porderType T, takes meet, join                 *)
+(* - distrLatticeMixin == on a latticeType T, takes meet, join                *)
 (*                   commutativity and associativity of meet and join         *)
 (*                   idempotence of meet and some De Morgan laws              *)
 (*                   (can build: distrLatticeType)                            *)
@@ -320,37 +321,51 @@ From mathcomp Require Import path fintype tuple bigop finset div prime.
 (* - IsoLatticeMixin creates a distrLatticeMixin from an ordered structure    *)
 (*   isomorphism (i.e., cancel f f', cancel f' f, {mono f : x y / x <= y})    *)
 (*                                                                            *)
+(* List of "big pack" notations:                                              *)
+(* - DistrLatticeOfChoiceType builds a distrLatticeType from a choiceType and *)
+(*   a meetJoinMixin.                                                         *)
+(* - OrderOfChoiceType builds an orderType from a choiceType, and a           *)
+(*   leOrderMixin or a ltOrderMixin.                                          *)
+(* - OrderOfPOrder builds an orderType from a porderType and a                *)
+(*   totalPOrderMixin.                                                        *)
+(* - OrderOfLattice builds an orderType from a latticeType and a              *)
+(*   totalLatticeMixin.                                                       *)
+(* NB: These big pack notations should be used only to construct instances on *)
+(*     the fly, e.g., in the middle of a proof, and should not be used to     *)
+(*     declare canonical instances. See field/algebraics_fundamentals.v for   *)
+(*     an example usage.                                                      *)
+(*                                                                            *)
 (* We provide the following canonical instances of ordered types              *)
 (* - all possible structures on bool                                          *)
-(* - porderType, distrLatticeType, orderType and bDistrLatticeType on nat for *)
-(*   the leq order                                                            *)
-(* - porderType, distrLatticeType, bDistrLatticeType, cbDistrLatticeType,     *)
-(*   ctbDistrLatticeType on nat for the dvdn order, where meet and join       *)
-(*   are respectively gcdn and lcmn                                           *)
-(* - porderType, distrLatticeType, orderType, bDistrLatticeType,              *)
+(* - porderType, latticeType, distrLatticeType, orderType and                 *)
+(*   bDistrLatticeType on nat for the leq order                               *)
+(* - porderType, latticeType, distrLatticeType, bDistrLatticeType,            *)
+(*   cbDistrLatticeType, ctbDistrLatticeType on nat for the dvdn order, where *)
+(*   meet and join are respectively gcdn and lcmn                             *)
+(* - porderType, latticeType, distrLatticeType, orderType, bDistrLatticeType, *)
 (*   tbDistrLatticeType, cbDistrLatticeType, ctbDistrLatticeType              *)
 (*   on T *prod[disp] T' a "copy" of T * T'                                   *)
 (*     using product order (and T *p T' its specialization to prod_display)   *)
-(* - porderType, distrLatticeType, and orderType,  on T *lexi[disp] T'        *)
-(*     another "copy" of T * T', with lexicographic ordering                  *)
+(* - porderType, latticeType, distrLatticeType, and orderType, on             *)
+(*     T *lexi[disp] T' another "copy" of T * T', with lexicographic ordering *)
 (*     (and T *l T' its specialization to lexi_display)                       *)
-(* - porderType, distrLatticeType, and orderType,  on {t : T & T' x}          *)
-(*     with lexicographic ordering                                            *)
-(* - porderType, distrLatticeType, orderType, bDistrLatticeType,              *)
+(* - porderType, latticeType, distrLatticeType, and orderType, on             *)
+(*     {t : T & T' x} with lexicographic ordering                             *)
+(* - porderType, latticeType, distrLatticeType, orderType, bDistrLatticeType, *)
 (*   cbDistrLatticeType, tbDistrLatticeType, ctbDistrLatticeType              *)
 (*   on seqprod_with disp T a "copy" of seq T                                 *)
 (*     using product order (and seqprod T' its specialization to prod_display)*)
-(* - porderType, distrLatticeType, and orderType, on seqlexi_with disp T      *)
-(*     another "copy" of seq T, with lexicographic ordering                   *)
-(*     (and seqlexi T its specialization to lexi_display)                     *)
-(* - porderType, distrLatticeType, orderType, bDistrLatticeType,              *)
+(* - porderType, latticeType, distrLatticeType, and orderType, on             *)
+(*     seqlexi_with disp T another "copy" of seq T, with lexicographic        *)
+(*     ordering (and seqlexi T its specialization to lexi_display)            *)
+(* - porderType, latticeType, distrLatticeType, orderType, bDistrLatticeType, *)
 (*   cbDistrLatticeType, tbDistrLatticeType, ctbDistrLatticeType              *)
 (*   on n.-tupleprod[disp] a "copy" of n.-tuple T                             *)
 (*     using product order (and n.-tupleprod T its specialization             *)
 (*     to prod_display)                                                       *)
-(* - porderType, distrLatticeType, and orderType,  on n.-tuplelexi[d] T       *)
-(*     another "copy" of n.-tuple T, with lexicographic ordering              *)
-(*     (and n.-tuplelexi T its specialization to lexi_display)                *)
+(* - porderType, latticeType, distrLatticeType, and orderType, on             *)
+(*     n.-tuplelexi[d] T another "copy" of n.-tuple T, with lexicographic     *)
+(*     ordering (and n.-tuplelexi T its specialization to lexi_display)       *)
 (* and all possible finite type instances                                     *)
 (*                                                                            *)
 (* In order to get a canonical order on prod or seq, one may import modules   *)
@@ -4269,7 +4284,7 @@ Notation leOrderMixin := of_.
 Notation LeOrderMixin := Build.
 Coercion distrLatticeMixin : leOrderMixin >-> meetJoinMixin.
 Coercion totalMixin : leOrderMixin >-> totalOrderMixin.
-Definition LeOrderOfChoiceType disp (T : choiceType) (m : of_ T) :=
+Definition OrderOfChoiceType disp (T : choiceType) (m : of_ T) :=
    OrderType (DistrLatticeOfChoiceType disp m) m.
 End Exports.
 
@@ -4296,62 +4311,40 @@ Record of_ := Build {
 
 Variables (m : of_).
 
-Let T_total_porderType : porderType tt :=
-  POrderType tt T (LtPOrderMixin (le_def m) (lt_irr m) (@lt_trans m)).
+Fact lt_def x y : lt m x y = (y != x) && le m x y.
+Proof. by rewrite le_def; case: eqVneq => //= ->; rewrite lt_irr. Qed.
 
-Fact le_total : totalPOrderMixin T_total_porderType.
+Fact meet_def_le x y : meet m x y = if le m x y then x else y.
+Proof. by rewrite meet_def le_def; case: eqP => //= ->; rewrite lt_irr. Qed.
+
+Fact join_def_le x y : join m x y = if le m y x then x else y.
+Proof. by rewrite join_def le_def; case: eqP => //= ->; rewrite lt_irr. Qed.
+
+Fact le_anti : antisymmetric (le m).
 Proof.
-by move=> x y; rewrite /<=%O /= !le_def; case: eqVneq; last exact: lt_total.
+move=> x y; rewrite !le_def; case: eqVneq => //= _ /andP [] hxy.
+by move/(lt_trans hxy); rewrite lt_irr.
 Qed.
 
-Let T_orderType := OrderOfPOrder le_total.
+Fact le_trans : transitive (le m).
+Proof.
+move=> y x z; rewrite !le_def; case: eqVneq => [->|_] //=.
+by case: eqVneq => [-> ->|_ hxy /(lt_trans hxy) ->]; rewrite orbT.
+Qed.
 
-Implicit Types (x y z : T_orderType).
+Fact le_total : total (le m).
+Proof. by move=> x y; rewrite !le_def; case: eqVneq => //; exact: lt_total. Qed.
 
-Fact leP x y :
-  lel_xor_gt x y (x <= y) (y < x) (y `&` x) (x `&` y) (y `|` x) (x `|` y).
-Proof. by apply/lcomparable_leP/le_total. Qed.
-Fact meetE x y : meet m x y = x `&` y.
-Proof. by rewrite meet_def (_ : lt m x y = (x < y)) //; case: (leP y). Qed.
-Fact joinE x y : join m x y = x `|` y.
-Proof. by rewrite join_def (_ : lt m y x = (y < x)) //; case: leP. Qed.
-Fact meetC : commutative (meet m).
-Proof. by move=> *; rewrite !meetE meetC. Qed.
-Fact joinC : commutative (join m).
-Proof. by move=> *; rewrite !joinE joinC. Qed.
-Fact meetA : associative (meet m).
-Proof. by move=> *; rewrite !meetE meetA. Qed.
-Fact joinA : associative (join m).
-Proof. by move=> *; rewrite !joinE joinA. Qed.
-Fact joinKI y x : meet m x (join m x y) = x.
-Proof. by rewrite meetE joinE joinKI. Qed.
-Fact meetKU y x : join m x (meet m x y) = x.
-Proof. by rewrite meetE joinE meetKU. Qed.
-Fact meetUl : left_distributive (meet m) (join m).
-Proof. by move=> *; rewrite !meetE !joinE meetUl. Qed.
-Fact meetxx : idempotent (meet m).
-Proof. by move=> *; rewrite meetE meetxx. Qed.
-Fact le_def' x y : x <= y = (meet m x y == x).
-Proof. by rewrite meetE (eq_meetl x y). Qed.
-
-Definition distrLatticeMixin : meetJoinMixin T :=
-  @MeetJoinMixin _ (le m) (lt m) (meet m) (join m)
-    le_def' (@lt_def _ T_orderType)
-    meetC joinC meetA joinA joinKI meetKU meetUl meetxx.
-
-Let T_distrLatticeType := DistrLatticeOfChoiceType tt distrLatticeMixin.
-
-Definition totalMixin : totalOrderMixin T_distrLatticeType := le_total.
+Definition orderMixin : leOrderMixin T :=
+  @LeOrderMixin _ (le m) (lt m) (meet m) (join m)
+                lt_def meet_def_le join_def_le le_anti le_trans le_total.
 
 End LtOrderMixin.
 
 Module Exports.
 Notation ltOrderMixin := of_.
 Notation LtOrderMixin := Build.
-Coercion distrLatticeMixin : ltOrderMixin >-> meetJoinMixin.
-Coercion totalMixin : ltOrderMixin >-> totalOrderMixin.
-Definition LtOrderOfChoiceType disp (T : choiceType) (m : of_ T) :=
-   OrderType (DistrLatticeOfChoiceType disp m) m.
+Coercion orderMixin : ltOrderMixin >-> leOrderMixin.
 End Exports.
 
 End LtOrderMixin.


### PR DESCRIPTION
##### Motivation for this change

This PR adds non-distributive lattice structures `latticeType`, `bLatticeType`, `tbLatticeType`, and `finLatticeType`, and *big pack* notations suggested by @CohenCyril. This PR was originally opened as PR #388, needed to be recreated to change the target branch from `experiment/order` to `master`.

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
