### PR TITLE
Putting ord1 in fintype

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -34,6 +34,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   reordering reordering)`, `op.[AC patternshape reordering]`, `op.[ACl
   reordering]` and `op.[ACof reordering reordering]`.
 
+- Added definition `cast_perm` with a group morphism canonical
+  structure, and lemmas `permX_fix`, `imset_perm1`, `permS0`,
+  `permS1`, `cast_perm_id`, `cast_ord_permE`, `cast_permE`,
+  `cast_permK`, `cast_permKV`, `cast_perm_inj`, `cast_perm_morphM`,
+  and `isom_cast_perm` in `perm` and `restr_perm_commute` in `action`
+
+- Added `card_porbit_neq0`, `porbitP`, and `porbitPmin` in `perm`
+
+- Added definition `Sym` with a group set canonical structure and
+  lemmas `card_Sn` and `card_Sym` in `perm` and `SymE` in `action`
+
 ### Changed
 
 - Reorganized the algebraic hierarchy and the theory of `ssrnum.v`.
@@ -164,12 +175,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The following naming inconsistencies have been fixed in `ssrnat.v`:
   + `homo_inj_lt(_in)` -> `inj_homo_ltn(in)`
   + `(inc|dec)r(_in)` -> `(inc|dev)n(_in)`
+
 - switching long suffixes to short suffixes
   + `odd_add` -> `oddD`
   + `odd_sub` -> `oddB`
   + `take_addn` -> `takeD`
   + `rot_addn` -> `rotD`
   + `nseq_addn` -> `nseqD`
+
+- Replaced `cycle` by `orbit` in `perm/action`:
+  + `pcycle` -> `porbit`
+  + `pcycles` -> `porbits`
+  + `pcycleE` -> `porbitE`
+  + `pcycle_actperm` -> `porbit_actperm`
+  + `mem_pcycle` -> `mem_porbit`
+  + `pcycle_id` -> `porbit_id`
+  + `uniq_traject_pcycle` -> `uniq_traject_porbit`
+  + `pcycle_traject` -> `porbit_traject`
+  + `iter_pcycle` -> `iter_porbit`
+  + `eq_pcycle_mem` -> `eq_porbit_mem`
+  + `pcycle_sym` -> `porbit_sym`
+  + `pcycle_perm` -> `porbit_perm`
+  + `ncycles_mul_tperm` -> `porbits_mul_tperm`
 
 ### Removed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -35,8 +35,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   reordering]` and `op.[ACof reordering reordering]`.
 
 - Added definition `cast_perm` with a group morphism canonical
-  structure, and lemmas `permX_fix`, `imset_perm1`, `permS0`,
-  `permS1`, `cast_perm_id`, `cast_ord_permE`, `cast_permE`,
+  structure, and lemmas `permX_fix`, `imset_perm1`, `permS0`, `permS1`,
+  `permSleq1` `cast_perm_id`, `cast_ord_permE`, `cast_permE`,
   `cast_perm_comp`, `cast_permK`, `cast_permKV`, `cast_perm_inj`,
   `cast_perm_sym`,`cast_perm_morphM`, and `isom_cast_perm` in `perm`
   and `restr_perm_commute` in `action`.
@@ -45,6 +45,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added definition `Sym` with a group set canonical structure and
   lemmas `card_Sn` and `card_Sym` in `perm` and `SymE` in `action`
+
+- Added lemma `ord1` in `fintype`, it is the same as `zmodp.ord1`,
+  except `fintype.ord1` does not rely on `'I_n` zmodType structure.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -37,8 +37,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added definition `cast_perm` with a group morphism canonical
   structure, and lemmas `permX_fix`, `imset_perm1`, `permS0`,
   `permS1`, `cast_perm_id`, `cast_ord_permE`, `cast_permE`,
-  `cast_permK`, `cast_permKV`, `cast_perm_inj`, `cast_perm_morphM`,
-  and `isom_cast_perm` in `perm` and `restr_perm_commute` in `action`
+  `cast_perm_comp`, `cast_permK`, `cast_permKV`, `cast_perm_inj`,
+  `cast_perm_sym`,`cast_perm_morphM`, and `isom_cast_perm` in `perm`
+  and `restr_perm_commute` in `action`.
 
 - Added `card_porbit_neq0`, `porbitP`, and `porbitPmin` in `perm`
 

