### PR TITLE
adding deprecations in ssrnat

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -162,8 +162,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `lerif_mean_square`, `lerif_AGM2`, `lerif_normC_Re_Creal`, `lerif_Re_Creal`,
     `lerif_rootC_AGM`.
 - The following naming inconsistencies have been fixed in `ssrnat.v`:
-  + `homo_inj_lt(_in)` -> `inj_homo_ltn(in)`
-  + `(inc|dec)r(_in)` -> `(inc|dev)n(_in)`
+  + `homo_inj_lt(_in)` -> `inj_homo_ltn(_in)`
+  + `(inc|dec)r_inj(_in)` -> `(inc|dec)n_inj(_in)`
 - switching long suffixes to short suffixes
   + `odd_add` -> `oddD`
   + `odd_sub` -> `oddB`

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -1922,3 +1922,24 @@ End mc_1_10.
 (* Temporary backward compatibility. *)
 Notation odd_add := (deprecate odd_add oddD _) (only parsing).
 Notation odd_sub := (deprecate odd_sub oddB _) (only parsing).
+
+Notation "@ 'homo_inj_lt'" :=
+  (deprecate homo_inj_lt inj_homo_ltn) (at level 10, only parsing) : fun_scope.
+Notation homo_inj_lt := (@homo_inj_lt _) (only parsing).
+Notation "@ 'homo_inj_lt_in'" :=
+  (deprecate homo_inj_lt_in inj_homo_ltn_in) (at level 10, only parsing) : fun_scope.
+Notation homo_inj_lt_in := (@homo_inj_lt_in _ _ _) (only parsing).
+
+Notation "@ 'incr_inj'" :=
+  (deprecate incr_inj incn_inj) (at level 10, only parsing) : fun_scope.
+Notation incr_inj := (@incr_inj _) (only parsing).
+Notation "@ 'incr_inj_in'" :=
+  (deprecate incr_inj_in incn_inj_in) (at level 10, only parsing) : fun_scope.
+Notation incr_inj_in := (@incr_inj_in _ _) (only parsing).
+
+Notation "@ 'decr_inj'" :=
+  (deprecate decr_inj decn_inj) (at level 10, only parsing) : fun_scope.
+Notation decr_inj := (@decr_inj _) (only parsing).
+Notation "@ 'decr_inj_in'" :=
+  (deprecate decr_inj_in decn_inj_in) (at level 10, only parsing) : fun_scope.
+Notation decr_inj_in := (@decr_inj_in _ _) (only parsing).


### PR DESCRIPTION
##### Motivation for this change

Some renaming from the changelog were not associated with deprecated notations. This PR intends to fix this.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
