### PR TITLE
Putting `ord1` in `fintype.v`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -161,7 +161,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added lemma `ord1` in `fintype`, it is the same as `zmodp.ord1`,
   except `fintype.ord1` does not rely on `'I_n` zmodType structure.
 
-### Changed
 
 - in `order.v`, `\join^d_` and `\meet^d_` notations are now properly specialized
   for `dual_display`.

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -158,6 +158,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   variant which does not require an `eqType` is currently named
   `big_uncond` (cf Added) but it will be renamed `big_mkcond` in the
   next release.
+- Added lemma `ord1` in `fintype`, it is the same as `zmodp.ord1`,
+  except `fintype.ord1` does not rely on `'I_n` zmodType structure.
+
+### Changed
 
 - in `order.v`, `\join^d_` and `\meet^d_` notations are now properly specialized
   for `dual_display`.

--- a/mathcomp/algebra/zmodp.v
+++ b/mathcomp/algebra/zmodp.v
@@ -181,8 +181,10 @@ Arguments Zp1 {p'}.
 Arguments inZp {p'} i.
 Arguments valZpK {p'} x.
 
+(* We redefine fintype.ord1 to specialize it with 0 instead of ord0 *)
+(* since 'I_n is now canonically a zmodType  *)
 Lemma ord1 : all_equal_to (0 : 'I_1).
-Proof. by case=> [[] // ?]; apply: val_inj. Qed.
+Proof. exact: ord1. Qed.
 
 Lemma lshift0 m n : lshift m (0 : 'I_n.+1) = (0 : 'I_(n + m).+1).
 Proof. exact: val_inj. Qed.

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -638,9 +638,7 @@ Lemma permS0 : all_equal_to (1 : 'S_0).
 Proof. by move=> g; apply/permP; case. Qed.
 
 Lemma permS1 : all_equal_to (1 : 'S_1).
-Proof.
-by move=> g; apply/permP => i; apply: val_inj; do ![case: (X in val X); case].
-Qed.
+Proof. by move=> g; apply/permP => i; rewrite !ord1. Qed.
 
 Section CastSn.
 

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -2220,6 +2220,9 @@ Arguments sub_ord {n'}.
 Arguments sub_ordK {n'}.
 Arguments inord_val {n'}.
 
+Lemma ord1 : all_equal_to (ord0 : 'I_1).
+Proof. by case=> [[] // ?]; apply: val_inj. Qed.
+
 (* Product of two fintypes which is a fintype *)
 Section ProdFinType.
 


### PR DESCRIPTION
##### Motivation for this change

`ord1` is in `zmodp`, but it does not really require the `zmodType` structure of `'I_n` to be stated and proven if we state it with `ord0`. We still keep the variant in `zmodp` with `0` instead of `ord0` (for readability purposes).

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] merge of #221 
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