--- a/mathcomp/algebra/zmodp.v
+++ b/mathcomp/algebra/zmodp.v
@@ -181,8 +181,10 @@ Arguments Zp1 {p'}.
 Arguments inZp {p'} i.
 Arguments valZpK {p'} x.
 
+(* We redefine fintype.ord1 to specialize it with 0 instead of ord0 *)
+(* since 'I_n is now canonically a zmodType  *)
 Lemma ord1 : all_equal_to (0 : 'I_1).
-Proof. by case=> [[] // ?]; apply: val_inj. Qed.
+Proof. exact: ord1. Qed.
 
 Lemma lshift0 m n : lshift m (0 : 'I_n.+1) = (0 : 'I_(n + m).+1).
 Proof. exact: val_inj. Qed.

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -1607,7 +1607,7 @@ Qed.
 
 Canonical perm_action := Action aperm_is_action.
 
-Lemma pcycleE a : pcycle a = orbit perm_action <[a]>%g.
+Lemma porbitE a : porbit a = orbit perm_action <[a]>%g.
 Proof. by []. Qed.
 
 Lemma perm_act1P a : reflect (forall x, aperm x a = x) (a == 1).
@@ -1643,11 +1643,11 @@ move=> sAD x; rewrite morphimEsub // /orbit -imset_comp.
 by apply: eq_imset => a //=; rewrite actpermK.
 Qed.
 
-Lemma pcycle_actperm (a : aT) :
-   a \in D -> pcycle (actperm to a) =1 orbit to <[a]>.
+Lemma porbit_actperm (a : aT) :
+   a \in D -> porbit (actperm to a) =1 orbit to <[a]>.
 Proof.
 move=> Da x.
-by rewrite pcycleE -orbit_morphim_actperm ?cycle_subG ?morphim_cycle.
+by rewrite porbitE -orbit_morphim_actperm ?cycle_subG ?morphim_cycle.
 Qed.
 
 End ActpermOrbits.
@@ -1680,26 +1680,8 @@ Proof. by rewrite ker_actperm astab_actby setIT (setIidPr (astab_sub _ _)). Qed.
 Lemma im_restr_perm p : restr_perm p @: S = S.
 Proof. exact: im_perm_on (restr_perm_on p). Qed.
 
-Definition perm_ong : {set {perm T}} := [set s | perm_on S s].
-Lemma group_set_perm_ong : group_set perm_ong.
-Proof using.
-apply/group_setP; split => [| s t]; rewrite !inE;
-   [exact: perm_on1 | exact: perm_onM].
-Qed.
-Canonical perm_ong_group : {group {perm T}} := Group group_set_perm_ong.
-Lemma card_perm_ong : #|perm_ong| = #|S|`!.
-Proof using. by rewrite cardsE /= card_perm. Qed.
-
-Lemma perm_ongE : perm_ong = 'C(~:S | 'P).
-Proof using.
-apply/setP => s; rewrite inE; apply/idP/astabP => [Hperm x | Hstab].
-- by rewrite inE /= apermE => /out_perm; apply.
-- apply/subsetP => x; rewrite unfold_in; apply contraR => H.
-  by move/(_ x): Hstab; rewrite inE /= apermE => ->.
-Qed.
-
 Lemma restr_perm_commute s : commute (restr_perm s) s.
-Proof using.
+Proof.
 case: (boolP (s \in 'N(S | 'P))) =>
     [HC | /triv_restr_perm ->]; last exact: (commute_sym (commute1 _)).
 apply/permP => x; case: (boolP (x \in S)) => Hx; rewrite !permM.
@@ -1711,6 +1693,19 @@ Qed.
 
 End RestrictPerm.
 
+Section Symmetry.
+
+Variables (T : finType) (S : {set T}).
+
+Lemma SymE : Sym S = 'C(~: S | 'P).
+Proof.
+apply/setP => s; rewrite inE; apply/idP/astabP => [Hperm x | Hstab].
+- by rewrite inE /= apermE => /out_perm; apply.
+- apply/subsetP => x; rewrite unfold_in; apply contraR => H.
+  by move/(_ x): Hstab; rewrite inE /= apermE => ->.
+Qed.
+
+End Symmetry.
 
 Section AutIn.
 
@@ -2403,7 +2398,7 @@ exact: (morph_afix (gact_stable to1) (injmP injh)).
 Qed.
 
 Lemma morph_gact_irr A M :
-    A \subset D1 -> M \subset R1 -> 
+    A \subset D1 -> M \subset R1 ->
   acts_irreducibly (f @* A) (h @* M) to2 = acts_irreducibly A M to1.
 Proof.
 move=> sAD1 sMR1.
@@ -2737,4 +2732,6 @@ Arguments aut_groupAction {gT} G%g.
 Notation "[ 'Aut' G ]" := (aut_action G) : action_scope.
 Notation "[ 'Aut' G ]" := (aut_groupAction G) : groupAction_scope.
 
-
+Notation pcycleE := (deprecate pcycleE porbitE _) (only parsing).
+Notation pcycle_actperm := (deprecate pcycle_actperm porbit_actperm _)
+  (only parsing).

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -1682,13 +1682,11 @@ Proof. exact: im_perm_on (restr_perm_on p). Qed.
 
 Lemma restr_perm_commute s : commute (restr_perm s) s.
 Proof.
-case: (boolP (s \in 'N(S | 'P))) =>
-    [HC | /triv_restr_perm ->]; last exact: (commute_sym (commute1 _)).
-apply/permP => x; case: (boolP (x \in S)) => Hx; rewrite !permM.
-- by rewrite !restr_permE //; move: HC => /astabsP/(_ x)/= ->.
-- have:= restr_perm_on s => /out_perm Hout.
-  rewrite (Hout _ Hx) {}Hout //.
-  by move: Hx; apply contra; move: HC => /astabsP/(_ x)/= ->.
+have [sC|/triv_restr_perm->] := boolP (s \in 'N(S | 'P)); last first.
+  exact: (commute_sym (commute1 _)).
+apply/permP => x; have /= xsS := astabsP sC x; rewrite !permM.
+have [xS|xNS] := boolP (x \in S); first by rewrite ?(restr_permE) ?xsS.
+by rewrite !(out_perm (restr_perm_on _)) ?xsS.
 Qed.
 
 End RestrictPerm.
@@ -1699,10 +1697,9 @@ Variables (T : finType) (S : {set T}).
 
 Lemma SymE : Sym S = 'C(~: S | 'P).
 Proof.
