### PR TITLE
Link between subrelations and path/sorted

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   sets (`porderType`, `latticeType`, `distrLatticeType`, `orderType`, etc.) and
   its theory.
 
+- Lemmas `path_map`, `eq_path_in`, `sub_path_in`, `path_sortedE`,
+  `sub_sorted` and `sub_sorted_in` in `path` (and refactored related proofs)
+
 ### Changed
 
 - Reorganized the algebraic hierarchy and the theory of `ssrnum.v`.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -168,7 +168,7 @@ Section HomoPath.
 Variables (T T' : Type) (f : T -> T') (leT : rel T) (leT' : rel T').
 
 Lemma path_map x s : path leT' (f x) (map f s) = path (relpre f leT') x s.
-Proof. by elim: s x => //= y s IHs x; rewrite -IHs. Qed.
+Proof. by elim: s x => //= y s <-. Qed.
 
 Lemma homo_path x s : {homo f : x y / leT x y >-> leT' x y} ->
   path leT x s -> path leT' (f x) (map f s).
@@ -190,12 +190,6 @@ Implicit Type p : seq T.
 
 Variant split x : seq T -> seq T -> seq T -> Type :=
   Split p1 p2 : split x (rcons p1 x ++ p2) p1 p2.
-
-Lemma eq_path_in e' x s : {in x :: s &, e =2 e'} -> path e x s = path e' x s.
-Proof.
-elim: s x => //= y s IHs x ee'; rewrite ee' ?(in_cons,eqxx,orbT)//.
-by rewrite IHs// => z t zys tys; rewrite ee'// in_cons (zys, tys) orbT.
-Qed.
 
 Lemma splitP p x (i := index x p) :
   x \in p -> split x p (take i p) (drop i.+1 p).
@@ -425,6 +419,10 @@ elim: s x => //= y s IHs x ee' /andP[/ee'->//=]; rewrite ?(eqxx,in_cons,orbT)//.
 by apply: IHs => z t zys tys; apply: ee'; rewrite in_cons (zys, tys) orbT.
 Qed.
 
+Lemma eq_path_in (e e' : rel T) x s : {in x :: s &, e =2 e'} ->
+  path e x s = path e' x s.
+Proof. by move=> ee'; apply/idP/idP => /sub_path_in->// y z /ee' P/P->. Qed.
+
 Lemma homo_path_in x s : {in x :: s &, {homo f : x y / leT x y >-> leT' x y}} ->
   path leT x s -> path leT' (f x) (map f s).
 Proof. by move=> f_homo xs; rewrite path_map (sub_path_in _ xs). Qed.
@@ -540,7 +538,7 @@ Qed.
 
 Hypothesis leT_tr : transitive leT.
 
-Lemma path_sortedE x s : path leT x s = (all (leT x) s && sorted s).
+Lemma path_sortedE x s : path leT x s = all (leT x) s && sorted s.
 Proof.
 apply/idP/idP => [xs|/andP[/path_min_sorted<-//]].
 by rewrite order_path_min//; apply: path_sorted xs.


### PR DESCRIPTION
##### Motivation for this change

Missing theorems linking `subrel` and `path` and `sorted`.
This allows to shorten some monotonicity proofs.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~~added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
