### PR TITLE
[ci] Simplify {Dockerfile,Dockerfile.make} & Restore the "opam clean -c" option

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,5 @@
 # Design:
 # - build stage (e.g. docker build -t mathcomp-dev:$IID_$SLUG_coq-8.7 .)
-#   - choice of the OCaml compiler: var OPAM_SWITCH in {base, edge}
-#     (Dockerfile containing: "opam switch set $compiler && eval $(opam env)")
 #   - all branches (not tags) => push on GitLab registry
 #   - GitHub PRs => push on GitLab and report back thanks to @coqbot
 # - test stage (image: mathcomp-dev:$IID_$SLUG_coq-8.7)
@@ -43,12 +41,11 @@ stages:
   variables:
     # This image will be built locally only (not pushed)
     IMAGE: "mathcomp-dev:make_coq-${COQ_VERSION}"
-    OPAM_SWITCH: "edge"
   before_script:
     - echo "${OPAM_SWITCH}"
     - echo "${COQ_VERSION}"
   script:
-    - docker build -f Dockerfile.make --pull --build-arg=coq_image="coqorg/coq:${COQ_VERSION}" --build-arg=compiler="${OPAM_SWITCH}" -t "${IMAGE}" .
+    - docker build -f Dockerfile.make --pull --build-arg=coq_image="coqorg/coq:${COQ_VERSION}" -t "${IMAGE}" .
   except:
     - tags
     - merge_requests
@@ -67,7 +64,6 @@ make-coq-latest:
     - docker:dind
   variables:
     IMAGE: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_IID}_${CI_COMMIT_REF_SLUG}_${CI_JOB_NAME}"
-    OPAM_SWITCH: "edge"
   before_script:
     - echo "${OPAM_SWITCH}"
     - echo "${CI_JOB_TOKEN}" | docker login -u "${CI_REGISTRY_USER}" --password-stdin "${CI_REGISTRY}"
@@ -85,7 +81,7 @@ make-coq-latest:
     - tags
     - merge_requests
     - schedules
-  
+
 coq-8.7:
   extends: .opam-build-once
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -221,16 +221,6 @@ ci-odd-order-dev:
     - opam pin add -n -k path coq-lemma-overloading .
     - opam install -y -v -j "${NJOBS}" coq-lemma-overloading
 
-ci-lemma-overloading-8.8:
-  extends: .ci-lemma-overloading
-  variables:
-    COQ_VERSION: "8.8"
-
-ci-lemma-overloading-8.9:
-  extends: .ci-lemma-overloading
-  variables:
-    COQ_VERSION: "8.9"
-
 ci-lemma-overloading-8.10:
   extends: .ci-lemma-overloading
   variables:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,12 @@ WORKDIR /home/coq/mathcomp
 
 COPY . .
 
-ARG compiler="base"
-# other possible value: "edge"
-
 RUN ["/bin/bash", "--login", "-c", "set -x \
-  && declare -A switch_table \
-  && switch_table=( [\"base\"]=\"${COMPILER}\" [\"edge\"]=\"${COMPILER_EDGE}\" ) \
-  && opam_switch=\"${switch_table[${compiler}]}\" \
-  && [ -n \"opam_switch\" ] \
-  && opam switch set ${opam_switch} \
+  && [ -n \"${COMPILER_EDGE}\" ] \
+  && opam switch set \"${COMPILER_EDGE}\" \
   && eval $(opam env) \
-  && unset \"switch_table[${compiler}]\" \
-  && for sw in \"${switch_table[@]}\"; do if [ -n \"$sw\" ]; then opam switch remove -y \"${sw}\"; fi; done \
+  && [ -n \"${COMPILER}\" ] \
+  && opam switch remove -y \"${COMPILER}\" \
   && opam repository add --all-switches --set-default coq-extra-dev https://coq.inria.fr/opam/extra-dev \
   && opam repository add --all-switches --set-default coq-core-dev https://coq.inria.fr/opam/core-dev \
   && opam update -y \
@@ -33,6 +27,7 @@ RUN ["/bin/bash", "--login", "-c", "set -x \
 
 FROM coqorg/base:bare
 
+ENV COMPILER=""
 ENV MATHCOMP_VERSION="dev"
 ENV MATHCOMP_PACKAGE="coq-mathcomp-character"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN ["/bin/bash", "--login", "-c", "set -x \
   && opam pin add -n -k path coq-mathcomp-field . \
   && opam pin add -n -k path coq-mathcomp-character . \
   && opam install -y -v -j ${NJOBS} coq-mathcomp-character \
-  && opam clean -a -s --logs"]
+  && opam clean -a -c -s --logs"]
 
 FROM coqorg/base:bare
 

--- a/Dockerfile.make
+++ b/Dockerfile.make
@@ -21,7 +21,7 @@ RUN ["/bin/bash", "--login", "-c", "set -x \
   && opam repository add --all-switches --set-default coq-core-dev https://coq.inria.fr/opam/core-dev \
   && opam update -y \
   && opam config list && opam repo list && opam list && coqc --version \
-  && opam clean -a -s --logs \
+  && opam clean -a -c -s --logs \
   && sudo chown -R coq:coq /home/coq/mathcomp \
   && cd mathcomp \
   && make Makefile.coq \

--- a/Dockerfile.make
+++ b/Dockerfile.make
@@ -5,18 +5,12 @@ WORKDIR /home/coq/mathcomp
 
 COPY . .
 
-ARG compiler="base"
-# other possible value: "edge"
-
 RUN ["/bin/bash", "--login", "-c", "set -x \
-  && declare -A switch_table \
-  && switch_table=( [\"base\"]=\"${COMPILER}\" [\"edge\"]=\"${COMPILER_EDGE}\" ) \
-  && opam_switch=\"${switch_table[${compiler}]}\" \
-  && [ -n \"opam_switch\" ] \
-  && opam switch set ${opam_switch} \
+  && [ -n \"${COMPILER_EDGE}\" ] \
+  && opam switch set \"${COMPILER_EDGE}\" \
   && eval $(opam env) \
-  && unset \"switch_table[${compiler}]\" \
-  && for sw in \"${switch_table[@]}\"; do [ -n \"$sw\" ] && opam switch remove -y \"${sw}\"; done \
+  && [ -n \"${COMPILER}\" ] \
+  && opam switch remove -y \"${COMPILER}\" \
   && opam repository add --all-switches --set-default coq-extra-dev https://coq.inria.fr/opam/extra-dev \
   && opam repository add --all-switches --set-default coq-core-dev https://coq.inria.fr/opam/core-dev \
   && opam update -y \


### PR DESCRIPTION
**Kind:** infrastructure

Related: https://github.com/coq-community/docker-base/issues/3

This reverts commit a03e0cb0ff40afabcaccba7f764076355ca82962.

##### Motivation for this change

With the recently release of opam 2.0.6, in presence of git pinning (used for both coq.dev and mathcomp.dev Dockerfiles) we can now do `opam clean -c` (without breaking a later `opam update`) and earn >100 MB for the size of the `mathcomp/mathcomp-dev` Docker images.

##### Things done/to do

- [x] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- [x] ~added corresponding documentation in the headers~

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.