### PR TITLE
Intro pattern extensions for rewrite

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -156,6 +156,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - In `ssrnum.v`:
   + new lemma `eqNr`
+- Added intro pattern ltac views for rewrite:
+  `/[1! rules]`, `/[! rules]`.
+
 
 - In `mxpoly.v`: developed the theory of diagonalization. To that
   effect, we define `conjmx`, `restrictmx`, and notations `A ~_P B`,

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -554,8 +554,7 @@ Canonical unit_action :=
   @TotalAction _ _ unit_act (@mulr1 _) (fun _ _ _ => mulrA _ _ _).
 Lemma unit_is_groupAction : @is_groupAction _ R setT setT unit_action.
 Proof.
-move=> u _ /=; rewrite inE; apply/andP; split.
-  by apply/subsetP=> x _; rewrite inE.
+move=> u _ /[1!inE]; apply/andP; split; first by apply/subsetP=> x /[1!inE].
 by apply/morphicP=> x y _ _; rewrite !actpermE /= [_ u]mulrDl.
 Qed.
 Canonical unit_groupAction := GroupAction unit_is_groupAction.

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -1006,7 +1006,7 @@ without loss{IHa} /forallP/(_ (_, _))/= a_dvM: / [forall k, a %| M k.1 k.2]%Z.
     by exists i; rewrite mxE.
   exists R^T; last exists L^T; rewrite ?unitmx_tr //; exists d => //.
   rewrite -[M]trmxK dM !trmx_mul mulmxA; congr (_ *m _ *m _).
-  by apply/matrixP=> i1 j1; rewrite !mxE; case: eqVneq => // ->.
+  by apply/matrixP=> i1 j1 /[!mxE]; case: eqVneq => // ->.
 without loss{nz_a a_dvM} a1: M a Da / a = 1.
   pose M1 := map_mx (divz^~ a) M; case/(_ M1 1)=> // [k|L uL [R uR [d dvD dM]]].
     by rewrite !mxE Da divzz nz_a.
@@ -1098,7 +1098,7 @@ case Zv: (map_mx denq (vv *m pinvmx T) == const_mx 1).
     rewrite {1}(coord_vbasis s_v); apply: eq_bigr => j _; congr (_ *: _).
     have ->: map_mx intr a = vv *m pinvmx T *m map_mx intr (dsubmx Gud).
       rewrite map_mxM /=; congr (_ *m _); apply/rowP=> i; rewrite 2!mxE numqE.
-      by have /eqP/rowP/(_ i) := Zv; rewrite !mxE => ->; rewrite mulr1.
+      by have /eqP/rowP/(_ i)/[!mxE]-> := Zv; rewrite mulr1.
     by rewrite -(mulmxA _ _ S) mulmxKpV ?mxE // -eqST submx_full.
   rewrite (coord_vbasis (s_Zs _)); apply: eq_bigr => j _; congr (_ *: _).
   rewrite linear_sum mxE; apply: eq_bigr => i _.

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -632,24 +632,24 @@ Proof. by apply/colP=> i; rewrite mxE [j]ord1. Qed.
 
 Lemma row_eq m1 m2 n i1 i2 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   row i1 A1 = row i2 A2 -> A1 i1 =1 A2 i2.
-Proof. by move/rowP=> eqA12 j; have:= eqA12 j; rewrite !mxE. Qed.
+Proof. by move/rowP=> eqA12 j; have /[!mxE] := eqA12 j. Qed.
 
 Lemma col_eq m n1 n2 j1 j2 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   col j1 A1 = col j2 A2 -> A1^~ j1 =1 A2^~ j2.
-Proof. by move/colP=> eqA12 i; have:= eqA12 i; rewrite !mxE. Qed.
+Proof. by move/colP=> eqA12 i; have /[!mxE] := eqA12 i. Qed.
 
 Lemma row'_eq m n i0 (A B : 'M_(m, n)) :
   row' i0 A = row' i0 B -> {in predC1 i0, A =2 B}.
 Proof.
-move/matrixP=> eqAB' i; rewrite !inE eq_sym; case/unlift_some=> i' -> _ j.
-by have:= eqAB' i' j; rewrite !mxE.
+move=> /matrixP eqAB' i /[!inE]/[1!eq_sym]/unlift_some[i' -> _] j.
+by have /[!mxE] := eqAB' i' j.
 Qed.
 
 Lemma col'_eq m n j0 (A B : 'M_(m, n)) :
   col' j0 A = col' j0 B -> forall i, {in predC1 j0, A i =1 B i}.
 Proof.
