### PR TITLE
Remove the tuple extensions in order.v that is available in tuple.v

### DIFF
--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -937,20 +937,6 @@ Reserved Notation "\max^l_ ( i 'in' A ) F"
   (at level 41, F at level 41, i, A at level 50,
            format "'[' \max^l_ ( i  'in'  A ) '/  '  F ']'").
 
-(* tuple extensions *)
-Lemma eqEtuple n (T : eqType) (t1 t2 : n.-tuple T) :
-  (t1 == t2) = [forall i, tnth t1 i == tnth t2 i].
-Proof. by apply/eqP/'forall_eqP => [->|/eq_from_tnth]. Qed.
-
-Lemma tnth_nseq n T x (i : 'I_n) : @tnth n T [tuple of nseq n x] i = x.
-Proof.
-by rewrite !(tnth_nth (tnth_default (nseq_tuple n x) i)) nth_nseq ltn_ord.
-Qed.
-
-Lemma tnthS n T x (t : n.-tuple T) i :
-   tnth [tuple of x :: t] (lift ord0 i) = tnth t i.
-Proof. by rewrite (tnth_nth (tnth_default t i)). Qed.
-
 Module Order.
 
 (**************)


### PR DESCRIPTION
##### Motivation for this change

This PR removes `eqEtuple`, `tnth_nseq`, and `tnthS` in order.v, that is available in tuple.v. I guess these lemmas have been introduced in the development process of order.v and immediately integrated into tuple.v.

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
