### PR TITLE
Adding lemma PermSleq1 to perm.v

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -250,6 +250,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    Its name will become `prodrMn` in the next release when this name will become available (cf. Renamed section)
 
 - in `polydiv.v`, new lemma `dvdpNl`.
+- in `perm.v` new lemma `permS01`.
 
 ### Changed
 

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -640,6 +640,9 @@ Proof. by move=> g; apply/permP; case. Qed.
 Lemma permS1 : all_equal_to (1 : 'S_1).
 Proof. by move=> g; apply/permP => i; rewrite !ord1. Qed.
 
+Lemma permS01 n : n <= 1 -> all_equal_to (1 : 'S_n).
+Proof. by case: n => [|[|]//=] _ g; rewrite (permS0, permS1). Qed.
+
 Section CastSn.
 
 Definition cast_perm m n (eq_mn : m = n) (s : 'S_m) :=


### PR DESCRIPTION
##### Motivation for this change

This lemma combines `permS0` and `permS1` in one so that no case analysis is necessary on `n` if one just knows `n <= 1`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] merge of #221 
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
