### PR TITLE
Reword a CHANGELOG entry introduced in #429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ This release is compatible with Coq versions 8.7, 8.8, 8.9 and 8.10.
     * `maxr_min(l|r)` -> `joinI(l|r)`
     * `minr_max(l|r)` -> `meetU(l|r)`
     * `minrP`, `maxrP` -> `leP`, `ltP`
+
+      Replacing `minrP` and `maxrP` with `leP` and `ltP` may require to provide some arguments explicitly.
+      The former ones respectively try to match with `minr` and `maxr` first but the latter ones try that in the order of `<`, `<=`, `maxr`, and `minr`.
     * `(minr|maxr)(r|C|A|CA|AC)` -> `(meet|join)(xx|C|A|CA|AC)`
     * `minr_(l|r)` -> `meet_(l|r)`
     * `maxr_(l|r)` -> `join_(l|r)`
@@ -119,37 +122,6 @@ This release is compatible with Coq versions 8.7, 8.8, 8.9 and 8.10.
     1.10 in newer versions by using the `mc_1_10.Num` module instead of the
     `Num` module. However, instances of the number structures may require
     changes.
-  + In the development process of this version of Mathematical Components, the
-    ordering of arguments of comparison predicates `lcomparableP`,
-    `(lcomparable_)ltgtP`, `(lcomparable_)leP`, and `(lcomparable_)ltP` in
-    `order.v` has been changed as follows. This is a potential source of
-    incompatibilities.
-    * before the change:
-      ```
-      lcomparableP x y : incomparel x y
-        (y == x) (x == y) (x >= y) (x <= y) (x > y) (x < y)
-        (y >=< x) (x >=< y) (y `&` x) (x `&` y) (y `|` x) (x `|` y).
-      ltgtP x y : comparel x y
-        (y == x) (x == y) (x >= y) (x <= y) (x > y) (x < y)
-        (y `&` x) (x `&` y) (y `|` x) (x `|` y).
-      leP x y :
-        lel_xor_gt x y (x <= y) (y < x) (y `&` x) (x `&` y) (y `|` x) (x `|` y).
-      ltP x y :
-        ltl_xor_ge x y (y <= x) (x < y) (y `&` x) (x `&` y) (y `|` x) (x `|` y).
-      ```
-    * after the change:
-      ```
-      lcomparableP x y : incomparel x y
-        (y `&` x) (x `&` y) (y `|` x) (x `|` y)
-        (y == x) (x == y) (x >= y) (x <= y) (x > y) (x < y) (y >=< x) (x >=< y).
-      ltgtP x y : comparel x y
-        (y `&` x) (x `&` y) (y `|` x) (x `|` y)
-        (y == x) (x == y) (x >= y) (x <= y) (x > y) (x < y).
-      leP x y :
-        lel_xor_gt x y (y `&` x) (x `&` y) (y `|` x) (x `|` y) (x <= y) (y < x).
-      ltP x y :
-        ltl_xor_ge x y (y `&` x) (x `&` y) (y `|` x) (x `|` y) (y <= x) (x < y).
-      ```
 
 - Extended comparison predicates `leqP`, `ltnP`, and `ltngtP` in ssrnat to
   allow case analysis on `minn` and `maxn`.


### PR DESCRIPTION
that explains an incompatibility between development versions, as I suggested in https://github.com/math-comp/math-comp/pull/429#discussion_r392858464.

##### Motivation for this change

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