-apply/setP => s; rewrite inE; apply/idP/astabP => [Hperm x | Hstab].
-- by rewrite inE /= apermE => /out_perm; apply.
-- apply/subsetP => x; rewrite unfold_in; apply contraR => H.
-  by move/(_ x): Hstab; rewrite inE /= apermE => ->.
+apply/setP => s; rewrite inE; apply/idP/astabP => [sS x|/= S_id].
+  by rewrite inE /= apermE => /out_perm->.
+by apply/subsetP => x; move=> /(contra_neqN (S_id _)); rewrite inE negbK.
 Qed.
 
 End Symmetry.

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -1680,7 +1680,37 @@ Proof. by rewrite ker_actperm astab_actby setIT (setIidPr (astab_sub _ _)). Qed.
 Lemma im_restr_perm p : restr_perm p @: S = S.
 Proof. exact: im_perm_on (restr_perm_on p). Qed.
 
+Definition perm_ong : {set {perm T}} := [set s | perm_on S s].
+Lemma group_set_perm_ong : group_set perm_ong.
+Proof using.
+apply/group_setP; split => [| s t]; rewrite !inE;
+   [exact: perm_on1 | exact: perm_onM].
+Qed.
+Canonical perm_ong_group : {group {perm T}} := Group group_set_perm_ong.
+Lemma card_perm_ong : #|perm_ong| = #|S|`!.
+Proof using. by rewrite cardsE /= card_perm. Qed.
+
+Lemma perm_ongE : perm_ong = 'C(~:S | 'P).
+Proof using.
+apply/setP => s; rewrite inE; apply/idP/astabP => [Hperm x | Hstab].
+- by rewrite inE /= apermE => /out_perm; apply.
+- apply/subsetP => x; rewrite unfold_in; apply contraR => H.
+  by move/(_ x): Hstab; rewrite inE /= apermE => ->.
+Qed.
+
+Lemma restr_perm_commute s : commute (restr_perm s) s.
+Proof using.
+case: (boolP (s \in 'N(S | 'P))) =>
+    [HC | /triv_restr_perm ->]; last exact: (commute_sym (commute1 _)).
+apply/permP => x; case: (boolP (x \in S)) => Hx; rewrite !permM.
+- by rewrite !restr_permE //; move: HC => /astabsP/(_ x)/= ->.
+- have:= restr_perm_on s => /out_perm Hout.
+  rewrite (Hout _ Hx) {}Hout //.
+  by move: Hx; apply contra; move: HC => /astabsP/(_ x)/= ->.
+Qed.
+
 End RestrictPerm.
