### PR TITLE
Add dual_finLatticeType and fix dual_finDistrLatticeType

### DIFF
--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -3549,6 +3549,10 @@ Lemma botEdual : (dual_bottom : L^d) = 1 :> L. Proof. by []. Qed.
 Lemma topEdual : (dual_top : L^d) = 0 :> L. Proof. by []. Qed.
 
 End DualTBLattice.
+
+Canonical dual_finLatticeType d (T : finLatticeType d) :=
+  [finLatticeType of T^d].
+
 End DualTBLattice.
 
 Module Import TBLatticeTheory.
@@ -3682,10 +3686,11 @@ Context {L : tbDistrLatticeType}.
 Canonical dual_bDistrLatticeType := [bDistrLatticeType of L^d].
 Canonical dual_tbDistrLatticeType := [tbDistrLatticeType of L^d].
 
+End DualTBDistrLattice.
+
 Canonical dual_finDistrLatticeType d (T : finDistrLatticeType d) :=
   [finDistrLatticeType of T^d].
 
-End DualTBDistrLattice.
 End DualTBDistrLattice.
 
 Module Import TBDistrLatticeTheory.


### PR DESCRIPTION
This PR fixes two issues:
- `dual_finLatticeType` was missing, and
- `dual_finDistrLatticeType` was just an identity function:
  ```coq
  dual_finDistrLatticeType
       : forall d : unit, finDistrLatticeType d -> finDistrLatticeType d.
  ```

This is a bug fix and should target 1.11.0. Should we record this kind of small bug fixes between 1.11.0+beta1 and 1.11.0 in CHANGELOG?

##### Motivation for this change

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