-move/matrixP=> eqAB' i j; rewrite !inE eq_sym; case/unlift_some=> j' -> _.
-by have:= eqAB' i j'; rewrite !mxE.
+move=> /matrixP eqAB' i j /[!inE]/[1!eq_sym]/unlift_some[j' -> _].
+by have  /[!mxE] := eqAB' i j'.
 Qed.
 
 Lemma tr_row m n i0 (A : 'M_(m, n)) : (row i0 A)^T = col i0 A^T.
@@ -777,9 +777,7 @@ Lemma row_mxKr A1 A2 : rsubmx (row_mx A1 A2) = A2.
 Proof. by apply/matrixP=> i j; rewrite mxE row_mxEr. Qed.
 
 Lemma hsubmxK A : row_mx (lsubmx A) (rsubmx A) = A.
-Proof.
-by apply/matrixP=> i j; rewrite !mxE; case: split_ordP => k ->; rewrite !mxE.
-Qed.
+Proof. by apply/matrixP=> i j /[!mxE]; case: split_ordP => k -> /[!mxE]. Qed.
 
 Lemma col_mxEu A1 A2 i j : col_mx A1 A2 (lshift m2 i) j = A1 i j.
 Proof. by rewrite mxE (unsplitK (inl _ _)). Qed.
@@ -879,7 +877,7 @@ apply: (canRL (castmxKV _ _)); apply/matrixP=> i j.
 rewrite castmxE !mxE cast_ord_id; case: splitP => j1 /= def_j.
   have: (j < n1 + n2) && (j < n1) by rewrite def_j lshift_subproof /=.
   by move: def_j; do 2![case: splitP => // ? ->; rewrite ?mxE] => /ord_inj->.
-case: splitP def_j => j2 ->{j} def_j; rewrite !mxE.
+case: splitP def_j => j2 ->{j} def_j /[!mxE].
   have: ~~ (j2 < n1) by rewrite -leqNgt def_j leq_addr.
   have: j1 < n2 by rewrite -(ltn_add2l n1) -def_j.
   by move: def_j; do 2![case: splitP => // ? ->] => /addnI/val_inj->.
@@ -898,7 +896,7 @@ Definition col_mxAx := col_mxA. (* bypass Prenex Implicits. *)
 Lemma row_row_mx m n1 n2 i0 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   row i0 (row_mx A1 A2) = row_mx (row i0 A1) (row i0 A2).
 Proof.
-by apply/matrixP=> i j; rewrite !mxE; case: (split j) => j'; rewrite mxE.
+by apply/matrixP=> i j /[!mxE]; case: (split j) => j' /[1!mxE].
 Qed.
 
 Lemma col_col_mx m1 m2 n j0 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
@@ -908,7 +906,7 @@ Proof. by apply: trmx_inj; rewrite !(tr_col, tr_col_mx, row_row_mx). Qed.
 Lemma row'_row_mx m n1 n2 i0 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   row' i0 (row_mx A1 A2) = row_mx (row' i0 A1) (row' i0 A2).
 Proof.
-by apply/matrixP=> i j; rewrite !mxE; case: (split j) => j'; rewrite mxE.
+by apply/matrixP=> i j /[!mxE]; case: (split j) => j' /[1!mxE].
 Qed.
 
 Lemma col'_col_mx m1 m2 n j0 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
@@ -1934,7 +1932,7 @@ Definition diag_mx n (d : 'rV[R]_n) :=
   \matrix[diag_mx_key]_(i, j) (d 0 i *+ (i == j)).
 
 Lemma tr_diag_mx n (d : 'rV_n) : (diag_mx d)^T = diag_mx d.
-Proof. by apply/matrixP=> i j; rewrite !mxE; case: eqVneq => // ->. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]; case: eqVneq => // ->. Qed.
 
 Lemma diag_mx_is_linear n : linear (@diag_mx n).
 Proof.
@@ -2067,7 +2065,7 @@ Local Notation "A *m B" := (mulmx A B) : ring_scope.
 Lemma mulmxA m n p q (A : 'M_(m, n)) (B : 'M_(n, p)) (C : 'M_(p, q)) :
   A *m (B *m C) = A *m B *m C.
 Proof.
-apply/matrixP=> i l; rewrite !mxE; under eq_bigr do rewrite mxE big_distrr/=.
+apply/matrixP=> i l /[!mxE]; under eq_bigr do rewrite mxE big_distrr/=.
 rewrite exchange_big; apply: eq_bigr => j _; rewrite mxE big_distrl /=.
 by under eq_bigr do rewrite mulrA.
 Qed.
@@ -2084,14 +2082,12 @@ Qed.
 
 Lemma mulmxN m n p (A : 'M_(m, n)) (B : 'M_(n, p)) : A *m (- B) = - (A *m B).
 Proof.
-apply/matrixP=> i k; rewrite !mxE -sumrN.
-by under eq_bigr do rewrite mxE mulrN.
+by apply/matrixP=> i k; rewrite !mxE -sumrN; under eq_bigr do rewrite mxE mulrN.
 Qed.
 
 Lemma mulNmx m n p (A : 'M_(m, n)) (B : 'M_(n, p)) : - A *m B = - (A *m B).
 Proof.
-apply/matrixP=> i k; rewrite !mxE -sumrN.
-by under eq_bigr do rewrite mxE mulNr.
+by apply/matrixP=> i k; rewrite !mxE -sumrN; under eq_bigr do rewrite mxE mulNr.
 Qed.
 
 Lemma mulmxDl m n p (A1 A2 : 'M_(m, n)) (B : 'M_(n, p)) :
@@ -2151,9 +2147,7 @@ Proof. by rewrite !rowE mulmxA. Qed.
 
 Lemma mulmx_sum_row m n (u : 'rV_m) (A : 'M_(m, n)) :
   u *m A = \sum_i u 0 i *: row i A.
-Proof.
-by apply/rowP=> j; rewrite mxE summxE; under [RHS]eq_bigr do rewrite !mxE.
-Qed.
+Proof. by apply/rowP => j /[!(mxE, summxE)]; apply: eq_bigr => i _ /[!mxE]. Qed.
 
 Lemma mxsub_mul m n m' n' p f g (A : 'M_(m, p)) (B : 'M_(p, n)) :
   mxsub f g (A *m B) = rowsub f A *m colsub g B :> 'M_(m', n').
@@ -2214,8 +2208,7 @@ Proof. by rewrite mul_scalar_mx scale1r. Qed.
 
 Lemma mulmx1 m n (A : 'M_(m, n)) : A *m 1%:M = A.
 Proof.
-rewrite -diag_const_mx mul_mx_diag.
-by apply/matrixP=> i j; rewrite !mxE mulr1.
+by rewrite -diag_const_mx mul_mx_diag; apply/matrixP=> i j; rewrite !mxE mulr1.
 Qed.
 
 Lemma rowsubE m m' n f (A : 'M_(m, n)) :
@@ -2341,12 +2334,12 @@ Qed.
 Lemma pid_mx_block m n r : pid_mx r = block_mx 1%:M 0 0 0 :> 'M_(r + m, r + n).
 Proof.
 apply/matrixP=> i j; rewrite !mxE row_mx0 andbC.
-do ![case: split_ordP => ? ->; rewrite !mxE//].
+do ![case: split_ordP => ? -> /[!mxE]//].
 by rewrite (val_eqE (lshift n _)) eq_shift.
 Qed.
 
 Lemma tr_pid_mx m n r : (pid_mx r)^T = pid_mx r :> 'M_(n, m).
-Proof. by apply/matrixP=> i j; rewrite !mxE; case: eqVneq => // ->. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]; case: eqVneq => // ->. Qed.
 
 Lemma pid_mx_minv m n r : pid_mx (minn m r) = pid_mx r :> 'M_(m, n).
 Proof. by apply/matrixP=> i j; rewrite !mxE leq_min ltn_ord. Qed.
@@ -2399,14 +2392,14 @@ Lemma mul_mx_row m n p1 p2 (A : 'M_(m, n)) (Bl : 'M_(n, p1)) (Br : 'M_(n, p2)) :
   A *m row_mx Bl Br = row_mx (A *m Bl) (A *m Br).
 Proof.
 apply/matrixP=> i k; rewrite !mxE.
-by case defk: (split k); rewrite mxE; under eq_bigr do rewrite mxE defk.
+by case defk: (split k) => /[!mxE]; under eq_bigr do rewrite mxE defk.
 Qed.
 
 Lemma mul_col_mx m1 m2 n p (Au : 'M_(m1, n)) (Ad : 'M_(m2, n)) (B : 'M_(n, p)) :
   col_mx Au Ad *m B = col_mx (Au *m B) (Ad *m B).
 Proof.
 apply/matrixP=> i k; rewrite !mxE.
-by case defi: (split i); rewrite mxE; under eq_bigr do rewrite mxE defi.
+by case defi: (split i) => /[!mxE]; under eq_bigr do rewrite mxE defi.
 Qed.
 
 Lemma mul_row_col m n1 n2 p (Al : 'M_(m, n1)) (Ar : 'M_(m, n2))
@@ -2687,7 +2680,7 @@ Notation "'\adj' A" := (adjugate A) : ring_scope.
 Lemma trmx_mul_rev (R : ringType) m n p (A : 'M[R]_(m, n)) (B : 'M[R]_(n, p)) :
   (A *m B)^T = (B : 'M[R^c]_(n, p))^T *m (A : 'M[R^c]_(m, n))^T.
 Proof.
-by apply/matrixP=> k i; rewrite !mxE; apply: eq_bigr => j _; rewrite !mxE.
+by apply/matrixP=> k i /[!mxE]; apply: eq_bigr => j _ /[!mxE].
 Qed.
 
 Canonical matrix_countZmodType (M : countZmodType) m n :=
@@ -3137,7 +3130,7 @@ Proof. by apply/matrixP=> i j; rewrite !mxE cofactorZ. Qed.
 (* Cramer Rule : adjugate on the left *)
 Lemma mul_mx_adj n (A : 'M[R]_n) : A *m \adj A = (\det A)%:M.
 Proof.
-apply/matrixP=> i1 i2; rewrite !mxE; have [->|Di] := eqVneq.
+apply/matrixP=> i1 i2 /[!mxE]; have [->|Di] := eqVneq.
   rewrite (expand_det_row _ i2) //=.
   by apply: eq_bigr => j _; congr (_ * _); rewrite mxE.
 pose B := \matrix_(i, j) (if i == i2 then A i1 j else A i j).
@@ -3468,8 +3461,8 @@ have [{detA0}A'0 | nzA'] := eqVneq (row 0 (\adj A)) 0; last first.
   by rewrite mul_mx_scalar scale0r.
 pose A' := col' 0 A; pose vA := col 0 A.
 have defA: A = row_mx vA A'.
-  apply/matrixP=> i j; rewrite !mxE.
-  by case: split_ordP => j' ->; rewrite !mxE ?ord1; congr (A i _); apply: val_inj.
+  apply/matrixP=> i j /[!mxE].
+  by case: split_ordP => j' -> /[!(mxE, ord1)]; congr (A i _); apply: val_inj.
 have{IHn} w_ j : exists w : 'rV_n.+1, [/\ w != 0, w 0 j = 0 & w *m A' = 0].
   have [|wj nzwj wjA'0] := IHn (row' j A').
     by apply/eqP; move/rowP/(_ j)/eqP: A'0; rewrite !mxE mulf_eq0 signr_eq0.
@@ -3505,7 +3498,7 @@ Local Notation "A ^f" := (map_mx f A) : ring_scope.
 Lemma map_mx_inj {m n} : injective (map_mx f : 'M_(m, n) -> 'M_(m, n)).
 Proof.
 move=> A B eq_AB; apply/matrixP=> i j.
-by move/matrixP/(_ i j): eq_AB; rewrite !mxE; apply: fmorph_inj.
+by move/matrixP/(_ i j): eq_AB => /[!mxE]; apply: fmorph_inj.
 Qed.
 
 Lemma map_mx_is_scalar n (A : 'M_n) : is_scalar_mx A^f = is_scalar_mx A.
@@ -3720,7 +3713,7 @@ Proof.
 case: k => [|[|k]]//= in D * => _.
   by rewrite [diag_mx _]mx11_scalar [D in RHS]mx11_scalar !mxE.
 apply/idP/andP => [/mxOverP DS|[S0 DS]]; last exact: mxOver_diag.
-split; first by have := DS 0 1; rewrite !mxE.
+split; first by have /[!mxE] := DS 0 1.
 by apply/mxOverP => i j; have := DS j j; rewrite ord1 !mxE eqxx.
 Qed.
 

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -179,7 +179,7 @@ Lemma Sylvester_mxE (i j : 'I_dS) :
   let S_ r k := r`_(j - k) *+ (k <= j) in
   Sylvester_mx i j = match split i with inl k => S_ p k | inr k => S_ q k end.
 Proof.
-move=> S_; rewrite mxE; case: {i}(split i) => i; rewrite !mxE /=;
+move=> S_ /[1!mxE]; case: {i}(split i) => i /[!mxE]/=;
   by rewrite rVpoly_delta coefXnM ltnNge if_neg -mulrb.
 Qed.
 
@@ -1160,7 +1160,7 @@ exists m, X => y; rewrite -/M; split=> [/defM[a [M2a]] | [q Sq]] -> {y}.
 have M_0: M 0 by exists 0; split=> [i|]; rewrite ?mul0mx mxE.
 have M_D: propD M.
   move=> _ _ [a [Fa ->]] [b [Fb ->]]; exists (a + b).
-  by rewrite mulmxDl !mxE; split=> // i; rewrite mxE; apply: memRD.
+  by rewrite mulmxDl !mxE; split=> // i /[1!mxE]; apply: memRD.
 have{M_0 M_D} Msum := big_ind _ M_0 M_D.
 rewrite horner_coef; apply: (Msum) => i _; case: i q`_i {Sq}(Sq i) => /=.
 elim: {q}(size q) => // n IHn i i_le_n y Sy.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -4406,7 +4406,7 @@ exists r`_0 => [|z n_gt0 /(mem_rP z n_gt0) r_z].
   have sz_r: size r = n by apply: succn_inj; rewrite -sz_p Dp size_prod_XsubC.
   case: posnP => [n0 | n_gt0]; first by rewrite nth_default // sz_r n0.
   by apply/mem_rP=> //; rewrite mem_nth ?sz_r.
-case: {Dp mem_rP}r r_z r_arg => // y r1; rewrite inE => /predU1P[-> _|r1z].
+case: {Dp mem_rP}r r_z r_arg => // y r1 /[1!inE] /predU1P[-> _|r1z].
   by apply/implyP=> ->; rewrite lexx.
 by move/(order_path_min argCle_trans)/allP->.
 Qed.

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -145,14 +145,14 @@ Fixpoint tprod  (m1 : nat) :
 Lemma dsumx_mul m1 m2 n p A B :
   dsubmx ((A *m B) : 'M[F]_(m1 + m2, n)) = dsubmx (A : 'M_(m1 + m2, p)) *m B.
 Proof.
-apply/matrixP=> i j; rewrite !mxE; apply: eq_bigr=> k _.
+apply/matrixP=> i j /[!mxE]; apply: eq_bigr=> k _.
 by rewrite !mxE.
 Qed.
 
 Lemma usumx_mul m1 m2 n p A B :
   usubmx ((A *m B) : 'M[F]_(m1 + m2, n)) = usubmx (A : 'M_(m1 + m2, p)) *m B.
 Proof.
-by apply/matrixP=> i j; rewrite !mxE; apply: eq_bigr=> k _; rewrite !mxE.
+by apply/matrixP=> i j /[!mxE]; apply: eq_bigr=> k _ /[!mxE].
 Qed.
 
 Let trow_mul (m1 m2 n2 p2 : nat) 
@@ -2511,7 +2511,7 @@ do [exists linG, cF; split=> //] => [|xi /inT[u <-]|u]; first 2 [by exists u].
     apply: can_inj (insubd one) _ => u; apply: val_inj.
     by rewrite insubdK /= ?irrK //; apply: cFlin.
   rewrite -(card_image inj_cFI) -card_lin_irr.
-  apply/eq_card=> i; rewrite inE; apply/codomP/idP=> [[u ->] | /inT[u Du]].
+  apply/eq_card=> i /[1!inE]; apply/codomP/idP=> [[u ->] | /inT[u Du]].
     by rewrite /= irrK; apply: cFlin.
   by exists u; apply: irr_inj; rewrite /= irrK.
 apply/eqP; rewrite eqn_dvd; apply/andP; split.
@@ -2720,7 +2720,7 @@ Lemma cfcenter_repr n (rG : mx_representation algCF G n) :
   'Z(cfRepr rG)%CF = rcenter rG.
 Proof.
 rewrite /cfcenter /rcenter cfRepr_char /=.
-apply/setP=> x; rewrite !inE; apply/andb_id2l=> Gx.
+apply/setP=> x /[!inE]; apply/andb_id2l=> Gx.
 apply/eqP/is_scalar_mxP=> [|[c rG_c]].
   by case/max_cfRepr_norm_scalar=> // c; exists c.
 rewrite -(sqrCK (char1_ge0 (cfRepr_char rG))) normC_def; congr (sqrtC _).
@@ -2755,7 +2755,7 @@ Lemma cfker_center_normal phi : cfker phi <| 'Z(phi)%CF.
 Proof.
 apply: normalS (cfcenter_sub phi) (cfker_normal phi).
 rewrite /= /cfcenter; case: ifP => // Hphi; rewrite cfkerEchar //.
-apply/subsetP=> x; rewrite !inE => /andP[-> /eqP->] /=.
+apply/subsetP=> x /[!inE] /andP[-> /eqP->] /=.
 by rewrite ger0_norm ?char1_ge0.
 Qed.
 
@@ -2803,7 +2803,7 @@ have sZG: Z \subset G by apply: cfcenter_sub.
 have ->: cfker chi = cfker xi.
   rewrite -(setIidPr (normal_sub (cfker_center_normal _))) -/Z.
   rewrite !cfkerEchar // ?lin_charW //= -/Z.
-  apply/setP=> x; rewrite !inE; apply: andb_id2l => Zx.
+  apply/setP=> x /[!inE]; apply: andb_id2l => Zx.
   rewrite (subsetP sZG) //= -!(cfResE chi sZG) ?group1 // def_chi !cfunE.
   by rewrite (inj_eq (mulfI _)) ?char1_eq0.
 have: abelian (Z / cfker xi) by rewrite sub_der1_abelian ?lin_char_der1.

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -1057,7 +1057,7 @@ pose Z := '[Y, V] / '[V] *: V; exists (X + Z).
   rewrite /Z -{4}(addKr U V) scalerDr scalerN addrA addrC span_cons.
   by rewrite memv_add ?memvB ?memvZ ?memv_line.
 exists (Y - Z); first by rewrite addrCA !addrA addrK addrC.
-apply/orthoPl=> psi; rewrite !inE => /predU1P[-> | Spsi]; last first.
+apply/orthoPl=> psi /[!inE] /predU1P[-> | Spsi]; last first.
   by rewrite cfdotBl cfdotZl (orthoPl oVS _ Spsi) mulr0 subr0 (orthoPl oYS).
 rewrite cfdotBl !cfdotDr (span_orthogonal oYS) // ?memv_span ?mem_head //.
 rewrite !cfdotZl (span_orthogonal oVS _ S_U) ?mulr0 ?memv_span ?mem_head //.
@@ -1099,7 +1099,7 @@ have [opS | not_opS] := allP; last first.
 rewrite (contra (opS _)) /= ?cfnorm_eq0 //.
 apply: (iffP IH) => [] [uniqS oSS]; last first.
   by split=> //; apply: sub_in2 oSS => psi Spsi; apply: mem_behead.
-split=> // psi xi; rewrite !inE => /predU1P[-> // | Spsi].
+split=> // psi xi /[!inE] /predU1P[-> // | Spsi].
   by case/predU1P=> [-> | /opS] /eqP.
 case/predU1P=> [-> _ | Sxi /oSS-> //].
 by apply/eqP; rewrite cfdotC conjC_eq0 [_ == 0]opS.
@@ -1502,7 +1502,7 @@ Proof. exact/rmorph_eq1/cfMorph_inj. Qed.
 
 Lemma cfker_morph phi : cfker (cfMorph phi) = G :&: f @*^-1 (cfker phi).
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 have Dx := subsetP sGD x Gx; rewrite Dx mem_morphim //=.
 apply/forallP/forallP=> Kx y.
   have [{y} /morphimP[y Dy Gy ->] | fG'y] := boolP (y \in f @* G).
@@ -2419,7 +2419,7 @@ Proof. by rewrite !cfun_onE (eq_subset (support_cfAut phi)). Qed.
 
 Lemma cfker_aut phi : cfker phi^u = cfker phi.
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 by apply/forallP/forallP=> Kx y;
   have:= Kx y; rewrite !cfunE (inj_eq (fmorph_inj u)).
 Qed.

--- a/mathcomp/character/inertia.v
+++ b/mathcomp/character/inertia.v
@@ -258,7 +258,7 @@ Proof. by apply/setP=> x; rewrite !inE linear0 eqxx andbT. Qed.
 Lemma inertia_add phi psi : 'I[phi] :&: 'I[psi] \subset 'I[phi + psi].
 Proof.
 rewrite !['I[_]]setIdE -setIIr setIS //.
-by apply/subsetP=> x; rewrite !inE linearD /= => /andP[/eqP-> /eqP->].
+by apply/subsetP=> x /[!(inE, linearD)]/= /andP[/eqP-> /eqP->].
 Qed.
 
 Lemma inertia_sum I r (P : pred I) (Phi : I -> 'CF(H)) :
@@ -293,7 +293,7 @@ Proof. by rewrite inertia1 => /normal_norm/setIidPl. Qed.
 Lemma inertia_mul phi psi : 'I[phi] :&: 'I[psi] \subset 'I[phi * psi].
 Proof.
 rewrite !['I[_]]setIdE -setIIr setIS //.
-by apply/subsetP=> x; rewrite !inE rmorphM /= => /andP[/eqP-> /eqP->].
+by apply/subsetP=> x /[!(inE, rmorphM)]/= /andP[/eqP-> /eqP->].
 Qed.
 
 Lemma inertia_prod I r (P : pred I) (Phi : I -> 'CF(H)) :
@@ -690,7 +690,7 @@ Proof.
 have [[_ defS] [injg <-]] := (isomP isoH, isomP isoG).
 rewrite morphimEdom (eq_in_imset eq_hg) -morphimEsub // in defS.
 rewrite /inertia !setIdE morphimIdom setIA -{1}defS -injm_norm ?injmI //.
-apply/setP=> gy; rewrite !inE; apply: andb_id2l => /morphimP[y Gy nHy ->] {gy}.
+apply/setP=> gy /[!inE]; apply: andb_id2l => /morphimP[y Gy nHy ->] {gy}.
 rewrite cfConjgIsom // -sub1set -morphim_set1 // injmSK ?sub1set //= inE.
 apply/eqP/eqP=> [Iphi_y | -> //].
 by apply/cfun_inP=> x Hx; rewrite -!(cfIsomE isoH) ?Iphi_y.
@@ -1558,7 +1558,7 @@ have actIirrK: is_action G (@conjg_Iirr _ K).
 pose ito := Action actIirrK; pose cto := ('Js \ (subsetT G))%act.
 have acts_Js : [acts G, on classes K | 'Js].
   apply/subsetP=> y Gy; have nKy := subsetP nKG y Gy.
-  rewrite !inE; apply/subsetP=> _ /imsetP[z Gz ->]; rewrite !inE /=.
+  rewrite !inE; apply/subsetP=> _ /imsetP[z Gz ->] /[!inE]/=.
   rewrite -class_rcoset norm_rlcoset // class_lcoset.
   by apply: imset_f; rewrite memJ_norm.
 have acts_cto : [acts G, on classes K | cto] by rewrite astabs_ract subsetIidl.

--- a/mathcomp/character/integral_char.v
+++ b/mathcomp/character/integral_char.v
@@ -117,7 +117,7 @@ have [w Gw Dg] := imsetP g1Gg; pose J2 (v : gT) xy := (xy.1 ^ v, xy.2 ^ v)%g.
 have J2inj: injective (J2 w).
   by apply: can_inj (J2 w^-1)%g _ => [[x y]]; rewrite /J2 /= !conjgK.
 rewrite -(card_imset _ J2inj) subset_leq_card //; apply/subsetP.
-move=> _ /imsetP[[x y] /setIdP[/andP[/= x1Gx y1Gy] Dxy1] ->]; rewrite !inE /=.
+move=> _ /imsetP[[x y] /setIdP[/andP[/= x1Gx y1Gy] Dxy1] ->] /[!inE]/=.
 rewrite !(class_sym _ (_ ^ _)) !classGidl // class_sym x1Gx class_sym y1Gy.
 by rewrite -conjMg (eqP Dxy1) /= -Dg.
 Qed.
@@ -589,7 +589,7 @@ have pa_dv_ZiG: (p ^ a %| #|G : 'Z(G)|)%N.
   exact: dvd_irr1_index_center.
 have [sPG pP p'PiG] := and3P sylP.
 have ZchiP: 'Res[P] 'chi_i \in 'CF(P, P :&: 'Z(G)).
-  apply/cfun_onP=> x; rewrite inE; have [Px | /cfun0->//] := boolP (x \in P).
+  apply/cfun_onP=> x /[1!inE]; have [Px | /cfun0->//] := boolP (x \in P).
   rewrite /= -(cfcenter_fful_irr fful_i) cfResE //.
   apply: coprime_degree_support_cfcenter.
   rewrite Dchi1 coprimeXl // prime_coprime // -p'natE //.

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -79,8 +79,7 @@ Canonical Structure mx_repr_action := Action mx_repr_is_action.
 
 Fact mx_repr_is_groupAction : is_groupAction [set: 'rV[R]_n] mx_repr_action.
 Proof.
-move=> x Gx /=; rewrite !inE.
-apply/andP; split; first by apply/subsetP=> u; rewrite !inE.
+move=> x Gx /[!inE]; apply/andP; split; first by apply/subsetP=> u /[!inE].
 by apply/morphicP=> /= u v _ _; rewrite !actpermE /= /mx_repr_act mulmxDl.
 Qed.
 Canonical Structure mx_repr_groupAction := GroupAction mx_repr_is_groupAction.
@@ -112,8 +111,7 @@ Qed.
 Canonical scale_action := Action scale_is_action.
 Fact scale_is_groupAction : is_groupAction setT scale_action.
 Proof.
-move=> a _ /=; rewrite inE; apply/andP.
-split; first by apply/subsetP=> A; rewrite !inE.
+move=> a _ /[1!inE]; apply/andP; split; first by apply/subsetP=> A /[!inE].
 by apply/morphicP=> u A _ _ /=; rewrite !actpermE /= /scale_act scalerDr.
 Qed.
 Canonical scale_groupAction := GroupAction scale_is_groupAction.
@@ -151,9 +149,8 @@ Proof. by apply/actsP=> a _ v; rewrite !inE eqmx_scale // -unitfE (valP a). Qed.
 Lemma rowgS m1 m2 (A : 'M_(m1, n)) (B : 'M_(m2, n)) :
   (rowg A \subset rowg B) = (A <= B)%MS.
 Proof.
-apply/subsetP/idP=> sAB => [| u].
-  by apply/row_subP=> i; have:= sAB (row i A); rewrite !inE row_sub => ->.
-by rewrite !inE => suA; apply: submx_trans sAB.
+apply/subsetP/idP=> sAB => [|u /[!inE] suA]; last exact: submx_trans sAB.
+by apply/row_subP=> i; have /[!(inE, row_sub)]-> := sAB (row i A).
 Qed.
 
 Lemma eq_rowg m1 m2 (A : 'M_(m1, n)) (B : 'M_(m2, n)) :
@@ -174,7 +171,7 @@ Definition rowg_mx (L : {set rVn}) := <<\matrix_(i < #|L|) enum_val i>>%MS.
 Lemma rowgK m (A : 'M_(m, n)) : (rowg_mx (rowg A) :=: A)%MS.
 Proof.
 apply/eqmxP; rewrite !genmxE; apply/andP; split.
-  by apply/row_subP=> i; rewrite rowK; have:= enum_valP i; rewrite /= inE.
+  by apply/row_subP=> i; rewrite rowK; have /[!inE] := enum_valP i.
 apply/row_subP=> i; set v := row i A.
 have Av: v \in rowg A by rewrite inE row_sub.
 by rewrite (eq_row_sub (enum_rank_in Av v)) // rowK enum_rankK_in.
@@ -260,7 +257,7 @@ Lemma bigdprod_rowg m (I : finType) (P : pred I) A (B : 'M[F]_(m, n)) :
 Proof.
 move=> S defS; rewrite mxdirectE defS /= => /eqP rankB.
 apply: bigcprod_card_dprod (bigcprod_rowg defS) (eq_leq _).
-by rewrite card_rowg rankB expn_sum; apply: eq_bigr => i _; rewrite card_rowg.
+by rewrite card_rowg rankB expn_sum; apply: eq_bigr => i; rewrite card_rowg.
 Qed.
 
 End RowGroup.
@@ -297,7 +294,7 @@ Qed.
 
 Lemma astab_rowg_repr m (A : 'M_(m, n)) : 'C(rowg A | 'MR rG) = rstab rG A.
 Proof.
-apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]/=; apply: andb_id2l => Gx.
 apply/subsetP/eqP=> cAx => [|u]; last first.
   by rewrite !inE mx_repr_actE // => /submxP[u' ->]; rewrite -mulmxA cAx.
 apply/row_matrixP=> i; apply/eqP; move/implyP: (cAx (row i A)).
@@ -306,7 +303,7 @@ Qed.
 
 Lemma astabs_rowg_repr m (A : 'M_(m, n)) : 'N(rowg A | 'MR rG) = rstabs rG A.
 Proof.
-apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]/=; apply: andb_id2l => Gx.
 apply/subsetP/idP=> nAx => [|u]; last first.
   by rewrite !inE mx_repr_actE // => Au; apply: (submx_trans (submxMr _ Au)).
 apply/row_subP=> i; move/implyP: (nAx (row i A)).
@@ -429,7 +426,7 @@ Proof. exact: fin_Fp_lmod_abelem. Qed.
 
 Lemma mx_Fp_stable (L : {group Mmn}) : [acts setT, on L | 'Zm].
 Proof.
-apply/subsetP=> a _; rewrite !inE; apply/subsetP=> A L_A.
+apply/subsetP=> a _ /[!inE]; apply/subsetP=> A L_A.
 by rewrite inE /= /scale_act -[val _]natr_Zp scaler_nat groupX.
 Qed.
 
@@ -638,9 +635,8 @@ Qed.
 
 Lemma rstab_abelem m (A : 'M_(m, n)) : rstab rG A = 'C_G(rV_E @* rowg A).
 Proof.
-apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
-apply/eqP/centP=> cAx => [_ /morphimP[u _ Au ->]|].
-  move: Au; rewrite inE => /submxP[u' ->] {u}.
+apply/setP=> x /[!inE]/=; apply: andb_id2l => Gx; apply/eqP/centP => cAx.
+move=> _ /morphimP[u _ + ->] => /[1!inE] /submxP[{}u ->].
   by apply/esym/commgP/conjg_fixP; rewrite -rVabelemJ -?mulmxA ?cAx.
 apply/row_matrixP=> i; apply: rVabelem_inj.
 by rewrite row_mul rVabelemJ // /conjg -cAx ?mulKg ?mem_morphim // inE row_sub.
@@ -648,7 +644,7 @@ Qed.
 
 Lemma rstabs_abelem m (A : 'M_(m, n)) : rstabs rG A = 'N_G(rV_E @* rowg A).
 Proof.
-apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]/=; apply: andb_id2l => Gx.
 by rewrite -rowgS -rVabelemS abelem_rowgJ.
 Qed.
 
@@ -701,7 +697,7 @@ Lemma rfix_abelem (H : {set gT}) :
 Proof.
 move/subsetP=> sHG; apply/eqmxP/andP; split.
   rewrite -rowgS rowg_mxK -sub_rVabelem_im // subsetI sub_rVabelem /=.
-  apply/centsP=> y /morphimP[v _]; rewrite inE => cGv ->{y} x Gx.
+  apply/centsP=> y /morphimP[v _] /[1!inE] cGv ->{y} x Gx.
   by apply/commgP/conjg_fixP; rewrite /= -rVabelemJ ?sHG ?(rfix_mxP H _).
 rewrite genmxE; apply/rfix_mxP=> x Hx; apply/row_matrixP=> i.
 rewrite row_mul rowK; case/morphimP: (enum_valP i) => z Ez /setIP[_ cHz] ->.
@@ -739,7 +735,7 @@ Qed.
 
 Lemma mxmodule_abelem_subg m (U : 'M_(m, n)) : mxmodule rHG U = mxmodule rH U.
 Proof.
-apply: eq_subset_r => x; rewrite !inE; apply: andb_id2l => Hx.
+apply: eq_subset_r => x /[!inE]; apply: andb_id2l => Hx.
 by rewrite eq_abelem_subg_repr.
 Qed.
 
@@ -884,7 +880,7 @@ have nb_irr: #|sS| = (p ^ n.*2 + p.-1)%N.
     rewrite (setIidPl _) ?indexgg // sub_cent1 (subsetP cSzS) //.
     exact: mem_repr (class_refl S z).
   rewrite sum1dep_card setIdE (setIidPr _) 1?cardsE ?cardZcl; last first.
-    by apply/subsetP=> zS; rewrite 2!inE => /andP[].
+    by apply/subsetP=> zS /[!inE] /andP[].
   have pn_gt0: p ^ n.*2 > 0 by rewrite expn_gt0 p_gt0.
   rewrite card_irr // oSpn expnS -(prednK pn_gt0) mulnS eqn_add2l.
   rewrite (eq_bigr (fun _ => p)) => [|xS]; last first.

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -380,8 +380,7 @@ Definition centgmx := G \subset rcent.
 
 Lemma centgmxP : reflect (forall x, x \in G -> f *m rG x = rG x *m f) centgmx.
 Proof.
-apply: (iffP subsetP) => cGf x Gx;
-  by have:= cGf x Gx; rewrite !inE Gx /=; move/eqP.
+by apply: (iffP subsetP) => cGf x Gx; have /[!(inE, Gx)] /eqP := cGf x Gx.
 Qed.
 
 End CentHom.
@@ -437,7 +436,7 @@ Canonical rcenter_group := Group rcenter_group_set.
 
 Lemma rcenter_normal : rcenter <| G.
 Proof.
-rewrite /normal /rcenter {1}setIdE subsetIl; apply/subsetP=> x Gx; rewrite inE.
+rewrite /normal /rcenter {1}setIdE subsetIl; apply/subsetP=> x Gx /[1!inE].
 apply/subsetP=> _ /imsetP[y /setIdP[Gy /is_scalar_mxP[c rGy]] ->].
 rewrite inE !repr_mxM ?groupM ?groupV //= mulmxA rGy scalar_mxC repr_mxKV //.
 exact: scalar_mx_is_scalar.
@@ -677,16 +676,14 @@ Proof. exact: quo_mx_coset. Qed.
 
 Lemma rcent_quo A : rcent rGH A = (rcent rG A / H)%g.
 Proof.
-apply/setP=> Hx; rewrite !inE.
-apply/andP/idP=> [[]|]; case/morphimP=> x Nx Gx ->{Hx}.
+apply/setP=> Hx /[!inE]; apply/andP/idP=> [[]|]; case/morphimP=> x Nx Gx ->{Hx}.
   by rewrite quo_repr_coset // => cAx; rewrite mem_morphim // inE Gx.
 by case/setIdP: Gx => Gx cAx; rewrite quo_repr_coset ?mem_morphim.
 Qed.
 
 Lemma rstab_quo m (U : 'M_(m, n)) : rstab rGH U = (rstab rG U / H)%g.
 Proof.
-apply/setP=> Hx; rewrite !inE.
-apply/andP/idP=> [[]|]; case/morphimP=> x Nx Gx ->{Hx}.
+apply/setP=> Hx /[!inE]; apply/andP/idP=> [[]|]; case/morphimP=> x Nx Gx ->{Hx}.
   by rewrite quo_repr_coset // => nUx; rewrite mem_morphim // inE Gx.
 by case/setIdP: Gx => Gx nUx; rewrite quo_repr_coset ?mem_morphim.
 Qed.
@@ -2713,14 +2710,14 @@ Qed.
 Lemma rstab_submod m (W : 'M_(m, \rank U)) :
   rstab rU W = rstab rG (val_submod W).
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 by rewrite -(inj_eq val_submod_inj) val_submodJ.
 Qed.
 
 Lemma rstabs_submod m (W : 'M_(m, \rank U)) :
   rstabs rU W = rstabs rG (val_submod W).
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 by rewrite -val_submodS val_submodJ.
 Qed.
 
@@ -2741,7 +2738,7 @@ Qed.
 Lemma rstabs_factmod m (W : 'M_(m, \rank (cokermx U))) :
   rstabs rU' W = rstabs rG (U + val_factmod W)%MS.
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 rewrite addsmxMr addsmx_sub (submx_trans (mxmoduleP Umod x Gx)) ?addsmxSl //.
 rewrite -val_factmodS val_factmodJ //= val_factmodS; apply/idP/idP=> nWx.
   rewrite (submx_trans (addsmxSr U _)) // -(in_factmodsK (addsmxSl U _)) //.
@@ -2875,7 +2872,7 @@ Qed.
 
 Lemma rstabs_quo m (U : 'M_(m, n)) : rstabs rGH U = (rstabs rG U / H)%g.
 Proof.
-apply/setP=> Hx; rewrite !inE; apply/andP/idP=> [[]|] /morphimP[x Nx Gx ->{Hx}].
+apply/setP=> Hx /[!inE]; apply/andP/idP=> [[]|] /morphimP[x Nx Gx ->{Hx}].
   by rewrite quo_repr_coset // => nUx; rewrite mem_morphim // inE Gx.
 by case/setIdP: Gx => Gx nUx; rewrite quo_repr_coset ?mem_morphim.
 Qed.
@@ -2883,8 +2880,7 @@ Qed.
 Lemma mxmodule_quo m (U : 'M_(m, n)) : mxmodule rGH U = mxmodule rG U.
 Proof.
 rewrite /mxmodule rstabs_quo quotientSGK // ?(subset_trans krH) //.
-apply/subsetP=> x; rewrite !inE mul1mx => /andP[-> /eqP->].
-by rewrite /= mulmx1.
+by apply/subsetP=> x /[!inE]/andP[-> /[1!mul1mx]/eqP->/=]; rewrite mulmx1.
 Qed.
 
 Lemma quo_mx_irr : mx_irreducible rGH <-> mx_irreducible rG.
@@ -3381,7 +3377,7 @@ apply: mxsimple_exists (mxmodule1 rH) nz1 _ _ => [[M simM _]].
 pose W1 := PackSocle (component_socle sH simM).
 have [X sXG [def1 _]] := Clifford_basis simM; move/subsetP: sXG => sXG.
 apply/imsetP; exists W1; first by rewrite inE.
-symmetry; apply/setP=> W; rewrite inE; have simW := socle_simple W.
+symmetry; apply/setP=> W /[1!inE]; have simW := socle_simple W.
 have:= submx1 (socle_base W); rewrite -def1 -[(\sum_(x in X) _)%MS]mulmx1.
 case/(hom_mxsemisimple_iso simW) => [x Xx _ | | x Xx isoMxW].
 - by apply: Clifford_simple; rewrite ?sXG.
@@ -3458,13 +3454,13 @@ Qed.
 Lemma Clifford_astab : H <*> 'C_G(H) \subset 'C([set: sH] | 'Cl).
 Proof.
 rewrite join_subG !subsetI sHG subsetIl /=; apply/andP; split.
-  apply/subsetP=> h Hh; have Gh := subsetP sHG h Hh; rewrite inE.
+  apply/subsetP=> h Hh /[1!inE]; have Gh := subsetP sHG h Hh.
   apply/subsetP=> W _; have simW := socle_simple W; have [modW _ _] := simW.
   have simWh: mxsimple rH (socle_base W *m rG h) by apply: Clifford_simple.
   rewrite inE -val_eqE /= PackSocleK eq_sym.
   apply/component_mx_isoP; rewrite ?subgK //; apply: component_mx_iso => //.
   by apply: submx_trans (component_mx_id simW); move/mxmoduleP: modW => ->.
-apply/subsetP=> z cHz; have [Gz _] := setIP cHz; rewrite inE.
+apply/subsetP=> z cHz /[1!inE]; have [Gz _] := setIP cHz.
 apply/subsetP=> W _; have simW := socle_simple W; have [modW _ _] := simW.
 have simWz: mxsimple rH (socle_base W *m rG z) by apply: Clifford_simple.
 rewrite inE -val_eqE /= PackSocleK eq_sym.
@@ -3473,7 +3469,7 @@ Qed.
 
 Lemma Clifford_astab1 (W : sH) : 'C[W | 'Cl] = rstabs rG W.
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 rewrite sub1set inE (sameP eqP socleP) !val_Clifford_act //.
 rewrite andb_idr // => sWxW; rewrite -mxrank_leqif_sup //.
 by rewrite mxrankMfree ?repr_mx_free.
@@ -3977,7 +3973,7 @@ Proof. by move=> x Gx; apply: subsetP; apply: class_subG. Qed.
 Lemma classg_base_free : row_free classg_base.
 Proof.
 rewrite -kermx_eq0; apply/rowV0P=> v /sub_kermxP; rewrite mulmx_sum_row => v0.
-apply/rowP=> k; rewrite mxE.
+apply/rowP=> k /[1!mxE].
 have [x Gx def_k] := imsetP (enum_valP k).
 transitivity (@gring_proj F _ G x (vec_mx 0) 0 0); last first.
   by rewrite !linear0 !mxE.
@@ -4583,7 +4579,7 @@ rewrite (reindex (fun j => irr_comp sG (rG j))) /=.
   by rewrite inE -lin_j -irr_degreeE irr_degree_abelian.
 pose sGlin := {i | i \in linear_irr sG}.
 have sG'k (i : sGlin) : G^`(1)%g \subset rker (irr_repr (val i)).
-  by case: i => i /=; rewrite !inE => lin; rewrite rker_linear //=; apply/eqP.
+  by case: i => i /= /[!inE] lin; rewrite rker_linear //=; apply/eqP.
 pose h' u := irr_comp sGq (quo_repr (sG'k u) nG'G).
 have irrGq u: mx_irreducible (quo_repr (sG'k u) nG'G).
   by apply/quo_mx_irr; apply: socle_irr.
@@ -5425,7 +5421,7 @@ Prenex Implicits val_genK in_genK.
 
 Lemma val_gen_rV (w : 'rV_nA) :
   val_gen w = mxvec (\matrix_j val (w 0 j)) *m base.
-Proof. by apply/rowP=> j; rewrite mxE. Qed.
+Proof. by apply/rowP=> j /[1!mxE]. Qed.
 
 Section Bijection2.
 
@@ -5434,7 +5430,7 @@ Variable m : nat.
 Lemma val_gen_row W (i : 'I_m) : val_gen (row i W) = row i (val_gen W).
 Proof.
 rewrite val_gen_rV rowK; congr (mxvec _ *m _).
-by apply/matrixP=> j k; rewrite !mxE.
+by apply/matrixP=> j k /[!mxE].
 Qed.
 
 Lemma in_gen_row W (i : 'I_m) : in_gen (row i W) = row i (in_gen W).
@@ -5444,7 +5440,7 @@ Lemma row_gen_sum_mxval W (i : 'I_m) :
   row i (val_gen W) = \sum_j row (gen_base 0 j) (mxval (W i j)).
 Proof.
 rewrite -val_gen_row [row i W]row_sum_delta val_gen_sum.
-apply: eq_bigr => /= j _; rewrite mxE; move: {W i}(W i j) => x.
+apply: eq_bigr => /= j _ /[1!mxE]; move: {W i}(W i j) => x.
 have ->: x = \sum_k gen (val x 0 k) * inFA (delta_mx 0 k).
   case: x => u; apply: mxval_inj; rewrite {1}[u]row_sum_delta.
   rewrite mxval_sum [mxval _]horner_rVpoly mulmx_suml linear_sum /=.
@@ -5567,21 +5563,20 @@ Qed.
 
 Lemma rstab_in_gen m (U : 'M_(m, n)) : rstab rGA (in_gen U) = rstab rG U.
 Proof.
-apply/setP=> x; rewrite !inE; case Gx: (x \in G) => //=.
+apply/setP=> x /[!inE]; case Gx: (x \in G) => //=.
 by rewrite -in_genJ // (inj_eq (can_inj in_genK)).
 Qed.
 
 Lemma rstabs_in_gen m (U : 'M_(m, n)) :
   rstabs rG U \subset rstabs rGA (in_gen U).
 Proof.
-apply/subsetP=> x; rewrite !inE => /andP[Gx nUx].
-by rewrite -in_genJ Gx // submx_in_gen.
+by apply/subsetP=> x /[!inE] /andP[Gx nUx]; rewrite -in_genJ Gx // submx_in_gen.
 Qed.
 
 Lemma rstabs_rowval_gen m (U : 'M_(m, nA)) :
   rstabs rG (rowval_gen U) = rstabs rGA U.
 Proof.
-apply/setP=> x; rewrite !inE; case Gx: (x \in G) => //=.
+apply/setP=> x /[!inE]; case Gx: (x \in G) => //=.
 by rewrite submx_rowval_gen in_genJ // (eqmxMr _ (rowval_genK U)).
 Qed.
 
@@ -5687,9 +5682,8 @@ elim: t => //=.
 - by move=> k _; apply/rowP=> i; rewrite !mxE /= nth_row_env nth_map_rVval.
 - by move=> x _; rewrite eval_mx_term.
 - by move=> x _; rewrite eval_mx_term.
-- move=> t1 + t2 + /andP[rt1 rt2] => <-// <-//.
-  by apply/rowP=> k; rewrite !mxE.
-- by move=> t1 + rt1 => <-//; apply/rowP=> k; rewrite !mxE.
+- by move=> t1 + t2 + /andP[rt1 rt2] => <-// <-//; apply/rowP => k /[!mxE].
+- by move=> t1 + rt1 => <-//; apply/rowP=> k /[!mxE].
 - move=> t1 IH1 n1 rt1; rewrite eval_mulmx eval_mx_term mul_scalar_mx.
   by rewrite scaler_nat {}IH1 //; elim: n1 => //= n1 IHn1; rewrite !mulrS IHn1.
 - by move=> t1 IH1 t2 IH2 /andP[rt1 rt2]; rewrite eval_mulT IH1 ?IH2.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -216,8 +216,7 @@ have FpxF q: Fpx (q ^ FtoL) = root (q ^ FtoL) x.
 pose p_ (I : {set 'I_n}) := \prod_(i <- enum I) ('X - (r`_i)%:P).
 have{px0 Dp} /ex_minset[I /minsetP[/andP[FpI pIx0] minI]]: exists I, Fpx (p_ I).
   exists setT; suffices ->: p_ setT = p ^ FtoL by rewrite FpxF.
-  rewrite Dp (big_nth 0) big_mkord /p_ big_enum /=.
-  by apply/eq_bigl=> i; rewrite inE.
+  by rewrite Dp (big_nth 0) big_mkord /p_ big_enum; apply/eq_bigl => i /[1!inE].
 have{p} [p DpI]: {p | p_ I = p ^ FtoL}.
   exists (p_ I ^ (fun y => if isF y is left Fy then sval (sig_eqW Fy) else 0)).
   rewrite -map_poly_comp map_poly_id // => y /(allP FpI) /=.
@@ -244,7 +243,7 @@ pose B := [set j in mask m (enum I)]; have{} Dq: q ^ FtoL = p_ B.
   congr (_ %= _): Dq; apply: perm_big => //.
   by rewrite uniq_perm ?mask_uniq ?enum_uniq // => j; rewrite mem_enum inE.
 rewrite -!(size_map_poly FtoL) Dq -DpI (minI B) // -?Dq ?FpxF //.
-by apply/subsetP=> j; rewrite inE => /mem_mask; rewrite mem_enum.
+by apply/subsetP=> j /[1!inE] /mem_mask; rewrite mem_enum.
 Qed.
 
 Lemma alg_integral (F : fieldType) (L : fieldExtType F) :

--- a/mathcomp/field/algnum.v
+++ b/mathcomp/field/algnum.v
@@ -599,7 +599,7 @@ have SmulX (i : 'I_m): {in S, forall x, x * X`_i \in S}.
       apply/familyP=> i1; rewrite inE ffunE /= fun_if fiK.
       by case: eqP => [-> // | _]; apply: fP.
     rewrite (bigD1 i isT) ffunE /= eqxx fiK; congr (_ * _).
-    by apply: eq_bigr => i1; rewrite ffunE /= => /negPf->.
+    by apply: eq_bigr => i1 /[!ffunE]/= /negPf->.
   have [/monicP ] := (minCpoly_monic X`_i, root_minCpoly X`_i).
   rewrite /root horner_coef lead_coefE -(subnKC (size_minCpoly _)) subn2.
   rewrite big_ord_recr /= addrC addr_eq0 => ->; rewrite mul1r => /eqP->.
@@ -612,7 +612,7 @@ have SmulX (i : 'I_m): {in S, forall x, x * X`_i \in S}.
     apply/familyP=> i1; rewrite inE ffunE /= fun_if eK.
     by case: eqP => [-> // | _]; apply: fP.
   rewrite (bigD1 i isT) ffunE /= eqxx eK; congr (_ * _).
-  by apply: eq_bigr => i1; rewrite ffunE /= => /negPf->.
+  by apply: eq_bigr => i1 /[!ffunE] /= /negPf->.
 exists S; last by exists (Tagged (fun n => n.-tuple _) [tuple of Y]).
 split=> [|x Xx]; last first.
   by rewrite -[x]mul1r -(nth_index 0 Xx) (SmulX (Ordinal _)) // ltnS index_size.
@@ -638,7 +638,7 @@ have ZP_C c: (ZtoC c)%:P \is a polyOver Cint by rewrite raddfMz rpred_int.
 move=> mulS S_P x Sx; pose v := \row_(i < n) Y`_i.
 have [v0 | nz_v] := eqVneq v 0.
   case/S_P: Sx => {}x ->; rewrite big1 ?isAlgInt0 // => i _.
-  by have /rowP/(_ i) := v0; rewrite !mxE => ->; rewrite mul0rz.
+  by have /rowP/(_ i)/[!mxE] -> := v0; rewrite mul0rz.
 have sYS (i : 'I_n): x * Y`_i \in S.
   by rewrite rpredM //; apply/S_P/Cint_spanP/mem_Cint_span/memt_nth.
 pose A := \matrix_(i, j < n) sval (sig_eqW (S_P _ (sYS j))) i.

--- a/mathcomp/field/falgebra.v
+++ b/mathcomp/field/falgebra.v
@@ -829,7 +829,7 @@ have sAY_AM: (AY <= A * M)%VS by rewrite [AY]big_cons subv_add ?prodvSr.
 have dxAY: directv AY.
   rewrite directvE /= !big_cons [_ == _]directv_addE dxAX directvE eqxx /=.
   rewrite -/(sumA X) eqEsubv sub0v andbT -limg_amulr.
-  apply/subvP=> _ /memv_capP[/memv_imgP[a Aa ->]]; rewrite lfunE /= => AXay.
+  apply/subvP=> _ /memv_capP[/memv_imgP[a Aa ->]]/[!lfunE]/= AXay.
   rewrite memv0 (mulIr_eq0 a (mulIr _)) ?fieldT //.
   apply: contraR notAXy => /fieldT-Ua; rewrite -[y](mulKr Ua) /sumA.
   by rewrite -big_distrr -(prodv_id A) /= -prodvA big_distrr memv_mul ?memvV.

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -609,7 +609,7 @@ pose C u := 'C[ofG u]%AS; pose Q := 'C(L)%AS; pose q := (p ^ \dim Q)%N.
 have defC u: 'C[u] =i projG (C u).
   by move=> v; rewrite cent1E !inE (sameP cent1vP eqP).
 have defQ: 'Z(G) =i projG Q.
-  move=> u; rewrite !inE.
+  move=> u /[!inE].
   apply/centP/centvP=> cGu v _; last exact/val_inj/cGu/memvf.
   by have [-> | /inG/cGu[]] := eqVneq v 0; first by rewrite commr0.
 have q_gt1: (1 < q)%N by rewrite (ltn_exp2l 0) ?prime_gt1 ?adim_gt0.

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -1159,7 +1159,7 @@ Lemma splitting_normalField E K :
           (normalField K E).
 Proof.
 move=> sKE; apply: (iffP idP) => [nKE| [p Kp [rs Dp defE]]]; last first.
-  apply/forall_inP=> g; rewrite inE kAutE => /andP[homKg _].
+  apply/forall_inP=> g /[!(inE, kAutE)] /andP[homKg _].
   rewrite -dimv_leqif_eq ?limg_dim_eq ?(eqP (AEnd_lker0 g)) ?capv0 //.
   rewrite -defE aimg_adjoin_seq; have [_ /fixedSpace_limg->] := andP homKg.
   apply/adjoin_seqSr=> _ /mapP[a rs_a ->].
@@ -1460,7 +1460,7 @@ exists w => [//|]; split=> [||gA].
   pose kv := \col_i k_ i.
   transitivity (kv j 0 * tnth w j); first by rewrite !mxE.
   suffices{j}/(canRL (mulKmx uM))->: M w *m kv = 0 by rewrite mulmx0 mxE mul0r.
-  apply/colP=> i; rewrite !mxE; pose Ai := nth 1%g (enum A) i.
+  apply/colP=> i /[!mxE]; pose Ai := nth 1%g (enum A) i.
   transitivity (Ai (\sum_j kw_ j)); last by rewrite sum_kw_0 rmorph0.
   rewrite rmorph_sum; apply: eq_bigr => j _; rewrite !mxE /= -/Ai.
   rewrite Dk_ mulrC rmorphM /=; congr (_ * _).
@@ -1473,7 +1473,7 @@ apply/subvP=> w0 Ew0; apply/memv_sumP.
 pose wv := \col_(i < #|A|) enum_val i w0; pose v := invmx (M w) *m wv.
 exists (fun i => tnth w i * v i 0) => [i _|]; last first.
   transitivity (wv (iG 1%g) 0); first by rewrite mxE enum_rankK_in ?gal_id.
-  rewrite -[wv](mulKVmx uM) -/v; rewrite mxE; apply: eq_bigr => i _.
+  rewrite -[wv](mulKVmx uM) -/v mxE; apply: eq_bigr => i _.
   by congr (_ * _); rewrite !mxE -enum_val_nth enum_rankK_in ?gal_id.
 rewrite mulrC memv_mul ?memv_line //; apply/fixedFieldP=> [|x Gx].
   rewrite mxE rpred_sum // => j _; rewrite !mxE rpredM //; last exact: memv_gal.
@@ -1485,7 +1485,7 @@ rewrite mulrC memv_mul ?memv_line //; apply/fixedFieldP=> [|x Gx].
 suffices{i} {2}<-: map_mx x v = v by rewrite [map_mx x v i 0]mxE.
 have uMx: map_mx x (M w) \in unitmx by rewrite map_unitmx.
 rewrite map_mxM map_invmx /=; apply: canLR {uMx}(mulKmx uMx) _.
-apply/colP=> i; rewrite !mxE; pose ix := iG (enum_val i * x)%g.
+apply/colP=> i /[!mxE]; pose ix := iG (enum_val i * x)%g.
 have Dix b: b \in E -> enum_val ix b = x (enum_val i b).
   by move=> Eb; rewrite enum_rankK_in ?groupM ?enum_valP // galM ?lfunE.
 transitivity ((M w *m v) ix 0); first by rewrite mulKVmx // mxE Dix.

--- a/mathcomp/field/separable.v
+++ b/mathcomp/field/separable.v
@@ -565,7 +565,7 @@ have KyxEqKx: (<< <<K; q.[x]>>; x>> = <<K; x>>)%VS.
   apply/eqP; rewrite eqEsubv andbC adjoinSl ?subv_adjoin //=.
   apply/FadjoinP/andP; rewrite memv_adjoin andbT.
   by apply/FadjoinP/andP; rewrite subv_adjoin mempx_Fadjoin.
-have:= extendDerivationP derD sepFyx; rewrite KyxEqKx => derDx.
+have /[!KyxEqKx] derDx := extendDerivationP derD sepFyx.
 rewrite -horner_comp (Derivation_horner derDx) ?memv_adjoin //; last first.
   by apply: (polyOverSv (subv_adjoin _ _)); apply: polyOver_comp.
 set Dx_p := map_poly _; have Dx_p_0 t: t \is a polyOver K -> (Dx_p t).[x] = 0.
@@ -730,7 +730,7 @@ have h0M: {morph h0: ij1 ij2 / (ij1 * ij2)%g >-> ij1 * ij2}.
   by rewrite /h0 => [] [i1 j1] [i2 j2] /=; rewrite mulrACA -!exprD !expr_mod.
 have memH ij: (ij \in H) = (h0 ij == 1).
   rewrite /= gen_set_id ?inE //; apply/group_setP; rewrite inE [h0 _]mulr1.
-  by split=> // ? ?; rewrite !inE h0M => /eqP-> /eqP->; rewrite mulr1.
+  by split=> // ? ? /[!(inE, h0M)] /eqP-> /eqP->; rewrite mulr1.
 have nH ij: ij \in 'N(H)%g.
   by apply/(subsetP (cent_sub _))/centP=> ij1 _; congr (_, _); rewrite Zp_mulgC.
 have hE ij: h (coset H ij) = h0 ij.

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -334,7 +334,7 @@ by rewrite inE xfix.
 Qed.
 
 Lemma afixS A B : A \subset B -> 'Fix_to(B) \subset 'Fix_to(A).
-Proof. by move=> sAB; apply/subsetP=> u; rewrite !inE; apply: subset_trans. Qed.
+Proof. by move=> sAB; apply/subsetP=> u /[!inE]; apply: subset_trans. Qed.
 
 Lemma afixU A B : 'Fix_to(A :|: B) = 'Fix_to(A) :&: 'Fix_to(B).
 Proof. by apply/setP=> x; rewrite !inE subUset. Qed.
@@ -351,13 +351,12 @@ Proof. by move=> a /setIP[]. Qed.
 Lemma astab_act S a x : a \in 'C(S | to) -> x \in S -> to x a = x.
 Proof.
 rewrite 2!inE => /andP[_ cSa] Sx; apply/eqP.
-by have:= subsetP cSa x Sx; rewrite inE.
+by have /[1!inE] := subsetP cSa x Sx.
 Qed.
 
 Lemma astabS S1 S2 : S1 \subset S2 -> 'C(S2 | to) \subset 'C(S1 | to).
 Proof.
-move=> sS12; apply/subsetP=> x; rewrite !inE => /andP[->].
-exact: subset_trans.
+by move=> sS12; apply/subsetP=> x /[!inE] /andP[->]; apply: subset_trans.
 Qed.
 
 Lemma astabsIdom S : 'N_D(S | to) = 'N(S | to).
@@ -424,7 +423,7 @@ Proof.
 move=> sAD; apply/subsetP/subsetP=> [sAC x xS | sSF a aA].
   by apply/afixP=> a aA; apply: astab_act (sAC _ aA) xS.
 rewrite !inE (subsetP sAD _ aA); apply/subsetP=> x xS.
-by move/afixP/(_ _ aA): (sSF _ xS); rewrite inE => ->.
+by move/afixP/(_ _ aA): (sSF _ xS) => /[1!inE] ->.
 Qed.
 
 Section ActsSetop.
@@ -728,7 +727,7 @@ Qed.
 Lemma acts_subnorm_fix A : [acts 'N_D(A), on 'Fix_to(D :&: A) | to].
 Proof.
 apply/subsetP=> a nAa; have [Da _] := setIP nAa; rewrite !inE Da.
-apply/subsetP=> x Cx; rewrite inE; apply/afixP=> b DAb.
+apply/subsetP=> x Cx /[1!inE]; apply/afixP=> b DAb.
 have [Db _]:= setIP DAb; rewrite -actMin // conjgCV  actMin ?groupJ ?groupV //.
 by rewrite /= (afixP Cx) // memJ_norm // groupV (subsetP (normsGI _ _) _ nAa).
 Qed.
@@ -1000,7 +999,7 @@ Proof. by rewrite mulnC card_orbit Lagrange ?subsetIl. Qed.
 Lemma actsP A S : reflect {acts A, on S | to} [acts A, on S | to].
 Proof.
 apply: (iffP idP) => [nSA x|nSA]; first exact: acts_act.
-by apply/subsetP=> a Aa; rewrite !inE; apply/subsetP=> x; rewrite inE nSA.
+by apply/subsetP=> a Aa /[!inE]; apply/subsetP=> x; rewrite inE nSA.
 Qed.
 Arguments actsP {A S}.
 
@@ -1198,8 +1197,8 @@ Proof. by rewrite /= /actby => -> ->. Qed.
 Lemma afix_actby B : 'Fix_<[nRA]>(B) = ~: R :|: 'Fix_to(A :&: B).
 Proof.
 apply/setP=> x; rewrite !inE /= /actby.
-case: (x \in R); last by apply/subsetP=> a _; rewrite !inE.
-apply/subsetP/subsetP=> [cBx a | cABx a Ba]; rewrite !inE.
+case: (x \in R); last by apply/subsetP=> a _ /[!inE].
+apply/subsetP/subsetP=> [cBx a | cABx a Ba] /[!inE].
   by case/andP=> Aa /cBx; rewrite inE Aa.
 by case: ifP => //= Aa; have:= cABx a; rewrite !inE Aa => ->.
 Qed.
@@ -1268,7 +1267,7 @@ Lemma astab_subact S : 'C(S | subaction) = subact_dom :&: 'C(val @: S | to).
 Proof.
 apply/setP=> a; rewrite inE in_setI; apply: andb_id2l => sDa.
 have [Da _] := setIP sDa; rewrite !inE Da.
-apply/subsetP/subsetP=> [cSa _ /imsetP[x Sx ->] | cSa x Sx]; rewrite !inE.
+apply/subsetP/subsetP=> [cSa _ /imsetP[x Sx ->] | cSa x Sx] /[!inE].
   by have:= cSa x Sx; rewrite inE -val_eqE val_subact sDa.
 by have:= cSa _ (imset_f val Sx); rewrite inE -val_eqE val_subact sDa.
 Qed.
@@ -1277,9 +1276,9 @@ Lemma astabs_subact S : 'N(S | subaction) = subact_dom :&: 'N(val @: S | to).
 Proof.
 apply/setP=> a; rewrite inE in_setI; apply: andb_id2l => sDa.
 have [Da _] := setIP sDa; rewrite !inE Da.
-apply/subsetP/subsetP=> [nSa _ /imsetP[x Sx ->] | nSa x Sx]; rewrite !inE.
-  by have:= nSa x Sx; rewrite inE => /(imset_f val); rewrite val_subact sDa.
-have:= nSa _ (imset_f val Sx); rewrite inE => /imsetP[y Sy def_y].
+apply/subsetP/subsetP=> [nSa _ /imsetP[x Sx ->] | nSa x Sx] /[!inE].
+  by have /[1!inE]/(imset_f val) := nSa x Sx; rewrite val_subact sDa.
+have /[1!inE]/imsetP[y Sy def_y] := nSa _ (imset_f val Sx).
 by rewrite ((_ a =P y) _) // -val_eqE val_subact sDa def_y.
 Qed.
 
@@ -1288,7 +1287,7 @@ Lemma afix_subact A :
 Proof.
 move/subsetP=> sAD; apply/setP=> u.
 rewrite !inE !(sameP setIidPl eqP); congr (_ == A).
-apply/setP=> a; rewrite !inE; apply: andb_id2l => Aa.
+apply/setP=> a /[!inE]; apply: andb_id2l => Aa.
 by rewrite -val_eqE val_subact sAD.
 
 Qed.
@@ -1491,7 +1490,7 @@ Proof. exact: actpermE. Qed.
 
 Lemma ker_actperm : 'ker actperm = 'C(setT | to).
 Proof.
-congr (_ :&: _); apply/setP=> a; rewrite !inE /=.
+congr (_ :&: _); apply/setP=> a /[!inE]/=.
 apply/eqP/subsetP=> [a1 x _ | a1]; first by rewrite inE -actpermE a1 perm1.
 by apply/permP=> x; apply/eqP; have:= a1 x; rewrite !inE actpermE perm1 => ->.
 Qed.
@@ -1570,7 +1569,7 @@ Definition comp_act x e := to x (f e).
 Lemma comp_is_action : is_action (f @*^-1 D) comp_act.
 Proof.
 split=> [e | x e1 e2]; first exact: act_inj.
-case/morphpreP=> Be1 Dfe1; case/morphpreP=> Be2 Dfe2.
+move=> /morphpreP[Be1 Dfe1] /morphpreP[Be2 Dfe2].
 by rewrite /comp_act morphM ?actMin.
 Qed.
 Canonical comp_action := Action comp_is_action.
@@ -1581,9 +1580,8 @@ Lemma afix_comp (A : {set gT}) :
   A \subset B -> 'Fix_comp_action(A) = 'Fix_to(f @* A).
 Proof.
 move=> sAB; apply/setP=> x; rewrite !inE /morphim (setIidPr sAB).
-apply/subsetP/subsetP=> [cAx _ /imsetP[a Aa ->] | cfAx a Aa].
-  by move/cAx: Aa; rewrite !inE.
-by rewrite inE; move/(_ (f a)): cfAx; rewrite inE imset_f // => ->.
+apply/subsetP/subsetP; first by move=> + _ /imsetP[a + ->] => /[apply]/[!inE].
+by move=> + a Aa => /(_ (f a)); rewrite !inE imset_f// => ->.
 Qed.
 
 Lemma astab_comp S : 'C(S | comp_action) = f @*^-1 'C(S | to).
@@ -2084,7 +2082,7 @@ apply/subsetP=> a nSa; have Da := astabs_dom nSa; rewrite !inE Da.
 apply: subset_trans (_ : <<S>> \subset actm to a @*^-1 <<S>>) _.
   rewrite gen_subG subsetI sSR; apply/subsetP=> x Sx.
   by rewrite inE /= actmE ?mem_gen // astabs_act.
-by apply/subsetP=> x; rewrite !inE; case/andP=> Rx; rewrite /= actmE.
+by apply/subsetP=> x /[!inE]; case/andP=> Rx; rewrite /= actmE.
 Qed.
 
 Lemma acts_joing A M N :
@@ -2190,7 +2188,7 @@ move=> sHR; apply/setP=> a; apply/idP/idP=> nHa; have Da := astabs_dom nHa.
   have /rcosetsP[y Ny defHy]: to^~ a @: H \in rcosets H 'N(H).
     by rewrite (astabs_act _ nHa); apply/rcosetsP; exists 1; rewrite ?mulg1.
   by rewrite (rcoset_eqP (_ : 1 \in H :* y)) -defHy -1?(gact1 Da) mem_setact.
-rewrite !inE Da; apply/subsetP=> Hx; rewrite inE => /rcosetsP[x Nx ->{Hx}].
+rewrite !inE Da; apply/subsetP=> Hx /[1!inE] /rcosetsP[x Nx ->{Hx}].
 apply/imsetP; exists (to x a).
   case Rx: (x \in R); last by rewrite gact_out ?Rx.
   rewrite inE; apply/subsetP=> _ /imsetP[y Hy ->].
@@ -2435,8 +2433,7 @@ Canonical conjg_action := TotalAction (@conjg1 gT) (@conjgM gT).
 
 Lemma conjg_is_groupAction : is_groupAction setT conjg_action.
 Proof.
-move=> a _; rewrite /= inE; apply/andP; split.
-  by apply/subsetP=> x _; rewrite inE.
+move=> a _; rewrite inE; apply/andP; split; first by apply/subsetP=> x /[1!inE].
 by apply/morphicP=> x y _ _; rewrite !actpermE /= conjMg.
 Qed.
 

--- a/mathcomp/fingroup/automorphism.v
+++ b/mathcomp/fingroup/automorphism.v
@@ -95,7 +95,7 @@ Lemma ker_autm : 'ker f = 1. Proof. by move/trivgP: injm_autm. Qed.
 Lemma im_autm : f @* G = G.
 Proof.
 apply/setP=> x; rewrite morphimEdom (can_imset_pre _ (permK a)) inE.
-by have:= AutGa; rewrite inE => /andP[/perm_closed <-]; rewrite permKV.
+by have /[1!inE] /andP[/perm_closed <-] := AutGa; rewrite permKV.
 Qed.
 
 Lemma Aut_closed x : x \in G -> a x \in G.
@@ -324,7 +324,7 @@ Canonical conj_aut_morphism := Morphism conj_aut_morphM.
 
 Lemma ker_conj_aut : 'ker conj_aut = 'C(G).
 Proof.
-apply/setP=> x; rewrite inE; case nGx: (x \in 'N(G)); last first.
+apply/setP=> x /[1!inE]; case nGx: (x \in 'N(G)); last first.
   by symmetry; apply/idP=> cGx; rewrite (subsetP (cent_sub G)) in nGx.
 rewrite 2!inE /=; apply/eqP/centP=> [cx1 y Gy | cGx].
   by rewrite /commute (conjgC y) -norm_conj_autE // cx1 perm1.

--- a/mathcomp/fingroup/fingroup.v
+++ b/mathcomp/fingroup/fingroup.v
@@ -666,7 +666,7 @@ Lemma repr_set1 x : repr [set x] = x.
 Proof. by apply/set1P/card_mem_repr; rewrite cards1. Qed.
 
 Lemma repr_set0 : repr set0 = 1.
-Proof. by rewrite /repr; case: pickP => [x|_]; rewrite !inE. Qed.
+Proof. by rewrite /repr; case: pickP => [x|_] /[!inE]. Qed.
 
 End Repr.
 

--- a/mathcomp/fingroup/gproduct.v
+++ b/mathcomp/fingroup/gproduct.v
@@ -1003,9 +1003,8 @@ Canonical prod_group := FinGroupType extprod_mulVg.
 
 Lemma group_setX (H1 : {group gT1}) (H2 : {group gT2}) : group_set (setX H1 H2).
 Proof.
-apply/group_setP; split; first by rewrite inE !group1.
-case=> [x1 x2] [y1 y2]; rewrite !inE; case/andP=> Hx1 Hx2; case/andP=> Hy1 Hy2.
-by rewrite /= !groupM.
+apply/group_setP; split; first by rewrite !inE !group1.
+by case=> [x1 x2] [y1 y2] /[!inE] /andP[Hx1 Hx2] /andP[Hy1 Hy2] /[!groupM].
 Qed.
 
 Canonical setX_group H1 H2 := Group (group_setX H1 H2).
@@ -1050,7 +1049,7 @@ Lemma morphim_fstX (H1: {set gT1}) (H2 : {group gT2}) :
 Proof.
 apply/eqP; rewrite eqEsubset morphimE setTI /=.
 apply/andP; split; apply/subsetP=> x.
-  by case/imsetP=> x0; rewrite inE; move/andP=> [Hx1 _] ->.
+  by case/imsetP=> x0 /[1!inE] /andP[Hx1 _] ->.
 move=> Hx1; apply/imsetP; exists (x, 1); last by trivial.
 by rewrite in_setX Hx1 /=.
 Qed.
@@ -1060,7 +1059,7 @@ Lemma morphim_sndX (H1: {group gT1}) (H2 : {set gT2}) :
 Proof.
 apply/eqP; rewrite eqEsubset morphimE setTI /=.
 apply/andP; split; apply/subsetP=> x.
-  by case/imsetP=> x0; rewrite inE; move/andP=> [_ Hx2] ->.
+  by case/imsetP=> x0 /[1!inE] /andP[_ Hx2] ->.
 move=> Hx2; apply/imsetP; exists (1, x); last by [].
 by rewrite in_setX Hx2 andbT.
 Qed.
@@ -1080,7 +1079,7 @@ Lemma setX_dprod (H1 : {group gT1}) (H2 : {group gT2}) :
   setX H1 1 \x setX 1 H2 = setX H1 H2.
 Proof.
 rewrite dprodE ?setX_prod //.
-  apply/centsP=> [[x u]]; rewrite !inE /= => /andP[/eqP-> _] [v y].
+  apply/centsP=> [[x u]] /[!inE]/= /andP[/eqP-> _] [v y].
   by rewrite !inE /= => /andP[_ /eqP->]; congr (_, _); rewrite ?mul1g ?mulg1.
 apply/trivgP; apply/subsetP=> [[x y]]; rewrite !inE /= -!andbA.
 by case/and4P=> _ /eqP-> /eqP->; rewrite eqxx.

--- a/mathcomp/fingroup/morphism.v
+++ b/mathcomp/fingroup/morphism.v
@@ -364,7 +364,7 @@ Lemma morphpreI R S : f @*^-1 (R :&: S) = f @*^-1 R :&: f @*^-1 S.
 Proof. by rewrite -setIIr -preimsetI. Qed.
 
 Lemma morphpreD R S : f @*^-1 (R :\: S) = f @*^-1 R :\: f @*^-1 S.
-Proof. by apply/setP=> x; rewrite !inE; case: (x \in D). Qed.
+Proof. by apply/setP=> x /[!inE]; case: (x \in D). Qed.
 
 (* kernel, domain properties *)
 
@@ -396,7 +396,7 @@ Proof. by move=> Dx Dy eqfxy; apply/rcosetP; apply/rcoset_kerP. Qed.
 
 Lemma ker_norm : D \subset 'N('ker f).
 Proof.
-apply/subsetP=> x Dx; rewrite inE; apply/subsetP=> _ /imsetP[y Ky ->].
+apply/subsetP=> x Dx /[1!inE]; apply/subsetP=> _ /imsetP[y Ky ->].
 by rewrite !inE groupJ ?morphJ // ?dom_ker //= mker ?conj1g.
 Qed.
 
@@ -660,8 +660,7 @@ Proof. exact: morphim_cents. Qed.
 
 Lemma morphpre_norm R : f @*^-1 'N(R) \subset 'N(f @*^-1 R).
 Proof.
-apply/subsetP=> x; rewrite !inE => /andP[Dx Nfx].
-by rewrite -morphpreJ ?morphpreS.
+by apply/subsetP=> x /[!inE] /andP[Dx Nfx]; rewrite -morphpreJ ?morphpreS.
 Qed.
 
 Lemma morphpre_norms R S : R \subset 'N(S) -> f @*^-1 R \subset 'N(f @*^-1 S).
@@ -1071,7 +1070,7 @@ Qed.
 
 Lemma morphpre_factm (C : {set rT}) : ff @*^-1 C =  q @* (f @*^-1 C).
 Proof.
-apply/setP=> y; rewrite !inE /=; apply/andP/morphimP=> [[]|[x Hx]]; last first.
+apply/setP=> y /[!inE]/=; apply/andP/morphimP=> [[]|[x Hx]]; last first.
   by case/morphpreP=> Gx Cfx ->; rewrite factmE ?imset_f ?inE ?Hx.
 case/morphimP=> x Hx Gx ->; rewrite factmE //.
 by exists x; rewrite // !inE Gx.

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -544,8 +544,7 @@ Definition Sym : {set {perm T}} := [set s | perm_on S s].
 
 Lemma Sym_group_set : group_set Sym.
 Proof.
-apply/group_setP; split => [| s t]; rewrite !inE;
-   [exact: perm_on1 | exact: perm_onM].
+apply/group_setP; split => [|s t] /[!inE]; [exact: perm_on1 | exact: perm_onM].
 Qed.
 Canonical Sym_group : {group {perm T}} := Group Sym_group_set.
 
@@ -688,7 +687,7 @@ Lemma isom_cast_perm m n eq_m_n : isom setT setT (@cast_perm m n eq_m_n).
 Proof.
 case: {n} _ / eq_m_n; apply/isomP; split.
   exact/injmP/(in2W (@cast_perm_inj _ _ _)).
-by apply/setP => /= s; rewrite !inE; apply/imsetP; exists s; rewrite ?inE.
+by apply/setP => /= s /[!inE]; apply/imsetP; exists s; rewrite ?inE.
 Qed.
 
 End CastSn.

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -348,7 +348,7 @@ by apply: cprod_exponent; rewrite cprodE.
 Qed.
 
 Lemma sub_LdivT A n : (A \subset 'Ldiv_n()) = (exponent A %| n).
-Proof. by apply/subsetP/exponentP=> eAn x /eAn; rewrite inE => /eqP. Qed.
+Proof. by apply/subsetP/exponentP=> eAn x /eAn /[1!inE] /eqP. Qed.
 
 Lemma LdivT_J n x : 'Ldiv_n() :^ x = 'Ldiv_n().
 Proof.
@@ -495,7 +495,7 @@ Arguments pElemP {p A E}.
 
 Lemma pElemS p A B : A \subset B -> 'E_p(A) \subset 'E_p(B).
 Proof.
-by move=> sAB; apply/subsetP=> E; rewrite !inE => /andP[/subset_trans->].
+by move=> sAB; apply/subsetP=> E /[!inE] /andP[/subset_trans->].
 Qed.
 
 Lemma pElemI p A B : 'E_p(A :&: B) = 'E_p(A) :&: subgroups B.
@@ -709,7 +709,7 @@ Qed.
 Lemma pmaxElemS p A B :
   A \subset B -> 'E*_p(B) :&: subgroups A \subset 'E*_p(A).
 Proof.
-move=> sAB; apply/subsetP=> E; rewrite !inE.
+move=> sAB; apply/subsetP=> E /[!inE].
 case/andP=> /maxgroupP[/pElemP[_ abelE] maxE] sEA.
 apply/maxgroupP; rewrite inE sEA; split=> // D EpD.
 by apply: maxE; apply: subsetP EpD; apply: pElemS.
@@ -774,7 +774,7 @@ Qed.
 Lemma p_rank_abelem p G : p.-abelem G -> 'r_p(G) = logn p #|G|.
 Proof.
 move=> abelG; apply/eqP; rewrite eqn_leq andbC (bigmax_sup G) //.
-  by apply/bigmax_leqP=> E; rewrite inE => /andP[/lognSg->].
+  by apply/bigmax_leqP=> E /[1!inE] /andP[/lognSg->].
 by rewrite inE subxx.
 Qed.
 
@@ -803,7 +803,7 @@ Qed.
 Lemma p_rank_Sylow p G H : p.-Sylow(G) H -> 'r_p(H) = 'r_p(G).
 Proof.
 move=> sylH; apply/eqP; rewrite eqn_leq (p_rankS _ (pHall_sub sylH)) /=.
-apply/bigmax_leqP=> E; rewrite inE => /andP[sEG abelE].
+apply/bigmax_leqP=> E /[1!inE] /andP[sEG abelE].
 have [P sylP sEP] := Sylow_superset sEG (abelem_pgroup abelE).
 have [x _ ->] := Sylow_trans sylP sylH.
 by rewrite p_rankJ -(p_rank_abelem abelE) (p_rankS _ sEP).
@@ -889,7 +889,7 @@ Proof.
 apply: (iffP idP) => [|[E]].
   have [p _ ->] := rank_witness G; case/p_rank_geP=> E.
   by rewrite def_pnElem; case/setIP; exists E.
-case/nElemP=> p; rewrite inE => /andP[EpG_E /eqP <-].
+case/nElemP=> p /[1!inE] /andP[EpG_E /eqP <-].
 by rewrite (leq_trans (logn_le_p_rank EpG_E)) ?p_rank_le_rank.
 Qed.
 
@@ -1159,13 +1159,13 @@ Qed.
 
 Lemma OhmS H G : H \subset G -> 'Ohm_n(H) \subset 'Ohm_n(G).
 Proof.
-move=> sHG; apply: genS; apply/subsetP=> x; rewrite !inE => /andP[Hx ->].
+move=> sHG; apply: genS; apply/subsetP=> x /[!inE] /andP[Hx ->].
 by rewrite (subsetP sHG).
 Qed.
 
 Lemma OhmE p G : p.-group G -> 'Ohm_n(G) = <<'Ldiv_(p ^ n)(G)>>.
 Proof.
-move=> pG; congr <<_>>; apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+move=> pG; congr <<_>>; apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 have [-> | ntx] := eqVneq x 1; first by rewrite !expg1n.
 by rewrite (pdiv_p_elt (mem_p_elt pG Gx)).
 Qed.
@@ -1344,8 +1344,7 @@ Implicit Types (A B C : {set gT}) (D G H E : {group gT}).
 
 Lemma Ohm0 G : 'Ohm_0(G) = 1.
 Proof.
-apply/trivgP; rewrite /= gen_subG.
-by apply/subsetP=> x /setIdP[_]; rewrite inE.
+by apply/trivgP; rewrite /= gen_subG; apply/subsetP=> x /setIdP[_] /[1!inE].
 Qed.
 
 Lemma Ohm_leq m n G : m <= n -> 'Ohm_m(G) \subset 'Ohm_n(G).

--- a/mathcomp/solvable/alt.v
+++ b/mathcomp/solvable/alt.v
@@ -343,7 +343,7 @@ have p1x_x: p1 x = x by apply: fix_p1.
 have{le_p_n} lt_p1_n: #|[set x | p1 x != x]| < n.
   move: le_p_n; rewrite ltnS (cardsD1 x1) Hx1; apply/leq_trans/subset_leq_card.
   rewrite subsetD1 inE permM tpermR eqxx andbT.
-  by apply/subsetP=> y; rewrite !inE; apply: contraNneq=> /fix_p1->.
+  by apply/subsetP=> y /[!inE]; apply: contraNneq=> /fix_p1->.
 transitivity (p1 (+) true); last first.
   by rewrite odd_permM odd_tperm -Hx1 inE eq_sym addbK.
 have ->: p = p1 * tperm x1 (p x1) by rewrite -tpermV mulgK.
@@ -364,7 +364,7 @@ have rfd_rgd p: rfd (rgd p) = p.
   apply/permP => [[z Hz]]; apply/val_eqP; rewrite !permE.
   by rewrite /= [rgd _ _]permE /= insubF eqxx // permE /= insubT.
 have sSd: 'C_('Alt_T)[x | 'P] \subset 'dom rfd.
-  by apply/subsetP=> p; rewrite !inE /=; case/andP.
+  by apply/subsetP=> p /[!inE]/= /andP[].
 apply/isogP; exists [morphism of restrm sSd rfd] => /=; last first.
   rewrite morphim_restrm setIid; apply/setP=> z; apply/morphimP/idP=> [[p _]|].
     case/setIP; rewrite Alt_even => Hp; move/astab1P=> Hp1 ->.

--- a/mathcomp/solvable/burnside_app.v
+++ b/mathcomp/solvable/burnside_app.v
@@ -128,8 +128,7 @@ Qed.
 
 Lemma rot_is_rot : rot = rotations.
 Proof.
-apply/setP=> r; apply/idP/idP; last by move/rotations_is_rot; rewrite inE.
-rewrite !inE => h.
+apply/setP=> r; apply/idP/idP => [|/rotations_is_rot] /[!inE]// h.
 have -> : r = r1 ^+ (r c0) by apply: rot_eq_c0; rewrite // -rot_r1.
 have e2: 2 = r2 c0 by rewrite permE /=.
 have e3: 3 = r3 c0 by rewrite permE /=.
@@ -381,12 +380,11 @@ move=> x y z t Uxt; rewrite -[n]card_ord.
 pose f (p : col_squares) := (p x, p z); rewrite -(@card_in_image _ _ f).
   rewrite -mulnn -card_prod; apply: eq_card => [] [c d] /=; apply/imageP.
   rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-  rewrite /= !orbF !andbT; case/norP; rewrite !inE => nxzt nyzt _.
+  rewrite /= !orbF !andbT => /norP[] /[!inE] nxzt nyzt _.
   exists [ffun i => if pred2 x y i then c else d].
     by rewrite inE !ffunE /= !eqxx orbT (negbTE nxzt) (negbTE nyzt) !eqxx.
   by rewrite {}/f !ffunE /= eqxx (negbTE nxzt).
-move=> p1 p2; rewrite !inE.
-case/andP=> p1y p1t; case/andP=> p2y p2t [px pz].
+move=> p1 p2 /[!inE] /andP[p1y p1t] /andP[p2y p2t] [px pz].
 have eqp12: all (fun i => p1 i == p2 i) [:: x; y; z; t].
   by rewrite /= -(eqP p1y) -(eqP p1t) -(eqP p2y) -(eqP p2t) px pz !eqxx.
 apply/ffunP=> i; apply/eqP; apply: (allP eqp12).
@@ -833,10 +831,10 @@ Canonical diso_group3 := Group group_set_diso3.
 
 Lemma gen_diso3 :  dir_iso3 = <<[set r05; r14]>>.
 Proof.
-apply/setP; apply/subset_eqP; apply/andP; split; first last.
-  by rewrite gen_subG; apply/subsetP => x; rewrite !inE;
-    case/orP; move/eqP ->; rewrite eqxx !orbT.
-apply/subsetP => x; rewrite !inE.
+apply/setP/subset_eqP/andP; split; first last.
+  rewrite gen_subG; apply/subsetP.
+  by move=> x /[!inE] /orP[] /eqP->; rewrite !eqxx !orbT.
+apply/subsetP => x /[!inE].
 have -> : s05 = r05 * r05  by iso_tac.
 have -> : s14 = r14 * r14  by iso_tac.
 have -> : s23 = r14 * r14 * r05 * r05 by iso_tac.
@@ -858,7 +856,7 @@ have -> : s3 = r05 * r14 * r05 by iso_tac.
 have -> : s4 = r05 * r14  * r14 * r14 * r05 by iso_tac.
 have -> : s5 = r14  * r05 * r05 by iso_tac.
 have -> : s6 = r05 * r05 * r14 by iso_tac.
-by do ?case/predU1P=> [<-|]; first exact: group1; last (move/eqP => <-);
+by do ?case/predU1P=> [<-|]; first exact: group1; last (move/eqP<-);
    rewrite ?groupMl ?mem_gen // !inE eqxx ?orbT.
 Qed.
 
@@ -1145,70 +1143,59 @@ move: (cardC (mem [:: x; y; z; t; u])); rewrite card_ord => hcard5.
 have: #|[predC [:: x; y; z; t; u]]| !=0.
   rewrite -lt0n  -(ltn_add2l #|[:: x; y; z; t; u]|) hcard5 addn0.
   by apply: (leq_ltn_trans (card_size [:: x; y; z; t; u])).
-case/existsP=> v; rewrite inE (mem_cat _ [:: _; _; _; _]).
-case/norP=> Hv Huv; exists v.
-rewrite (cat_uniq [:: x; y; z; t]) Uxt andTb.
+case/existsP => v; rewrite inE (mem_cat _ [:: _; _; _; _]) => /norP[Hv Huv].
+exists v; rewrite (cat_uniq [:: x; y; z; t]) Uxt andTb.
 by rewrite -rev_uniq /= negb_or Hu orbF Hv Huv.
 Qed.
 
 Lemma card_n4 : forall x y z t : cube, uniq [:: x; y; z; t] ->
    #|[set p : col_cubes | (p x == p y) && (p z == p t)]| = (n ^ 4)%N.
 Proof.
-move=> x y z t  Uxt. rewrite -[n]card_ord .
-case: (uniq4_uniq6 Uxt) => u; case=> v Uxv.
-pose ff (p : col_cubes) := (p x, p z, p u , p v).
+move=> x y z t Uxt; rewrite -[n]card_ord.
+case: (uniq4_uniq6 Uxt) => u [v Uxv].
+pose ff (p : col_cubes) := (p x, p z, p u, p v).
 rewrite -(@card_in_image _ _ ff); first last.
-  move=> p1 p2; rewrite !inE.
-  case/andP=> p1y p1t; case/andP=> p2y p2t  [px pz] pu pv.
-  have eqp12: all (fun i => p1 i == p2 i) [:: x; y; z; t; u; v].
+  move=> p1 p2 /[!inE] /andP[p1y p1t] /andP[p2y p2t] [px pz] pu pv.
+  have eqp12 : all (fun i => p1 i == p2 i) [:: x; y; z; t; u; v].
    by rewrite /= -(eqP p1y) -(eqP p1t) -(eqP p2y) -(eqP p2t) px pz pu pv !eqxx.
   apply/ffunP=> i; apply/eqP; apply: (allP eqp12).
   by rewrite (subset_cardP _ (subset_predT _)) // (card_uniqP Uxv) card_ord.
-have ->:forall n, (n ^ 4)%N= (n*n*n*n)%N.
-  by move=> n0; rewrite (expnD n0 2 2) -mulnn mulnA.
-rewrite -!card_prod; apply: eq_card => [] [[[c d]e ]g] /=; apply/imageP.
-rewrite (cat_uniq [::x; y; z; t]) in Uxv; case/and3P: Uxv => _ hasxt.
-rewrite /= !inE andbT.
-move/negbTE=> nuv .
-rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-rewrite /= !andbT orbF; case/norP; rewrite !inE => nxyz nxyt _.
-move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE orbA.
-case/norP  => nxyu nztu.
-rewrite orbA; case/norP=> nxyv nztv.
+have -> : forall n, (n ^ 4 = n * n * n * n)%N by move=> ?; rewrite -!mulnA.
+rewrite -!card_prod; apply: eq_card => [] [[[c d] e] g] /=; apply/imageP => /=.
+move: Uxv; rewrite (cat_uniq [:: x; y; z; t]) => /and3P[_]/=; rewrite orbF.
+move=> /norP[] /[!inE] + + /andP[/negPf nuv _].
+rewrite orbA => /norP[/negPf nxyu /negPf nztu].
+rewrite orbA => /norP[/negPf nxyv /negPf nztv].
+move: Uxt; rewrite (cat_uniq [::x; y]) => /and3P[_]/= /[!(andbT, orbF)].
+move=> /norP[] /[!inE] /negPf nxyz /negPf nxyt _.
 exists [ffun i => if pred2 x y i then c else if pred2 z t i then d
-                    else if u==i then e else g].
-  rewrite !inE /= !ffunE //= !eqxx orbT //= !eqxx /= orbT.
-  by rewrite (negbTE nxyz) (negbTE nxyt).
-rewrite {}/ff !ffunE /= !eqxx /=.
-rewrite (negbTE nxyz) (negbTE nxyu) (negbTE nztu) (negbTE nxyv) (negbTE nztv).
-by rewrite nuv.
+                  else if u == i then e else g].
+  by rewrite !(inE, ffunE, eqxx,orbT)//= nxyz nxyt.
+by rewrite {}/ff !ffunE /= !eqxx /= nxyz nxyu nztu nxyv nztv nuv.
 Qed.
 
 Lemma card_n3_3 : forall x y z t: cube, uniq [:: x; y; z; t] ->
   #|[set p : col_cubes | (p x == p y) && (p y == p z)&& (p z == p t)]|
       = (n ^ 3)%N.
 Proof.
-move=> x y z t Uxt; rewrite -[n]card_ord .
-case: (uniq4_uniq6 Uxt) => u; case=> v Uxv.
-pose ff (p : col_cubes) := (p x, p u , p v);
-   rewrite -(@card_in_image _ _ ff); first last.
-  move=> p1 p2; rewrite !inE.
-  case/andP; case/andP => p1xy p1yz p1zt.
-  case/andP; case/andP => p2xy p2yz p2zt [px pu] pv.
+move=> x y z t Uxt; rewrite -[n]card_ord.
+case: (uniq4_uniq6 Uxt) => u [v Uxv].
+pose ff (p : col_cubes) := (p x, p u, p v);
+    rewrite -(@card_in_image _ _ ff); first last.
+  move=> p1 p2 /[!inE]; rewrite -!andbA.
+  move=> /and3P[/eqP p1xy /eqP p1yz /eqP p1zt].
+  move=> /and3P[/eqP p2xy /eqP p2yz /eqP p2zt] [px pu] pv.
   have eqp12: all (fun i => p1 i == p2 i) [:: x; y; z; t; u; v].
-    by rewrite /= -(eqP p1zt) -(eqP p2zt) -(eqP p1yz) -(eqP p2yz) -(eqP p1xy)
-     -(eqP p2xy) px pu pv !eqxx.
+    by rewrite /= -p1zt -p2zt -p1yz -p2yz -p1xy -p2xy px pu pv !eqxx.
   apply/ffunP=> i; apply/eqP; apply: (allP eqp12).
   by rewrite (subset_cardP _ (subset_predT _)) // (card_uniqP Uxv) card_ord.
-have ->:forall n, (n ^ 3)%N= (n*n*n)%N.
-  by move=> n0; rewrite (expnD n0 2 1) -mulnn expn1.
-rewrite -!card_prod; apply: eq_card => [] [[c d]e ] /=; apply/imageP.
-rewrite (cat_uniq [::x; y; z; t]) in Uxv; case/and3P: Uxv => _ hasxt.
-rewrite /uniq !inE !andbT; move/negbTE=> nuv.
-exists
-   [ffun i => if (i \in [:: x; y; z; t]) then c else if u == i then d else e].
-  by rewrite /= !inE   !ffunE !inE  !eqxx !orbT !eqxx.
-rewrite {}/ff !ffunE !inE /= !eqxx /=; move: hasxt; rewrite nuv.
+have -> : forall n, (n ^ 3 = n * n * n)%N by move=> ?; rewrite -!mulnA.
+rewrite -!card_prod; apply: eq_card => [] [[c d] e] /=; apply/imageP.
+move: Uxv; rewrite (cat_uniq [::x; y; z; t]) => /and3P[_ hasxt].
+rewrite /uniq !inE !andbT => /negPf nuv.
+exists [ffun i => if i \in [:: x; y; z; t] then c else if u == i then d else e].
+  by rewrite /= !(inE, ffunE, eqxx, orbT).
+rewrite {}/ff !(ffunE, inE, eqxx) /=; move: hasxt; rewrite nuv.
 by do 8![case E: ( _ ==  _ ); rewrite ?(eqP E)/= ?inE ?eqxx //= ?E {E}].
 Qed.
 
@@ -1217,71 +1204,63 @@ Lemma card_n2_3 : forall x y z t u v: cube, uniq [:: x; y; z; t; u; v] ->
                             && (p u== p v)]|  = (n ^ 2)%N.
 Proof.
 move=> x y z t u v  Uxv; rewrite -[n]card_ord .
-pose ff (p : col_cubes) := (p x, p t); rewrite -(@card_in_image _ _ ff); first last.
-  move=> p1 p2; rewrite !inE.
-  case/andP; case/andP; case/andP => p1xy p1yz p1tu p1uv.
-  case/andP; case/andP; case/andP => p2xy p2yz p2tu p2uv [px pu].
+pose ff (p : col_cubes) := (p x, p t).
+rewrite -(@card_in_image _ _ ff); first last.
+  move=> p1 p2 /[!inE]; rewrite -!andbA.
+  move=> /and4P[/eqP p1xy /eqP p1yz /eqP p1tu /eqP p1uv].
+  move=> /and4P[/eqP p2xy/eqP  p2yz /eqP p2tu /eqP p2uv] [px pu].
   have eqp12: all (fun i => p1 i == p2 i) [:: x; y; z; t; u; v].
-    by rewrite /= -(eqP p1yz) -(eqP p2yz) -(eqP p1xy) -(eqP p2xy) -(eqP p1uv)
-      -(eqP p2uv) -(eqP p1tu) -(eqP p2tu) px  pu !eqxx.
+    by rewrite /= -p1yz -p2yz -p1xy -p2xy -p1uv -p2uv -p1tu -p2tu px pu !eqxx.
   apply/ffunP=> i; apply/eqP; apply: (allP eqp12).
   by rewrite (subset_cardP _ (subset_predT _)) // (card_uniqP Uxv) card_ord.
-have ->:forall n, (n ^ 2)%N= (n*n)%N by move=> n0; rewrite -mulnn .
-   rewrite -!card_prod; apply: eq_card => [] [c d]/=; apply/imageP.
-rewrite (cat_uniq [::x; y; z]) in Uxv; case/and3P: Uxv => Uxt hasxt nuv .
-move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE => nxyzt.
-case/norP => nxyzu nxyzv.
-exists [ffun i =>  if (i \in [:: x; y; z] ) then c else  d].
-  rewrite !inE /= !ffunE !inE //= !eqxx !orbT !eqxx //=.
-  by rewrite (negbTE nxyzt) (negbTE nxyzu)(negbTE nxyzv) !eqxx.
-by rewrite {}/ff !ffunE  !inE /= !eqxx /= (negbTE nxyzt).
+rewrite -mulnn -!card_prod; apply: eq_card => [] [c d]/=; apply/imageP.
+move: Uxv; rewrite (cat_uniq [::x; y; z]) => /= /and3P[Uxt + nuv].
+move=> /[!orbF] /norP[] /[!inE] /negPf nxyzt /norP[/negPf nxyzu /negPf nxyzv].
+exists [ffun i =>  if (i \in [:: x; y; z] ) then c else d].
+  by rewrite /= !(inE, ffunE, eqxx, orbT, nxyzt, nxyzu, nxyzv).
+by rewrite {}/ff !ffunE  !inE /= !eqxx /= nxyzt.
 Qed.
 
 Lemma card_n3s : forall x y z t u v: cube, uniq [:: x; y; z; t; u; v] ->
   #|[set p : col_cubes | (p x == p y) && (p z == p t)&& (p u == p v )]|
     = (n ^ 3)%N.
 Proof.
-move=> x y z t u v  Uxv; rewrite -[n]card_ord .
+move=> x y z t u v Uxv; rewrite -[n]card_ord .
 pose ff (p : col_cubes) := (p x, p z, p u).
 rewrite -(@card_in_image _ _ ff); first last.
-  move=> p1 p2; rewrite !inE.
-  case/andP; case/andP =>  p1xy p1zt p1uv.
-  case/andP; case/andP => p2xy p2zt p2uv  [px pz] pu.
+  move=> p1 p2 /[!inE]; rewrite -!andbA.
+  move=> /and3P[/eqP p1xy /eqP p1zt /eqP p1uv].
+  move=> /and3P[/eqP p2xy /eqP p2zt /eqP p2uv] [px pz] pu.
   have eqp12: all (fun i => p1 i == p2 i) [:: x; y; z; t; u; v].
-    by rewrite /= -(eqP p1xy) -(eqP p2xy) -(eqP p1zt) -(eqP p2zt) -(eqP p1uv)
-      -(eqP p2uv)  px  pz pu !eqxx.
+    by rewrite /= -p1xy -p2xy -p1zt -p2zt -p1uv -p2uv px pz pu !eqxx.
   apply/ffunP=> i; apply/eqP; apply: (allP eqp12).
   by rewrite (subset_cardP _ (subset_predT _)) // (card_uniqP Uxv) card_ord.
-have ->:forall n, (n ^ 3)%N= (n*n*n)%N.
-  by move=> n0; rewrite (expnD n0 2 1) -mulnn expn1.
-rewrite -!card_prod. apply: eq_card => [] [[c d]e ] /=; apply/imageP.
-rewrite (cat_uniq [::x; y; z; t]) in Uxv; case/and3P: Uxv => Uxt hasxt nuv .
-rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-rewrite /= !orbF !andbT; case/norP; rewrite !inE => nxyz nxyt _.
-move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE orbA.
-case/norP => nxyu nztu.
-rewrite orbA; case/norP=> nxyv nztv.
-exists [ffun i =>  if (i \in [:: x; y] ) then c else  if (i \in [:: z; t] )
-                         then d else e].
-  rewrite !inE /= !ffunE !inE // !eqxx !orbT !eqxx //=.
-  by rewrite (negbTE nxyz) (negbTE nxyt)(negbTE nxyu) (negbTE nztu)
-           (negbTE nxyv) (negbTE nztv) !eqxx.
-rewrite {}/ff !ffunE !inE  /= !eqxx /=.
-by rewrite (negbTE nxyz) (negbTE nxyu) (negbTE nztu).
+have -> : forall n, (n ^ 3 = n * n * n)%N by move=> ?; rewrite -!mulnA.
+rewrite -!card_prod; apply: eq_card => [] [[c d] e] /=; apply/imageP.
+move: Uxv; rewrite (cat_uniq [::x; y; z; t]) => /and3P[Uxt + nuv].
+move=> /= /[!orbF] /norP[] /[!inE].
+rewrite orbA => /norP[/negPf nxyu /negPf nztu].
+rewrite orbA => /norP[/negPf nxyv /negPf nztv].
+move: Uxt; rewrite (cat_uniq [::x; y]) => /and3P[_].
+rewrite /= !orbF !andbT => /norP[] /[!inE] /negPf nxyz /negPf nxyt _.
+exists [ffun i => if i \in [:: x; y] then c
+                  else if i \in [:: z; t] then d else e].
+  by rewrite !(inE, ffunE, eqxx,orbT)//= nxyz nxyt nxyu nztu nxyv nztv !eqxx.
+by rewrite {}/ff !ffunE !inE /= !eqxx nxyz nxyu nztu.
 Qed.
 
 Lemma burnside_app_iso3 :
   (cube_coloring_number24 * 24 =
-                   n ^ 6 + 6 * n ^ 3 + 3 * n ^ 4 + 8 * (n ^ 2)  + 6 * n ^ 3)%N.
+   n ^ 6 + 6 * n ^ 3 + 3 * n ^ 4 + 8 * (n ^ 2)  + 6 * n ^ 3)%N.
 Proof.
-pose iso_list :=[::id3; s05; s14; s23; r05; r14; r23; r50; r41; r32;
-  r024; r042; r012; r021; r031; r013; r043; r034;
-  s1; s2; s3; s4; s5; s6].
-rewrite (burnside_formula iso_list) => [||p]; last first.
-- by rewrite !inE /= !(eq_sym _ p).
+pose iso_list := [:: id3; s05; s14; s23; r05; r14; r23; r50; r41; r32;
+                     r024; r042; r012; r021; r031; r013; r043; r034;
+                     s1; s2; s3; s4; s5; s6].
+rewrite (burnside_formula iso_list); last first.
+- by move=> p; rewrite !inE /= !(eq_sym _ p).
 - apply: map_uniq (fun p : {perm cube} => (p F0, p F1)) _ _.
-  have bsr:(fun p : {perm cube} => (p F0, p F1)) =1
-    (fun p  => (nth F0 p F0, nth F0 p F1)) \o sop.
+  have bsr : (fun p : {perm cube} => (p F0, p F1)) =1
+             (fun p => (nth F0 p F0, nth F0 p F1)) \o sop.
     by move=> x; rewrite /= -2!sop_spec.
   by rewrite (eq_map bsr) map_comp  -(eqP Lcorrect); vm_compute.
 rewrite !big_cons big_nil {1}card_Fid3 /= F_s05 F_s14 F_s23 F_r05 F_r14 F_r23
@@ -1295,9 +1274,7 @@ End cube_colouring.
 End colouring.
 
 Corollary burnside_app_iso_3_3col: cube_coloring_number24 3 = 57.
-Proof.
-by apply/eqP; rewrite -(@eqn_pmul2r 24) // burnside_app_iso3.
-Qed.
+Proof. by apply/eqP; rewrite -(@eqn_pmul2r 24) // burnside_app_iso3. Qed.
 
 
 Corollary burnside_app_iso_2_4col: square_coloring_number8 4 = 55.

--- a/mathcomp/solvable/center.v
+++ b/mathcomp/solvable/center.v
@@ -309,7 +309,7 @@ Proof.
 rewrite -(center_dprod (setX_dprod H K)) -morphim_pairg1 -morphim_pair1g.
 rewrite -!injm_center ?subsetT ?injm_pair1g ?injm_pairg1 //=.
 rewrite morphim_pairg1 morphim_pair1g setX_dprod.
-apply/subsetP=> [[x y]]; rewrite inE => /andP[Zx /eqP->].
+apply/subsetP=> [[x y]] /[1!inE] /andP[Zx /eqP->].
 by rewrite inE /= Zx groupV (subsetP sgzZZ) ?mem_morphim.
 Qed.
 

--- a/mathcomp/solvable/cyclic.v
+++ b/mathcomp/solvable/cyclic.v
@@ -665,7 +665,7 @@ have [lea1 | lt1a] := leqP #[a] 1.
   rewrite /order card_le1_trivg // cards1 (@eq_card1 _ 1) // => x.
   by rewrite !inE -cycle_eq1 eq_sym.
 rewrite -(card_injm (injm_invm (injm_Zpm a))) /= ?im_Zpm; last first.
-  by apply/subsetP=> x; rewrite inE; apply: cycle_generator.
+  by apply/subsetP=> x /[1!inE]; apply: cycle_generator.
 rewrite -card_units_Zp // cardsE card_sub morphim_invmE; apply: eq_card => /= d.
 by rewrite !inE /= qualifE /= /Zp lt1a inE /= generator_coprime {1}Zp_cast.
 Qed.
@@ -690,7 +690,7 @@ pose h (x : gT) : 'I_#|G|.+1 := inord #[x].
 symmetry; rewrite -{1}sum1_card (partition_big h xpredT) //=.
 apply: eq_bigr => d _; set Gd := finset _.
 rewrite -sum_nat_const sum1dep_card -sum1_card (_ : finset _ = Gd); last first.
-  apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+  apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
   by rewrite /eq_op /= inordK // ltnS subset_leq_card ?cycle_subG.
 rewrite (partition_big_imset cycle) {}/Gd; apply: eq_bigr => C /=.
 case/imsetP=> x /setIdP[Gx /eqP <-] -> {C d}.

--- a/mathcomp/solvable/extraspecial.v
+++ b/mathcomp/solvable/extraspecial.v
@@ -69,8 +69,7 @@ Canonical action := Action actP.
 
 Lemma gactP : is_groupAction [set: 'Z_p * 'Z_p] action.
 Proof.
-move=> k _ /=; rewrite inE.
-apply/andP; split; first by apply/subsetP=> ij _; rewrite inE.
+move=> k _ /[1!inE]; apply/andP; split; first by apply/subsetP=> ij _ /[1!inE].
 apply/morphicP=> /= [[i1 j1] [i2 j2] _ _].
 by rewrite !permE /= mulrDr -addrA (addrCA i2) (addrA i1).
 Qed.

--- a/mathcomp/solvable/extremal.v
+++ b/mathcomp/solvable/extremal.v
@@ -792,7 +792,7 @@ have defK: K = [set w].
   rewrite add0n -[j./2]odd_double_half addnC doubleD -!muln2 -mulnA.
   rewrite -(expg_mod_order v) ov modnMDl; case: (odd _); last first.
     right; rewrite mulg1 /r -(subnKC n_gt2) expnSr mulnA expgM.
-    by apply: imset_f; rewrite inE.
+    by apply: imset_f => /[1!inE].
   rewrite (inj_eq (mulIg _)) -expg_mod_order ou -[k]odd_double_half.
   rewrite addnC -muln2 mulnDl -mulnA def2r modnMDl -ou expg_mod_order.
   case: (odd k); [left | right]; rewrite ?mul1n ?mul1g //.
@@ -1455,7 +1455,7 @@ split.
     by rewrite -(groupMr _ (sX'G2 y X'y)) !sX'G2.
   rewrite eqEsubset andbC gen_subG class_sub_norm ?gFnorm //.
   rewrite (OhmE 1 pG) mem_gen ?inE ?Gy -?order_dvdn ?oy // gen_subG /= -/My.
-  apply/subsetP=> t; rewrite !inE; case/andP=> Gt t2.
+  apply/subsetP=> t /[!inE]; case/andP=> Gt t2.
   have pX := pgroupS sXG pG.
   case Xt: (t \in X).
     have: t \in 'Ohm_1(X) by rewrite (OhmE 1 pX) mem_gen // !inE Xt.

--- a/mathcomp/solvable/finmodule.v
+++ b/mathcomp/solvable/finmodule.v
@@ -194,8 +194,7 @@ Qed.
 
 Fact actr_is_groupAction : is_groupAction setT 'M.
 Proof.
-move=> a Na /=; rewrite inE; apply/andP; split.
-  by apply/subsetP=> u _; rewrite inE.
+move=> a Na /[1!inE]; apply/andP; split; first by apply/subsetP=> u _ /[1!inE].
 by apply/morphicP=> u v _ _; rewrite !permE /= actAr.
 Qed.
 

--- a/mathcomp/solvable/frobenius.v
+++ b/mathcomp/solvable/frobenius.v
@@ -598,7 +598,7 @@ have partG: partition (gval K |: (H^# :^: K)) G.
   apply: Frobenius_partition; apply/andP; rewrite defG; split=> //.
   by apply/Frobenius_actionP; apply: HasFrobeniusAction FrobG.
 have{FrobG} [ffulG transG regG ntH [u Su defH]]:= FrobG.
-apply/setP=> x; rewrite !inE; have [-> | ntx] := eqVneq; first exact: group1.
+apply/setP=> x /[!inE]; have [-> | ntx] := eqVneq; first exact: group1.
 rewrite /= -(cover_partition partG) /cover.
 have neKHy y: gval K <> H^# :^ y.
   by move/setP/(_ 1); rewrite group1 conjD1g setD11.

--- a/mathcomp/solvable/gseries.v
+++ b/mathcomp/solvable/gseries.v
@@ -130,7 +130,7 @@ set f := fun _ => <<_>>; have idf: iter _ f H == H.
 have [m] := ubnP (size s); elim: m s Hsn => // m IHm /lastP[//|s G].
 rewrite size_rcons last_rcons rcons_path /= ltnS.
 set K := last H s => /andP[Hsn /andP[sKG nKG]] lt_s_m.
-have:= sKG; rewrite subEproper => /predU1P[<-|prKG]; first exact: IHm.
+have /[1!subEproper]/predU1P[<-|prKG] := sKG; first exact: IHm.
 pose L := [group of f G].
 have sHK: H \subset K by case/IHm: Hsn.
 have sLK: L \subset K by rewrite gen_subG class_support_sub_norm.
@@ -195,7 +195,7 @@ Proof.
 case/subnormalP=> s Hs <-{G}.
 elim/last_ind: s Hs => [|s G IHs]; first by left.
 rewrite last_rcons -cats1 cat_path /= andbT; set K := last H s.
-case/andP=> Hs nsKG; have:= normal_sub nsKG; rewrite subEproper.
+case/andP=> Hs nsKG; have /[1!subEproper] := normal_sub nsKG.
 case/predU1P=> [<- | prKG]; [exact: IHs | right; exists K; split=> //].
 by apply/subnormalP; exists s.
 Qed.
@@ -204,7 +204,7 @@ Lemma subnormalEl G H : H <|<| G ->
   H :=: G \/ (exists K : {group gT}, [/\ H <| K, K <|<| G & H \proper K]).
 Proof.
 case/subnormalP=> s Hs <-{G}; elim: s H Hs => /= [|K s IHs] H; first by left.
-case/andP=> nsHK Ks; have:= normal_sub nsHK; rewrite subEproper.
+case/andP=> nsHK Ks; have /[1!subEproper] := normal_sub nsHK.
 case/predU1P=> [-> | prHK]; [exact: IHs | right; exists K; split=> //].
 by apply/subnormalP; exists s.
 Qed.

--- a/mathcomp/solvable/jordanholder.v
+++ b/mathcomp/solvable/jordanholder.v
@@ -248,7 +248,7 @@ Variable to : groupAction A D.
 Lemma gactsP (G : {set rT}) : reflect {acts A, on G | to} [acts A, on G | to].
 Proof.
 apply: (iffP idP) => [nGA x|nGA]; first exact: acts_act.
-apply/subsetP=> a Aa; rewrite !inE; rewrite Aa.
+apply/subsetP=> a Aa /[!inE]; rewrite Aa.
 by  apply/subsetP=> x; rewrite inE nGA.
 Qed.
 
@@ -269,7 +269,7 @@ Lemma gactsI (N1 N2 : {set rT}) :
   [acts A, on N1 | to] -> [acts A, on N2 | to] -> [acts A, on N1 :&: N2 | to].
 Proof.
 move=> aAN1 aAN2.
-apply/subsetP=> x Ax; rewrite !inE Ax /=; apply/subsetP=> y Ny; rewrite inE.
+apply/subsetP=> x Ax; rewrite !inE Ax /=; apply/subsetP=> y Ny /[1!inE].
 case/setIP: Ny=> N1y N2y; rewrite inE ?astabs_act  ?N1y ?N2y //.
 - by move/subsetP: aAN2; move/(_ x Ax).
 - by move/subsetP: aAN1; move/(_ x Ax).
@@ -315,7 +315,7 @@ Lemma qacts_cosetpre (H : {group rT}) (K' : {group coset_of H}) :
 Proof.
 move=> sHD aH aK'; apply/subsetP=> x Ax; move: (Ax) (subsetP aK').
 rewrite -{1}(acts_qact_doms sHD aH) => qdx; move/(_ x qdx) => nx.
-rewrite !inE Ax; apply/subsetP=> y; case/morphpreP=> Ny /= K'Hy; rewrite inE.
+rewrite !inE Ax; apply/subsetP=> y; case/morphpreP=> Ny /= K'Hy /[1!inE].
 apply/morphpreP; split; first by rewrite acts_qact_dom_norm.
 by move/gastabsP: nx; move/(_  qdx (coset H y)); rewrite K'Hy qactE.
 Qed.
@@ -522,9 +522,7 @@ have: K' :=: 1%G \/ K' :=: (G / H).
   suff h: qact_dom to H \subset A.
     by rewrite astabs_act // (subsetP aK) //; apply: (subsetP h).
   by apply/subsetP=> t; rewrite qact_domE // inE; case/andP.
-case; last first.
-  move/quotient_injG; rewrite !inE /=; move/(_ nKH nHG)=> c; move: nsGK.
-  by rewrite c subxx.
+case=> [|/quotient_injG /[!inE]/(_ nKH nHG) c]; last by rewrite c subxx in nsGK.
 rewrite /= -trivg_quotient => tK'; apply: (congr1 (@gval _)); move: tK'.
 by apply: (@quotient_injG _ H); rewrite ?inE /= ?normal_refl.
 Qed.

--- a/mathcomp/solvable/maximal.v
+++ b/mathcomp/solvable/maximal.v
@@ -1170,7 +1170,7 @@ have injf: {in A &, injective f}.
 have sfA_XS': f @: A \subset pffun_on 1 X S^`(1).
   apply/subsetP=> _ /imsetP[_ /morphimP[y nSy Ry ->] ->].
   apply/pffun_onP; split=> [|_ /imageP[x /= Xx ->]].
-    by apply/subsetP=> x; apply: contraR; rewrite ffunE => /negPf->.
+    by apply/subsetP=> x; apply: contraNT => /[!ffunE]/negPf->.
   have Sx := subsetP sXS x Xx.
   by rewrite ffunE Xx norm_conj_autE // (subsetP sSR_S') ?mem_commg.
 rewrite -(card_in_imset injf) (leq_trans (subset_leq_card sfA_XS')) // defS'.
@@ -1523,7 +1523,7 @@ have{nsXG} pU := pgroupS (subset_trans sUX (normal_sub nsXG)) pG.
 case gsetU1: (group_set 'Ldiv_p(U)).
   by rewrite -defU1 (OhmE 1 pU) gen_set_id // -sub_LdivT subsetIr.
 move: gsetU1; rewrite /group_set 2!inE group1 expg1n eqxx; case/subsetPn=> xy.
-case/imset2P=> x y; rewrite !inE => /andP[Ux xp1] /andP[Uy yp1] ->{xy}.
+case/imset2P=> x y /[!inE] /andP[Ux xp1] /andP[Uy yp1] ->{xy}.
 rewrite groupM //= => nt_xyp; pose XY := <[x]> <*> <[y]>.
 have{yp1 nt_xyp} defXY: XY = U.
   have sXY_U: XY \subset U by rewrite join_subG !cycle_subG Ux Uy.

--- a/mathcomp/solvable/primitive_action.v
+++ b/mathcomp/solvable/primitive_action.v
@@ -213,7 +213,7 @@ Qed.
 
 Lemma dtuple_on_subset n (S1 S2 : {set sT}) t :
   S1 \subset S2 -> t \in n.-dtuple(S1) -> t \in n.-dtuple(S2).
-Proof. by move=> sS12; rewrite !inE => /andP[-> /subset_trans]; apply. Qed.
+Proof. by move=> sS12 /[!inE] /andP[-> /subset_trans]; apply. Qed.
 
 Lemma n_act_add n x (t : n.-tuple sT) a :
   n_act to [tuple of x :: t] a = [tuple of to x a :: n_act to t a].
@@ -236,7 +236,7 @@ have ext_t t: t \in dtuple_on m S ->
 - move=> dt.
   have [sSt | /subsetPn[x Sx ntx]] := boolP (S \subset t); last first.
     by exists x; rewrite dtuple_on_add andbA /= Sx ntx.
-  case/imsetP: tr_m1 dt => t1; rewrite !inE => /andP[Ut1 St1] _ /andP[Ut _].
+  case/imsetP: tr_m1 dt => t1 /[!inE] /andP[Ut1 St1] _ /andP[Ut _].
   have /subset_leq_card := subset_trans St1 sSt.
   by rewrite !card_uniq_tuple // ltnn.
 case/imsetP: (tr_m1); case/tupleP=> [x t]; rewrite dtuple_on_add.

--- a/mathcomp/solvable/sylow.v
+++ b/mathcomp/solvable/sylow.v
@@ -126,7 +126,7 @@ have [P S_P]: exists P, P \in S.
 have trS: [transitive G, on S | 'JG].
   apply/imsetP; exists P => //; apply/eqP.
   rewrite eqEsubset andbC acts_sub_orbit // S_P; apply/subsetP=> Q S_Q.
-  have:= S_P; rewrite inE => /maxgroupP[/andP[_ pP]].
+  have /[1!inE] /maxgroupP[/andP[_ pP]] := S_P.
   have [-> max1 | ntP _] := eqVneq P 1%G.
     move/andP/max1: (S_pG _ S_Q) => Q1.
     by rewrite (group_inj (Q1 (sub1G Q))) orbit_refl.
@@ -175,7 +175,7 @@ Proof. by case Sylow's_theorem. Qed.
 Lemma Sylow_trans P Q :
   p.-Sylow(G) P -> p.-Sylow(G) Q -> exists2 x, x \in G & Q :=: P :^ x.
 Proof.
-move=> sylP sylQ; have:= (atransP2 Syl_trans) P Q; rewrite !inE.
+move=> sylP sylQ; have /[!inE] := (atransP2 Syl_trans) P Q.
 by case=> // x Gx ->; exists x.
 Qed.
 
@@ -618,8 +618,7 @@ have{n leGn IHn nDG} pN: p.-group <<'N_E(D)>>.
   - by rewrite inE Nx1 (subsetP sEG) ?mem_gen.
   have Ex1y: x1 ^ y \in E.
     by rewrite -mem_conjgV (normsP nEG) // groupV; case/setIP: Ny.
-  apply: pgroupS (genS _) (pE _ _ Ex1 Ex1y).
-  by apply/subsetP=> u; rewrite !inE.
+  by apply: pgroupS (genS _) (pE _ _ Ex1 Ex1y); apply/subsetP => u /[!inE].
 have [y1 Ny1 Py1]: exists2 y1, y1 \in 'N_E(D) & y1 \notin P.
   case sNN: ('N_<<B>>('N_<<B>>(D)) \subset 'N_<<B>>(D)).
     exists y0 => //; have By0: y0 \in <<B>> by rewrite mem_gen ?setU11.

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1539,7 +1539,7 @@ Lemma reindex (I J : finType) (h : J -> I) (P : pred I) F :
   \big[*%M/1]_(i | P i) F i = \big[*%M/1]_(j | P (h j)) F (h j).
 Proof.
 case=> h' hK h'K; rewrite (reindex_onto h h' h'K).
-by apply: eq_bigl => j; rewrite !inE; case Pi: (P _); rewrite //= hK ?eqxx.
+by apply: eq_bigl => j /[!inE]; case Pi: (P _); rewrite //= hK ?eqxx.
 Qed.
 Arguments reindex [I J] h [P F].
 
@@ -1795,10 +1795,10 @@ rewrite big_distrr; apply: eq_big => [f | f eq_f]; last first.
   rewrite big_cons ffunE eqxx !big_seq; congr (_ * _).
   by apply: eq_bigr => k; rewrite ffunE; case: eqP nri => // -> ->.
 rewrite !ffunE !eqxx andbT; apply/andP/familyP=> /= [[Pjf fij0] k | Pff].
-  have:= familyP Pjf k; rewrite /= ffunE inE; case: eqP => // -> _.
+  have /[!(ffunE, inE)] := familyP Pjf k; case: eqP => // -> _.
   by rewrite nri -(eqP fij0) !ffunE !inE !eqxx.
-split; [apply/familyP | apply/eqP/ffunP] => k; have:= Pff k; rewrite !ffunE.
-  by rewrite inE; case: eqP => // ->.
+split; [apply/familyP | apply/eqP/ffunP] => k; have /[!(ffunE, inE)]:= Pff k.
+  by case: eqP => // ->.
 by case: eqP => // ->; rewrite nri /= => /eqP.
 Qed.
 

--- a/mathcomp/ssreflect/binomial.v
+++ b/mathcomp/ssreflect/binomial.v
@@ -432,13 +432,12 @@ rewrite -andbA.
 apply/and3P/injectiveP=> [[_ /injectiveP inj_f0p _] i j eq_pij | inj_p].
   by apply: inj_f0p; rewrite !ffunE eq_pij.
 set f := finfun _.
-have injf: injective f by move=> i j; rewrite !ffunE => /inj_f0; apply: inj_p.
+have injf: injective f by move=> i j /[!ffunE] /inj_f0; apply: inj_p.
 have imIkf : imIk f == A.
   rewrite eqEcard card_imset // cardAk card_ord leqnn andbT -im_f0.
   by apply/subsetP=> x /imsetP[i _ ->]; rewrite ffunE imset_f.
 split; [|exact/injectiveP|exact: imIkf].
-apply/ffun_onP => x; apply: (subsetP AsubB).
-by rewrite -(eqP imIkf) imset_f.
+by apply/ffun_onP => x; apply: (subsetP AsubB); rewrite -(eqP imIkf) imset_f.
 Qed.
 
 Lemma card_draws T k : #|[set A : {set T} | #|A| == k]| = 'C(#|T|, k).
@@ -558,7 +557,7 @@ rewrite -card_partial_ord_partitions -!sum1dep_card (reindex f_add) /=.
   by apply: eq_bigl => t; rewrite big_cons /= addnC (sameP maxn_idPr eqP) maxnE.
 exists (fun t : m.+1.-tuple In1 => [tuple of behead t]) => [t _|].
   exact: val_inj.
-case/tupleP=> x t; rewrite inE /= big_cons => /eqP def_n.
+case/tupleP=> x t /[!(inE, big_cons)] /eqP def_n.
 by apply: val_inj; congr (_ :: _); apply: val_inj; rewrite /= -{1}def_n addnK.
 Qed.
 

--- a/mathcomp/ssreflect/eqtype.v
+++ b/mathcomp/ssreflect/eqtype.v
@@ -955,16 +955,15 @@ Variable D' : pred aT.
 Lemma homoW_in : {in D & D', {homo f : x y / aR' x y >-> rR' x y}} ->
                  {in D & D', {homo f : x y / aR x y >-> rR x y}}.
 Proof.
-move=> mf x y xD yD /=; rewrite aRE => /orP[/eqP->|/mf];
-by rewrite rRE ?eqxx // orbC => ->.
+by move=> mf x y xD yD /[!aRE]/orP[/eqP->|/mf]; rewrite rRE ?eqxx// orbC => ->.
 Qed.
 
 Lemma inj_homo_in : {in D & D', injective f} ->
   {in D & D', {homo f : x y / aR x y >-> rR x y}} ->
   {in D & D', {homo f : x y / aR' x y >-> rR' x y}}.
 Proof.
-move=> fI mf x y xD yD /=; rewrite aR'E rR'E => /andP[neq_xy xy].
-by rewrite mf ?andbT //; apply: contra_neq neq_xy => /fI; apply.
+move=> fI mf x y xD yD /[!(aR'E, rR'E)] /andP[neq_xy xy].
+by rewrite mf ?andbT//; apply: contra_neq neq_xy; apply: fI.
 Qed.
 
 End DifferentDom.

--- a/mathcomp/ssreflect/finfun.v
+++ b/mathcomp/ssreflect/finfun.v
@@ -426,7 +426,7 @@ elim: E uniqE => /= [_ | x0 E IH_E /andP[E'x0 uniqE]] in F trivF *.
     have /pred0Pn[y Fy]: #|F x| != 0 by rewrite trivF.
     by exists y; apply/fsym/subset_cardP; rewrite ?subset_pred1 // card1 trivF.
   apply: eq_card1 (finfun f0 : fT) _ _ => f; apply/familyP/eqP=> [Ff | {f}-> x].
-    by apply/ffunP=> x; have:= Ff x; rewrite Ff0 ffunE => /eqP.
+    by apply/ffunP=> x; have /[!(Ff0, ffunE)]/eqP := Ff x.
   by rewrite ffunE Ff0 inE /=.
 have [y0 Fxy0 | Fx00] := pickP (F x0); last first.
   by rewrite !eq_card0 // => f; apply: contraFF (Fx00 (f x0))=> /familyP; apply.

--- a/mathcomp/ssreflect/fingraph.v
+++ b/mathcomp/ssreflect/fingraph.v
@@ -326,7 +326,7 @@ Lemma connect_closed x : closed e (connect e x).
 Proof. by move=> y z /connect1/same_connect_r; apply. Qed.
 
 Lemma predC_closed a : closed e a -> closed e [predC a].
-Proof. by move=> cl_a x y /cl_a; rewrite !inE => ->. Qed.
+Proof. by move=> cl_a x y /cl_a /[!inE] ->. Qed.
 
 Lemma closure_closed a : closed e (closure e a).
 Proof.

--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -431,11 +431,11 @@ Lemma setD11 b A : (b \in A :\ b) = false.
 Proof. by rewrite !inE eqxx. Qed.
 
 Lemma setD1K a A : a \in A -> a |: (A :\ a) = A.
-Proof. by move=> Aa; apply/setP=> x; rewrite !inE; case: eqP => // ->. Qed.
+Proof. by move=> Aa; apply/setP=> x /[!inE]; case: eqP => // ->. Qed.
 
 Lemma setU1K a B : a \notin B -> (a |: B) :\ a = B.
 Proof.
-by move/negPf=> nBa; apply/setP=> x; rewrite !inE; case: eqP => // ->.
+by move/negPf=> nBa; apply/setP=> x /[!inE]; case: eqP => // ->.
 Qed.
 
 Lemma set2P x a b : reflect (x = a \/ x = b) (x \in [set a; b]).
@@ -717,7 +717,7 @@ Proof. by rewrite inE. Qed.
 
 Lemma powersetS A B : (powerset A \subset powerset B) = (A \subset B).
 Proof.
-apply/subsetP/idP=> [sAB | sAB C]; last by rewrite !inE => /subset_trans ->.
+apply/subsetP/idP=> [sAB | sAB C /[!inE]/subset_trans->//].
 by rewrite -powersetE sAB // inE.
 Qed.
 
@@ -800,13 +800,13 @@ Qed.
 (* other inclusions *)
 
 Lemma subsetIl A B : A :&: B \subset A.
-Proof. by apply/subsetP=> x; rewrite inE; case/andP. Qed.
+Proof. by apply/subsetP=> x /[!inE] /andP[]. Qed.
 
 Lemma subsetIr A B : A :&: B \subset B.
-Proof. by apply/subsetP=> x; rewrite inE; case/andP. Qed.
+Proof. by apply/subsetP=> x /[!inE] /andP[]. Qed.
 
 Lemma subsetUl A B : A \subset A :|: B.
-Proof. by apply/subsetP=> x; rewrite inE => ->. Qed.
+Proof. by apply/subsetP=> x /[!inE] ->. Qed.
 
 Lemma subsetUr A B : B \subset A :|: B.
 Proof. by apply/subsetP=> x; rewrite inE orbC => ->. Qed.
@@ -860,7 +860,7 @@ Proof. by apply/setP=> A; rewrite !inE subset1 orbC. Qed.
 Lemma setIidPl A B : reflect (A :&: B = A) (A \subset B).
 Proof.
 apply: (iffP subsetP) => [sAB | <- x /setIP[] //].
-by apply/setP=> x; rewrite inE; apply/andb_idr/sAB.
+by apply/setP=> x /[1!inE]; apply/andb_idr/sAB.
 Qed.
 Arguments setIidPl {A B}.
 
@@ -1217,7 +1217,7 @@ by move=> f_inj; apply/imsetP/idP;[case=> [y] ? /f_inj -> | move=> ?; exists x].
 Qed.
 
 Lemma imset0 : f @: set0 = set0.
-Proof. by apply/setP => y; rewrite inE; apply/imsetP=> [[x]]; rewrite inE. Qed.
+Proof. by apply/setP => y /[!inE]; apply/imsetP => -[x /[!inE]]. Qed.
 
 Lemma imset_eq0 (A : {set aT}) : (f @: A == set0) = (A == set0).
 Proof.
@@ -1250,12 +1250,12 @@ Lemma sub_imset_pre (A : {pred aT}) (B : {pred rT}) :
 Proof.
 apply/subsetP/subsetP=> [sfAB x Ax | sAf'B fx].
   by rewrite inE sfAB ?imset_f.
-by case/imsetP=> x Ax ->; move/sAf'B: Ax; rewrite inE.
+by move=> /imsetP[a + ->] => /sAf'B /[!inE].
 Qed.
 
 Lemma preimsetS (A B : {pred rT}) :
   A \subset B -> (f @^-1: A) \subset (f @^-1: B).
-Proof. by move=> sAB; apply/subsetP=> y; rewrite !inE; apply: subsetP. Qed.
+Proof. by move=> sAB; apply/subsetP=> y /[!inE]; apply: subsetP. Qed.
 
 Lemma preimset0 : f @^-1: set0 = set0.
 Proof. by apply/setP=> x; rewrite !inE. Qed.
@@ -1280,7 +1280,7 @@ Proof. by apply/setP=> y; rewrite !inE. Qed.
 
 Lemma imsetS (A B : {pred aT}) : A \subset B -> f @: A \subset f @: B.
 Proof.
-move=> sAB; apply/subsetP=> _ /imsetP[x Ax ->].
+move=> sAB; apply/subsetP => _ /imsetP[x Ax ->].
 by apply/imsetP; exists x; rewrite ?(subsetP sAB).
 Qed.
 
@@ -1668,7 +1668,7 @@ Proof.
 elim: r => [|i r IHr]; first by rewrite big_nil big_pred0.
 rewrite big_cons {}IHr; case r_i: (i \in r).
   rewrite (setUidPr _) ?bigcup_sup //.
-  by apply: eq_bigl => j; rewrite !inE; case: eqP => // ->.
+  by apply: eq_bigl => j /[!inE]; case: eqP => // ->.
 rewrite (bigD1 i (mem_head i r)) /=; congr (_ :|: _).
 by apply: eq_bigl => j /=; rewrite andbC; case: eqP => // ->.
 Qed.
@@ -1856,7 +1856,7 @@ Lemma eq_pblock P x y :
 Proof.
 move=> tiP Px; apply/eqP/idP=> [eq_xy | /same_pblock-> //].
 move: Px; rewrite -mem_pblock eq_xy /pblock.
-by case: pickP => [B /andP[] // | _]; rewrite inE.
+by case: pickP => [B /andP[] // | _] /[1!inE].
 Qed.
 
 Lemma trivIsetU1 A P :
@@ -1972,8 +1972,8 @@ have defD: cover P == D.
   by apply/subsetP=> x Dx; apply/bigcupP; exists (Px x); rewrite (Pxx, PPx).
 have tiP: trivIset P.
   apply/trivIsetP=> _ _ /imsetP[x Dx ->] /imsetP[y Dy ->]; apply: contraR.
-  case/pred0Pn=> z /andP[]; rewrite !inE => /andP[Dz Rxz] /andP[_ Ryz].
-  apply/eqP/setP=> t; rewrite !inE; apply: andb_id2l => Dt.
+  case/pred0Pn=> z /andP[] /[!inE] /andP[Dz Rxz] /andP[_ Ryz].
+  apply/eqP/setP=> t /[!inE]; apply: andb_id2l => Dt.
   by rewrite (eqiR Dx Dz Dt) // (eqiR Dy Dz Dt).
 rewrite /partition tiP defD /=.
 by apply/imsetP=> [[x /Pxx Px_x Px0]]; rewrite -Px0 inE in Px_x.
@@ -2294,14 +2294,14 @@ Qed.
 Lemma in_iter_fix_orderE (x : T) :
   (x \in iterF (fix_order x)) = (x \in fixset).
 Proof.
-rewrite /fix_order; case: eqP; last by move=>/negP/negPf->; rewrite inE.
-by move=> x_in; case: ex_minnP => m ->; rewrite x_in.
+rewrite /fix_order; case: eqP => [x_in | /negP/negPf-> /[1!inE]//].
+by case: ex_minnP => m ->; rewrite x_in.
 Qed.
 
 Lemma fix_order_gt0 (x : T) : (fix_order x > 0) = (x \in fixset).
 Proof.
-rewrite /fix_order; case: eqP => [x_in|/negP/negPf->//].
-by rewrite x_in; case: ex_minnP => -[|m]; rewrite ?inE//= => _; apply.
+rewrite /fix_order; case: eqP => [x_in | /negP/negPf->//].
+by rewrite x_in; case: ex_minnP => -[/[!inE] | m].
 Qed.
 
 Lemma fix_order_eq0 (x : T) : (fix_order x == 0) = (x \notin fixset).
@@ -2311,7 +2311,7 @@ Lemma in_iter_fixE (x : T) k : (x \in iterF k) = (0 < fix_order x <= k).
 Proof.
 rewrite /fix_order; case: eqP => //= [x_in|/negP xNin]; last first.
   by apply: contraNF xNin; apply/subsetP/iter_sub_fix.
-case: ex_minnP => -[|m]; rewrite ?inE// => xm mP.
+case: ex_minnP => -[/[!inE]//|m] xm mP.
 by apply/idP/idP=> [/mP//|lt_mk]; apply: subsetP xm; apply: subset_iter.
 Qed.
 

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -553,7 +553,7 @@ Proof. by rewrite !cardE !size_filter count_predC. Qed.
 Lemma cardU1 x A : #|[predU1 x & A]| = (x \notin A) + #|A|.
 Proof.
 case Ax: (x \in A).
-  by apply: eq_card => y; rewrite inE /=; case: eqP => // ->.
+  by apply: eq_card => y /[1!inE]/=; case: eqP => // ->.
 rewrite /= -(card1 x) -cardUI addnC.
 rewrite [#|predI _ _|]eq_card0 => [|y /=]; first exact: eq_card.
 by rewrite !inE; case: eqP => // ->.
@@ -568,10 +568,10 @@ Proof. by rewrite -(cardC (pred1 x)) card1. Qed.
 Lemma cardD1 x A : #|A| = (x \in A) + #|[predD1 A & x]|.
 Proof.
 case Ax: (x \in A); last first.
-  by apply: eq_card => y; rewrite !inE /=; case: eqP => // ->.
+  by apply: eq_card => y /[!inE]/=; case: eqP => // ->.
 rewrite /= -(card1 x) -cardUI addnC /=.
 rewrite [#|predI _ _|]eq_card0 => [|y]; last by rewrite !inE; case: eqP.
-by apply: eq_card => y; rewrite !inE; case: eqP => // ->.
+by apply: eq_card => y /[!inE]; case: eqP => // ->.
 Qed.
 
 Lemma max_card A : #|A| <= #|T|.
@@ -811,10 +811,9 @@ Lemma card_gt1P A :
   reflect (exists x y, [/\ x \in A, y \in A & x != y]) (1 < #|A|).
 Proof.
 apply: (iffP card_geqP) => [[s] []|[x] [y] [xA yA xDy]].
-  case: s => [|a [|b []]]//=; rewrite inE andbT => aDb _ subD.
+  case: s => [|a [|b []]]//= /[!(inE, andbT)] aDb _ subD.
   by exists a, b; rewrite aDb !subD ?inE ?eqxx ?orbT.
-exists [:: x; y]; rewrite /= !inE xDy.
-by split=> // z; rewrite !inE => /pred2P[]->.
+by exists [:: x; y]; rewrite /= !inE xDy; split=> // z /[!inE] /pred2P[]->.
 Qed.
 
 Lemma card_gt2P A :

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -1315,7 +1315,7 @@ Proof. by move=> subseq_ts /(sorted_sort leT_tr) <-; exact: subseq_sort. Qed.
 
 Lemma mem2_sort s x y : leT x y -> mem2 s x y -> mem2 (sort leT s) x y.
 Proof.
-move=> lexy; rewrite !mem2E => /subseq_sort.
+move=> lexy /[!mem2E] /subseq_sort.
 by case: eqP => // _; rewrite {1}/sort /= lexy /=.
 Qed.
 

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1773,7 +1773,7 @@ Proof. by move/perm_mem/eq_all_r. Qed.
 Lemma perm_small_eq s1 s2 : size s2 <= 1 -> perm_eq s1 s2 -> s1 = s2.
 Proof.
 move=> s2_le1 eqs12; move/perm_size: eqs12 s2_le1 (perm_mem eqs12).
-by case: s2 s1 => [|x []] // [|y []] // _ _ /(_ x); rewrite !inE eqxx => /eqP->.
+by case: s2 s1 => [|x []] // [|y []] // _ _ /(_ x) /[!(inE, eqxx)] /eqP->.
 Qed.
 
 Lemma uniq_leq_size s1 s2 : uniq s1 -> {subset s1 <= s2} -> size s1 <= size s2.
@@ -2198,7 +2198,7 @@ Lemma mem_subseq s1 s2 : subseq s1 s2 -> {subset s1 <= s2}.
 Proof. by case/subseqP=> m _ -> x; apply: mem_mask. Qed.
 
 Lemma sub1seq x s : subseq [:: x] s = (x \in s).
-Proof. by elim: s => //= y s; rewrite inE; case: ifP; rewrite ?sub0seq. Qed.
+Proof. by elim: s => //= y s /[1!inE]; case: ifP; rewrite ?sub0seq. Qed.
 
 Lemma size_subseq s1 s2 : subseq s1 s2 -> size s1 <= size s2.
 Proof. by case/subseqP=> m sz_m ->; rewrite size_mask -sz_m ?count_size. Qed.
@@ -2451,7 +2451,7 @@ Proof.
 elim: m s => [|[] m ih] [|x s] //=.
 - by move=> _; elim: s.
 - case/andP => /negP x_notin_s /ih {1}->; rewrite inE eqxx /=; congr cons.
-  by apply/eq_in_filter => ?; rewrite inE; case: eqP => // ->.
+  by apply/eq_in_filter => ? /[1!inE]; case: eqP => // ->.
 - by case: ifP => [/mem_mask -> // | _ /andP [] _ /ih].
 Qed.
 
@@ -3508,7 +3508,7 @@ Proof.
 elim: s => [|x s IHs]; first by constructor.
 rewrite /= all_cat all_map /preim.
 apply/(iffP andP)=> [[/allP /= ? ? x' y x'_in_xs]|p_xs_t].
-  by move: x'_in_xs y; rewrite inE => /predU1P [-> //|? ?]; exact: IHs.
+  by move: x'_in_xs y => /[1!inE] /predU1P [-> //|? ?]; exact: IHs.
 split; first by apply/allP => ?; exact/p_xs_t/mem_head.
 by apply/IHs => x' y x'_in_s; apply: p_xs_t; rewrite inE x'_in_s orbT.
 Qed.
@@ -3867,14 +3867,14 @@ move=> bs /andP[]; elim: bs => [|[x [|n]] bs IHbs] //= /andP[bs'x Ubs] bs'0.
 rewrite inE /tseq /tally /= -[n.+1]addn1 in bs'0 *.
 elim: n 1 => /= [|n IHn] m; last by rewrite eqxx IHn addnS.
 rewrite -{}[in RHS]IHbs {Ubs bs'0}// /tally /tally_seq add0n.
-elim: bs bs'x [::] => [|[y n] bs IHbs] //=; rewrite inE => /norP[y'x bs'x].
+elim: bs bs'x [::] => [|[y n] bs IHbs] //= /[1!inE] /norP[y'x bs'x].
 by elim: n => [|n IHn] bs1 /=; [rewrite IHbs | rewrite eq_sym ifN // IHn].
 Qed.
 
 Lemma incr_tallyP x : {homo incr_tally^~ x : bs / bs \in wf_tally}.
 Proof.
 move=> bs /andP[]; rewrite unfold_in.
-elim: bs => [|[y [|n]] bs IHbs] //= /andP[bs'y Ubs]; rewrite inE /= => bs'0.
+elim: bs => [|[y [|n]] bs IHbs] //= /andP[bs'y Ubs] /[1!inE] /= bs'0.
 have [<- | y'x] /= := eqVneq y; first by rewrite bs'y Ubs.
 rewrite -andbA {}IHbs {Ubs bs'0}// andbT.
 elim: bs bs'y => [|b bs IHbs] /=; rewrite inE ?y'x // => /norP[b'y bs'y].
@@ -4007,7 +4007,7 @@ rewrite {}IHbs; first 1 last; first by rewrite (perm_size (perm_tseq bsCA)).
 rewrite (map_inj_uniq (rcons_injl x)) {}IHn {Dn}//=.
 have: x \notin unzip1 bs by apply: contraL Ubs; rewrite map_cat mem_cat => ->.
 move: {bs2 m Ubs}(perms_rec n _ _ _) (_ :: bs2) => ts.
-elim: bs => [|[y [|m]] bs IHbs] //=; rewrite inE => bs2 /norP[x'y /IHbs//].
+elim: bs => [|[y [|m]] bs IHbs] //= /[1!inE] bs2 /norP[x'y /IHbs//].
 rewrite cons_permsE has_cat negb_or has_map => ->.
 by apply/hasPn=> t _; apply: contra x'y => /mapP[t1 _ /rcons_inj[_ ->]].
 Qed.

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -124,21 +124,21 @@ Let allQ2 f'' := {all2 Q2 f''}.
 Lemma in_on1P : {in D1, {on D2, allQ1 f}} <->
                 {in [pred x in D1 | f x \in D2], allQ1 f}.
 Proof.
-split => allf x; have := allf x; rewrite inE => Q1f; first by case/andP.
+split => allf x; have /[!inE] Q1f := allf x; first by case/andP.
 by move=> ? ?; apply: Q1f; apply/andP.
 Qed.
 
 Lemma in_on1lP : {in D1, {on D2, allQ1l f & h}} <->
                 {in [pred x in D1 | f x \in D2], allQ1l f h}.
 Proof.
-split => allf x; have := allf x; rewrite inE => Q1f; first by case/andP.
+split => allf x; have /[!inE] Q1f := allf x; first by case/andP.
 by move=> ? ?; apply: Q1f; apply/andP.
 Qed.
 
 Lemma in_on2P : {in D1 &, {on D2 &, allQ2 f}} <->
                 {in [pred x in D1 | f x \in D2] &, allQ2 f}.
 Proof.
-split => allf x y; have := allf x y; rewrite !inE => Q2f.
+split => allf x y; have /[!inE] Q2f := allf x y.
   by move=> /andP[? ?] /andP[? ?]; apply: Q2f.
 by move=> ? ? ? ?; apply: Q2f; apply/andP.
 Qed.

--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -14,6 +14,9 @@ Global Set Bullet Behavior "None".
 (*   --> This will become standard with the Coq v8.11 SSReflect core library. *)
 (*                                                                            *)
 (*   Intro pattern ltac views:                                                *)
+(*   - calling rewrite from an intro pattern, use with parsimony              *)
+(*     => /[1! rules]  := rewrite rules                                       *)
+(*     => /[! rules]   := rewrite !rules                                      *)
 (*   - top of the stack actions:                                              *)
 (*     => /[apply]     := => hyp {}/hyp                                       *)
 (*     => /[swap]      := => x y; move: y x                                   *)
@@ -91,6 +94,10 @@ Export Deprecation.Exports.
 
 Module Export ipat.
 
+Notation "'[' '1' '!' rules ']'"     := (ltac:(rewrite rules))
+  (at level 0, rules at level 200, only parsing) : ssripat_scope.
+Notation "'[' '!' rules ']'"         := (ltac:(rewrite !rules))
+  (at level 0, rules at level 200, only parsing) : ssripat_scope.
 Notation "'[' 'apply' ']'" := (ltac:(let f := fresh "_top_" in move=> f {}/f))
   (at level 0, only parsing) : ssripat_scope.
 


### PR DESCRIPTION
##### Motivation for this change

 Intro pattern ltac views (rewrite, dup, swap, apply) in order not to break intro patterns for silly rewrites.
  - calling rewrite from an intro pattern, use with parsimony
    `=> /[1! rules]`  does `rewrite 1!rules`
    `=> /[! rules]`  does `rewrite !rules`

This is a part of #372, simplified, rewritten and rebased.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
- [ ] open corresponding PR in Coq to integrate changes from `ssreflect.v`

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