+
 
 Section AutIn.
 

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -634,13 +634,14 @@ End LiftPerm.
 
 Prenex Implicits lift_perm lift_permK.
 
-Lemma permS0 (g : 'S_0) : g = 1%g. Proof. by apply/permP => - []. Qed.
+Lemma permS0 : all_equal_to (1 : 'S_0).
+Proof. by move=> g; apply/permP; case. Qed.
 
-Lemma permS1 (g : 'S_1) : g = 1%g.
-Proof.
-apply/permP => i; apply: val_inj.
-by case: (X in val X) (X in val X) => [[]//= _] [[]//= _].
-Qed.
+Lemma permS1 : all_equal_to (1 : 'S_1).
+Proof. by move=> g; apply/permP => i; rewrite !ord1. Qed.
+
+Lemma permSleq1 n : n <= 1 -> all_equal_to (1 : 'S_n).
+Proof. by case: n => [|[|]//=] _ g; rewrite (permS0, permS1). Qed.
 
 Section CastSn.
 

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -634,14 +634,12 @@ End LiftPerm.
 
 Prenex Implicits lift_perm lift_permK.
 
-Lemma permS0 (g : 'S_0) : g = 1%g.
-Proof. by apply permP => x; case x. Qed.
+Lemma permS0 (g : 'S_0) : g = 1%g. Proof. by apply/permP => - []. Qed.
 
 Lemma permS1 (g : 'S_1) : g = 1%g.
 Proof.
-apply/permP => i; rewrite perm1.
-case: (g i) => a Ha; case: i => b Hb.
-by apply val_inj => /=; case: a b Ha Hb => [|a] [|b].
+apply/permP => i; apply: val_inj.
+by case: (X in val X) (X in val X) => [[]//= _] [[]//= _].
 Qed.
 
 Section CastSn.
@@ -657,8 +655,12 @@ Lemma cast_ord_permE m n eq_m_n (s : 'S_m) i :
 Proof. by subst m; rewrite cast_perm_id !cast_ord_id. Qed.
 
 Lemma cast_permE m n (eq_m_n : m = n) (s : 'S_m) (i : 'I_n) :
-  cast_ord eq_m_n (s (cast_ord (esym eq_m_n) i)) = cast_perm eq_m_n s i.
+  cast_perm eq_m_n s i = cast_ord eq_m_n (s (cast_ord (esym eq_m_n) i)).
 Proof. by rewrite cast_ord_permE cast_ordKV. Qed.
+
+Lemma cast_perm_comp m n p (eq_m_n : m = n) (eq_n_p : n = p) s :
+  cast_perm eq_n_p (cast_perm eq_m_n s) = cast_perm (etrans eq_m_n eq_n_p) s.
+Proof. by case: _ / eq_n_p. Qed.
 
 Lemma cast_permK m n eq_m_n :
   cancel (@cast_perm m n eq_m_n) (cast_perm (esym eq_m_n)).
@@ -668,6 +670,10 @@ Lemma cast_permKV m n eq_m_n :
   cancel (cast_perm (esym eq_m_n)) (@cast_perm m n eq_m_n).
 Proof. by subst m. Qed.
 
+Lemma cast_perm_sym m n (eq_m_n : m = n) s t :
+  s = cast_perm eq_m_n t -> t = cast_perm (esym eq_m_n) s.
+Proof. by move/(canLR (cast_permK _)). Qed.
+
 Lemma cast_perm_inj m n eq_m_n : injective (@cast_perm m n eq_m_n).
 Proof. exact: can_inj (cast_permK eq_m_n). Qed.
 
@@ -675,15 +681,13 @@ Lemma cast_perm_morphM m n eq_m_n :
   {morph @cast_perm m n eq_m_n : x y / x * y >-> x * y}.
 Proof. by subst m. Qed.
 Canonical morph_of_cast_perm m n eq_m_n :=
-  Morphism (D := setT) (in2W (@cast_perm_morphM m n eq_m_n)).
+  @Morphism _ _ setT (cast_perm eq_m_n) (in2W (@cast_perm_morphM m n eq_m_n)).
 
 Lemma isom_cast_perm m n eq_m_n : isom setT setT (@cast_perm m n eq_m_n).
 Proof.
-subst m.
-apply/isomP; split.
-- apply/injmP=> i j _ _; exact: cast_perm_inj.
-- apply/setP => /= s; rewrite !inE.
-  by apply/imsetP; exists s; rewrite ?inE.
+case: {n} _ / eq_m_n; apply/isomP; split.
+  exact/injmP/(in2W (@cast_perm_inj _ _ _)).
+by apply/setP => /= s; rewrite !inE; apply/imsetP; exists s; rewrite ?inE.
 Qed.
 
 End CastSn.

--- a/mathcomp/solvable/finmodule.v
+++ b/mathcomp/solvable/finmodule.v
@@ -480,8 +480,8 @@ Let n_ x := #|<[g]> : H :* x|.
 
 Lemma mulg_exp_card_rcosets x : x * (g ^+ n_ x) \in H :* x.
 Proof.
-rewrite /n_ /indexg -orbitRs -pcycle_actperm ?inE //.
-rewrite -{2}(iter_pcycle (actperm 'Rs g) (H :* x)) -permX -morphX ?inE //.
+rewrite /n_ /indexg -orbitRs -porbit_actperm ?inE //.
+rewrite -{2}(iter_porbit (actperm 'Rs g) (H :* x)) -permX -morphX ?inE //.
 by rewrite actpermE //= rcosetE -rcosetM rcoset_refl.
 Qed.
 
@@ -540,12 +540,12 @@ Lemma transfer_cycle_expansion :
 Proof.
 pose Y := \bigcup_(x in X) [set x * g ^+ i | i : 'I_(n_ x)].
 pose rY := transversal_repr 1 Y.
-pose pcyc x := pcycle (actperm 'Rs g) (H :* x).
+pose pcyc x := porbit (actperm 'Rs g) (H :* x).
 pose traj x := traject (actperm 'Rs g) (H :* x) #|pcyc x|.
 have Hgr_eq x: H_g_rcosets x = pcyc x.
-  by rewrite /H_g_rcosets -orbitRs -pcycle_actperm ?inE.
-have pcyc_eq x: pcyc x =i traj x by apply: pcycle_traject.
-have uniq_traj x: uniq (traj x) by apply: uniq_traject_pcycle.
+  by rewrite /H_g_rcosets -orbitRs -porbit_actperm ?inE.
+have pcyc_eq x: pcyc x =i traj x by apply: porbit_traject.
+have uniq_traj x: uniq (traj x) by apply: uniq_traject_porbit.
 have n_eq x: n_ x = #|pcyc x| by rewrite -Hgr_eq.
 have size_traj x: size (traj x) = n_ x by rewrite n_eq size_traject.
 have nth_traj x j: j < n_ x -> nth (H :* x) (traj x) j = H :* (x * g ^+ j).
@@ -590,7 +590,7 @@ rewrite conjgE invgK -{1}[H :* x]rcoset1 -{1}(expg0 g).
 elim: {1 3}n 0%N (addn0 n) => [|m IHm] i def_i /=.
   rewrite big_seq1 {i}[i]def_i rYE // ?def_n //.
   rewrite -(mulgA _ _ g) -rcosetM -expgSr -[(H :* x) :* _]rcosetE.
-  rewrite -actpermE morphX ?inE // permX // -{2}def_n n_eq iter_pcycle mulgA.
+  rewrite -actpermE morphX ?inE // permX // -{2}def_n n_eq iter_porbit mulgA.
   by rewrite -[H :* x]rcoset1 (rYE _ 0%N) ?mulg1.
 rewrite big_cons rYE //; last by rewrite def_n -def_i ltnS leq_addl.
 rewrite permE /= rcosetE -rcosetM -(mulgA _ _ g) -expgSr.

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -2100,6 +2100,9 @@ Arguments sub_ord {n'}.
 Arguments sub_ordK {n'}.
 Arguments inord_val {n'}.
 
+Lemma ord1 : all_equal_to (ord0 : 'I_1).
+Proof. by case=> [[] // ?]; apply: val_inj. Qed.
+
 (* Product of two fintypes which is a fintype *)
 Section ProdFinType.
 


### PR DESCRIPTION
##### Motivation for this change

`ord1` is in `zmodp`, but it does not really require the `zmodType` structure of `'I_n` to be stated and proven if we state it with `ord0`. We still keep the variant in `zmodp` with `0` instead of `ord0` (for readability purposes).
- also rephrased permS0 and permS1 in a better way
- and added permSleq1

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~added corresponding documentation in the headers~
- [ ] wait until #221 is merged.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
