### PR TITLE
Intro discharge subst

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,15 +82,6 @@ make-coq-latest:
     - merge_requests
     - schedules
 
-coq-8.7:
-  extends: .opam-build-once
-
-coq-8.8:
-  extends: .opam-build-once
-
-coq-8.9:
-  extends: .opam-build-once
-
 coq-8.10:
   extends: .opam-build-once
 
@@ -149,21 +140,6 @@ coq-dev:
     - merge_requests
     - schedules
 
-ci-fourcolor-8.7:
-  extends: .ci-fourcolor
-  variables:
-    COQ_VERSION: "8.7"
-
-ci-fourcolor-8.8:
-  extends: .ci-fourcolor
-  variables:
-    COQ_VERSION: "8.8"
-
-ci-fourcolor-8.9:
-  extends: .ci-fourcolor
-  variables:
-    COQ_VERSION: "8.9"
-
 ci-fourcolor-8.10:
   extends: .ci-fourcolor
   variables:
@@ -187,21 +163,6 @@ ci-fourcolor-dev:
     - tags
     - merge_requests
     - schedules
-
-ci-odd-order-8.7:
-  extends: .ci-odd-order
-  variables:
-    COQ_VERSION: "8.7"
-
-ci-odd-order-8.8:
-  extends: .ci-odd-order
-  variables:
-    COQ_VERSION: "8.8"
-
-ci-odd-order-8.9:
-  extends: .ci-odd-order
-  variables:
-    COQ_VERSION: "8.9"
 
 ci-odd-order-8.10:
   extends: .ci-odd-order
@@ -248,21 +209,6 @@ ci-lemma-overloading-dev:
     - opam pin add -n -k path coq-mathcomp-bigenough .
     - opam install -y -v -j "${NJOBS}" coq-mathcomp-bigenough
 
-ci-bigenough-8.7:
-  extends: .ci-bigenough
-  variables:
-    COQ_VERSION: "8.7"
-
-ci-bigenough-8.8:
-  extends: .ci-bigenough
-  variables:
-    COQ_VERSION: "8.8"
-
-ci-bigenough-8.9:
-  extends: .ci-bigenough
-  variables:
-    COQ_VERSION: "8.9"
-
 ci-bigenough-8.10:
   extends: .ci-bigenough
   variables:
@@ -284,21 +230,6 @@ ci-bigenough-dev:
 #     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-real-closed
 #     - opam install -y -v -j "${NJOBS}" coq-mathcomp-real-closed
 # 
-# ci-real-closed-8.7:
-#   extends: .ci-real-closed
-#   variables:
-#     COQ_VERSION: "8.7"
-# 
-# ci-real-closed-8.8:
-#   extends: .ci-real-closed
-#   variables:
-#     COQ_VERSION: "8.8"
-# 
-# ci-real-closed-8.9:
-#   extends: .ci-real-closed
-#   variables:
-#     COQ_VERSION: "8.9"
-# 
 # ci-real-closed-dev:
 #   extends: .ci-real-closed
 #   variables:
@@ -315,16 +246,6 @@ ci-bigenough-dev:
 #     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-analysis
 #     - opam install -y -v -j "${NJOBS}" coq-mathcomp-analysis
 # 
-# ci-analysis-8.8:
-#   extends: .ci-analysis
-#   variables:
-#     COQ_VERSION: "8.8"
-# 
-# ci-analysis-8.9:
-#   extends: .ci-analysis
-#   variables:
-#     COQ_VERSION: "8.9"
-# 
 # ci-analysis-dev:
 #   extends: .ci-analysis
 #   variables:
@@ -340,21 +261,6 @@ ci-bigenough-dev:
     - opam pin add -n -k path coq-mathcomp-finmap .
     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-finmap
     - opam install -y -v -j "${NJOBS}" coq-mathcomp-finmap
-
-ci-finmap-8.7:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "8.7"
-
-ci-finmap-8.8:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "8.8"
-
-ci-finmap-8.9:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "8.9"
 
 ci-finmap-8.10:
   extends: .ci-finmap
@@ -422,15 +328,6 @@ ci-fcsl-pcm-dev:
   extends: .docker-deploy
   except:
     - schedules
-
-mathcomp-dev:coq-8.7:
-  extends: .docker-deploy-once
-
-mathcomp-dev:coq-8.8:
-  extends: .docker-deploy-once
-
-mathcomp-dev:coq-8.9:
-  extends: .docker-deploy-once
 
 mathcomp-dev:coq-8.10:
   extends: .docker-deploy-once

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -12,8 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added intro pattern ltac views (rewrite, dup, swap, apply):
   `/[1 rules]`, `/[-1 rules]`,  `/[! rules]`, `/[-! rules]`,
-  `/[? rules]`, `/[-? rules]`, `/[/def]`, `/apply`, `/swap`
-  and `/dup`.
+  `/[? rules]`, `/[-? rules]`, `/[/def]`, `/apply`, `/swap`, `/dup`,
+  `/[: x @y z]`, `/[-> in x0 .. x6]`, and `/[<- in x0 .. x6]`.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added intro pattern ltac views (rewrite, dup, swap, apply):
+  `/[1 rules]`, `/[-1 rules]`,  `/[! rules]`, `/[-! rules]`,
+  `/[? rules]`, `/[-? rules]`, `/[/def]`, `/apply`, `/swap`
+  and `/dup`.
+
 ### Changed
 
 ### Renamed

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -554,8 +554,8 @@ Canonical unit_action :=
   @TotalAction _ _ unit_act (@mulr1 _) (fun _ _ _ => mulrA _ _ _).
 Lemma unit_is_groupAction : @is_groupAction _ R setT setT unit_action.
 Proof.
-move=> u _ /=; rewrite inE; apply/andP; split.
-  by apply/subsetP=> x _; rewrite inE.
+move=> u _ /= /[1inE]; apply/andP; split.
+  by apply/subsetP=> x _ /[1inE].
 by apply/morphicP=> x y _ _; rewrite !actpermE /= [_ u]mulrDl.
 Qed.
 Canonical unit_groupAction := GroupAction unit_is_groupAction.

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -968,7 +968,7 @@ without loss{IHa} /forallP/(_ (_, _))/= a_dvM: / [forall k, a %| M k.1 k.2]%Z.
     by exists i; rewrite mxE.
   exists R^T; last exists L^T; rewrite ?unitmx_tr //; exists d => //.
   rewrite -[M]trmxK dM !trmx_mul mulmxA; congr (_ *m _ *m _).
-  by apply/matrixP=> i1 j1; rewrite !mxE; case: eqVneq => // ->.
+  by apply/matrixP=> i1 j1 /[!mxE]; case: eqVneq => // ->.
 without loss{nz_a a_dvM} a1: M a Da / a = 1.
   pose M1 := map_mx (divz^~ a) M; case/(_ M1 1)=> // [k|L uL [R uR [d dvD dM]]].
     by rewrite !mxE Da divzz nz_a.
@@ -1048,7 +1048,7 @@ have{kerGu} defS: map_mx intr (rsubmx G'lr) *m T = S.
 pose vv := \row_j coord (vbasis <<s>>) j v.
 have uS: row_full S.
   apply/row_fullP; exists (\matrix_(i, j) coord s j (vbasis <<s>>)`_i).
-  apply/matrixP=> j1 j2; rewrite !mxE.
+  apply/matrixP=> j1 j2 /[!mxE].
   rewrite -(coord_free _ _ (basis_free (vbasisP _))).
   rewrite -!tnth_nth (coord_span (vbasis_mem (mem_tnth j1 _))) linear_sum.
   by apply: eq_bigr => i _; rewrite !mxE (tnth_nth 0) !linearZ.
@@ -1060,7 +1060,7 @@ case Zv: (map_mx denq (vv *m pinvmx T) == const_mx 1).
     rewrite {1}(coord_vbasis s_v); apply: eq_bigr => j _; congr (_ *: _).
     have ->: map_mx intr a = vv *m pinvmx T *m map_mx intr (dsubmx Gud).
       rewrite map_mxM /=; congr (_ *m _); apply/rowP=> i; rewrite 2!mxE numqE.
-      by have /eqP/rowP/(_ i) := Zv; rewrite !mxE => ->; rewrite mulr1.
+      by have /eqP/rowP/(_ i)/[!mxE]-> := Zv; rewrite mulr1.
     by rewrite -(mulmxA _ _ S) mulmxKpV ?mxE // -eqST submx_full.
   rewrite (coord_vbasis (s_Zs _)); apply: eq_bigr => j _; congr (_ *: _).
   rewrite linear_sum mxE; apply: eq_bigr => i _.

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -353,13 +353,13 @@ Lemma castmx_const m' n' (eq_mn : (m = m') * (n = n')) a :
 Proof. by case: eq_mn; case: m' /; case: n' /. Qed.
 
 Lemma trmx_const a : trmx (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma row_perm_const s a : row_perm s (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma col_perm_const s a : col_perm s (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma xrow_const i1 i2 a : xrow i1 i2 (const_mx a) = const_mx a.
 Proof. exact: row_perm_const. Qed.
@@ -371,28 +371,28 @@ Lemma rowP (u v : 'rV[R]_n) : u 0 =1 v 0 <-> u = v.
 Proof. by split=> [eq_uv | -> //]; apply/matrixP=> i; rewrite ord1. Qed.
 
 Lemma rowK u_ i0 : row i0 (\matrix_i u_ i) = u_ i0.
-Proof. by apply/rowP=> i'; rewrite !mxE. Qed.
+Proof. by apply/rowP=> i' /[!mxE]. Qed.
 
 Lemma row_matrixP A B : (forall i, row i A = row i B) <-> A = B.
 Proof.
 split=> [eqAB | -> //]; apply/matrixP=> i j.
-by move/rowP/(_ j): (eqAB i); rewrite !mxE.
+by move/rowP/(_ j): (eqAB i) => /[!mxE].
 Qed.
 
 Lemma colP (u v : 'cV[R]_m) : u^~ 0 =1 v^~ 0 <-> u = v.
 Proof. by split=> [eq_uv | -> //]; apply/matrixP=> i j; rewrite ord1. Qed.
 
 Lemma row_const i0 a : row i0 (const_mx a) = const_mx a.
-Proof. by apply/rowP=> j; rewrite !mxE. Qed.
+Proof. by apply/rowP=> j /[!mxE]. Qed.
 
 Lemma col_const j0 a : col j0 (const_mx a) = const_mx a.
-Proof. by apply/colP=> i; rewrite !mxE. Qed.
+Proof. by apply/colP=> i /[!mxE]. Qed.
 
 Lemma row'_const i0 a : row' i0 (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma col'_const j0 a : col' j0 (const_mx a) = const_mx a.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma col_perm1 A : col_perm 1 A = A.
 Proof. by apply/matrixP=> i j; rewrite mxE perm1. Qed.
@@ -408,7 +408,7 @@ Proof. by apply/matrixP=> i j; rewrite !mxE permM. Qed.
 
 Lemma col_row_permC s t A :
   col_perm s (row_perm t A) = row_perm t (col_perm s A).
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 End FixedDim.
 
@@ -458,7 +458,7 @@ Lemma conform_castmx m1 n1 m2 n2 m3 n3
 Proof. by do [case: e_mn; case: m3 /; case: n3 /] in A *. Qed.
 
 Lemma trmxK m n : cancel (@trmx m n) (@trmx n m).
-Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by move=> A; apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma trmx_inj m n : injective (@trmx m n).
 Proof. exact: can_inj (@trmxK m n). Qed.
@@ -470,10 +470,10 @@ by case: eq_mn => eq_m eq_n; apply/matrixP=> i j; rewrite !(mxE, castmxE).
 Qed.
 
 Lemma tr_row_perm m n s (A : 'M_(m, n)) : (row_perm s A)^T = col_perm s A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_col_perm m n s (A : 'M_(m, n)) : (col_perm s A)^T = row_perm s A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_xrow m n i1 i2 (A : 'M_(m, n)) : (xrow i1 i2 A)^T = xcol i1 i2 A^T.
 Proof. exact: tr_row_perm. Qed.
@@ -489,37 +489,37 @@ Proof. by apply/colP=> i; rewrite mxE [j]ord1. Qed.
 
 Lemma row_eq m1 m2 n i1 i2 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
   row i1 A1 = row i2 A2 -> A1 i1 =1 A2 i2.
-Proof. by move/rowP=> eqA12 j; have:= eqA12 j; rewrite !mxE. Qed.
+Proof. by move/rowP=> eqA12 j; have /[!mxE] := eqA12 j. Qed.
 
 Lemma col_eq m n1 n2 j1 j2 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   col j1 A1 = col j2 A2 -> A1^~ j1 =1 A2^~ j2.
-Proof. by move/colP=> eqA12 i; have:= eqA12 i; rewrite !mxE. Qed.
+Proof. by move/colP=> eqA12 i; have /[!mxE] := eqA12 i. Qed.
 
 Lemma row'_eq m n i0 (A B : 'M_(m, n)) :
   row' i0 A = row' i0 B -> {in predC1 i0, A =2 B}.
 Proof.
 move/matrixP=> eqAB' i; rewrite !inE eq_sym; case/unlift_some=> i' -> _ j.
-by have:= eqAB' i' j; rewrite !mxE.
+by have /[!mxE] := eqAB' i' j.
 Qed.
 
 Lemma col'_eq m n j0 (A B : 'M_(m, n)) :
   col' j0 A = col' j0 B -> forall i, {in predC1 j0, A i =1 B i}.
 Proof.
 move/matrixP=> eqAB' i j; rewrite !inE eq_sym; case/unlift_some=> j' -> _.
-by have:= eqAB' i j'; rewrite !mxE.
+by have  /[!mxE] := eqAB' i j'.
 Qed.
 
 Lemma tr_row m n i0 (A : 'M_(m, n)) : (row i0 A)^T = col i0 A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_row' m n i0 (A : 'M_(m, n)) : (row' i0 A)^T = col' i0 A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_col m n j0 (A : 'M_(m, n)) : (col j0 A)^T = row j0 A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_col' m n j0 (A : 'M_(m, n)) : (col' j0 A)^T = row' j0 A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Ltac split_mxE := apply/matrixP=> i j; do ![rewrite mxE | case: split => ?].
 
@@ -573,8 +573,8 @@ Proof. by apply/matrixP=> i j; rewrite mxE row_mxEr. Qed.
 
 Lemma hsubmxK A : row_mx (lsubmx A) (rsubmx A) = A.
 Proof.
-apply/matrixP=> i j; rewrite !mxE.
-by case: splitP => k Dk //=; rewrite !mxE //=; congr (A _ _); apply: val_inj.
+apply/matrixP=> i j /[!mxE].
+by case: splitP => k Dk //= /[!mxE]//=; congr (A _ _); apply: val_inj.
 Qed.
 
 Lemma col_mxEu A1 A2 i j : col_mx A1 A2 (lshift m2 i) j = A1 i j.
@@ -651,7 +651,7 @@ apply: (canRL (castmxKV _ _)); apply/matrixP=> i j.
 rewrite castmxE !mxE cast_ord_id; case: splitP => j1 /= def_j.
   have: (j < n1 + n2) && (j < n1) by rewrite def_j lshift_subproof /=.
   by move: def_j; do 2![case: splitP => // ? ->; rewrite ?mxE] => /ord_inj->.
-case: splitP def_j => j2 ->{j} def_j; rewrite !mxE.
+case: splitP def_j => j2 ->{j} def_j /[!mxE].
   have: ~~ (j2 < n1) by rewrite -leqNgt def_j leq_addr.
   have: j1 < n2 by rewrite -(ltn_add2l n1) -def_j.
   by move: def_j; do 2![case: splitP => // ? ->] => /addnI/val_inj->.
@@ -670,7 +670,7 @@ Definition col_mxAx := col_mxA. (* bypass Prenex Implicits. *)
 Lemma row_row_mx m n1 n2 i0 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   row i0 (row_mx A1 A2) = row_mx (row i0 A1) (row i0 A2).
 Proof.
-by apply/matrixP=> i j; rewrite !mxE; case: (split j) => j'; rewrite mxE.
+by apply/matrixP=> i j /[!mxE]; case: (split j) => j' /[1mxE].
 Qed.
 
 Lemma col_col_mx m1 m2 n j0 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
@@ -680,7 +680,7 @@ Proof. by apply: trmx_inj; rewrite !(tr_col, tr_col_mx, row_row_mx). Qed.
 Lemma row'_row_mx m n1 n2 i0 (A1 : 'M_(m, n1)) (A2 : 'M_(m, n2)) :
   row' i0 (row_mx A1 A2) = row_mx (row' i0 A1) (row' i0 A2).
 Proof.
-by apply/matrixP=> i j; rewrite !mxE; case: (split j) => j'; rewrite mxE.
+by apply/matrixP=> i j /[!mxE]; case: (split j) => j' /[1mxE].
 Qed.
 
 Lemma col'_col_mx m1 m2 n j0 (A1 : 'M_(m1, n)) (A2 : 'M_(m2, n)) :
@@ -813,16 +813,16 @@ Variables m1 m2 n1 n2 : nat.
 Variable A : 'M[R]_(m1 + m2, n1 + n2).
 
 Lemma trmx_ulsub : (ulsubmx A)^T = ulsubmx A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma trmx_ursub : (ursubmx A)^T = dlsubmx A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma trmx_dlsub : (dlsubmx A)^T = ursubmx A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma trmx_drsub : (drsubmx A)^T = drsubmx A^T.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 End TrCutBlock.
 
@@ -939,34 +939,34 @@ Section OneMatrix.
 Variables (m n : nat) (A : 'M[aT]_(m, n)).
 
 Lemma map_trmx : A^f^T = A^T^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_const_mx a : (const_mx a)^f = const_mx (f a) :> 'M_(m, n).
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_row i : (row i A)^f = row i A^f.
-Proof. by apply/rowP=> j; rewrite !mxE. Qed.
+Proof. by apply/rowP=> j /[!mxE]. Qed.
 
 Lemma map_col j : (col j A)^f = col j A^f.
-Proof. by apply/colP=> i; rewrite !mxE. Qed.
+Proof. by apply/colP=> i /[!mxE]. Qed.
 
 Lemma map_row' i0 : (row' i0 A)^f = row' i0 A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_col' j0 : (col' j0 A)^f = col' j0 A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_row_perm s : (row_perm s A)^f = row_perm s A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_col_perm s : (col_perm s A)^f = col_perm s A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_xrow i1 i2 : (xrow i1 i2 A)^f = xrow i1 i2 A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_xcol j1 j2 : (xcol j1 j2 A)^f = xcol j1 j2 A^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_castmx m' n' c : (castmx c A)^f = castmx c A^f :> 'M_(m', n').
 Proof. by apply/matrixP=> i j; rewrite !(castmxE, mxE). Qed.
@@ -983,7 +983,7 @@ Lemma map_mxvec : (mxvec A)^f = mxvec A^f.
 Proof. by apply/rowP=> i; rewrite !(castmxE, mxE). Qed.
 
 Lemma map_vec_mx (v : 'rV_(m * n)) : (vec_mx v)^f = vec_mx v^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 End OneMatrix.
 
@@ -1006,28 +1006,28 @@ Lemma map_block_mx :
 Proof. by apply/matrixP=> i j; do 3![rewrite !mxE //; case: split => ?]. Qed.
 
 Lemma map_lsubmx : (lsubmx Bh)^f = lsubmx Bh^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_rsubmx : (rsubmx Bh)^f = rsubmx Bh^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_usubmx : (usubmx Bv)^f = usubmx Bv^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_dsubmx : (dsubmx Bv)^f = dsubmx Bv^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_ulsubmx : (ulsubmx B)^f = ulsubmx B^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_ursubmx : (ursubmx B)^f = ursubmx B^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_dlsubmx : (dlsubmx B)^f = dlsubmx B^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma map_drsubmx : (drsubmx B)^f = drsubmx B^f.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 End Block.
 
@@ -1077,10 +1077,10 @@ Proof. by elim: d => [|d IHd]; rewrite ?mulrS mxE ?IHd. Qed.
 
 Lemma summxE I r (P : pred I) (E : I -> 'M_(m, n)) i j :
   (\sum_(k <- r | P k) E k) i j = \sum_(k <- r | P k) E k i j.
-Proof. by apply: (big_morph (fun A => A i j)) => [A B|]; rewrite mxE. Qed.
+Proof. by apply: (big_morph (fun A => A i j)) => [A B|] /[1mxE]. Qed.
 
 Lemma const_mx_is_additive : additive const_mx.
-Proof. by move=> a b; apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by move=> a b; apply/matrixP=> i j /[!mxE]. Qed.
 Canonical const_mx_additive := Additive const_mx_is_additive.
 
 End FixedDim.
@@ -1093,7 +1093,7 @@ Definition swizzle_mx k (A : 'M[V]_(m, n)) :=
   \matrix[k]_(i, j) A (f i j) (g i j).
 
 Lemma swizzle_mx_is_additive k : additive (swizzle_mx k).
-Proof. by move=> A B; apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by move=> A B; apply/matrixP=> i j /[!mxE]. Qed.
 Canonical swizzle_mx_additive k := Additive (swizzle_mx_is_additive k).
 
 End Additive.
@@ -1282,7 +1282,7 @@ Canonical matrix_lmodType :=
   Eval hnf in LmodType R 'M[R]_(m, n) matrix_lmodMixin.
 
 Lemma scalemx_const a b : a *: const_mx b = const_mx (a * b).
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma matrix_sum_delta A :
   A = \sum_(i < m) \sum_(j < n) A i j *: delta_mx i j.
@@ -1300,7 +1300,7 @@ Section StructuralLinear.
 
 Lemma swizzle_mx_is_scalable m n p q f g k :
   scalable (@swizzle_mx R m n p q f g k).
-Proof. by move=> a A; apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by move=> a A; apply/matrixP=> i j /[!mxE]. Qed.
 Canonical swizzle_mx_scalable m n p q f g k :=
   AddLinear (@swizzle_mx_is_scalable m n p q f g k).
 
@@ -1349,14 +1349,14 @@ Lemma delta_mx_ushift m1 m2 n i j :
   delta_mx (lshift m2 i) j = col_mx (delta_mx i j) 0 :> 'M_(m1 + m2, n).
 Proof.
 apply/matrixP=> i' j'; rewrite !mxE -(can_eq splitK) (unsplitK (inl _ _)).
-by  case: split => ?; rewrite mxE.
+by  case: split => ? /[1mxE].
 Qed.
 
 Lemma delta_mx_dshift m1 m2 n i j :
   delta_mx (rshift m1 i) j = col_mx 0 (delta_mx i j) :> 'M_(m1 + m2, n).
 Proof.
 apply/matrixP=> i' j'; rewrite !mxE -(can_eq splitK) (unsplitK (inr _ _)).
-by case: split => ?; rewrite mxE.
+by case: split => ? /[1mxE].
 Qed.
 
 Lemma vec_mx_delta m n i j :
@@ -1392,7 +1392,7 @@ Definition diag_mx n (d : 'rV[R]_n) :=
   \matrix[diag_mx_key]_(i, j) (d 0 i *+ (i == j)).
 
 Lemma tr_diag_mx n (d : 'rV_n) : (diag_mx d)^T = diag_mx d.
-Proof. by apply/matrixP=> i j; rewrite !mxE; case: eqVneq => // ->. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]; case: eqVneq => // ->. Qed.
 
 Lemma diag_mx_is_linear n : linear (@diag_mx n).
 Proof.
@@ -1420,7 +1420,7 @@ Definition scalar_mx x : 'M[R]_n :=
 Notation "x %:M" := (scalar_mx x) : ring_scope.
 
 Lemma diag_const_mx a : diag_mx (const_mx a) = a%:M :> 'M_n.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma tr_scalar_mx a : (a%:M)^T = a%:M.
 Proof. by apply/matrixP=> i j; rewrite !mxE eq_sym. Qed.
@@ -1439,7 +1439,7 @@ Proof. by rewrite scale_scalar_mx mulr1. Qed.
 
 Lemma scalar_mx_sum_delta a : a%:M = \sum_i a *: delta_mx i i.
 Proof.
-by rewrite -diag_const_mx diag_mx_sum_delta; apply: eq_bigr => i _; rewrite mxE.
+by rewrite -diag_const_mx diag_mx_sum_delta; apply: eq_bigr => i _ /[1mxE].
 Qed.
 
 Lemma mx1_sum_delta : 1%:M = \sum_i delta_mx i i.
@@ -1489,7 +1489,7 @@ Local Notation "A *m B" := (mulmx A B) : ring_scope.
 Lemma mulmxA m n p q (A : 'M_(m, n)) (B : 'M_(n, p)) (C : 'M_(p, q)) :
   A *m (B *m C) = A *m B *m C.
 Proof.
-apply/matrixP=> i l; rewrite !mxE.
+apply/matrixP=> i l /[!mxE].
 transitivity (\sum_j (\sum_k (A i j * (B j k * C k l)))).
   by apply: eq_bigr => j _; rewrite mxE big_distrr.
 rewrite exchange_big; apply: eq_bigr => j _; rewrite mxE big_distrl /=.
@@ -1573,7 +1573,7 @@ Proof. by rewrite !rowE mulmxA. Qed.
 Lemma mulmx_sum_row m n (u : 'rV_m) (A : 'M_(m, n)) :
   u *m A = \sum_i u 0 i *: row i A.
 Proof.
-by apply/rowP=> j; rewrite mxE summxE; apply: eq_bigr => i _; rewrite !mxE.
+by apply/rowP=> j; rewrite mxE summxE; apply: eq_bigr => i _ /[!mxE].
 Qed.
 
 Lemma mul_delta_mx_cond m n p (j1 j2 : 'I_n) (i1 : 'I_m) (k2 : 'I_p) :
@@ -1612,7 +1612,7 @@ Proof. by apply/matrixP=> i j; rewrite mul_diag_mx !mxE mulrnAr. Qed.
 
 Lemma mul_scalar_mx m n a (A : 'M_(m, n)) : a%:M *m A = a *: A.
 Proof.
-by rewrite -diag_const_mx mul_diag_mx; apply/matrixP=> i j; rewrite !mxE.
+by rewrite -diag_const_mx mul_diag_mx; apply/matrixP=> i j /[!mxE].
 Qed.
 
 Lemma scalar_mxM n a b : (a * b)%:M = a%:M *m b%:M :> 'M_n.
@@ -1726,7 +1726,7 @@ Proof. by apply/matrixP=> i j; rewrite !mxE ltn_ord andbT. Qed.
 Lemma pid_mx_row n r : pid_mx r = row_mx 1%:M 0 :> 'M_(r, r + n).
 Proof.
 apply/matrixP=> i j; rewrite !mxE ltn_ord andbT.
-case: splitP => j' ->; rewrite !mxE // .
+case: splitP => j' -> /[!mxE]//.
 by rewrite eqn_leq andbC leqNgt lshift_subproof.
 Qed.
 
@@ -1739,12 +1739,12 @@ Qed.
 Lemma pid_mx_block m n r : pid_mx r = block_mx 1%:M 0 0 0 :> 'M_(r + m, r + n).
 Proof.
 apply/matrixP=> i j; rewrite !mxE row_mx0 andbC.
-case: splitP => i' ->; rewrite !mxE //; case: splitP => j' ->; rewrite !mxE //=.
+case: splitP => i' -> /[!mxE]//; case: splitP => j' -> /[!mxE]//=.
 by rewrite eqn_leq andbC leqNgt lshift_subproof.
 Qed.
 
 Lemma tr_pid_mx m n r : (pid_mx r)^T = pid_mx r :> 'M_(n, m).
-Proof. by apply/matrixP=> i j; rewrite !mxE; case: eqVneq => // ->. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]; case: eqVneq => // ->. Qed.
 
 Lemma pid_mx_minv m n r : pid_mx (minn m r) = pid_mx r :> 'M_(m, n).
 Proof. by apply/matrixP=> i j; rewrite !mxE leq_min ltn_ord. Qed.
@@ -1788,15 +1788,15 @@ Qed.
 Lemma mul_mx_row m n p1 p2 (A : 'M_(m, n)) (Bl : 'M_(n, p1)) (Br : 'M_(n, p2)) :
   A *m row_mx Bl Br = row_mx (A *m Bl) (A *m Br).
 Proof.
-apply/matrixP=> i k; rewrite !mxE.
-by case defk: (split k); rewrite mxE; apply: eq_bigr => j _; rewrite mxE defk.
+apply/matrixP=> i k /[!mxE].
+by case defk: (split k) => /[1mxE]; apply: eq_bigr => j _; rewrite mxE defk.
 Qed.
 
 Lemma mul_col_mx m1 m2 n p (Au : 'M_(m1, n)) (Ad : 'M_(m2, n)) (B : 'M_(n, p)) :
   col_mx Au Ad *m B = col_mx (Au *m B) (Ad *m B).
 Proof.
-apply/matrixP=> i k; rewrite !mxE.
-by case defi: (split i); rewrite mxE; apply: eq_bigr => j _; rewrite mxE defi.
+apply/matrixP=> i k /[!mxE].
+by case defi: (split i) => /[1mxE]; apply: eq_bigr => j _; rewrite mxE defi.
 Qed.
 
 Lemma mul_row_col m n1 n2 p (Al : 'M_(m, n1)) (Ar : 'M_(m, n2))
@@ -1920,7 +1920,7 @@ Definition mxtrace (A : 'M[R]_n) := \sum_i A i i.
 Local Notation "'\tr' A" := (mxtrace A) : ring_scope.
 
 Lemma mxtrace_tr A : \tr A^T = \tr A.
-Proof. by apply: eq_bigr=> i _; rewrite mxE. Qed.
+Proof. by apply: eq_bigr=> i _ /[1mxE]. Qed.
 
 Lemma mxtrace_is_scalar : scalar mxtrace.
 Proof.
@@ -2067,7 +2067,7 @@ Notation "'\adj' A" := (adjugate A) : ring_scope.
 Lemma trmx_mul_rev (R : ringType) m n p (A : 'M[R]_(m, n)) (B : 'M[R]_(n, p)) :
   (A *m B)^T = (B : 'M[R^c]_(n, p))^T *m (A : 'M[R^c]_(m, n))^T.
 Proof.
-by apply/matrixP=> k i; rewrite !mxE; apply: eq_bigr => j _; rewrite !mxE.
+by apply/matrixP=> k i /[!mxE]; apply: eq_bigr => j _ /[!mxE].
 Qed.
 
 Canonical matrix_countZmodType (M : countZmodType) m n :=
@@ -2123,13 +2123,13 @@ Lemma map_pid_mx r : (pid_mx r)^f = pid_mx r :> 'M_(m, n).
 Proof. by apply/matrixP=> i j; rewrite !mxE rmorph_nat. Qed.
 
 Lemma trace_map_mx (A : 'M_n) : \tr A^f = f (\tr A).
-Proof. by rewrite rmorph_sum; apply: eq_bigr => i _; rewrite mxE. Qed.
+Proof. by rewrite rmorph_sum; apply: eq_bigr => i _ /[1mxE]. Qed.
 
 Lemma det_map_mx n' (A : 'M_n') : \det A^f = f (\det A).
 Proof.
 rewrite rmorph_sum //; apply: eq_bigr => s _.
 rewrite rmorphM rmorph_sign rmorph_prod; congr (_ * _).
-by apply: eq_bigr => i _; rewrite mxE.
+by apply: eq_bigr => i _ /[1mxE].
 Qed.
 
 Lemma cofactor_map_mx (A : 'M_n) i j : cofactor A^f i j = f (cofactor A i j).
@@ -2176,7 +2176,7 @@ Implicit Type B : 'M[R]_(n, p).
 
 Lemma trmx_mul A B : (A *m B)^T = B^T *m A^T.
 Proof.
-rewrite trmx_mul_rev; apply/matrixP=> k i; rewrite !mxE.
+rewrite trmx_mul_rev; apply/matrixP=> k i /[!mxE].
 by apply: eq_bigr => j _; rewrite mulrC.
 Qed.
 
@@ -2263,7 +2263,7 @@ Lemma mxtrace_mulC m n (A : 'M[R]_(m, n)) B :
    \tr (A *m B) = \tr (B *m A).
 Proof.
 have expand_trM C D: \tr (C *m D) = \sum_i \sum_j C i j * D j i.
-  by apply: eq_bigr => i _; rewrite mxE.
+  by apply: eq_bigr => i _ /[1mxE].
 rewrite !{}expand_trM exchange_big /=.
 by do 2!apply: eq_bigr => ? _; apply: mulrC.
 Qed.
@@ -2323,7 +2323,7 @@ Lemma detZ n a (A : 'M[R]_n) : \det (a *: A) = a ^+ n * \det A.
 Proof.
 rewrite big_distrr /=; apply: eq_bigr => s _; rewrite mulrCA; congr (_ * _).
 rewrite -[n in a ^+ n]card_ord -prodr_const -big_split /=.
-by apply: eq_bigr=> i _; rewrite mxE.
+by apply: eq_bigr=> i _ /[1mxE].
 Qed.
 
 Lemma det0 n' : \det (0 : 'M[R]_n'.+1) = 0.
@@ -2342,7 +2342,7 @@ pose F := ('I_n ^ n)%type; pose AB s i j := A i j * B j (s i).
 transitivity (\sum_(f : F) \sum_(s : 'S_n) (-1) ^+ s * \prod_i AB s i (f i)).
   rewrite exchange_big; apply: eq_bigr => /= s _; rewrite -big_distrr /=.
   congr (_ * _); rewrite -(bigA_distr_bigA (AB s)) /=.
-  by apply: eq_bigr => x _; rewrite mxE.
+  by apply: eq_bigr => x _ /[1mxE].
 rewrite (bigID (fun f : F => injectiveb f)) /= addrC big1 ?add0r => [|f Uf].
   rewrite (reindex (@pval _)) /=; last first.
     pose in_Sn := insubd (1%g : 'S_n).
@@ -2355,7 +2355,7 @@ rewrite (bigID (fun f : F => injectiveb f)) /= addrC big1 ?add0r => [|f Uf].
 transitivity (\det (\matrix_(i, j) B (f i) j) * \prod_i A i (f i)).
   rewrite mulrC big_distrr /=; apply: eq_bigr => s _.
   rewrite mulrCA big_split //=; congr (_ * (_ * _)).
-  by apply: eq_bigr => x _; rewrite mxE.
+  by apply: eq_bigr => x _ /[1mxE].
 case/injectivePn: Uf => i1 [i2 Di12 Ef12].
 by rewrite (determinant_alternate Di12) ?simp //= => j; rewrite !mxE Ef12.
 Qed.
@@ -2369,7 +2369,7 @@ rewrite /(\det _) (bigD1 1%g) //= addrC big1 => [|p p1].
   by rewrite add0r odd_perm1 mul1r; apply: eq_bigr => i; rewrite perm1 mxE eqxx.
 have{p1}: ~~ perm_on set0 p.
   apply: contra p1; move/subsetP=> p1; apply/eqP/permP=> i.
-  by rewrite perm1; apply/eqP/idPn; move/p1; rewrite inE.
+  by rewrite perm1; apply/eqP/idPn; move/p1 /[1inE].
 case/subsetPn=> i; rewrite !inE eq_sym; move/negPf=> p_i _.
 by rewrite (bigD1 i) //= mulrCA mxE p_i mul0r.
 Qed.
@@ -2418,7 +2418,7 @@ Lemma cofactor_tr n (A : 'M[R]_n) i j : cofactor A^T i j = cofactor A j i.
 Proof.
 rewrite /cofactor addnC; congr (_ * _).
 rewrite -tr_row' -tr_col' det_tr; congr (\det _).
-by apply/matrixP=> ? ?; rewrite !mxE.
+by apply/matrixP=> ? ? /[!mxE].
 Qed.
 
 Lemma cofactorZ n a (A : 'M[R]_n) i j : 
@@ -2441,7 +2441,7 @@ Proof. by apply/matrixP=> i j; rewrite !mxE cofactorZ. Qed.
 (* Cramer Rule : adjugate on the left *)
 Lemma mul_mx_adj n (A : 'M[R]_n) : A *m \adj A = (\det A)%:M.
 Proof.
-apply/matrixP=> i1 i2; rewrite !mxE; have [->|Di] := eqVneq.
+apply/matrixP=> i1 i2 /[!mxE]; have [->|Di] := eqVneq.
   rewrite (expand_det_row _ i2) //=.
   by apply: eq_bigr => j _; congr (_ * _); rewrite mxE.
 pose B := \matrix_(i, j) (if i == i2 then A i1 j else A i j).
@@ -2753,8 +2753,8 @@ have [{detA0}A'0 | nzA'] := eqVneq (row 0 (\adj A)) 0; last first.
   by rewrite mul_mx_scalar scale0r.
 pose A' := col' 0 A; pose vA := col 0 A.
 have defA: A = row_mx vA A'.
-  apply/matrixP=> i j; rewrite !mxE.
-  case: splitP => j' def_j; rewrite mxE; congr (A i _); apply: val_inj => //=.
+  apply/matrixP=> i j /[!mxE].
+  case: splitP => j' def_j /[1mxE]; congr (A i _); apply: val_inj => //=.
   by rewrite def_j [j']ord1.
 have{IHn} w_ j : exists w : 'rV_n.+1, [/\ w != 0, w 0 j = 0 & w *m A' = 0].
   have [|wj nzwj wjA'0] := IHn (row' j A').
@@ -2769,7 +2769,7 @@ have{IHn} w_ j : exists w : 'rV_n.+1, [/\ w != 0, w 0 j = 0 & w *m A' = 0].
   by rewrite eq_sym; case/unlift_some=> ? ? ->.
 have [w0 [nz_w0 w00_0 w0A']] := w_ 0; pose a0 := (w0 *m vA) 0 0.
 have [j {nz_w0}/= nz_w0j | w00] := pickP [pred j | w0 0 j != 0]; last first.
-  by case/eqP: nz_w0; apply/rowP=> j; rewrite mxE; move/eqP: (w00 j).
+  by case/eqP: nz_w0; apply/rowP=> j /[1mxE]; move/eqP: (w00 j).
 have{w_} [wj [nz_wj wj0_0 wjA']] := w_ j; pose aj := (wj *m vA) 0 0.
 have [aj0 | nz_aj] := eqVneq aj 0.
   exists wj => //; rewrite defA (@mul_mx_row _ _ _ 1) [_ *m _]mx11_scalar -/aj.
@@ -2795,7 +2795,7 @@ Local Notation "A ^f" := (map_mx f A) : ring_scope.
 Lemma map_mx_inj {m n} : injective (map_mx f : 'M_(m, n) -> 'M_(m, n)).
 Proof.
 move=> A B eq_AB; apply/matrixP=> i j.
-by move/matrixP/(_ i j): eq_AB; rewrite !mxE; apply: fmorph_inj.
+by move/matrixP/(_ i j): eq_AB => /[!mxE]; apply: fmorph_inj.
 Qed.
 
 Lemma map_mx_is_scalar n (A : 'M_n) : is_scalar_mx A^f = is_scalar_mx A.

--- a/mathcomp/algebra/mxalgebra.v
+++ b/mathcomp/algebra/mxalgebra.v
@@ -2157,7 +2157,7 @@ rewrite -sum1_card (partition_big lsubmx nzC) => [|A]; last first.
   by rewrite det_lblock [0]mx11_scalar det_scalar1 mxE mul0r.
 rewrite -sum_nat_const; apply: eq_bigr; rewrite /= -[n.+1]/(1 + n)%N => v nzv.
 case: (pickP (fun i => v i 0 != 0)) => [k nza | v0]; last first.
-  by case/eqP: nzv; apply/colP=> i; move/eqP: (v0 i); rewrite mxE.
+  by case/eqP: nzv; apply/colP=> i; move/eqP: (v0 i) => /[1mxE].
 have xrkK: involutive (@xrow F _ _ 0 k).
   by move=> m A /=; rewrite /xrow -row_permM tperm2 row_perm1.
 rewrite (reindex_inj (inv_inj (xrkK (1 + n)%N))) /= -[n.+1]/(1 + n)%N.

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -129,7 +129,7 @@ Lemma Sylvester_mxE (i j : 'I_dS) :
   let S_ r k := r`_(j - k) *+ (k <= j) in
   Sylvester_mx i j = match split i with inl k => S_ p k | inr k => S_ q k end.
 Proof.
-move=> S_; rewrite mxE; case: {i}(split i) => i; rewrite !mxE /=;
+move=> S_ /[1mxE]; case: {i}(split i) => i /[!mxE]/=;
   by rewrite rVpoly_delta coefXnM ltnNge if_neg -mulrb.
 Qed.
 
@@ -157,7 +157,7 @@ exists (u _ (lshift dp), u _ ((rshift dq) _)).
   apply/bigmax_leqP=> i _.
   have ->: cofactor Ss (s i) j0 = (cofactor S (s i) j0)%:P.
     rewrite rmorphM rmorph_sign -det_map_mx; congr (_ * \det _).
-    by apply/matrixP=> i' j'; rewrite !mxE.
+    by apply/matrixP=> i' j' /[!mxE].
   apply: leq_trans (size_mul_leq _ _) (leq_trans _ (valP i)).
   by rewrite size_polyC size_polyXn addnS /= -add1n leq_add2r leq_b1.
 transitivity (\det Ss); last first.
@@ -402,7 +402,7 @@ have phi_is_rmorphism : rmorphism phi.
   by rewrite mxE; apply: eq_bigr => k1 _; rewrite !coef_phi.
 have bij_phi: bijective phi.
   exists (fun P : MR_X => \matrix_(i, j) \poly_(k < size P) P`_k i j) => [A|P].
-    apply/matrixP=> i j; rewrite mxE; apply/polyP=> k.
+    apply/matrixP=> i j /[1mxE]; apply/polyP=> k.
     rewrite coef_poly -coef_phi.
     by case: leqP => // P_le_k; rewrite nth_default ?mxE.
   apply/polyP=> k; apply/matrixP=> i j; rewrite coef_phi mxE coef_poly.
@@ -801,7 +801,7 @@ have tensorM E n1 n2 X Y: finM E (memM (memM E n2 Y) n1 X).
     by case/mxvec_indexP=> i j; rewrite mxvecE mxE; apply: Ea.
   rewrite -[mxvec _]trmxK -trmx_mul mxvec_dotmul -mulmxA trmx_mul !mxE.
   apply: eq_bigr => i _; rewrite Da1 !mxE; congr (_ * _).
-  by apply: eq_bigr => j _; rewrite !mxE.
+  by apply: eq_bigr => j _ /[!mxE].
 suffices [m [X [[u [_ Du]] idealM]]]: exists m,
   exists X, let M := memM memR m X in M 1 /\ forall y, M y -> M (q.[w] * y).
 - do [set M := memM _ m X; move: q.[w] => z] in idealM *.
@@ -876,7 +876,7 @@ exists m, X => y; rewrite -/M; split=> [/defM[a [M2a]] | [q Sq]] -> {y}.
 have M_0: M 0 by exists 0; split=> [i|]; rewrite ?mul0mx mxE.
 have M_D: propD M.
   move=> _ _ [a [Fa ->]] [b [Fb ->]]; exists (a + b).
-  by rewrite mulmxDl !mxE; split=> // i; rewrite mxE; apply: memRD.
+  by rewrite mulmxDl !mxE; split=> // i /[1mxE]; apply: memRD.
 have{M_0 M_D} Msum := big_ind _ M_0 M_D.
 rewrite horner_coef; apply: (Msum) => i _; case: i q`_i {Sq}(Sq i) => /=.
 elim: {q}(size q) => // n IHn i i_le_n y Sy.
@@ -1054,7 +1054,7 @@ Definition eval_mx (e : seq F) := @map_mx term F (eval e).
 Definition mx_term := @map_mx F term GRing.Const.
 
 Lemma eval_mx_term e m n (A : 'M_(m, n)) : eval_mx e (mx_term A) = A.
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Definition mulmx_term m n p (A : 'M[term]_(m, n)) (B : 'M_(n, p)) :=
   \matrix_(i, k) (\big[Add/0]_j (A i j * B j k))%T.
@@ -1099,7 +1099,7 @@ Qed.
 
 Lemma eval_vec_mx e m n (u : 'rV_(m * n)) :
   eval_mx e (vec_mx u) = vec_mx (eval_mx e u).
-Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+Proof. by apply/matrixP=> i j /[!mxE]. Qed.
 
 Lemma eval_mxvec e m n (A : 'M_(m, n)) :
   eval_mx e (mxvec A) = mxvec (eval_mx e A).

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -1673,7 +1673,7 @@ Hint Resolve real1 : core.
 Lemma realn n : n%:R \is @real R. Proof. by rewrite ger0_real. Qed.
 
 Lemma ler_leVge x y : x <= 0 -> y <= 0 -> (x <= y) || (y <= x).
-Proof. by rewrite -!oppr_ge0 => /(ger_leVge _) h /h; rewrite !ler_opp2. Qed.
+Proof. by rewrite -!oppr_ge0 => /(ger_leVge _) /apply; rewrite !ler_opp2. Qed.
 
 Lemma real_leVge x y : x \is real -> y \is real -> (x <= y) || (y <= x).
 Proof.
@@ -4115,7 +4115,7 @@ exists r`_0 => [|z n_gt0 /(mem_rP z n_gt0) r_z].
   have sz_r: size r = n by apply: succn_inj; rewrite -sz_p Dp size_prod_XsubC.
   case: posnP => [n0 | n_gt0]; first by rewrite nth_default // sz_r n0.
   by apply/mem_rP=> //; rewrite mem_nth ?sz_r.
-case: {Dp mem_rP}r r_z r_arg => // y r1; rewrite inE => /predU1P[-> _|r1z].
+case: {Dp mem_rP}r r_z r_arg => // y r1 /[1inE] /predU1P[-> _|r1z].
   by apply/implyP=> ->; rewrite lexx.
 by move/(order_path_min argCle_trans)/allP->.
 Qed.

--- a/mathcomp/algebra/vector.v
+++ b/mathcomp/algebra/vector.v
@@ -410,7 +410,7 @@ Qed.
 
 Let lin_b2mx n (X : n.-tuple vT) k :  
   \sum_(i < n) k i *: X`_i = r2v (\row_i k i *m b2mx X).
-Proof. by rewrite -mul_b2mx; apply: eq_bigr => i _; rewrite mxE. Qed.
+Proof. by rewrite -mul_b2mx; apply: eq_bigr => i _ /[1mxE]. Qed.
 
 Let free_b2mx n (X : n.-tuple vT) : free X = row_free (b2mx X).
 Proof. by rewrite /free /dimv span_b2mx genmxE size_tuple. Qed.
@@ -1935,7 +1935,7 @@ exists (fun w => \row_i coord (vbasis U) i (vsval w)).
   by move=> k w1 w2; apply/rowP=> i; rewrite !mxE linearP.
 exists (fun rw : 'rV_(\dim U) => vsproj (\sum_i rw 0 i *: (vbasis U)`_i)).
   move=> w /=; congr (vsproj _ = w): (vsvalK w).
-  by rewrite {1}(coord_vbasis (subvsP w)); apply: eq_bigr => i _; rewrite mxE.
+  by rewrite {1}(coord_vbasis (subvsP w)); apply: eq_bigr => i _ /[1mxE].
 move=> rw; apply/rowP=> i; rewrite mxE vsprojK.
   by rewrite coord_sum_free ?(basis_free (vbasisP U)).
 by apply: rpred_sum => j _; rewrite rpredZ ?vbasis_mem ?memt_nth.

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -97,8 +97,8 @@ Lemma trow0 n1 m2 n2 B : @trow n1 0 m2 n2 B = 0.
 Proof.
 elim: n1=> //= n1 IH.
 rewrite !mxE scale0r linear0.
-rewrite IH //; apply/matrixP=> i j; rewrite !mxE.
-by case: split=> *; rewrite mxE.
+rewrite IH //; apply/matrixP=> i j /[!mxE].
+by case: split=> * /[1mxE].
 Qed.
 
 Definition trowb n1 m2 n2 B A :=  @trow n1 A m2 n2 B.
@@ -124,7 +124,7 @@ Lemma trow_is_linear n1 m2 n2 (A : 'rV_n1) : linear (@trow n1 A m2 n2).
 Proof.
 elim: n1 A => [|n1 IH] //= A k A1 A2 /=; first by rewrite scaler0 add0r.
 rewrite linearD /= linearZ /=.
-apply/matrixP=> i j; rewrite !mxE.
+apply/matrixP=> i j /[!mxE].
 by case: split=> a; rewrite ?IH !mxE.
 Qed.
 
@@ -145,14 +145,14 @@ Fixpoint tprod  (m1 : nat) :
 Lemma dsumx_mul m1 m2 n p A B :
   dsubmx ((A *m B) : 'M[F]_(m1 + m2, n)) = dsubmx (A : 'M_(m1 + m2, p)) *m B.
 Proof.
-apply/matrixP=> i j; rewrite !mxE; apply: eq_bigr=> k _.
+apply/matrixP=> i j /[!mxE]; apply: eq_bigr=> k _.
 by rewrite !mxE.
 Qed.
 
 Lemma usumx_mul m1 m2 n p A B :
   usubmx ((A *m B) : 'M[F]_(m1 + m2, n)) = usubmx (A : 'M_(m1 + m2, p)) *m B.
 Proof.
-by apply/matrixP=> i j; rewrite !mxE; apply: eq_bigr=> k _; rewrite !mxE.
+by apply/matrixP=> i j /[!mxE]; apply: eq_bigr=> k _ /[!mxE].
 Qed.
 
 Let trow_mul (m1 m2 n2 p2 : nat) 
@@ -196,11 +196,11 @@ elim: m1 n1 A m2 n2 B=> [|m1 IH] n1 A m2 n2 B //=.
 rewrite !IH.
 pose A1 := A :  'M_(1 + m1, 1 + n1).
 have F1: dsubmx (rsubmx A1) = rsubmx (dsubmx A1).
-  by apply/matrixP=> i j; rewrite !mxE.
+  by apply/matrixP=> i j /[!mxE].
 have F2: rsubmx (usubmx A1) = usubmx (rsubmx A1).
-  by apply/matrixP=> i j; rewrite !mxE.
+  by apply/matrixP=> i j /[!mxE].
 have F3: lsubmx (dsubmx A1) = dsubmx (lsubmx A1).
-  by apply/matrixP=> i j; rewrite !mxE.
+  by apply/matrixP=> i j /[!mxE].
 rewrite tr_row_mx -block_mxEv -block_mxEh !(F1,F2,F3); congr block_mx.
 - by rewrite !mxE linearZ /= trmxK.
 by rewrite -trmx_dsub.
@@ -211,13 +211,13 @@ Proof.
 elim: m n => [|m IH] n //=; first by rewrite [1%:M]flatmx0.
 rewrite tprod_tr.
 set u := rsubmx _; have->: u = 0.
-  apply/matrixP=> i j; rewrite !mxE.
+  apply/matrixP=> i j /[!mxE].
   by case: i; case: j=> /= j Hj; case.
 set v := lsubmx (dsubmx _); have->: v = 0.
-  apply/matrixP=> i j; rewrite !mxE.
+  apply/matrixP=> i j /[!mxE].
   by case: i; case: j; case.
 set w := rsubmx _; have->: w = 1%:M.
-  apply/matrixP=> i j; rewrite !mxE.
+  apply/matrixP=> i j /[!mxE].
   by case: i; case: j; case.
 rewrite IH -!trowbE !linear0.
 rewrite -block_mxEv.
@@ -1323,7 +1323,7 @@ symmetry; transitivity (\tr Qa).
   rewrite reindex_irr_class; apply: eq_bigr => i _; rewrite !mxE invgK permE.
   by rewrite inE sub1set inE -(can_eq cK) iCK //; case: ifP.
 rewrite -[Pa](mulmxK uX) -[Qa](mulKmx uX) mxtrace_mulC; congr (\tr(_ *m _)).
-rewrite -row_permE -col_permE; apply/matrixP=> i j; rewrite !mxE.
+rewrite -row_permE -col_permE; apply/matrixP=> i j /[!mxE].
 rewrite -{2}[j](permKV qa); move: {j}(_ j) => j; rewrite !permE iCK //.
 apply: stabAchi; first by case/repr_classesP: (cP j).
 by rewrite repr_irr_classK (mem_repr_classes (Gca _)).
@@ -1614,7 +1614,7 @@ Lemma cfkerE chi :
     chi \is a character ->
   cfker chi = G :&: \bigcap_(i in irr_constt chi) cfker 'chi_i.
 Proof.
-move=> Nchi; rewrite cfkerEchar //; apply/setP=> x; rewrite !inE.
+move=> Nchi; rewrite cfkerEchar //; apply/setP=> x /[!inE].
 apply: andb_id2l => Gx; rewrite {1 2}[chi]cfun_sum_constt !sum_cfunE.
 apply/eqP/bigcapP=> [Kx i Ci | Kx]; last first.
   by apply: eq_bigr => i /Kx Kx_i; rewrite !cfunE cfker1.
@@ -2511,7 +2511,7 @@ do [exists linG, cF; split=> //] => [|xi /inT[u <-]|u]; first 2 [by exists u].
     apply: can_inj (insubd one) _ => u; apply: val_inj.
     by rewrite insubdK /= ?irrK //; apply: cFlin.
   rewrite -(card_image inj_cFI) -card_lin_irr.
-  apply/eq_card=> i; rewrite inE; apply/codomP/idP=> [[u ->] | /inT[u Du]].
+  apply/eq_card=> i /[1inE]; apply/codomP/idP=> [[u ->] | /inT[u Du]].
     by rewrite /= irrK; apply: cFlin.
   by exists u; apply: irr_inj; rewrite /= irrK.
 apply/eqP; rewrite eqn_dvd; apply/andP; split.
@@ -2720,7 +2720,7 @@ Lemma cfcenter_repr n (rG : mx_representation algCF G n) :
   'Z(cfRepr rG)%CF = rcenter rG.
 Proof.
 rewrite /cfcenter /rcenter cfRepr_char /=.
-apply/setP=> x; rewrite !inE; apply/andb_id2l=> Gx.
+apply/setP=> x /[!inE]; apply/andb_id2l=> Gx.
 apply/eqP/is_scalar_mxP=> [|[c rG_c]].
   by case/max_cfRepr_norm_scalar=> // c; exists c.
 rewrite -(sqrCK (char1_ge0 (cfRepr_char rG))) normC_def; congr (sqrtC _).
@@ -2755,7 +2755,7 @@ Lemma cfker_center_normal phi : cfker phi <| 'Z(phi)%CF.
 Proof.
 apply: normalS (cfcenter_sub phi) (cfker_normal phi).
 rewrite /= /cfcenter; case: ifP => // Hphi; rewrite cfkerEchar //.
-apply/subsetP=> x; rewrite !inE => /andP[-> /eqP->] /=.
+apply/subsetP=> x /[!inE] /andP[-> /eqP->] /=.
 by rewrite ger0_norm ?char1_ge0.
 Qed.
 
@@ -2803,7 +2803,7 @@ have sZG: Z \subset G by apply: cfcenter_sub.
 have ->: cfker chi = cfker xi.
   rewrite -(setIidPr (normal_sub (cfker_center_normal _))) -/Z.
   rewrite !cfkerEchar // ?lin_charW //= -/Z.
-  apply/setP=> x; rewrite !inE; apply: andb_id2l => Zx.
+  apply/setP=> x /[!inE]; apply: andb_id2l => Zx.
   rewrite (subsetP sZG) //= -!(cfResE chi sZG) ?group1 // def_chi !cfunE.
   by rewrite (inj_eq (mulfI _)) ?char1_eq0.
 have: abelian (Z / cfker xi) by rewrite sub_der1_abelian ?lin_char_der1.

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -528,7 +528,7 @@ Qed.
 Lemma cfun_on_sum A :
   'CF(G, A) = (\sum_(xG in classes G | xG \subset A) <['1_xG]>)%VS.
 Proof.
-by rewrite ['CF(G, A)]span_def big_image; apply: eq_bigl => xG; rewrite !inE.
+by rewrite ['CF(G, A)]span_def big_image; apply: eq_bigl => xG /[!inE].
 Qed.
 
 Lemma cfun_onP A phi :
@@ -591,7 +591,7 @@ Proof. by rewrite (eqnP (cfun_base_free A)) size_tuple. Qed.
 Lemma dim_cfun_on_abelian A : abelian G -> A \subset G -> \dim 'CF(G, A) = #|A|.
 Proof.
 move/abelian_classP=> cGG sAG; rewrite -(card_imset _ set1_inj) dim_cfun_on.
-apply/eq_card=> xG; rewrite !inE.
+apply/eq_card=> xG /[!inE].
 apply/andP/imsetP=> [[/imsetP[x Gx ->] Ax] | [x Ax ->]] {xG}.
   by rewrite cGG ?sub1set // in Ax *; exists x.
 by rewrite -{1}(cGG x) ?mem_classes ?(subsetP sAG) ?sub1set.
@@ -1056,7 +1056,7 @@ pose Z := '[Y, V] / '[V] *: V; exists (X + Z).
   rewrite /Z -{4}(addKr U V) scalerDr scalerN addrA addrC span_cons.
   by rewrite memv_add ?memvB ?memvZ ?memv_line.
 exists (Y - Z); first by rewrite addrCA !addrA addrK addrC.
-apply/orthoPl=> psi; rewrite !inE => /predU1P[-> | Spsi]; last first.
+apply/orthoPl=> psi /[!inE] /predU1P[-> | Spsi]; last first.
   by rewrite cfdotBl cfdotZl (orthoPl oVS _ Spsi) mulr0 subr0 (orthoPl oYS).
 rewrite cfdotBl !cfdotDr (span_orthogonal oYS) // ?memv_span ?mem_head //.
 rewrite !cfdotZl (span_orthogonal oVS _ S_U) ?mulr0 ?memv_span ?mem_head //.
@@ -1098,7 +1098,7 @@ have [opS | not_opS] := allP; last first.
 rewrite (contra (opS _)) /= ?cfnorm_eq0 //.
 apply: (iffP IH) => [] [uniqS oSS]; last first.
   by split=> //; apply: sub_in2 oSS => psi Spsi; apply: mem_behead.
-split=> // psi xi; rewrite !inE => /predU1P[-> // | Spsi].
+split=> // psi xi /[!inE] /predU1P[-> // | Spsi].
   by case/predU1P=> [-> | /opS] /eqP.
 case/predU1P=> [-> _ | Sxi /oSS-> //].
 by apply/eqP; rewrite cfdotC conjC_eq0 [_ == 0]opS.
@@ -1501,7 +1501,7 @@ Proof. exact/rmorph_eq1/cfMorph_inj. Qed.
 
 Lemma cfker_morph phi : cfker (cfMorph phi) = G :&: f @*^-1 (cfker phi).
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 have Dx := subsetP sGD x Gx; rewrite Dx mem_morphim //=.
 apply/forallP/forallP=> Kx y.
   have [{y} /morphimP[y Dy Gy ->] | fG'y] := boolP (y \in f @* G).
@@ -2418,7 +2418,7 @@ Proof. by rewrite !cfun_onE (eq_subset (support_cfAut phi)). Qed.
 
 Lemma cfker_aut phi : cfker phi^u = cfker phi.
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 by apply/forallP/forallP=> Kx y;
   have:= Kx y; rewrite !cfunE (inj_eq (fmorph_inj u)).
 Qed.

--- a/mathcomp/character/inertia.v
+++ b/mathcomp/character/inertia.v
@@ -690,7 +690,7 @@ Proof.
 have [[_ defS] [injg <-]] := (isomP isoH, isomP isoG).
 rewrite morphimEdom (eq_in_imset eq_hg) -morphimEsub // in defS.
 rewrite /inertia !setIdE morphimIdom setIA -{1}defS -injm_norm ?injmI //.
-apply/setP=> gy; rewrite !inE; apply: andb_id2l => /morphimP[y Gy nHy ->] {gy}.
+apply/setP=> gy /[!inE]; apply: andb_id2l => /morphimP[y Gy nHy ->] {gy}.
 rewrite cfConjgIsom // -sub1set -morphim_set1 // injmSK ?sub1set //= inE.
 apply/eqP/eqP=> [Iphi_y | -> //].
 by apply/cfun_inP=> x Hx; rewrite -!(cfIsomE isoH) ?Iphi_y.
@@ -1558,7 +1558,7 @@ have actIirrK: is_action G (@conjg_Iirr _ K).
 pose ito := Action actIirrK; pose cto := ('Js \ (subsetT G))%act.
 have acts_Js : [acts G, on classes K | 'Js].
   apply/subsetP=> y Gy; have nKy := subsetP nKG y Gy.
-  rewrite !inE; apply/subsetP=> _ /imsetP[z Gz ->]; rewrite !inE /=.
+  rewrite !inE; apply/subsetP=> _ /imsetP[z Gz ->] /[!inE]/=.
   rewrite -class_rcoset norm_rlcoset // class_lcoset.
   by apply: mem_imset; rewrite memJ_norm.
 have acts_cto : [acts G, on classes K | cto] by rewrite astabs_ract subsetIidl.

--- a/mathcomp/character/integral_char.v
+++ b/mathcomp/character/integral_char.v
@@ -117,7 +117,7 @@ have [w Gw Dg] := imsetP g1Gg; pose J2 (v : gT) xy := (xy.1 ^ v, xy.2 ^ v)%g.
 have J2inj: injective (J2 w).
   by apply: can_inj (J2 w^-1)%g _ => [[x y]]; rewrite /J2 /= !conjgK.
 rewrite -(card_imset _ J2inj) subset_leq_card //; apply/subsetP.
-move=> _ /imsetP[[x y] /setIdP[/andP[/= x1Gx y1Gy] Dxy1] ->]; rewrite !inE /=.
+move=> _ /imsetP[[x y] /setIdP[/andP[/= x1Gx y1Gy] Dxy1] ->] /[!inE]/=.
 rewrite !(class_sym _ (_ ^ _)) !classGidl // class_sym x1Gx class_sym y1Gy.
 by rewrite -conjMg (eqP Dxy1) /= -Dg.
 Qed.
@@ -589,7 +589,7 @@ have pa_dv_ZiG: (p ^ a %| #|G : 'Z(G)|)%N.
   exact: dvd_irr1_index_center.
 have [sPG pP p'PiG] := and3P sylP.
 have ZchiP: 'Res[P] 'chi_i \in 'CF(P, P :&: 'Z(G)).
-  apply/cfun_onP=> x; rewrite inE; have [Px | /cfun0->//] := boolP (x \in P).
+  apply/cfun_onP=> x /[1inE]; have [Px | /cfun0->//] := boolP (x \in P).
   rewrite /= -(cfcenter_fful_irr fful_i) cfResE //.
   apply: coprime_degree_support_cfcenter.
   rewrite Dchi1 coprime_expl // prime_coprime // -p'natE //.

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -77,8 +77,8 @@ Canonical Structure mx_repr_action := Action mx_repr_is_action.
 
 Fact mx_repr_is_groupAction : is_groupAction [set: 'rV[R]_n] mx_repr_action.
 Proof.
-move=> x Gx /=; rewrite !inE.
-apply/andP; split; first by apply/subsetP=> u; rewrite !inE.
+move=> x Gx /= /[!inE].
+apply/andP; split; first by apply/subsetP=> u /[!inE].
 by apply/morphicP=> /= u v _ _; rewrite !actpermE /= /mx_repr_act mulmxDl.
 Qed.
 Canonical Structure mx_repr_groupAction := GroupAction mx_repr_is_groupAction.
@@ -110,8 +110,8 @@ Qed.
 Canonical scale_action := Action scale_is_action.
 Fact scale_is_groupAction : is_groupAction setT scale_action.
 Proof.
-move=> a _ /=; rewrite inE; apply/andP.
-split; first by apply/subsetP=> A; rewrite !inE.
+move=> a _ /= /[1inE]; apply/andP.
+split; first by apply/subsetP=> A /[!inE].
 by apply/morphicP=> u A _ _ /=; rewrite !actpermE /= /scale_act scalerDr.
 Qed.
 Canonical scale_groupAction := GroupAction scale_is_groupAction.
@@ -295,7 +295,7 @@ Qed.
 
 Lemma astab_rowg_repr m (A : 'M_(m, n)) : 'C(rowg A | 'MR rG) = rstab rG A.
 Proof.
-apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]/=; apply: andb_id2l => Gx.
 apply/subsetP/eqP=> cAx => [|u]; last first.
   by rewrite !inE mx_repr_actE // => /submxP[u' ->]; rewrite -mulmxA cAx.
 apply/row_matrixP=> i; apply/eqP; move/implyP: (cAx (row i A)).
@@ -304,7 +304,7 @@ Qed.
 
 Lemma astabs_rowg_repr m (A : 'M_(m, n)) : 'N(rowg A | 'MR rG) = rstabs rG A.
 Proof.
-apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]/=; apply: andb_id2l => Gx.
 apply/subsetP/idP=> nAx => [|u]; last first.
   by rewrite !inE mx_repr_actE // => Au; apply: (submx_trans (submxMr _ Au)).
 apply/row_subP=> i; move/implyP: (nAx (row i A)).
@@ -326,7 +326,7 @@ Qed.
 Lemma afix_repr (H : {set gT}) :
   H \subset G -> 'Fix_('MR rG)(H) = rowg (rfix_mx rG H).
 Proof.
-move/subsetP=> sHG; apply/setP=> /= u; rewrite !inE.
+move/subsetP=> sHG; apply/setP=> /= u /[!inE].
 apply/subsetP/rfix_mxP=> cHu x Hx; have:= cHu x Hx;
   by rewrite !inE /= => /eqP; rewrite mx_repr_actE ?sHG.
 Qed.
@@ -427,7 +427,7 @@ Proof. exact: fin_Fp_lmod_abelem. Qed.
 
 Lemma mx_Fp_stable (L : {group Mmn}) : [acts setT, on L | 'Zm].
 Proof.
-apply/subsetP=> a _; rewrite !inE; apply/subsetP=> A L_A.
+apply/subsetP=> a _ /[!inE]; apply/subsetP=> A L_A.
 by rewrite inE /= /scale_act -[val _]natr_Zp scaler_nat groupX.
 Qed.
 
@@ -636,9 +636,9 @@ Qed.
 
 Lemma rstab_abelem m (A : 'M_(m, n)) : rstab rG A = 'C_G(rV_E @* rowg A).
 Proof.
-apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]/=; apply: andb_id2l => Gx.
 apply/eqP/centP=> cAx => [_ /morphimP[u _ Au ->]|].
-  move: Au; rewrite inE => /submxP[u' ->] {u}.
+  move: Au => /[1inE] /submxP[u' ->] {u}.
   by apply/esym/commgP/conjg_fixP; rewrite -rVabelemJ -?mulmxA ?cAx.
 apply/row_matrixP=> i; apply: rVabelem_inj.
 by rewrite row_mul rVabelemJ // /conjg -cAx ?mulKg ?mem_morphim // inE row_sub.
@@ -646,7 +646,7 @@ Qed.
 
 Lemma rstabs_abelem m (A : 'M_(m, n)) : rstabs rG A = 'N_G(rV_E @* rowg A).
 Proof.
-apply/setP=> x; rewrite !inE /=; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]/=; apply: andb_id2l => Gx.
 by rewrite -rowgS -rVabelemS abelem_rowgJ.
 Qed.
 
@@ -699,7 +699,7 @@ Lemma rfix_abelem (H : {set gT}) :
 Proof.
 move/subsetP=> sHG; apply/eqmxP/andP; split.
   rewrite -rowgS rowg_mxK -sub_rVabelem_im // subsetI sub_rVabelem /=.
-  apply/centsP=> y /morphimP[v _]; rewrite inE => cGv ->{y} x Gx.
+  apply/centsP=> y /morphimP[v _] /[1inE] cGv ->{y} x Gx.
   by apply/commgP/conjg_fixP; rewrite /= -rVabelemJ ?sHG ?(rfix_mxP H _).
 rewrite genmxE; apply/rfix_mxP=> x Hx; apply/row_matrixP=> i.
 rewrite row_mul rowK; case/morphimP: (enum_valP i) => z Ez /setIP[_ cHz] ->.
@@ -737,7 +737,7 @@ Qed.
 
 Lemma mxmodule_abelem_subg m (U : 'M_(m, n)) : mxmodule rHG U = mxmodule rH U.
 Proof.
-apply: eq_subset_r => x; rewrite !inE; apply: andb_id2l => Hx.
+apply: eq_subset_r => x /[!inE]; apply: andb_id2l => Hx.
 by rewrite eq_abelem_subg_repr.
 Qed.
 

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -434,7 +434,7 @@ Canonical rcenter_group := Group rcenter_group_set.
 
 Lemma rcenter_normal : rcenter <| G.
 Proof.
-rewrite /normal /rcenter {1}setIdE subsetIl; apply/subsetP=> x Gx; rewrite inE.
+rewrite /normal /rcenter {1}setIdE subsetIl; apply/subsetP=> x Gx /[1inE].
 apply/subsetP=> _ /imsetP[y /setIdP[Gy /is_scalar_mxP[c rGy]] ->].
 rewrite inE !repr_mxM ?groupM ?groupV //= mulmxA rGy scalar_mxC repr_mxKV //.
 exact: scalar_mx_is_scalar.
@@ -674,7 +674,7 @@ Proof. exact: quo_mx_coset. Qed.
 
 Lemma rcent_quo A : rcent rGH A = (rcent rG A / H)%g.
 Proof.
-apply/setP=> Hx; rewrite !inE.
+apply/setP=> Hx /[!inE].
 apply/andP/idP=> [[]|]; case/morphimP=> x Nx Gx ->{Hx}.
   by rewrite quo_repr_coset // => cAx; rewrite mem_morphim // inE Gx.
 by case/setIdP: Gx => Gx cAx; rewrite quo_repr_coset ?mem_morphim.
@@ -682,7 +682,7 @@ Qed.
 
 Lemma rstab_quo m (U : 'M_(m, n)) : rstab rGH U = (rstab rG U / H)%g.
 Proof.
-apply/setP=> Hx; rewrite !inE.
+apply/setP=> Hx /[!inE].
 apply/andP/idP=> [[]|]; case/morphimP=> x Nx Gx ->{Hx}.
   by rewrite quo_repr_coset // => nUx; rewrite mem_morphim // inE Gx.
 by case/setIdP: Gx => Gx nUx; rewrite quo_repr_coset ?mem_morphim.
@@ -2710,14 +2710,14 @@ Qed.
 Lemma rstab_submod m (W : 'M_(m, \rank U)) :
   rstab rU W = rstab rG (val_submod W).
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 by rewrite -(inj_eq val_submod_inj) val_submodJ.
 Qed.
 
 Lemma rstabs_submod m (W : 'M_(m, \rank U)) :
   rstabs rU W = rstabs rG (val_submod W).
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 by rewrite -val_submodS val_submodJ.
 Qed.
 
@@ -2738,7 +2738,7 @@ Qed.
 Lemma rstabs_factmod m (W : 'M_(m, \rank (cokermx U))) :
   rstabs rU' W = rstabs rG (U + val_factmod W)%MS.
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 rewrite addsmxMr addsmx_sub (submx_trans (mxmoduleP Umod x Gx)) ?addsmxSl //.
 rewrite -val_factmodS val_factmodJ //= val_factmodS; apply/idP/idP=> nWx.
   rewrite (submx_trans (addsmxSr U _)) // -(in_factmodsK (addsmxSl U _)) //.
@@ -2872,7 +2872,7 @@ Qed.
 
 Lemma rstabs_quo m (U : 'M_(m, n)) : rstabs rGH U = (rstabs rG U / H)%g.
 Proof.
-apply/setP=> Hx; rewrite !inE; apply/andP/idP=> [[]|] /morphimP[x Nx Gx ->{Hx}].
+apply/setP=> Hx /[!inE]; apply/andP/idP=> [[]|] /morphimP[x Nx Gx ->{Hx}].
   by rewrite quo_repr_coset // => nUx; rewrite mem_morphim // inE Gx.
 by case/setIdP: Gx => Gx nUx; rewrite quo_repr_coset ?mem_morphim.
 Qed.
@@ -3378,7 +3378,7 @@ apply: mxsimple_exists (mxmodule1 rH) nz1 _ _ => [[M simM _]].
 pose W1 := PackSocle (component_socle sH simM).
 have [X sXG [def1 _]] := Clifford_basis simM; move/subsetP: sXG => sXG.
 apply/imsetP; exists W1; first by rewrite inE.
-symmetry; apply/setP=> W; rewrite inE; have simW := socle_simple W.
+symmetry; apply/setP=> W /[1inE]; have simW := socle_simple W.
 have:= submx1 (socle_base W); rewrite -def1 -[(\sum_(x in X) _)%MS]mulmx1.
 case/(hom_mxsemisimple_iso simW) => [x Xx _ | | x Xx isoMxW].
 - by apply: Clifford_simple; rewrite ?sXG.
@@ -3455,13 +3455,13 @@ Qed.
 Lemma Clifford_astab : H <*> 'C_G(H) \subset 'C([set: sH] | 'Cl).
 Proof.
 rewrite join_subG !subsetI sHG subsetIl /=; apply/andP; split.
-  apply/subsetP=> h Hh; have Gh := subsetP sHG h Hh; rewrite inE.
+  apply/subsetP=> h Hh /[1inE]; have Gh := subsetP sHG h Hh.
   apply/subsetP=> W _; have simW := socle_simple W; have [modW _ _] := simW.
   have simWh: mxsimple rH (socle_base W *m rG h) by apply: Clifford_simple.
   rewrite inE -val_eqE /= PackSocleK eq_sym.
   apply/component_mx_isoP; rewrite ?subgK //; apply: component_mx_iso => //.
   by apply: submx_trans (component_mx_id simW); move/mxmoduleP: modW => ->.
-apply/subsetP=> z cHz; have [Gz _] := setIP cHz; rewrite inE.
+apply/subsetP=> z cHz /[1inE]; have [Gz _] := setIP cHz.
 apply/subsetP=> W _; have simW := socle_simple W; have [modW _ _] := simW.
 have simWz: mxsimple rH (socle_base W *m rG z) by apply: Clifford_simple.
 rewrite inE -val_eqE /= PackSocleK eq_sym.
@@ -3470,7 +3470,7 @@ Qed.
 
 Lemma Clifford_astab1 (W : sH) : 'C[W | 'Cl] = rstabs rG W.
 Proof.
-apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 rewrite sub1set inE (sameP eqP socleP) !val_Clifford_act //.
 rewrite andb_idr // => sWxW; rewrite -mxrank_leqif_sup //.
 by rewrite mxrankMfree ?repr_mx_free.
@@ -3974,7 +3974,7 @@ Proof. by move=> x Gx; apply: subsetP; apply: class_subG. Qed.
 Lemma classg_base_free : row_free classg_base.
 Proof.
 rewrite -kermx_eq0; apply/rowV0P=> v /sub_kermxP; rewrite mulmx_sum_row => v0.
-apply/rowP=> k; rewrite mxE.
+apply/rowP=> k /[1mxE].
 have [x Gx def_k] := imsetP (enum_valP k).
 transitivity (@gring_proj F _ G x (vec_mx 0) 0 0); last first.
   by rewrite !linear0 !mxE.
@@ -4580,7 +4580,7 @@ rewrite (reindex (fun j => irr_comp sG (rG j))) /=.
   by rewrite inE -lin_j -irr_degreeE irr_degree_abelian.
 pose sGlin := {i | i \in linear_irr sG}.
 have sG'k (i : sGlin) : G^`(1)%g \subset rker (irr_repr (val i)).
-  by case: i => i /=; rewrite !inE => lin; rewrite rker_linear //=; apply/eqP.
+  by case: i => i /= /[!inE] lin; rewrite rker_linear //=; apply/eqP.
 pose h' u := irr_comp sGq (quo_repr (sG'k u) nG'G).
 have irrGq u: mx_irreducible (quo_repr (sG'k u) nG'G).
   by apply/quo_mx_irr; apply: socle_irr.
@@ -5423,7 +5423,7 @@ Prenex Implicits val_genK in_genK.
 
 Lemma val_gen_rV (w : 'rV_nA) :
   val_gen w = mxvec (\matrix_j val (w 0 j)) *m base.
-Proof. by apply/rowP=> j; rewrite mxE. Qed.
+Proof. by apply/rowP=> j /[1mxE]. Qed.
 
 Section Bijection2.
 
@@ -5432,7 +5432,7 @@ Variable m : nat.
 Lemma val_gen_row W (i : 'I_m) : val_gen (row i W) = row i (val_gen W).
 Proof.
 rewrite val_gen_rV rowK; congr (mxvec _ *m _).
-by apply/matrixP=> j k; rewrite !mxE.
+by apply/matrixP=> j k /[!mxE].
 Qed.
 
 Lemma in_gen_row W (i : 'I_m) : in_gen (row i W) = row i (in_gen W).
@@ -5442,7 +5442,7 @@ Lemma row_gen_sum_mxval W (i : 'I_m) :
   row i (val_gen W) = \sum_j row (gen_base 0 j) (mxval (W i j)).
 Proof.
 rewrite -val_gen_row [row i W]row_sum_delta val_gen_sum.
-apply: eq_bigr => /= j _; rewrite mxE; move: {W i}(W i j) => x.
+apply: eq_bigr => /= j _ /[1mxE]; move: {W i}(W i j) => x.
 have ->: x = \sum_k gen (val x 0 k) * inFA (delta_mx 0 k).
   case: x => u; apply: mxval_inj; rewrite {1}[u]row_sum_delta.
   rewrite mxval_sum [mxval _]horner_rVpoly mulmx_suml linear_sum /=.
@@ -5565,21 +5565,21 @@ Qed.
 
 Lemma rstab_in_gen m (U : 'M_(m, n)) : rstab rGA (in_gen U) = rstab rG U.
 Proof.
-apply/setP=> x; rewrite !inE; case Gx: (x \in G) => //=.
+apply/setP=> x /[!inE]; case Gx: (x \in G) => //=.
 by rewrite -in_genJ // (inj_eq (can_inj in_genK)).
 Qed.
 
 Lemma rstabs_in_gen m (U : 'M_(m, n)) :
   rstabs rG U \subset rstabs rGA (in_gen U).
 Proof.
-apply/subsetP=> x; rewrite !inE => /andP[Gx nUx].
+apply/subsetP=> x /[!inE] /andP[Gx nUx].
 by rewrite -in_genJ Gx // submx_in_gen.
 Qed.
 
 Lemma rstabs_rowval_gen m (U : 'M_(m, nA)) :
   rstabs rG (rowval_gen U) = rstabs rGA U.
 Proof.
-apply/setP=> x; rewrite !inE; case Gx: (x \in G) => //=.
+apply/setP=> x /[!inE]; case Gx: (x \in G) => //=.
 by rewrite submx_rowval_gen in_genJ // (eqmxMr _ (rowval_genK U)).
 Qed.
 
@@ -5686,8 +5686,8 @@ elim: t => //=.
 - by move=> x _; rewrite eval_mx_term.
 - by move=> x _; rewrite eval_mx_term.
 - move=> t1 IH1 t2 IH2 /andP[rt1 rt2]; rewrite -{}IH1 // -{}IH2 //.
-  by apply/rowP=> k; rewrite !mxE.
-- by move=> t1 IH1 rt1; rewrite -{}IH1 //; apply/rowP=> k; rewrite !mxE.
+  by apply/rowP=> k /[!mxE].
+- by move=> t1 IH1 rt1; rewrite -{}IH1 //; apply/rowP=> k /[!mxE].
 - move=> t1 IH1 n1 rt1; rewrite eval_mulmx eval_mx_term mul_scalar_mx.
   by rewrite scaler_nat {}IH1 //; elim: n1 => //= n1 IHn1; rewrite !mulrS IHn1.
 - by move=> t1 IH1 t2 IH2 /andP[rt1 rt2]; rewrite eval_mulT IH1 ?IH2.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -217,7 +217,7 @@ pose p_ (I : {set 'I_n}) := \prod_(i <- enum I) ('X - (r`_i)%:P).
 have{px0 Dp} /ex_minset[I /minsetP[/andP[FpI pIx0] minI]]: exists I, Fpx (p_ I).
   exists setT; suffices ->: p_ setT = p ^ FtoL by rewrite FpxF.
   rewrite Dp (big_nth 0) big_mkord /p_ big_enum /=.
-  by apply/eq_bigl=> i; rewrite inE.
+  by apply/eq_bigl=> i /[1inE].
 have{p} [p DpI]: {p | p_ I = p ^ FtoL}.
   exists (p_ I ^ (fun y => if isF y is left Fy then sval (sig_eqW Fy) else 0)).
   rewrite -map_poly_comp map_poly_id // => y /(allP FpI) /=.
@@ -244,7 +244,7 @@ pose B := [set j in mask m (enum I)]; have{Dq} Dq: q ^ FtoL = p_ B.
   congr (_ %= _): Dq; apply: perm_big => //.
   by rewrite uniq_perm ?mask_uniq ?enum_uniq // => j; rewrite mem_enum inE.
 rewrite -!(size_map_poly FtoL) Dq -DpI (minI B) // -?Dq ?FpxF //.
-by apply/subsetP=> j; rewrite inE => /mem_mask; rewrite mem_enum.
+by apply/subsetP=> j /[1inE] /mem_mask; rewrite mem_enum.
 Qed.
 
 Lemma alg_integral (F : fieldType) (L : fieldExtType F) :

--- a/mathcomp/field/algnum.v
+++ b/mathcomp/field/algnum.v
@@ -635,7 +635,7 @@ have ZP_C c: (ZtoC c)%:P \is a polyOver Cint by rewrite raddfMz rpred_int.
 move=> mulS S_P x Sx; pose v := \row_(i < n) Y`_i.
 have [v0 | nz_v] := eqVneq v 0.
   case/S_P: Sx => {x}x ->; rewrite big1 ?isAlgInt0 // => i _.
-  by have /rowP/(_ i) := v0; rewrite !mxE => ->; rewrite mul0rz.
+  by have /rowP/(_ i)/[!mxE] -> := v0; rewrite mul0rz.
 have sYS (i : 'I_n): x * Y`_i \in S.
   by rewrite rpredM //; apply/S_P/Cint_spanP/mem_Cint_span/memt_nth.
 pose A := \matrix_(i, j < n) sval (sig_eqW (S_P _ (sYS j))) i.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -856,7 +856,7 @@ have v2rP x: {r : 'rV[K_F]_n | x = r2v r}.
   apply: sig_eqW; have /memv_sumP[y Fy ->]: x \in SbL by rewrite defL memvf.
   have /fin_all_exists[r Dr] i: exists r, y i = r *: (bL`_i : L_F).
     by have /memv_cosetP[a Fa ->] := Fy i isT; exists (Subvs Fa).
-  by exists (\row_i r i); apply: eq_bigr => i _; rewrite mxE.
+  by exists (\row_i r i); apply: eq_bigr => i _ /[1mxE].
 pose v2r x := sval (v2rP x).
 have v2rK: cancel v2r (Linear r2v_lin) by rewrite /v2r => x; case: (v2rP x).
 suffices r2vK: cancel r2v v2r.
@@ -1023,9 +1023,9 @@ have v2rK: cancel v2r r2v.
     (* The -/m takes 8s, and without it then apply: eq_bigr takes 12s. *)
     (* The time drops to 2s with  a -[GRing.Field.ringType F]/(F : fieldType) *)
   apply: eq_bigr => i _; rewrite mxvecK; congr (_ *: _ : L).
-  by rewrite (coordF (coord bL i x)); apply: eq_bigr => j _; rewrite mxE.
+  by rewrite (coordF (coord bL i x)); apply: eq_bigr => j _ /[1mxE].
 exists (m * n)%N, v2r => //; exists r2v => // r.
-apply: (canLR vec_mxK); apply/matrixP=> i j; rewrite mxE.
+apply: (canLR vec_mxK); apply/matrixP=> i j /[1mxE].
 by rewrite !coord_sum_free ?(basis_free (vbasisP _)).
 Qed.
 

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -144,7 +144,7 @@ have rV2V_K: cancel rV2V V2rV.
   by move=> rv; apply/rowP=> i; rewrite mxE coord_sum_free.
 rewrite -[n]mul1n -card_matrix -(card_imset _ (can_inj rV2V_K)).
 apply: eq_card => v; apply/idP/imsetP=> [/coord_vbasis-> | [rv _ ->]].
-  by exists (V2rV v) => //; apply: eq_bigr => i _; rewrite mxE.
+  by exists (V2rV v) => //; apply: eq_bigr => i _ /[1mxE].
 by apply: (@rpred_sum vT) => i _; rewrite rpredZ ?vbasis_mem ?memt_nth.
 Qed.
 
@@ -609,7 +609,7 @@ pose C u := 'C[ofG u]%AS; pose Q := 'C(L)%AS; pose q := (p ^ \dim Q)%N.
 have defC u: 'C[u] =i projG (C u).
   by move=> v; rewrite cent1E !inE (sameP cent1vP eqP).
 have defQ: 'Z(G) =i projG Q.
-  move=> u; rewrite !inE.
+  move=> u /[!inE].
   apply/centP/centvP=> cGu v _; last exact/val_inj/cGu/memvf.
   by have [-> | /inG/cGu[]] := eqVneq v 0; first by rewrite commr0.
 have q_gt1: (1 < q)%N by rewrite (ltn_exp2l 0) ?prime_gt1 ?adim_gt0.

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -1452,7 +1452,7 @@ have [w [Ew nzw] uM]: {w : #|A|.-tuple L | nzE w & M w \in unitmx}.
   congr (_ != 0): nzS; rewrite [_ - _]mx11_scalar det_scalar !mxE opprB /=.
   rewrite -big_uniq // big_cons /= cx_n1 mulN1r addrC; congr (_ + _).
   rewrite (big_nth 1%g) big_mkord; apply: eq_bigr => j _.
-  by rewrite /c_ index_uniq // valK; congr (_ * _); rewrite !mxE.
+  by rewrite /c_ index_uniq // valK; congr (_ * _) => /[!mxE].
 exists w => [//|]; split=> [||gA].
 - by congr (_ \in unitmx): uM; apply/matrixP=> i j; rewrite !mxE -enum_val_nth.
 - apply/directv_sum_independent=> kw_ Kw_kw sum_kw_0 j _.
@@ -1460,7 +1460,7 @@ exists w => [//|]; split=> [||gA].
   pose kv := \col_i k_ i.
   transitivity (kv j 0 * tnth w j); first by rewrite !mxE.
   suffices{j}/(canRL (mulKmx uM))->: M w *m kv = 0 by rewrite mulmx0 mxE mul0r.
-  apply/colP=> i; rewrite !mxE; pose Ai := nth 1%g (enum A) i.
+  apply/colP=> i /[!mxE]; pose Ai := nth 1%g (enum A) i.
   transitivity (Ai (\sum_j kw_ j)); last by rewrite sum_kw_0 rmorph0.
   rewrite rmorph_sum; apply: eq_bigr => j _; rewrite !mxE /= -/Ai.
   rewrite Dk_ mulrC rmorphM /=; congr (_ * _).
@@ -1473,7 +1473,7 @@ apply/subvP=> w0 Ew0; apply/memv_sumP.
 pose wv := \col_(i < #|A|) enum_val i w0; pose v := invmx (M w) *m wv.
 exists (fun i => tnth w i * v i 0) => [i _|]; last first.
   transitivity (wv (iG 1%g) 0); first by rewrite mxE enum_rankK_in ?gal_id.
-  rewrite -[wv](mulKVmx uM) -/v; rewrite mxE; apply: eq_bigr => i _.
+  rewrite -[wv](mulKVmx uM) -/v mxE; apply: eq_bigr => i _.
   by congr (_ * _); rewrite !mxE -enum_val_nth enum_rankK_in ?gal_id.
 rewrite mulrC memv_mul ?memv_line //; apply/fixedFieldP=> [|x Gx].
   rewrite mxE rpred_sum // => j _; rewrite !mxE rpredM //; last exact: memv_gal.
@@ -1485,7 +1485,7 @@ rewrite mulrC memv_mul ?memv_line //; apply/fixedFieldP=> [|x Gx].
 suffices{i} {2}<-: map_mx x v = v by rewrite [map_mx x v i 0]mxE.
 have uMx: map_mx x (M w) \in unitmx by rewrite map_unitmx.
 rewrite map_mxM map_invmx /=; apply: canLR {uMx}(mulKmx uMx) _.
-apply/colP=> i; rewrite !mxE; pose ix := iG (enum_val i * x)%g.
+apply/colP=> i /[!mxE]; pose ix := iG (enum_val i * x)%g.
 have Dix b: b \in E -> enum_val ix b = x (enum_val i b).
   by move=> Eb; rewrite enum_rankK_in ?groupM ?enum_valP // galM ?lfunE.
 transitivity ((M w *m v) ix 0); first by rewrite mulKVmx // mxE Dix.

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -331,7 +331,7 @@ by rewrite inE xfix.
 Qed.
 
 Lemma afixS A B : A \subset B -> 'Fix_to(B) \subset 'Fix_to(A).
-Proof. by move=> sAB; apply/subsetP=> u; rewrite !inE; apply: subset_trans. Qed.
+Proof. by move=> sAB; apply/subsetP=> u /[!inE]; apply: subset_trans. Qed.
 
 Lemma afixU A B : 'Fix_to(A :|: B) = 'Fix_to(A) :&: 'Fix_to(B).
 Proof. by apply/setP=> x; rewrite !inE subUset. Qed.
@@ -348,12 +348,12 @@ Proof. by move=> a /setIP[]. Qed.
 Lemma astab_act S a x : a \in 'C(S | to) -> x \in S -> to x a = x.
 Proof.
 rewrite 2!inE => /andP[_ cSa] Sx; apply/eqP.
-by have:= subsetP cSa x Sx; rewrite inE.
+by have /[1inE] := subsetP cSa x Sx.
 Qed.
 
 Lemma astabS S1 S2 : S1 \subset S2 -> 'C(S2 | to) \subset 'C(S1 | to).
 Proof.
-move=> sS12; apply/subsetP=> x; rewrite !inE => /andP[->].
+move=> sS12; apply/subsetP=> x /[!inE] /andP[->].
 exact: subset_trans.
 Qed.
 
@@ -421,7 +421,7 @@ Proof.
 move=> sAD; apply/subsetP/subsetP=> [sAC x xS | sSF a aA].
   by apply/afixP=> a aA; apply: astab_act (sAC _ aA) xS.
 rewrite !inE (subsetP sAD _ aA); apply/subsetP=> x xS.
-by move/afixP/(_ _ aA): (sSF _ xS); rewrite inE => ->.
+by move/afixP/(_ _ aA): (sSF _ xS) => /[1inE] ->.
 Qed.
 
 Section ActsSetop.
@@ -725,7 +725,7 @@ Qed.
 Lemma acts_subnorm_fix A : [acts 'N_D(A), on 'Fix_to(D :&: A) | to].
 Proof.
 apply/subsetP=> a nAa; have [Da _] := setIP nAa; rewrite !inE Da.
-apply/subsetP=> x Cx; rewrite inE; apply/afixP=> b DAb.
+apply/subsetP=> x Cx /[1inE]; apply/afixP=> b DAb.
 have [Db _]:= setIP DAb; rewrite -actMin // conjgCV  actMin ?groupJ ?groupV //.
 by rewrite /= (afixP Cx) // memJ_norm // groupV (subsetP (normsGI _ _) _ nAa).
 Qed.
@@ -900,10 +900,10 @@ Lemma actM x a b : to x (a * b) = to (to x a) b.
 Proof. by rewrite actMin ?inE. Qed.
 
 Lemma actK : right_loop invg to.
-Proof. by move=> a; apply: actKin; rewrite inE. Qed.
+Proof. by move=> a; apply: actKin => /[1inE]. Qed.
 
 Lemma actKV : rev_right_loop invg to.
-Proof. by move=> a; apply: actKVin; rewrite inE. Qed.
+Proof. by move=> a; apply: actKVin => /[1inE]. Qed.
 
 Lemma actX x a n : to x (a ^+ n) = iter n (to^~ a) x.
 Proof. by elim: n => [|n /= <-]; rewrite ?act1 // -actM expgSr. Qed.
@@ -997,7 +997,7 @@ Proof. by rewrite mulnC card_orbit Lagrange ?subsetIl. Qed.
 Lemma actsP A S : reflect {acts A, on S | to} [acts A, on S | to].
 Proof.
 apply: (iffP idP) => [nSA x|nSA]; first exact: acts_act.
-by apply/subsetP=> a Aa; rewrite !inE; apply/subsetP=> x; rewrite inE nSA.
+by apply/subsetP=> a Aa /[!inE]; apply/subsetP=> x; rewrite inE nSA.
 Qed.
 Arguments actsP {A S}.
 
@@ -1029,7 +1029,7 @@ Proof. by move=> GtrS x y /(atransP GtrS) <- /imsetP. Qed.
 
 Lemma atrans_acts G S : [transitive G, on S | to] -> [acts G, on S | to].
 Proof.
-move=> GtrS; apply/subsetP=> a Ga; rewrite !inE.
+move=> GtrS; apply/subsetP=> a Ga /[!inE].
 by apply/subsetP=> x /(atransP GtrS) <-; rewrite inE mem_imset.
 Qed.
 
@@ -1195,8 +1195,8 @@ Proof. by rewrite /= /actby => -> ->. Qed.
 Lemma afix_actby B : 'Fix_<[nRA]>(B) = ~: R :|: 'Fix_to(A :&: B).
 Proof.
 apply/setP=> x; rewrite !inE /= /actby.
-case: (x \in R); last by apply/subsetP=> a _; rewrite !inE.
-apply/subsetP/subsetP=> [cBx a | cABx a Ba]; rewrite !inE.
+case: (x \in R); last by apply/subsetP=> a _ /[!inE].
+apply/subsetP/subsetP=> [cBx a | cABx a Ba] /[!inE].
   by case/andP=> Aa /cBx; rewrite inE Aa.
 by case: ifP => //= Aa; have:= cABx a; rewrite !inE Aa => ->.
 Qed.
@@ -1265,7 +1265,7 @@ Lemma astab_subact S : 'C(S | subaction) = subact_dom :&: 'C(val @: S | to).
 Proof.
 apply/setP=> a; rewrite inE in_setI; apply: andb_id2l => sDa.
 have [Da _] := setIP sDa; rewrite !inE Da.
-apply/subsetP/subsetP=> [cSa _ /imsetP[x Sx ->] | cSa x Sx]; rewrite !inE.
+apply/subsetP/subsetP=> [cSa _ /imsetP[x Sx ->] | cSa x Sx] /[!inE].
   by have:= cSa x Sx; rewrite inE -val_eqE val_subact sDa.
 by have:= cSa _ (mem_imset val Sx); rewrite inE -val_eqE val_subact sDa.
 Qed.
@@ -1274,9 +1274,9 @@ Lemma astabs_subact S : 'N(S | subaction) = subact_dom :&: 'N(val @: S | to).
 Proof.
 apply/setP=> a; rewrite inE in_setI; apply: andb_id2l => sDa.
 have [Da _] := setIP sDa; rewrite !inE Da.
-apply/subsetP/subsetP=> [nSa _ /imsetP[x Sx ->] | nSa x Sx]; rewrite !inE.
-  by have:= nSa x Sx; rewrite inE => /(mem_imset val); rewrite val_subact sDa.
-have:= nSa _ (mem_imset val Sx); rewrite inE => /imsetP[y Sy def_y].
+apply/subsetP/subsetP=> [nSa _ /imsetP[x Sx ->] | nSa x Sx] /[!inE].
+  by have /[1inE] /(mem_imset val) := nSa x Sx; rewrite val_subact sDa.
+have /[1inE] /imsetP[y Sy def_y] := nSa _ (mem_imset val Sx).
 by rewrite ((_ a =P y) _) // -val_eqE val_subact sDa def_y.
 Qed.
 
@@ -1285,7 +1285,7 @@ Lemma afix_subact A :
 Proof.
 move/subsetP=> sAD; apply/setP=> u.
 rewrite !inE !(sameP setIidPl eqP); congr (_ == A).
-apply/setP=> a; rewrite !inE; apply: andb_id2l => Aa.
+apply/setP=> a /[!inE]; apply: andb_id2l => Aa.
 by rewrite -val_eqE val_subact sAD.
 
 Qed.
@@ -1424,7 +1424,7 @@ Lemma astabs_mod : 'N(S | mod_action) = 'N(S | to) / H.
 Proof.
 apply/setP=> Ha; apply/idP/morphimP=> [nSa | [a nHa nSa ->]].
   case/morphimP: (astabs_dom nSa) => a nHa Da defHa.
-  exists a => //; rewrite !inE Da; apply/subsetP=> x Sx; rewrite !inE.
+  exists a => //; rewrite !inE Da; apply/subsetP=> x Sx /[!inE].
   by have:= Sx; rewrite -(astabs_act x nSa) defHa /= modactE ?(subsetP fixSH).
 have Da := astabs_dom nSa; rewrite !inE mem_quotient //; apply/subsetP=> x Sx.
 by rewrite !inE /= modactE ?(astabs_act x nSa) ?(subsetP fixSH).
@@ -1434,7 +1434,7 @@ Lemma astab_mod : 'C(S | mod_action) = 'C(S | to) / H.
 Proof.
 apply/setP=> Ha; apply/idP/morphimP=> [cSa | [a nHa cSa ->]].
   case/morphimP: (astab_dom cSa) => a nHa Da defHa.
-  exists a => //; rewrite !inE Da; apply/subsetP=> x Sx; rewrite !inE.
+  exists a => //; rewrite !inE Da; apply/subsetP=> x Sx /[!inE].
   by rewrite -{2}[x](astab_act cSa) // defHa /= modactE ?(subsetP fixSH).
 have Da := astab_dom cSa; rewrite !inE mem_quotient //; apply/subsetP=> x Sx.
 by rewrite !inE /= modactE ?(astab_act cSa) ?(subsetP fixSH).
@@ -1488,7 +1488,7 @@ Proof. exact: actpermE. Qed.
 
 Lemma ker_actperm : 'ker actperm = 'C(setT | to).
 Proof.
-congr (_ :&: _); apply/setP=> a; rewrite !inE /=.
+congr (_ :&: _); apply/setP=> a /[!inE]/=.
 apply/eqP/subsetP=> [a1 x _ | a1]; first by rewrite inE -actpermE a1 perm1.
 by apply/permP=> x; apply/eqP; have:= a1 x; rewrite !inE actpermE perm1 => ->.
 Qed.
@@ -1579,7 +1579,7 @@ Lemma afix_comp (A : {set gT}) :
 Proof.
 move=> sAB; apply/setP=> x; rewrite !inE /morphim (setIidPr sAB).
 apply/subsetP/subsetP=> [cAx _ /imsetP[a Aa ->] | cfAx a Aa].
-  by move/cAx: Aa; rewrite !inE.
+  by move/cAx: Aa => /[!inE].
 by rewrite inE; move/(_ (f a)): cfAx; rewrite inE mem_imset // => ->.
 Qed.
 
@@ -1697,7 +1697,7 @@ Variables (T : finType) (S : {set T}).
 
 Lemma SymE : Sym S = 'C(~: S | 'P).
 Proof.
-apply/setP => s; rewrite inE; apply/idP/astabP => [sS x|/= S_id].
+apply/setP => s /[1inE]; apply/idP/astabP => [sS x|/= S_id].
   by rewrite inE /= apermE => /out_perm->.
 by apply/subsetP => x; move=> /(contra_neqN (S_id _)); rewrite inE negbK.
 Qed.
@@ -1966,7 +1966,7 @@ Proof. by move=> a Da /= x Rx y Ry; rewrite -!actmE // morphR. Qed.
 Lemma gact_stable : {acts D, on R | to}.
 Proof.
 apply: acts_act; apply/subsetP=> a Da; rewrite !inE Da.
-apply/subsetP=> x; rewrite inE; apply: contraLR => R'xa.
+apply/subsetP=> x /[1inE]; apply: contraLR => R'xa.
 by rewrite -(actKin to Da x) gact_out ?groupV.
 Qed.
 
@@ -2044,7 +2044,7 @@ Proof. by rewrite astabs_set1 astab1. Qed.
 
 Lemma astabs_range : 'N(R | to) = D.
 Proof.
-apply/setIidPl; apply/subsetP=> a Da; rewrite inE.
+apply/setIidPl; apply/subsetP=> a Da /[1inE].
 by apply/subsetP=> x Rx; rewrite inE gact_stable.
 Qed.
 
@@ -2081,7 +2081,7 @@ apply/subsetP=> a nSa; have Da := astabs_dom nSa; rewrite !inE Da.
 apply: subset_trans (_ : <<S>> \subset actm to a @*^-1 <<S>>) _.
   rewrite gen_subG subsetI sSR; apply/subsetP=> x Sx.
   by rewrite inE /= actmE ?mem_gen // astabs_act.
-by apply/subsetP=> x; rewrite !inE; case/andP=> Rx; rewrite /= actmE.
+by apply/subsetP=> x /[!inE]; case/andP=> Rx; rewrite /= actmE.
 Qed.
 
 Lemma acts_joing A M N :
@@ -2160,7 +2160,7 @@ Lemma acts_qact_dom_norm : {acts qact_dom to H, on 'N(H) | to}.
 Proof.
 move=> a HDa /= x; rewrite {2}(('N(H) =P to^~ a @^-1: 'N(H)) _) ?inE {x}//.
 rewrite eqEcard (card_preimset _ (act_inj _ _)) leqnn andbT.
-apply/subsetP=> x Nx; rewrite inE; move/(astabs_act (H :* x)): HDa.
+apply/subsetP=> x Nx /[1inE]; move/(astabs_act (H :* x)): HDa.
 rewrite mem_rcosets mulSGid ?normG // Nx => /rcosetsP[y Ny defHy].
 suffices: to x a \in H :* y by apply: subsetP; rewrite mul_subG ?sub1set ?normG.
 by rewrite -defHy; apply: mem_imset; apply: rcoset_refl.
@@ -2187,7 +2187,7 @@ move=> sHR; apply/setP=> a; apply/idP/idP=> nHa; have Da := astabs_dom nHa.
   have /rcosetsP[y Ny defHy]: to^~ a @: H \in rcosets H 'N(H).
     by rewrite (astabs_act _ nHa); apply/rcosetsP; exists 1; rewrite ?mulg1.
   by rewrite (rcoset_eqP (_ : 1 \in H :* y)) -defHy -1?(gact1 Da) mem_setact.
-rewrite !inE Da; apply/subsetP=> Hx; rewrite inE => /rcosetsP[x Nx ->{Hx}].
+rewrite !inE Da; apply/subsetP=> Hx /[1inE] /rcosetsP[x Nx ->{Hx}].
 apply/imsetP; exists (to x a).
   case Rx: (x \in R); last by rewrite gact_out ?Rx.
   rewrite inE; apply/subsetP=> _ /imsetP[y Hy ->].
@@ -2433,7 +2433,7 @@ Canonical conjg_action := TotalAction (@conjg1 gT) (@conjgM gT).
 Lemma conjg_is_groupAction : is_groupAction setT conjg_action.
 Proof.
 move=> a _; rewrite /= inE; apply/andP; split.
-  by apply/subsetP=> x _; rewrite inE.
+  by apply/subsetP=> x _ /[1inE].
 by apply/morphicP=> x y _ _; rewrite !actpermE /= conjMg.
 Qed.
 

--- a/mathcomp/fingroup/automorphism.v
+++ b/mathcomp/fingroup/automorphism.v
@@ -95,7 +95,7 @@ Lemma ker_autm : 'ker f = 1. Proof. by move/trivgP: injm_autm. Qed.
 Lemma im_autm : f @* G = G.
 Proof.
 apply/setP=> x; rewrite morphimEdom (can_imset_pre _ (permK a)) inE.
-by have:= AutGa; rewrite inE => /andP[/perm_closed <-]; rewrite permKV.
+by have /[1inE] /andP[/perm_closed <-] := AutGa; rewrite permKV.
 Qed.
 
 Lemma Aut_closed x : x \in G -> a x \in G.
@@ -324,7 +324,7 @@ Canonical conj_aut_morphism := Morphism conj_aut_morphM.
 
 Lemma ker_conj_aut : 'ker conj_aut = 'C(G).
 Proof.
-apply/setP=> x; rewrite inE; case nGx: (x \in 'N(G)); last first.
+apply/setP=> x /[1inE]; case nGx: (x \in 'N(G)); last first.
   by symmetry; apply/idP=> cGx; rewrite (subsetP (cent_sub G)) in nGx.
 rewrite 2!inE /=; apply/eqP/centP=> [cx1 y Gy | cGx].
   by rewrite /commute (conjgC y) -norm_conj_autE // cx1 perm1.

--- a/mathcomp/fingroup/fingroup.v
+++ b/mathcomp/fingroup/fingroup.v
@@ -664,7 +664,7 @@ Lemma repr_set1 x : repr [set x] = x.
 Proof. by apply/set1P/card_mem_repr; rewrite cards1. Qed.
 
 Lemma repr_set0 : repr set0 = 1.
-Proof. by rewrite /repr; case: pickP => [x|_]; rewrite !inE. Qed.
+Proof. by rewrite /repr; case: pickP => [x|_] /[!inE]. Qed.
 
 End Repr.
 
@@ -703,7 +703,7 @@ Proof. by move=> A; apply/setP=> x; rewrite !inE invgK. Qed.
 
 Lemma set_invgM : {morph set_invg : A B / set_mulg A B >-> set_mulg B A}.
 Proof.
-move=> A B; apply/setP=> z; rewrite inE.
+move=> A B; apply/setP=> z /[1inE].
 apply/imset2P/imset2P=> [[x y Ax By /(canRL invgK)->] | [y x]].
   by exists y^-1 x^-1; rewrite ?invMg // inE invgK.
 by rewrite !inE => By1 Ax1 ->; exists x^-1 y^-1; rewrite ?invMg.
@@ -1159,7 +1159,7 @@ Qed.
 
 Lemma classVg x A : x^-1 ^: A = (x ^: A)^-1.
 Proof.
-apply/setP=> xy; rewrite inE; apply/imsetP/imsetP=> [] [y Ay def_xy].
+apply/setP=> xy /[1inE]; apply/imsetP/imsetP=> [] [y Ay def_xy].
   by rewrite def_xy conjVg invgK; exists y.
 by rewrite -[xy]invgK def_xy -conjVg; exists y.
 Qed.
@@ -1284,7 +1284,7 @@ Canonical one_group := group group_set_one.
 Canonical set1_group := @group [set 1] group_set_one.
 
 Lemma group_setT (phT : phant gT) : group_set (setTfor phT).
-Proof. by apply/group_setP; split=> [|x y _ _]; rewrite inE. Qed.
+Proof. by apply/group_setP; split=> [|x y _ _] /[1inE]. Qed.
 
 Canonical setT_group phT := group (group_setT phT).
 
@@ -2351,7 +2351,7 @@ Qed.
 
 Lemma commGC A B : [~: A, B] = [~: B, A].
 Proof.
-rewrite -[[~: A, B]]genV; congr <<_>>; apply/setP=> z; rewrite inE.
+rewrite -[[~: A, B]]genV; congr <<_>>; apply/setP=> z /[1inE].
 by apply/imset2P/imset2P=> [] [x y Ax Ay]; last rewrite -{1}(invgK z);
   rewrite -invg_comm => /invg_inj->; exists y x.
 Qed.
@@ -2738,7 +2738,7 @@ Proof. by rewrite (bigcap_min 1) ?conjsg1. Qed.
 
 Lemma gcore_norm A G : G \subset 'N(gcore A G).
 Proof.
-apply/subsetP=> x Gx; rewrite inE; apply/bigcapsP=> y Gy.
+apply/subsetP=> x Gx /[1inE]; apply/bigcapsP=> y Gy.
 by rewrite sub_conjg -conjsgM bigcap_inf ?groupM ?groupV.
 Qed.
 
@@ -2798,7 +2798,7 @@ Proof. by rewrite !cent1E eq_sym. Qed.
 Canonical centraliser_group A : {group _} := Eval hnf in [group of 'C(A)].
 
 Lemma cent_set1 x : 'C([set x]) = 'C[x].
-Proof. by apply: big_pred1 => y /=; rewrite inE. Qed.
+Proof. by apply: big_pred1 => y /= /[1inE]. Qed.
 
 Lemma cent1J x y : 'C[x ^ y] = 'C[x] :^ y.
 Proof. by rewrite -conjg_set1 normJ. Qed.
@@ -2823,7 +2823,7 @@ Proof. by rewrite -cent_set1 cent1T. Qed.
 
 Lemma cent_sub A : 'C(A) \subset 'N(A).
 Proof.
-apply/subsetP=> x /centP cAx; rewrite inE.
+apply/subsetP=> x /centP cAx /[1inE].
 by apply/subsetP=> _ /imsetP[y Ay ->]; rewrite /conjg -cAx ?mulKg.
 Qed.
 

--- a/mathcomp/fingroup/gproduct.v
+++ b/mathcomp/fingroup/gproduct.v
@@ -137,12 +137,12 @@ Proof. by move/setP/(_ 1); rewrite inE group1. Qed.
 
 Lemma mulg0 : right_zero (@set0 gT) mulg.
 Proof.
-by move=> A; apply/setP=> x; rewrite inE; apply/imset2P=> [[y z]]; rewrite inE.
+by move=> A; apply/setP=> x /[1inE]; apply/imset2P=> [[y z]] /[1inE].
 Qed.
 
 Lemma mul0g : left_zero (@set0 gT) mulg.
 Proof.
-by move=> A; apply/setP=> x; rewrite inE; apply/imset2P=> [[y z]]; rewrite inE.
+by move=> A; apply/setP=> x /[1inE]; apply/imset2P=> [[y z]] /[1inE].
 Qed.
 
 Lemma pprodP A B G :
@@ -1004,7 +1004,7 @@ Canonical prod_group := FinGroupType extprod_mulVg.
 Lemma group_setX (H1 : {group gT1}) (H2 : {group gT2}) : group_set (setX H1 H2).
 Proof.
 apply/group_setP; split; first by rewrite inE !group1.
-case=> [x1 x2] [y1 y2]; rewrite !inE; case/andP=> Hx1 Hx2; case/andP=> Hy1 Hy2.
+case=> [x1 x2] [y1 y2] /[!inE]; case/andP=> Hx1 Hx2; case/andP=> Hy1 Hy2.
 by rewrite /= !groupM.
 Qed.
 
@@ -1050,7 +1050,7 @@ Lemma morphim_fstX (H1: {set gT1}) (H2 : {group gT2}) :
 Proof.
 apply/eqP; rewrite eqEsubset morphimE setTI /=.
 apply/andP; split; apply/subsetP=> x.
-  by case/imsetP=> x0; rewrite inE; move/andP=> [Hx1 _] ->.
+  by case/imsetP=> x0 /[1inE]; move/andP=> [Hx1 _] ->.
 move=> Hx1; apply/imsetP; exists (x, 1); last by trivial.
 by rewrite in_setX Hx1 /=.
 Qed.
@@ -1060,7 +1060,7 @@ Lemma morphim_sndX (H1: {group gT1}) (H2 : {set gT2}) :
 Proof.
 apply/eqP; rewrite eqEsubset morphimE setTI /=.
 apply/andP; split; apply/subsetP=> x.
-  by case/imsetP=> x0; rewrite inE; move/andP=> [_ Hx2] ->.
+  by case/imsetP=> x0 /[1inE]; move/andP=> [_ Hx2] ->.
 move=> Hx2; apply/imsetP; exists (1, x); last by [].
 by rewrite in_setX Hx2 andbT.
 Qed.
@@ -1068,7 +1068,7 @@ Qed.
 Lemma setX_prod (H1 : {set gT1}) (H2 : {set gT2}) :
   setX H1 1 * setX 1 H2 = setX H1 H2.
 Proof.
-apply/setP=> [[x y]]; rewrite !inE /=.
+apply/setP=> [[x y]] /[!inE]/=.
 apply/imset2P/andP=> [[[x1 u1] [v1 y1]] | [Hx Hy]].
   rewrite !inE /= => /andP[Hx1 /eqP->] /andP[/eqP-> Hx] [-> ->].
   by rewrite mulg1 mul1g.
@@ -1080,7 +1080,7 @@ Lemma setX_dprod (H1 : {group gT1}) (H2 : {group gT2}) :
   setX H1 1 \x setX 1 H2 = setX H1 H2.
 Proof.
 rewrite dprodE ?setX_prod //.
-  apply/centsP=> [[x u]]; rewrite !inE /= => /andP[/eqP-> _] [v y].
+  apply/centsP=> [[x u]] /[!inE]/= /andP[/eqP-> _] [v y].
   by rewrite !inE /= => /andP[_ /eqP->]; congr (_, _); rewrite ?mul1g ?mulg1.
 apply/trivgP; apply/subsetP=> [[x y]]; rewrite !inE /= -!andbA.
 by case/and4P=> _ /eqP-> /eqP->; rewrite eqxx.
@@ -1286,7 +1286,7 @@ have ssGR := subsetP sGR; apply/setP=> a; apply/idP/idP=> [cGa|].
   rewrite mem_morphpre ?(astab_dom cGa) //.
   apply/centP=> _ /morphimP[x Rx Gx ->]; symmetry.
   by rewrite conjgC -sdpair_act ?(astab_act cGa)  ?(astab_dom cGa).
-case/morphpreP=> Da cGa; rewrite !inE Da; apply/subsetP=> x Gx; rewrite inE.
+case/morphpreP=> Da cGa; rewrite !inE Da; apply/subsetP=> x Gx /[1inE].
 apply/eqP; apply: (injmP injm_sdpair1); rewrite ?gact_stable ?ssGR //=.
 by rewrite sdpair_act ?ssGR // /conjg -(centP cGa) ?mulKg ?mem_morphim ?ssGR.
 Qed.

--- a/mathcomp/fingroup/morphism.v
+++ b/mathcomp/fingroup/morphism.v
@@ -304,7 +304,7 @@ Qed.
 Lemma morphpreMl R S :
   R \subset f @* D -> f @*^-1 (R * S) = f @*^-1 R * f @*^-1 S.
 Proof.
-move=> sRfD; apply/setP=> x; rewrite !inE.
+move=> sRfD; apply/setP=> x /[!inE].
 apply/andP/imset2P=> [[Dx] | [y z]]; last first.
   rewrite !inE => /andP[Dy Rfy] /andP[Dz Rfz] ->.
   by rewrite ?(groupM, morphM, mem_imset2).
@@ -364,7 +364,7 @@ Lemma morphpreI R S : f @*^-1 (R :&: S) = f @*^-1 R :&: f @*^-1 S.
 Proof. by rewrite -setIIr -preimsetI. Qed.
 
 Lemma morphpreD R S : f @*^-1 (R :\: S) = f @*^-1 R :\: f @*^-1 S.
-Proof. by apply/setP=> x; rewrite !inE; case: (x \in D). Qed.
+Proof. by apply/setP=> x /[!inE]; case: (x \in D). Qed.
 
 (* kernel, domain properties *)
 
@@ -396,7 +396,7 @@ Proof. by move=> Dx Dy eqfxy; apply/rcosetP; apply/rcoset_kerP. Qed.
 
 Lemma ker_norm : D \subset 'N('ker f).
 Proof.
-apply/subsetP=> x Dx; rewrite inE; apply/subsetP=> _ /imsetP[y Ky ->].
+apply/subsetP=> x Dx /[1inE]; apply/subsetP=> _ /imsetP[y Ky ->].
 by rewrite !inE groupJ ?morphJ // ?dom_ker //= mker ?conj1g.
 Qed.
 
@@ -465,7 +465,7 @@ Qed.
 
 Lemma morphimK A : A \subset D -> f @*^-1 (f @* A) = 'ker f * A.
 Proof.
-move=> sAD; apply/setP=> x; rewrite !inE.
+move=> sAD; apply/setP=> x /[!inE].
 apply/idP/idP=> [/andP[Dx /morphimP[y Dy Ay eqxy]] | /imset2P[z y Kz Ay ->{x}]].
   rewrite -(mulgKV y x) mem_mulg // !inE !(groupM, morphM, groupV) //.
   by rewrite morphV //= eqxy mulgV.
@@ -660,7 +660,7 @@ Proof. exact: morphim_cents. Qed.
 
 Lemma morphpre_norm R : f @*^-1 'N(R) \subset 'N(f @*^-1 R).
 Proof.
-apply/subsetP=> x; rewrite !inE => /andP[Dx Nfx].
+apply/subsetP=> x /[!inE] /andP[Dx Nfx].
 by rewrite -morphpreJ ?morphpreS.
 Qed.
 
@@ -898,7 +898,7 @@ by apply/setP=> x; apply/imsetP/idP=> [[y By ->]|Bx]; last exists x.
 Qed.
 
 Lemma morphpre_idm A B : idm A @*^-1 B = A :&: B.
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma im_idm A : idm A @* A = A.
 Proof. exact: morphim_idm. Qed.
@@ -980,12 +980,12 @@ Canonical triv_morph A := Morphism (@trivm_morphM A).
 
 Lemma morphim_trivm (G H : {group aT}) : trivm G @* H = 1.
 Proof.
-apply/setP=> /= y; rewrite inE; apply/idP/eqP=> [|->]; first by case/morphimP.
+apply/setP=> /= y /[1inE]; apply/idP/eqP=> [|->]; first by case/morphimP.
 by apply/morphimP; exists (1 : aT); rewrite /= ?group1.
 Qed.
 
 Lemma ker_trivm (G : {group aT}) : 'ker (trivm G) = G.
-Proof. by apply/setIidPl/subsetP=> x _; rewrite !inE /=. Qed.
+Proof. by apply/setIidPl/subsetP=> x _ /[!inE]/=. Qed.
 
 End TrivMorphism.
 
@@ -1071,7 +1071,7 @@ Qed.
 
 Lemma morphpre_factm (C : {set rT}) : ff @*^-1 C =  q @* (f @*^-1 C).
 Proof.
-apply/setP=> y; rewrite !inE /=; apply/andP/morphimP=> [[]|[x Hx]]; last first.
+apply/setP=> y /[!inE]/=; apply/andP/morphimP=> [[]|[x Hx]]; last first.
   by case/morphpreP=> Gx Cfx ->; rewrite factmE ?mem_imset ?inE ?Hx.
 case/morphimP=> x Hx Gx ->; rewrite factmE //.
 by exists x; rewrite // !inE Gx.

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -544,7 +544,7 @@ Definition Sym : {set {perm T}} := [set s | perm_on S s].
 
 Lemma Sym_group_set : group_set Sym.
 Proof.
-apply/group_setP; split => [| s t]; rewrite !inE;
+apply/group_setP; split => [| s t] /[!inE];
    [exact: perm_on1 | exact: perm_onM].
 Qed.
 Canonical Sym_group : {group {perm T}} := Group Sym_group_set.
@@ -687,7 +687,7 @@ Lemma isom_cast_perm m n eq_m_n : isom setT setT (@cast_perm m n eq_m_n).
 Proof.
 case: {n} _ / eq_m_n; apply/isomP; split.
   exact/injmP/(in2W (@cast_perm_inj _ _ _)).
-by apply/setP => /= s; rewrite !inE; apply/imsetP; exists s; rewrite ?inE.
+by apply/setP => /= s /[!inE]; apply/imsetP; exists s; rewrite ?inE.
 Qed.
 
 End CastSn.

--- a/mathcomp/fingroup/quotient.v
+++ b/mathcomp/fingroup/quotient.v
@@ -740,7 +740,7 @@ Lemma qisom_isog : [set: coset_of G] \isog [set: coset_of H].
 Proof. exact: isom_isog qisom_isom. Qed.
 
 Lemma qisom_inj : injective qisom.
-Proof. by move=> x y; apply: (injmP injm_qisom); rewrite inE. Qed.
+Proof. by move=> x y; apply: (injmP injm_qisom) => /[1inE]. Qed.
 
 Lemma morphim_qisom_inj : injective (fun Gx => qisom @* Gx).
 Proof.

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -348,7 +348,7 @@ by apply: cprod_exponent; rewrite cprodE.
 Qed.
 
 Lemma sub_LdivT A n : (A \subset 'Ldiv_n()) = (exponent A %| n).
-Proof. by apply/subsetP/exponentP=> eAn x /eAn; rewrite inE => /eqP. Qed.
+Proof. by apply/subsetP/exponentP=> eAn x /eAn /[1inE] /eqP. Qed.
 
 Lemma LdivT_J n x : 'Ldiv_n() :^ x = 'Ldiv_n().
 Proof.
@@ -495,7 +495,7 @@ Arguments pElemP {p A E}.
 
 Lemma pElemS p A B : A \subset B -> 'E_p(A) \subset 'E_p(B).
 Proof.
-by move=> sAB; apply/subsetP=> E; rewrite !inE => /andP[/subset_trans->].
+by move=> sAB; apply/subsetP=> E /[!inE] /andP[/subset_trans->].
 Qed.
 
 Lemma pElemI p A B : 'E_p(A :&: B) = 'E_p(A) :&: subgroups B.
@@ -709,7 +709,7 @@ Qed.
 Lemma pmaxElemS p A B :
   A \subset B -> 'E*_p(B) :&: subgroups A \subset 'E*_p(A).
 Proof.
-move=> sAB; apply/subsetP=> E; rewrite !inE.
+move=> sAB; apply/subsetP=> E /[!inE].
 case/andP=> /maxgroupP[/pElemP[_ abelE] maxE] sEA.
 apply/maxgroupP; rewrite inE sEA; split=> // D EpD.
 by apply: maxE; apply: subsetP EpD; apply: pElemS.
@@ -774,7 +774,7 @@ Qed.
 Lemma p_rank_abelem p G : p.-abelem G -> 'r_p(G) = logn p #|G|.
 Proof.
 move=> abelG; apply/eqP; rewrite eqn_leq andbC (bigmax_sup G) //.
-  by apply/bigmax_leqP=> E; rewrite inE => /andP[/lognSg->].
+  by apply/bigmax_leqP=> E /[1inE] /andP[/lognSg->].
 by rewrite inE subxx.
 Qed.
 
@@ -803,7 +803,7 @@ Qed.
 Lemma p_rank_Sylow p G H : p.-Sylow(G) H -> 'r_p(H) = 'r_p(G).
 Proof.
 move=> sylH; apply/eqP; rewrite eqn_leq (p_rankS _ (pHall_sub sylH)) /=.
-apply/bigmax_leqP=> E; rewrite inE => /andP[sEG abelE].
+apply/bigmax_leqP=> E /[1inE] /andP[sEG abelE].
 have [P sylP sEP] := Sylow_superset sEG (abelem_pgroup abelE).
 have [x _ ->] := Sylow_trans sylP sylH.
 by rewrite p_rankJ -(p_rank_abelem abelE) (p_rankS _ sEP).
@@ -889,7 +889,7 @@ Proof.
 apply: (iffP idP) => [|[E]].
   have [p _ ->] := rank_witness G; case/p_rank_geP=> E.
   by rewrite def_pnElem; case/setIP; exists E.
-case/nElemP=> p; rewrite inE => /andP[EpG_E /eqP <-].
+case/nElemP=> p /[1inE] /andP[EpG_E /eqP <-].
 by rewrite (leq_trans (logn_le_p_rank EpG_E)) ?p_rank_le_rank.
 Qed.
 
@@ -1159,13 +1159,13 @@ Qed.
 
 Lemma OhmS H G : H \subset G -> 'Ohm_n(H) \subset 'Ohm_n(G).
 Proof.
-move=> sHG; apply: genS; apply/subsetP=> x; rewrite !inE => /andP[Hx ->].
+move=> sHG; apply: genS; apply/subsetP=> x /[!inE] /andP[Hx ->].
 by rewrite (subsetP sHG).
 Qed.
 
 Lemma OhmE p G : p.-group G -> 'Ohm_n(G) = <<'Ldiv_(p ^ n)(G)>>.
 Proof.
-move=> pG; congr <<_>>; apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+move=> pG; congr <<_>>; apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
 have [-> | ntx] := eqVneq x 1; first by rewrite !expg1n.
 by rewrite (pdiv_p_elt (mem_p_elt pG Gx)).
 Qed.
@@ -1345,7 +1345,7 @@ Implicit Types (A B C : {set gT}) (D G H E : {group gT}).
 Lemma Ohm0 G : 'Ohm_0(G) = 1.
 Proof.
 apply/trivgP; rewrite /= gen_subG.
-by apply/subsetP=> x /setIdP[_]; rewrite inE.
+by apply/subsetP=> x /setIdP[_] /[1inE].
 Qed.
 
 Lemma Ohm_leq m n G : m <= n -> 'Ohm_m(G) \subset 'Ohm_n(G).

--- a/mathcomp/solvable/alt.v
+++ b/mathcomp/solvable/alt.v
@@ -73,7 +73,7 @@ Qed.
 Lemma card_Sym : #|'Sym_T| = n`!.
 Proof.
 rewrite -[n]cardsE -card_perm; apply: eq_card => p.
-by apply/idP/subsetP=> [? ?|]; rewrite !inE.
+by apply/idP/subsetP=> [? ?|] /[!inE].
 Qed.
 
 Lemma card_Alt : 1 < n -> (2 * #|'Alt_T|)%N = n`!.
@@ -86,7 +86,7 @@ Proof.
 apply/imsetP; pose t1 := [tuple of enum T].
 have dt1: t1 \in n.-dtuple(setT) by rewrite inE enum_uniq; apply/subsetP.
 exists t1 => //; apply/setP=> t; apply/idP/imsetP=> [|[a _ ->{t}]]; last first.
-  by apply: n_act_dtuple => //; apply/astabsP=> x; rewrite !inE.
+  by apply: n_act_dtuple => //; apply/astabsP=> x /[!inE].
 case/dtuple_onP=> injt _; have injf := inj_comp injt enum_rank_inj.
 exists (perm injf); first by rewrite inE.
 apply: eq_from_tnth => i; rewrite tnth_map /= [aperm _ _]permE; congr tnth.
@@ -101,7 +101,7 @@ case/imsetP: tr_m2; case/tupleP=> x; case/tupleP=> y t.
 rewrite !dtuple_on_add 2![x \in _]inE inE negb_or /= -!andbA.
 case/and4P=> nxy ntx nty dt _; apply/imsetP; exists t => //; apply/setP=> u.
 apply/idP/imsetP=> [|[a _ ->{u}]]; last first.
-  by apply: n_act_dtuple => //; apply/astabsP=> z; rewrite !inE.
+  by apply: n_act_dtuple => //; apply/astabsP=> z /[!inE].
 case/(atransP2 tr_m dt)=> /= a _ ->{u}.
 case odd_a: (odd_perm a); last by exists a => //; rewrite !inE /= odd_a.
 exists (tperm x y * a); first by rewrite !inE /= odd_permM odd_tperm nxy odd_a.
@@ -343,7 +343,7 @@ have p1x_x: p1 x = x by apply: fix_p1.
 have{le_p_n} lt_p1_n: #|[set x | p1 x != x]| < n.
   move: le_p_n; rewrite ltnS (cardsD1 x1) Hx1; apply/leq_trans/subset_leq_card.
   rewrite subsetD1 inE permM tpermR eqxx andbT.
-  by apply/subsetP=> y; rewrite !inE; apply: contraNneq=> /fix_p1->.
+  by apply/subsetP=> y /[!inE]; apply: contraNneq=> /fix_p1->.
 transitivity (p1 (+) true); last first.
   by rewrite odd_permM odd_tperm -Hx1 inE eq_sym addbK.
 have ->: p = p1 * tperm x1 (p x1) by rewrite -tpermV mulgK.
@@ -364,7 +364,7 @@ have rfd_rgd p: rfd (rgd p) = p.
   apply/permP => [[z Hz]]; apply/val_eqP; rewrite !permE.
   by rewrite /= [rgd _ _]permE /= insubF eqxx // permE /= insubT.
 have sSd: 'C_('Alt_T)[x | 'P] \subset 'dom rfd.
-  by apply/subsetP=> p; rewrite !inE /=; case/andP.
+  by apply/subsetP=> p /[!inE]/=; case/andP.
 apply/isogP; exists [morphism of restrm sSd rfd] => /=; last first.
   rewrite morphim_restrm setIid; apply/setP=> z; apply/morphimP/idP=> [[p _]|].
     case/setIP; rewrite Alt_even => Hp; move/astab1P=> Hp1 ->.

--- a/mathcomp/solvable/burnside_app.v
+++ b/mathcomp/solvable/burnside_app.v
@@ -21,7 +21,7 @@ Proof.
 move=> gT s G Us sG sT to.
 rewrite big_uniq // -(card_uniqP Us) (eq_card sG) -Frobenius_Cauchy.
   by apply: eq_big => // p _; rewrite setTI.
-by apply/actsP=> ? _ ?; rewrite !inE.
+by apply/actsP=> ? _ ? /[!inE].
 Qed.
 
 Arguments burnside_formula {gT}.
@@ -128,7 +128,7 @@ Qed.
 
 Lemma rot_is_rot : rot = rotations.
 Proof.
-apply/setP=> r; apply/idP/idP; last by move/rotations_is_rot; rewrite inE.
+apply/setP=> r; apply/idP/idP; last by move/rotations_is_rot /[1inE].
 rewrite !inE => h.
 have -> : r = r1 ^+ (r c0) by apply: rot_eq_c0; rewrite // -rot_r1.
 have e2: 2 = r2 c0 by rewrite permE /=.
@@ -230,7 +230,7 @@ Definition is_iso (p : {perm square}) := forall ci, p (opp ci) = opp (p ci).
 
 Lemma isometries_iso : forall p, p \in isometries -> is_iso p.
 Proof.
-move=> p; rewrite inE.
+move=> p /[1inE].
 by do ?case/orP; move/eqP=> -> a; rewrite !permE; case: a; do 4?case.
 Qed.
 
@@ -381,11 +381,11 @@ move=> x y z t Uxt; rewrite -[n]card_ord.
 pose f (p : col_squares) := (p x, p z); rewrite -(@card_in_image _ _ f).
   rewrite -mulnn -card_prod; apply: eq_card => [] [c d] /=; apply/imageP.
   rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-  rewrite /= !orbF !andbT; case/norP; rewrite !inE => nxzt nyzt _.
+  rewrite /= !orbF !andbT; case/norP => /[!inE] nxzt nyzt _.
   exists [ffun i => if pred2 x y i then c else d].
     by rewrite inE !ffunE /= !eqxx orbT (negbTE nxzt) (negbTE nyzt) !eqxx.
   by rewrite {}/f !ffunE /= eqxx (negbTE nxzt).
-move=> p1 p2; rewrite !inE.
+move=> p1 p2 /[!inE].
 case/andP=> p1y p1t; case/andP=> p2y p2t [px pz].
 have eqp12: all (fun i => p1 i == p2 i) [:: x; y; z; t].
   by rewrite /= -(eqP p1y) -(eqP p1t) -(eqP p2y) -(eqP p2t) px pz !eqxx.
@@ -674,13 +674,13 @@ Definition is_iso3 (p : {perm cube}) := forall fi, p (s0 fi) = s0 (p fi).
 
 Lemma dir_iso_iso3 : forall p, p \in dir_iso3  -> is_iso3 p.
 Proof.
-move=> p; rewrite inE.
+move=> p /[1inE].
 by do ?case/orP; move/eqP=> <- a; rewrite !permE; case: a; do 6?case.
 Qed.
 
 Lemma iso3_ndir : forall p, p \in dir_iso3  -> is_iso3 (s0 * p).
 Proof.
-move=> p; rewrite inE.
+move=> p /[1inE].
 by do ?case/orP; move/eqP=> <- a; rewrite !(permM, permE); case: a; do 6?case.
 Qed.
 
@@ -834,9 +834,9 @@ Canonical diso_group3 := Group group_set_diso3.
 Lemma gen_diso3 :  dir_iso3 = <<[set r05; r14]>>.
 Proof.
 apply/setP; apply/subset_eqP; apply/andP; split; first last.
-  by rewrite gen_subG; apply/subsetP => x; rewrite !inE;
+  by rewrite gen_subG; apply/subsetP => x /[!inE];
     case/orP; move/eqP ->; rewrite eqxx !orbT.
-apply/subsetP => x; rewrite !inE.
+apply/subsetP => x /[!inE].
 have -> : s05 = r05 * r05  by iso_tac.
 have -> : s14 = r14 * r14  by iso_tac.
 have -> : s23 = r14 * r14 * r05 * r05 by iso_tac.
@@ -1158,7 +1158,7 @@ move=> x y z t  Uxt. rewrite -[n]card_ord .
 case: (uniq4_uniq6 Uxt) => u; case=> v Uxv.
 pose ff (p : col_cubes) := (p x, p z, p u , p v).
 rewrite -(@card_in_image _ _ ff); first last.
-  move=> p1 p2; rewrite !inE.
+  move=> p1 p2 /[!inE].
   case/andP=> p1y p1t; case/andP=> p2y p2t  [px pz] pu pv.
   have eqp12: all (fun i => p1 i == p2 i) [:: x; y; z; t; u; v].
    by rewrite /= -(eqP p1y) -(eqP p1t) -(eqP p2y) -(eqP p2t) px pz pu pv !eqxx.
@@ -1171,7 +1171,7 @@ rewrite (cat_uniq [::x; y; z; t]) in Uxv; case/and3P: Uxv => _ hasxt.
 rewrite /= !inE andbT.
 move/negbTE=> nuv .
 rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-rewrite /= !andbT orbF; case/norP; rewrite !inE => nxyz nxyt _.
+rewrite /= !andbT orbF; case/norP => /[!inE] nxyz nxyt _.
 move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE orbA.
 case/norP  => nxyu nztu.
 rewrite orbA; case/norP=> nxyv nztv.
@@ -1192,7 +1192,7 @@ move=> x y z t Uxt; rewrite -[n]card_ord .
 case: (uniq4_uniq6 Uxt) => u; case=> v Uxv.
 pose ff (p : col_cubes) := (p x, p u , p v);
    rewrite -(@card_in_image _ _ ff); first last.
-  move=> p1 p2; rewrite !inE.
+  move=> p1 p2 /[!inE].
   case/andP; case/andP => p1xy p1yz p1zt.
   case/andP; case/andP => p2xy p2yz p2zt [px pu] pv.
   have eqp12: all (fun i => p1 i == p2 i) [:: x; y; z; t; u; v].
@@ -1218,7 +1218,7 @@ Lemma card_n2_3 : forall x y z t u v: cube, uniq [:: x; y; z; t; u; v] ->
 Proof.
 move=> x y z t u v  Uxv; rewrite -[n]card_ord .
 pose ff (p : col_cubes) := (p x, p t); rewrite -(@card_in_image _ _ ff); first last.
-  move=> p1 p2; rewrite !inE.
+  move=> p1 p2 /[!inE].
   case/andP; case/andP; case/andP => p1xy p1yz p1tu p1uv.
   case/andP; case/andP; case/andP => p2xy p2yz p2tu p2uv [px pu].
   have eqp12: all (fun i => p1 i == p2 i) [:: x; y; z; t; u; v].
@@ -1229,7 +1229,7 @@ pose ff (p : col_cubes) := (p x, p t); rewrite -(@card_in_image _ _ ff); first l
 have ->:forall n, (n ^ 2)%N= (n*n)%N by move=> n0; rewrite -mulnn .
    rewrite -!card_prod; apply: eq_card => [] [c d]/=; apply/imageP.
 rewrite (cat_uniq [::x; y; z]) in Uxv; case/and3P: Uxv => Uxt hasxt nuv .
-move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE => nxyzt.
+move: hasxt; rewrite /= !orbF; case/norP => /[!inE] nxyzt.
 case/norP => nxyzu nxyzv.
 exists [ffun i =>  if (i \in [:: x; y; z] ) then c else  d].
   rewrite !inE /= !ffunE !inE //= !eqxx !orbT !eqxx //=.
@@ -1244,7 +1244,7 @@ Proof.
 move=> x y z t u v  Uxv; rewrite -[n]card_ord .
 pose ff (p : col_cubes) := (p x, p z, p u).
 rewrite -(@card_in_image _ _ ff); first last.
-  move=> p1 p2; rewrite !inE.
+  move=> p1 p2 /[!inE].
   case/andP; case/andP =>  p1xy p1zt p1uv.
   case/andP; case/andP => p2xy p2zt p2uv  [px pz] pu.
   have eqp12: all (fun i => p1 i == p2 i) [:: x; y; z; t; u; v].
@@ -1257,7 +1257,7 @@ have ->:forall n, (n ^ 3)%N= (n*n*n)%N.
 rewrite -!card_prod. apply: eq_card => [] [[c d]e ] /=; apply/imageP.
 rewrite (cat_uniq [::x; y; z; t]) in Uxv; case/and3P: Uxv => Uxt hasxt nuv .
 rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
-rewrite /= !orbF !andbT; case/norP; rewrite !inE => nxyz nxyt _.
+rewrite /= !orbF !andbT; case/norP => /[!inE] nxyz nxyt _.
 move: hasxt; rewrite /= !orbF; case/norP; rewrite !inE orbA.
 case/norP => nxyu nztu.
 rewrite orbA; case/norP=> nxyv nztv.

--- a/mathcomp/solvable/center.v
+++ b/mathcomp/solvable/center.v
@@ -309,7 +309,7 @@ Proof.
 rewrite -(center_dprod (setX_dprod H K)) -morphim_pairg1 -morphim_pair1g.
 rewrite -!injm_center ?subsetT ?injm_pair1g ?injm_pairg1 //=.
 rewrite morphim_pairg1 morphim_pair1g setX_dprod.
-apply/subsetP=> [[x y]]; rewrite inE => /andP[Zx /eqP->].
+apply/subsetP=> [[x y]] /[1inE] /andP[Zx /eqP->].
 by rewrite inE /= Zx groupV (subsetP sgzZZ) ?mem_morphim.
 Qed.
 

--- a/mathcomp/solvable/cyclic.v
+++ b/mathcomp/solvable/cyclic.v
@@ -373,7 +373,7 @@ Proof.
 move=> sHa; apply: lone_subgroup_char => // J sJa isoJH.
 have dvHa: #|H| %| #[a] by apply: cardSg.
 have{dvHa} /setP Huniq := esym (cycle_sub_group dvHa).
-move: (Huniq H) (Huniq J); rewrite !inE /=.
+move: (Huniq H) (Huniq J) => /[!inE]/=.
 by rewrite sHa sJa (card_isog isoJH) eqxx => /eqP<- /eqP<-.
 Qed.
 
@@ -665,7 +665,7 @@ have [lea1 | lt1a] := leqP #[a] 1.
   rewrite /order card_le1_trivg // cards1 (@eq_card1 _ 1) // => x.
   by rewrite !inE -cycle_eq1 eq_sym.
 rewrite -(card_injm (injm_invm (injm_Zpm a))) /= ?im_Zpm; last first.
-  by apply/subsetP=> x; rewrite inE; apply: cycle_generator.
+  by apply/subsetP=> x /[1inE]; apply: cycle_generator.
 rewrite -card_units_Zp // cardsE card_sub morphim_invmE; apply: eq_card => /= d.
 by rewrite !inE /= qualifE /= /Zp lt1a inE /= generator_coprime {1}Zp_cast.
 Qed.
@@ -690,7 +690,7 @@ pose h (x : gT) : 'I_#|G|.+1 := inord #[x].
 symmetry; rewrite -{1}sum1_card (partition_big h xpredT) //=.
 apply: eq_bigr => d _; set Gd := finset _.
 rewrite -sum_nat_const sum1dep_card -sum1_card (_ : finset _ = Gd); last first.
-  apply/setP=> x; rewrite !inE; apply: andb_id2l => Gx.
+  apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
   by rewrite /eq_op /= inordK // ltnS subset_leq_card ?cycle_subG.
 rewrite (partition_big_imset cycle) {}/Gd; apply: eq_bigr => C /=.
 case/imsetP=> x /setIdP[Gx /eqP <-] -> {C d}.

--- a/mathcomp/solvable/extraspecial.v
+++ b/mathcomp/solvable/extraspecial.v
@@ -69,8 +69,8 @@ Canonical action := Action actP.
 
 Lemma gactP : is_groupAction [set: 'Z_p * 'Z_p] action.
 Proof.
-move=> k _ /=; rewrite inE.
-apply/andP; split; first by apply/subsetP=> ij _; rewrite inE.
+move=> k _ /= /[1inE].
+apply/andP; split; first by apply/subsetP=> ij _ /[1inE].
 apply/morphicP=> /= [[i1 j1] [i2 j2] _ _].
 by rewrite !permE /= mulrDr -addrA (addrCA i2) (addrA i1).
 Qed.

--- a/mathcomp/solvable/extremal.v
+++ b/mathcomp/solvable/extremal.v
@@ -792,7 +792,7 @@ have defK: K = [set w].
   rewrite add0n -[j./2]odd_double_half addnC doubleD -!muln2 -mulnA.
   rewrite -(expg_mod_order v) ov modnMDl; case: (odd _); last first.
     right; rewrite mulg1 /r -(subnKC n_gt2) expnSr mulnA expgM.
-    by apply: mem_imset; rewrite inE.
+    by apply: mem_imset => /[1inE].
   rewrite (inj_eq (mulIg _)) -expg_mod_order ou -[k]odd_double_half.
   rewrite addnC -muln2 mulnDl -mulnA def2r modnMDl -ou expg_mod_order.
   case: (odd k); [left | right]; rewrite ?mul1n ?mul1g //.
@@ -1455,7 +1455,7 @@ split.
     by rewrite -(groupMr _ (sX'G2 y X'y)) !sX'G2.
   rewrite eqEsubset andbC gen_subG class_sub_norm ?gFnorm //.
   rewrite (OhmE 1 pG) mem_gen ?inE ?Gy -?order_dvdn ?oy // gen_subG /= -/My.
-  apply/subsetP=> t; rewrite !inE; case/andP=> Gt t2.
+  apply/subsetP=> t /[!inE]; case/andP=> Gt t2.
   have pX := pgroupS sXG pG.
   case Xt: (t \in X).
     have: t \in 'Ohm_1(X) by rewrite (OhmE 1 pX) mem_gen // !inE Xt.

--- a/mathcomp/solvable/finmodule.v
+++ b/mathcomp/solvable/finmodule.v
@@ -194,8 +194,8 @@ Qed.
 
 Fact actr_is_groupAction : is_groupAction setT 'M.
 Proof.
-move=> a Na /=; rewrite inE; apply/andP; split.
-  by apply/subsetP=> u _; rewrite inE.
+move=> a Na /= /[1inE]; apply/andP; split.
+  by apply/subsetP=> u _ /[1inE].
 by apply/morphicP=> u v _ _; rewrite !permE /= actAr.
 Qed.
 

--- a/mathcomp/solvable/frobenius.v
+++ b/mathcomp/solvable/frobenius.v
@@ -598,7 +598,7 @@ have partG: partition (gval K |: (H^# :^: K)) G.
   apply: Frobenius_partition; apply/andP; rewrite defG; split=> //.
   by apply/Frobenius_actionP; apply: HasFrobeniusAction FrobG.
 have{FrobG} [ffulG transG regG ntH [u Su defH]]:= FrobG.
-apply/setP=> x; rewrite !inE; have [-> | ntx] := eqVneq; first exact: group1.
+apply/setP=> x /[!inE]; have [-> | ntx] := eqVneq; first exact: group1.
 rewrite /= -(cover_partition partG) /cover.
 have neKHy y: gval K <> H^# :^ y.
   by move/setP/(_ 1); rewrite group1 conjD1g setD11.

--- a/mathcomp/solvable/jordanholder.v
+++ b/mathcomp/solvable/jordanholder.v
@@ -247,7 +247,7 @@ Variable to : groupAction A D.
 Lemma gactsP (G : {set rT}) : reflect {acts A, on G | to} [acts A, on G | to].
 Proof.
 apply: (iffP idP) => [nGA x|nGA]; first exact: acts_act.
-apply/subsetP=> a Aa; rewrite !inE; rewrite Aa.
+apply/subsetP=> a Aa /[!inE]; rewrite Aa.
 by  apply/subsetP=> x; rewrite inE nGA.
 Qed.
 
@@ -268,7 +268,7 @@ Lemma gactsI (N1 N2 : {set rT}) :
   [acts A, on N1 | to] -> [acts A, on N2 | to] -> [acts A, on N1 :&: N2 | to].
 Proof.
 move=> aAN1 aAN2.
-apply/subsetP=> x Ax; rewrite !inE Ax /=; apply/subsetP=> y Ny; rewrite inE.
+apply/subsetP=> x Ax; rewrite !inE Ax /=; apply/subsetP=> y Ny /[1inE].
 case/setIP: Ny=> N1y N2y; rewrite inE ?astabs_act  ?N1y ?N2y //.
 - by move/subsetP: aAN2; move/(_ x Ax).
 - by move/subsetP: aAN1; move/(_ x Ax).
@@ -314,7 +314,7 @@ Lemma qacts_cosetpre (H : {group rT}) (K' : {group coset_of H}) :
 Proof.
 move=> sHD aH aK'; apply/subsetP=> x Ax; move: (Ax) (subsetP aK').
 rewrite -{1}(acts_qact_doms sHD aH) => qdx; move/(_ x qdx) => nx.
-rewrite !inE Ax; apply/subsetP=> y; case/morphpreP=> Ny /= K'Hy; rewrite inE.
+rewrite !inE Ax; apply/subsetP=> y; case/morphpreP=> Ny /= K'Hy /[1inE].
 apply/morphpreP; split; first by rewrite acts_qact_dom_norm.
 by move/gastabsP: nx; move/(_  qdx (coset H y)); rewrite K'Hy qactE.
 Qed.
@@ -522,8 +522,8 @@ have: K' :=: 1%G \/ K' :=: (G / H).
     by rewrite astabs_act // (subsetP aK) //; apply: (subsetP h).
   by apply/subsetP=> t; rewrite qact_domE // inE; case/andP.
 case; last first.
-  move/quotient_injG; rewrite !inE /=; move/(_ nKH nHG)=> c; move: nsGK.
-  by rewrite c subxx.
+  move=> /quotient_injG /[!inE]/= /(_ nKH nHG) c.
+  by rewrite c subxx in nsGK.
 rewrite /= -trivg_quotient => tK'; apply: (congr1 (@gval _)); move: tK'.
 by apply: (@quotient_injG _ H); rewrite ?inE /= ?normal_refl.
 Qed.
@@ -635,7 +635,7 @@ have nNN1 : N <| N1.
 have nNN2 : N <| N2.
   by apply: (normalS _ _ nNG); rewrite ?subsetIr ?normal_sub.
 have aN : [ acts A, on N1 :&: N2 | to].
-  apply/subsetP=> x Ax; rewrite !inE Ax /=; apply/subsetP=> y Ny; rewrite inE.
+  apply/subsetP=> x Ax; rewrite !inE Ax /=; apply/subsetP=> y Ny /[1inE].
   case/setIP: Ny=> N1y N2y. rewrite inE ?astabs_act  ?N1y ?N2y //.
     by move/subsetP: aN2; move/(_ x Ax).
   by move/subsetP: aN1; move/(_ x Ax).

--- a/mathcomp/solvable/maximal.v
+++ b/mathcomp/solvable/maximal.v
@@ -1457,7 +1457,7 @@ have{nil_classY pY sXW sZY sZCA} defW: W = <[x]> * Z.
   rewrite -[W](setIidPr (Ohm_sub _ _)) /= -/Y {1}defY -group_modl //= -/Y -/W.
   congr (_ * _); apply/eqP; rewrite eqEsubset {1}[Z](OhmE 1 pA).
   rewrite subsetI setIAC subIset //; first by rewrite sZCA -[Z]Ohm_id OhmS.
-  rewrite sub_gen ?setIS //; apply/subsetP=> w Ww; rewrite inE.
+  rewrite sub_gen ?setIS //; apply/subsetP=> w Ww /[1inE].
   by apply/eqP; apply: exponentP w Ww; apply: exponent_Ohm1_class2.
 have{sXG sAG} sXAG: XA \subset G by rewrite join_subG sXG.
 have{sXAG} nilXA: nilpotent XA := nilpotentS sXAG (pgroup_nil pG).
@@ -1523,7 +1523,7 @@ have{nsXG} pU := pgroupS (subset_trans sUX (normal_sub nsXG)) pG.
 case gsetU1: (group_set 'Ldiv_p(U)).
   by rewrite -defU1 (OhmE 1 pU) gen_set_id // -sub_LdivT subsetIr.
 move: gsetU1; rewrite /group_set 2!inE group1 expg1n eqxx; case/subsetPn=> xy.
-case/imset2P=> x y; rewrite !inE => /andP[Ux xp1] /andP[Uy yp1] ->{xy}.
+case/imset2P=> x y /[!inE] /andP[Ux xp1] /andP[Uy yp1] ->{xy}.
 rewrite groupM //= => nt_xyp; pose XY := <[x]> <*> <[y]>.
 have{yp1 nt_xyp} defXY: XY = U.
   have sXY_U: XY \subset U by rewrite join_subG !cycle_subG Ux Uy.

--- a/mathcomp/solvable/primitive_action.v
+++ b/mathcomp/solvable/primitive_action.v
@@ -213,7 +213,7 @@ Qed.
 
 Lemma dtuple_on_subset n (S1 S2 : {set sT}) t :
   S1 \subset S2 -> t \in n.-dtuple(S1) -> t \in n.-dtuple(S2).
-Proof. by move=> sS12; rewrite !inE => /andP[-> /subset_trans]; apply. Qed.
+Proof. by move=> sS12 /[!inE] /andP[-> /subset_trans]; apply. Qed.
 
 Lemma n_act_add n x (t : n.-tuple sT) a :
   n_act to [tuple of x :: t] a = [tuple of to x a :: n_act to t a].
@@ -236,7 +236,7 @@ have ext_t t: t \in dtuple_on m S ->
 - move=> dt.
   have [sSt | /subsetPn[x Sx ntx]] := boolP (S \subset t); last first.
     by exists x; rewrite dtuple_on_add andbA /= Sx ntx.
-  case/imsetP: tr_m1 dt => t1; rewrite !inE => /andP[Ut1 St1] _ /andP[Ut _].
+  case/imsetP: tr_m1 dt => t1 /[!inE] /andP[Ut1 St1] _ /andP[Ut _].
   have /subset_leq_card := subset_trans St1 sSt.
   by rewrite !card_uniq_tuple // ltnn.
 case/imsetP: (tr_m1); case/tupleP=> [x t]; rewrite dtuple_on_add.

--- a/mathcomp/solvable/sylow.v
+++ b/mathcomp/solvable/sylow.v
@@ -126,7 +126,7 @@ have [P S_P]: exists P, P \in S.
 have trS: [transitive G, on S | 'JG].
   apply/imsetP; exists P => //; apply/eqP.
   rewrite eqEsubset andbC acts_sub_orbit // S_P; apply/subsetP=> Q S_Q.
-  have:= S_P; rewrite inE => /maxgroupP[/andP[_ pP]].
+  have /[1inE] /maxgroupP[/andP[_ pP]] := S_P.
   have [-> max1 | ntP _] := eqVneq P 1%G.
     move/andP/max1: (S_pG _ S_Q) => Q1.
     by rewrite (group_inj (Q1 (sub1G Q))) orbit_refl.
@@ -175,7 +175,7 @@ Proof. by case Sylow's_theorem. Qed.
 Lemma Sylow_trans P Q :
   p.-Sylow(G) P -> p.-Sylow(G) Q -> exists2 x, x \in G & Q :=: P :^ x.
 Proof.
-move=> sylP sylQ; have:= (atransP2 Syl_trans) P Q; rewrite !inE.
+move=> sylP sylQ; have /[!inE] := (atransP2 Syl_trans) P Q.
 by case=> // x Gx ->; exists x.
 Qed.
 
@@ -286,7 +286,7 @@ Lemma Sylow_gen G : <<\bigcup_(P : {group gT} | Sylow G P) P>> = G.
 Proof.
 set T := [set P : {group gT} | Sylow G P].
 rewrite -{2}(@Sylow_transversal_gen T G) => [|P | q _].
-- by congr <<_>>; apply: eq_bigl => P; rewrite inE.
+- by congr <<_>>; apply: eq_bigl => P /[1inE].
 - by rewrite inE => /and3P[].
 by case: (Sylow_exists q G) => P sylP; exists P; rewrite // inE (p_Sylow sylP).
 Qed.
@@ -619,7 +619,7 @@ have{n leGn IHn nDG} pN: p.-group <<'N_E(D)>>.
   have Ex1y: x1 ^ y \in E.
     by rewrite -mem_conjgV (normsP nEG) // groupV; case/setIP: Ny.
   apply: pgroupS (genS _) (pE _ _ Ex1 Ex1y).
-  by apply/subsetP=> u; rewrite !inE.
+  by apply/subsetP=> u /[!inE].
 have [y1 Ny1 Py1]: exists2 y1, y1 \in 'N_E(D) & y1 \notin P.
   case sNN: ('N_<<B>>('N_<<B>>(D)) \subset 'N_<<B>>(D)).
     exists y0 => //; have By0: y0 \in <<B>> by rewrite mem_gen ?setU11.

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1492,7 +1492,7 @@ Lemma reindex (I J : finType) (h : J -> I) (P : pred I) F :
   \big[*%M/1]_(i | P i) F i = \big[*%M/1]_(j | P (h j)) F (h j).
 Proof.
 case=> h' hK h'K; rewrite (reindex_onto h h' h'K).
-by apply: eq_bigl => j; rewrite !inE; case Pi: (P _); rewrite //= hK ?eqxx.
+by apply: eq_bigl => j /[!inE]; case Pi: (P _); rewrite //= hK ?eqxx.
 Qed.
 Arguments reindex [I J] h [P F].
 

--- a/mathcomp/ssreflect/binomial.v
+++ b/mathcomp/ssreflect/binomial.v
@@ -538,14 +538,14 @@ rewrite -card_sorted_tuples -!sum1dep_card (reindex f_add) /=.
 pose sub_mn (i j : In1) := Ordinal (leq_ltn_trans (leq_subr i j) (valP j)).
 exists (fun t : m.-tuple In1 => [tuple of pairmap sub_mn x0 t]) => /= t inc_t.
   apply: val_inj => /=; have{inc_t}: path leq x0 (map val (f_add t)).
-    by move: inc_t; rewrite inE /=; case: map.
+    by move: inc_t => /[1inE]/=; case: map.
   rewrite [map _ _]/=; elim: {t}(val t) (x0) => //= x t IHt s.
   case/andP=> le_s_sx /IHt->; congr (_ :: _); apply: val_inj => /=.
   move: le_s_sx; rewrite val_insubd.
   case le_sx_n: (_ < n.+1); first by rewrite addKn.
   by case: (val s) le_sx_n; rewrite ?ltn_ord.
 apply: val_inj => /=; have{inc_t}: path leq x0 (map val t).
-  by move: inc_t; rewrite inE /=; case: map.
+  by move: inc_t => /[1inE]/=; case: map.
 elim: {t}(val t) (x0) => //= x t IHt s /andP[le_s_sx inc_t].
 suffices ->: add_mn s (sub_mn s x) = x by rewrite IHt.
 by apply: val_inj; rewrite /add_mn /= subnKC ?inord_val.

--- a/mathcomp/ssreflect/fingraph.v
+++ b/mathcomp/ssreflect/fingraph.v
@@ -326,7 +326,7 @@ Lemma connect_closed x : closed e (connect e x).
 Proof. by move=> y z /connect1/same_connect_r; apply. Qed.
 
 Lemma predC_closed a : closed e a -> closed e [predC a].
-Proof. by move=> cl_a x y /cl_a; rewrite !inE => ->. Qed.
+Proof. by move=> cl_a x y /cl_a /[!inE] ->. Qed.
 
 Lemma closure_closed a : closed e (closure e a).
 Proof.

--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -335,7 +335,7 @@ Lemma in_set0 x : x \in set0 = false.
 Proof. by rewrite inE. Qed.
 
 Lemma sub0set A : set0 \subset A.
-Proof. by apply/subsetP=> x; rewrite inE. Qed.
+Proof. by apply/subsetP=> x /[1inE]. Qed.
 
 Lemma subset0 A : (A \subset set0) = (A == set0).
 Proof. by rewrite eqEsubset sub0set andbT. Qed.
@@ -349,17 +349,17 @@ Proof. by rewrite -!proper0 => sAB /proper_sub_trans->. Qed.
 Lemma set_0Vmem A : (A = set0) + {x : T | x \in A}.
 Proof.
 case: (pickP (mem A)) => [x Ax | A0]; [by right; exists x | left].
-by apply/setP=> x; rewrite inE; apply: A0.
+by apply/setP=> x /[1inE]; apply: A0.
 Qed.
 
 Lemma enum_set0 : enum set0 = [::] :> seq T.
 Proof. by rewrite (eq_enum (in_set _)) enum0. Qed.
 
 Lemma subsetT A : A \subset setT.
-Proof. by apply/subsetP=> x; rewrite inE. Qed.
+Proof. by apply/subsetP=> x /[1inE]. Qed.
 
 Lemma subsetT_hint mA : subset mA (mem [set: T]).
-Proof. by rewrite unlock; apply/pred0P=> x; rewrite !inE. Qed.
+Proof. by rewrite unlock; apply/pred0P=> x /[!inE]. Qed.
 Hint Resolve subsetT_hint : core.
 
 Lemma subTset A : (setT \subset A) = (A == setT).
@@ -393,7 +393,7 @@ Lemma in_setU1 x a B : (x \in a |: B) = (x == a) || (x \in B).
 Proof. by rewrite !inE. Qed.
 
 Lemma set_cons a s : [set x in a :: s] = a |: [set x in s].
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma setU11 x B : x \in x |: B.
 Proof. by rewrite !inE eqxx. Qed.
@@ -425,11 +425,11 @@ Lemma setD11 b A : (b \in A :\ b) = false.
 Proof. by rewrite !inE eqxx. Qed.
 
 Lemma setD1K a A : a \in A -> a |: (A :\ a) = A.
-Proof. by move=> Aa; apply/setP=> x; rewrite !inE; case: eqP => // ->. Qed.
+Proof. by move=> Aa; apply/setP=> x /[!inE]; case: eqP => // ->. Qed.
 
 Lemma setU1K a B : a \notin B -> (a |: B) :\ a = B.
 Proof.
-by move/negPf=> nBa; apply/setP=> x; rewrite !inE; case: eqP => // ->.
+by move/negPf=> nBa; apply/setP=> x /[!inE]; case: eqP => // ->.
 Qed.
 
 Lemma set2P x a b : reflect (x = a \/ x = b) (x \in [set a; b]).
@@ -455,7 +455,7 @@ Proof. by apply/setP => x; rewrite !inE orbC. Qed.
 
 Lemma setUS A B C : A \subset B -> C :|: A \subset C :|: B.
 Proof.
-move=> sAB; apply/subsetP=> x; rewrite !inE.
+move=> sAB; apply/subsetP=> x /[!inE].
 by case: (x \in C) => //; apply: (subsetP sAB).
 Qed.
 
@@ -509,7 +509,7 @@ Lemma setId2P x pA pB pC :
 Proof. by rewrite !inE; apply: and3P. Qed.
 
 Lemma setIdE A pB : [set x in A | pB x] = A :&: [set x | pB x].
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma setIP x A B : reflect (x \in A /\ x \in B) (x \in A :&: B).
 Proof. exact: (iffP (@setIdP _ _ _)). Qed.
@@ -522,7 +522,7 @@ Proof. by apply/setP => x; rewrite !inE andbC. Qed.
 
 Lemma setIS A B C : A \subset B -> C :&: A \subset C :&: B.
 Proof.
-move=> sAB; apply/subsetP=> x; rewrite !inE.
+move=> sAB; apply/subsetP=> x /[!inE].
 by case: (x \in C) => //; apply: (subsetP sAB).
 Qed.
 
@@ -607,7 +607,7 @@ Lemma setC_inj : injective (@setC T).
 Proof. exact: can_inj setCK. Qed.
 
 Lemma subsets_disjoint A B : (A \subset B) = [disjoint A & ~: B].
-Proof. by rewrite subset_disjoint; apply: eq_disjoint_r => x; rewrite !inE. Qed.
+Proof. by rewrite subset_disjoint; apply: eq_disjoint_r => x /[!inE]. Qed.
 
 Lemma disjoints_subset A B : [disjoint A & B] = (A \subset ~: B).
 Proof. by rewrite subsets_disjoint setCK. Qed.
@@ -631,7 +631,7 @@ Lemma setICr A : A :&: ~: A = set0.
 Proof. by apply/setP=> x; rewrite !inE andbN. Qed.
 
 Lemma setC0 : ~: set0 = [set: T].
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma setCT : ~: [set: T] = set0.
 Proof. by rewrite -setC0 setCK. Qed.
@@ -657,13 +657,13 @@ Lemma setDSS A B C D : A \subset C -> D \subset B -> A :\: B \subset C :\: D.
 Proof. by move=> /(setSD B) /subset_trans sAC /(setDS C) /sAC. Qed.
 
 Lemma setD0 A : A :\: set0 = A.
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma set0D A : set0 :\: A = set0.
 Proof. by apply/setP=> x; rewrite !inE andbF. Qed.
 
 Lemma setDT A : A :\: setT = set0.
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma setTD A : setT :\: A = ~: A.
 Proof. by apply/setP=> x; rewrite !inE andbT. Qed.
@@ -719,7 +719,7 @@ Lemma powersetT : powerset [set: T] = [set: {set T}].
 Proof. by apply/setP=> A; rewrite !inE subsetT. Qed.
 
 Lemma setI_powerset P A : P :&: powerset A = P ::&: A.
-Proof. by apply/setP=> B; rewrite !inE. Qed.
+Proof. by apply/setP=> B /[!inE]. Qed.
 
 (* cardinal lemmas for sets *)
 
@@ -775,29 +775,29 @@ Lemma cardsCs A : #|A| = #|T| - #|~: A|.
 Proof. by rewrite -(cardsC A) addnK. Qed.
 
 Lemma cardsU1 a A : #|a |: A| = (a \notin A) + #|A|.
-Proof. by rewrite -cardU1; apply: eq_card=> x; rewrite !inE. Qed.
+Proof. by rewrite -cardU1; apply: eq_card=> x /[!inE]. Qed.
 
 Lemma cards2 a b : #|[set a; b]| = (a != b).+1.
-Proof. by rewrite -card2; apply: eq_card=> x; rewrite !inE. Qed.
+Proof. by rewrite -card2; apply: eq_card=> x /[!inE]. Qed.
 
 Lemma cardsC1 a : #|[set~ a]| = #|T|.-1.
-Proof. by rewrite -(cardC1 a); apply: eq_card=> x; rewrite !inE. Qed.
+Proof. by rewrite -(cardC1 a); apply: eq_card=> x /[!inE]. Qed.
 
 Lemma cardsD1 a A : #|A| = (a \in A) + #|A :\ a|.
 Proof.
-by rewrite (cardD1 a); congr (_ + _); apply: eq_card => x; rewrite !inE.
+by rewrite (cardD1 a); congr (_ + _); apply: eq_card => x /[!inE].
 Qed.
 
 (* other inclusions *)
 
 Lemma subsetIl A B : A :&: B \subset A.
-Proof. by apply/subsetP=> x; rewrite inE; case/andP. Qed.
+Proof. by apply/subsetP=> x /[1inE]; case/andP. Qed.
 
 Lemma subsetIr A B : A :&: B \subset B.
-Proof. by apply/subsetP=> x; rewrite inE; case/andP. Qed.
+Proof. by apply/subsetP=> x /[1inE]; case/andP. Qed.
 
 Lemma subsetUl A B : A \subset A :|: B.
-Proof. by apply/subsetP=> x; rewrite inE => ->. Qed.
+Proof. by apply/subsetP=> x /[1inE] ->. Qed.
 
 Lemma subsetUr A B : B \subset A :|: B.
 Proof. by apply/subsetP=> x; rewrite inE orbC => ->. Qed.
@@ -815,7 +815,7 @@ Lemma subsetDr A B : A :\: B \subset ~: B.
 Proof. by rewrite setDE subsetIr. Qed.
 
 Lemma sub1set A x : ([set x] \subset A) = (x \in A).
-Proof. by rewrite -subset_pred1; apply: eq_subset=> y; rewrite !inE. Qed.
+Proof. by rewrite -subset_pred1; apply: eq_subset=> y /[!inE]. Qed.
 
 Lemma cards1P A : reflect (exists x, A = [set x]) (#|A| == 1).
 Proof.
@@ -836,7 +836,7 @@ Proof. by apply/setP=> A; rewrite !inE subset1 orbC. Qed.
 Lemma setIidPl A B : reflect (A :&: B = A) (A \subset B).
 Proof.
 apply: (iffP subsetP) => [sAB | <- x /setIP[] //].
-by apply/setP=> x; rewrite inE; apply/andb_idr/sAB.
+by apply/setP=> x /[1inE]; apply/andb_idr/sAB.
 Qed.
 Arguments setIidPl {A B}.
 
@@ -898,7 +898,7 @@ Proof. by rewrite setDE subsetI -disjoints_subset. Qed.
 
 Lemma subDset A B C : (A :\: B \subset C) = (A \subset B :|: C).
 Proof.
-apply/subsetP/subsetP=> sABC x; rewrite !inE.
+apply/subsetP/subsetP=> sABC x /[!inE].
   by case Bx: (x \in B) => // Ax; rewrite sABC ?inE ?Bx.
 by case Bx: (x \in B) => //; move/sABC; rewrite inE Bx.
 Qed.
@@ -1220,7 +1220,7 @@ Lemma mem_imset (D : {pred aT}) x : x \in D -> f x \in f @: D.
 Proof. by move=> Dx; apply/imsetP; exists x. Qed.
 
 Lemma imset0 : f @: set0 = set0.
-Proof. by apply/setP => y; rewrite inE; apply/imsetP=> [[x]]; rewrite inE. Qed.
+Proof. by apply/setP => y /[1inE]; apply/imsetP=> [[x]] /[1inE]. Qed.
 
 Lemma imset_eq0 (A : {set aT}) : (f @: A == set0) = (A == set0).
 Proof.
@@ -1244,33 +1244,33 @@ Lemma sub_imset_pre (A : {pred aT}) (B : {pred rT}) :
 Proof.
 apply/subsetP/subsetP=> [sfAB x Ax | sAf'B fx].
   by rewrite inE sfAB ?mem_imset.
-by case/imsetP=> x Ax ->; move/sAf'B: Ax; rewrite inE.
+by case/imsetP=> x Ax ->; move/sAf'B: Ax => /[1inE].
 Qed.
 
 Lemma preimsetS (A B : {pred rT}) :
   A \subset B -> (f @^-1: A) \subset (f @^-1: B).
-Proof. by move=> sAB; apply/subsetP=> y; rewrite !inE; apply: subsetP. Qed.
+Proof. by move=> sAB; apply/subsetP=> y /[!inE]; apply: subsetP. Qed.
 
 Lemma preimset0 : f @^-1: set0 = set0.
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma preimsetT : f @^-1: setT = setT.
-Proof. by apply/setP=> x; rewrite !inE. Qed.
+Proof. by apply/setP=> x /[!inE]. Qed.
 
 Lemma preimsetI (A B : {set rT}) :
   f @^-1: (A :&: B) = (f @^-1: A) :&: (f @^-1: B).
-Proof. by apply/setP=> y; rewrite !inE. Qed.
+Proof. by apply/setP=> y /[!inE]. Qed.
 
 Lemma preimsetU (A B : {set rT}) :
   f @^-1: (A :|: B) = (f @^-1: A) :|: (f @^-1: B).
-Proof. by apply/setP=> y; rewrite !inE. Qed.
+Proof. by apply/setP=> y /[!inE]. Qed.
 
 Lemma preimsetD (A B : {set rT}) :
   f @^-1: (A :\: B) = (f @^-1: A) :\: (f @^-1: B).
-Proof. by apply/setP=> y; rewrite !inE. Qed.
+Proof. by apply/setP=> y /[!inE]. Qed.
 
 Lemma preimsetC (A : {set rT}) : f @^-1: (~: A) = ~: f @^-1: A.
-Proof. by apply/setP=> y; rewrite !inE. Qed.
+Proof. by apply/setP=> y /[!inE]. Qed.
 
 Lemma imsetS (A B : {pred aT}) : A \subset B -> f @: A \subset f @: B.
 Proof.
@@ -1363,7 +1363,7 @@ End ImsetTheory.
 Lemma imset2_pair (A : {set aT}) (B : {set aT2}) :
   [set (x, y) | x in A, y in B] = setX A B.
 Proof.
-apply/setP=> [[x y]]; rewrite !inE /=.
+apply/setP=> [[x y]] /[!inE]/=.
 by apply/imset2P/andP=> [[_ _ _ _ [-> ->]//]| []]; exists x y.
 Qed.
 
@@ -1387,14 +1387,14 @@ Implicit Type P : pred I.
 Implicit Type F : I -> R.
 
 Lemma big_set0 F : \big[op/idx]_(i in set0) F i = idx.
-Proof. by apply: big_pred0 => i; rewrite inE. Qed.
+Proof. by apply: big_pred0 => i /[1inE]. Qed.
 
 Lemma big_set1 a F : \big[op/idx]_(i in [set a]) F i = F a.
-Proof. by apply: big_pred1 => i; rewrite !inE. Qed.
+Proof. by apply: big_pred1 => i /[!inE]. Qed.
 
 Lemma big_set (A : pred I) F :
    \big[op/idx]_(i in [set i | A i]) (F i) = \big[op/idx]_(i in A) (F i).
-Proof. by apply: eq_bigl => i; rewrite inE. Qed.
+Proof. by apply: eq_bigl => i /[1inE]. Qed.
 
 Lemma big_setID A B F :
   \big[aop/idx]_(i in A) F i =
@@ -1402,7 +1402,7 @@ Lemma big_setID A B F :
          (\big[aop/idx]_(i in A :\: B) F i).
 Proof.
 rewrite (bigID (mem B)) setDE.
-by congr (aop _ _); apply: eq_bigl => i; rewrite !inE.
+by congr (aop _ _); apply: eq_bigl => i /[!inE].
 Qed.
 
 Lemma big_setIDcond A B P F :
@@ -1502,7 +1502,7 @@ Proof. by rewrite [@imset]unlock cardsE; apply: image_injP. Qed.
 Lemma can2_in_imset_pre :
   {in D, cancel f g} -> {on D, cancel g & f} -> f @: D = g @^-1: D.
 Proof.
-move=> fK gK; apply/setP=> y; rewrite inE.
+move=> fK gK; apply/setP=> y /[1inE].
 by apply/imsetP/idP=> [[x Ax ->] | Agy]; last exists (g y); rewrite ?(fK, gK).
 Qed.
 
@@ -1666,7 +1666,7 @@ Proof.
 elim: r => [|i r IHr]; first by rewrite big_nil big_pred0.
 rewrite big_cons {}IHr; case r_i: (i \in r).
   rewrite (setUidPr _) ?bigcup_sup //.
-  by apply: eq_bigl => j; rewrite !inE; case: eqP => // ->.
+  by apply: eq_bigl => j /[!inE]; case: eqP => // ->.
 rewrite (bigD1 i (mem_head i r)) /=; congr (_ :|: _).
 by apply: eq_bigl => j /=; rewrite andbC; case: eqP => // ->.
 Qed.
@@ -1684,7 +1684,7 @@ Lemma bigcapsP U P F :
 Proof.
 apply: (iffP idP) => [sUF i Pi | sUF].
   by apply: subset_trans sUF _; apply: bigcap_inf.
-elim/big_rec: _ => [|i V Pi sUV]; apply/subsetP=> x Ux; rewrite inE //.
+elim/big_rec: _ => [|i V Pi sUV]; apply/subsetP=> x Ux /[1inE]//.
 by rewrite !(subsetP _ x Ux) ?sUF.
 Qed.
 
@@ -1734,7 +1734,7 @@ Variables (D1 : {pred aT1}) (D2 : {pred aT2}).
 Lemma curry_imset2X : f @2: (A1, A2) = prod_curry f @: (setX A1 A2).
 Proof.
 rewrite [@imset]unlock unlock; apply/setP=> x; rewrite !in_set; congr (x \in _).
-by apply: eq_image => u //=; rewrite !inE.
+by apply: eq_image => u //= /[!inE].
 Qed.
 
 Lemma curry_imset2l : f @2: (D1, D2) = \bigcup_(x1 in D1) f x1 @: D2.
@@ -1797,7 +1797,7 @@ Lemma trivIsetP P :
 Proof.
 have->: P = [set x in enum (mem P)] by apply/setP=> x; rewrite inE mem_enum.
 elim: {P}(enum _) (enum_uniq (mem P)) => [_ | A e IHe] /=.
-  by rewrite /trivIset /cover !big_set0 cards0; left=> A; rewrite inE.
+  by rewrite /trivIset /cover !big_set0 cards0; left=> A /[1inE].
 case/andP; rewrite set_cons -(in_set (fun B => B \in e)) => PA {IHe}/IHe.
 move: {e}[set x in e] PA => P PA IHP.
 rewrite /trivIset /cover !big_setU1 //= eq_sym.
@@ -1831,7 +1831,7 @@ Qed.
 
 Lemma pblock_mem P x : x \in cover P -> pblock P x \in P.
 Proof.
-by rewrite -mem_pblock /pblock; case: pickP => [A /andP[]| _] //=; rewrite inE.
+by rewrite -mem_pblock /pblock; case: pickP => [A /andP[]| _] //= /[1inE].
 Qed.
 
 Lemma def_pblock P B x : trivIset P -> B \in P -> x \in B -> pblock P x = B.
@@ -1854,7 +1854,7 @@ Lemma eq_pblock P x y :
 Proof.
 move=> tiP Px; apply/eqP/idP=> [eq_xy | /same_pblock-> //].
 move: Px; rewrite -mem_pblock eq_xy /pblock.
-by case: pickP => [B /andP[] // | _]; rewrite inE.
+by case: pickP => [B /andP[] // | _] /[1inE].
 Qed.
 
 Lemma trivIsetU1 A P :
@@ -1942,7 +1942,7 @@ have ->: \bigcup_i F i = cover P.
   apply/esym; rewrite cover_imset big_mkcond; apply: eq_bigr => i _.
   by rewrite inE; case: eqP.
 rewrite big_trivIset // /rhs big_imset => [|i j _ /setIdP[_ notFj0] eqFij].
-  rewrite big_mkcond; apply: eq_bigr => i _; rewrite inE.
+  rewrite big_mkcond; apply: eq_bigr => i _ /[1inE].
   by case: eqP => //= ->; rewrite big_set0.
 by apply: contraNeq (disjF _ _) _; rewrite -setI_eq0 eqFij setIid.
 Qed.
@@ -1970,8 +1970,8 @@ have defD: cover P == D.
   by apply/subsetP=> x Dx; apply/bigcupP; exists (Px x); rewrite (Pxx, PPx).
 have tiP: trivIset P.
   apply/trivIsetP=> _ _ /imsetP[x Dx ->] /imsetP[y Dy ->]; apply: contraR.
-  case/pred0Pn=> z /andP[]; rewrite !inE => /andP[Dz Rxz] /andP[_ Ryz].
-  apply/eqP/setP=> t; rewrite !inE; apply: andb_id2l => Dt.
+  case/pred0Pn=> z /andP[] /[!inE] /andP[Dz Rxz] /andP[_ Ryz].
+  apply/eqP/setP=> t /[!inE]; apply: andb_id2l => Dt.
   by rewrite (eqiR Dx Dz Dt) // (eqiR Dy Dz Dt).
 rewrite /partition tiP defD /=.
 by apply/imsetP=> [[x /Pxx Px_x Px0]]; rewrite -Px0 inE in Px_x.
@@ -2292,7 +2292,7 @@ Qed.
 Lemma in_iter_fix_orderE (x : T) :
   (x \in iterF (fix_order x)) = (x \in fixset).
 Proof.
-rewrite /fix_order; case: eqP; last by move=>/negP/negPf->; rewrite inE.
+rewrite /fix_order; case: eqP; last by move=>/negP/negPf-> /[1inE].
 by move=> x_in; case: ex_minnP => m ->; rewrite x_in.
 Qed.
 

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -549,7 +549,7 @@ Proof. by rewrite !cardE !size_filter count_predC. Qed.
 Lemma cardU1 x A : #|[predU1 x & A]| = (x \notin A) + #|A|.
 Proof.
 case Ax: (x \in A).
-  by apply: eq_card => y; rewrite inE /=; case: eqP => // ->.
+  by apply: eq_card => y /[1inE]/=; case: eqP => // ->.
 rewrite /= -(card1 x) -cardUI addnC.
 rewrite [#|predI _ _|]eq_card0 => [|y /=]; first exact: eq_card.
 by rewrite !inE; case: eqP => // ->.
@@ -564,10 +564,10 @@ Proof. by rewrite -(cardC (pred1 x)) card1. Qed.
 Lemma cardD1 x A : #|A| = (x \in A) + #|[predD1 A & x]|.
 Proof.
 case Ax: (x \in A); last first.
-  by apply: eq_card => y; rewrite !inE /=; case: eqP => // ->.
+  by apply: eq_card => y /[!inE]/=; case: eqP => // ->.
 rewrite /= -(card1 x) -cardUI addnC /=.
 rewrite [#|predI _ _|]eq_card0 => [|y]; last by rewrite !inE; case: eqP.
-by apply: eq_card => y; rewrite !inE; case: eqP => // ->.
+by apply: eq_card => y /[!inE]; case: eqP => // ->.
 Qed.
 
 Lemma max_card A : #|A| <= #|T|.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -3489,7 +3489,7 @@ Lemma le_joins I (A B : {set I}) (F : I -> L) :
 Proof.
 move=> AsubB; rewrite -(setID B A).
 rewrite [X in _ <= X](eq_bigl [predU B :&: A & B :\: A]); last first.
-  by move=> i; rewrite !inE.
+  by move=> i /[!inE].
 rewrite bigU //=; last by rewrite -setI_eq0 setDE setIACA setICr setI0.
 by rewrite lexU2 // (setIidPr _) // lexx.
 Qed.
@@ -3498,18 +3498,18 @@ Lemma joins_setU I (A B : {set I}) (F : I -> L) :
    \join_(i in (A :|: B)) F i = \join_(i in A) F i `|` \join_(i in B) F i.
 Proof.
 apply/eqP; rewrite eq_le leUx !le_joins ?subsetUl ?subsetUr ?andbT //.
-apply/joinsP => i; rewrite inE; move=> /orP.
+apply/joinsP => i /[1inE]; move=> /orP.
 by case=> ?; rewrite lexU2 //; [rewrite join_sup|rewrite orbC join_sup].
 Qed.
 
 Lemma join_seq I (r : seq I) (F : I -> L) :
    \join_(i <- r) F i = \join_(i in r) F i.
 Proof.
-rewrite [RHS](eq_bigl (mem [set i | i \in r])); last by move=> i; rewrite !inE.
+rewrite [RHS](eq_bigl (mem [set i | i \in r])); last by move=> i /[!inE].
 elim: r => [|i r ihr]; first by rewrite big_nil big1 // => i; rewrite ?inE.
 rewrite big_cons {}ihr; apply/eqP; rewrite eq_le set_cons.
 rewrite leUx join_sup ?inE ?eqxx // le_joins //= ?subsetUr //.
-apply/joinsP => j; rewrite !inE => /predU1P [->|jr]; rewrite ?lexU2 ?lexx //.
+apply/joinsP => j /[!inE] /predU1P [->|jr]; rewrite ?lexU2 ?lexx //.
 by rewrite join_sup ?orbT ?inE.
 Qed.
 

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -252,7 +252,7 @@ Qed.
 Lemma mem_next p x : (next p x \in p) = (x \in p).
 Proof.
 rewrite next_nth; case p_x: (x \in p) => //.
-case: p (index x p) p_x => [|y0 p'] //= i _; rewrite inE.
+case: p (index x p) p_x => [|y0 p'] //= i _ /[1inE].
 have [lt_ip | ge_ip] := ltnP i (size p'); first by rewrite orbC mem_nth.
 by rewrite nth_default ?eqxx.
 Qed.
@@ -277,7 +277,7 @@ Proof. by case/andP. Qed.
 
 Lemma next_cycle p x : cycle e p -> x \in p -> e x (next p x).
 Proof.
-case: p => //= y0 p; elim: p {1 3 5}y0 => [|z p IHp] y /=; rewrite inE.
+case: p => //= y0 p; elim: p {1 3 5}y0 => [|z p IHp] y /= /[1inE].
   by rewrite andbT; case: (x =P y) => // ->.
 by case/andP=> eyz /IHp; case: (x =P y) => // ->.
 Qed.

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1309,7 +1309,7 @@ Proof. by elim: s => //= x s ->; rewrite mem_cat; do 2 case: in_mem => //=. Qed.
 
 Lemma undup_rcons s x : undup (rcons s x) = rcons [seq y <- undup s | y != x] x.
 Proof.
-by rewrite -!cats1 undup_cat; congr cat; apply: eq_filter => y; rewrite inE.
+by rewrite -!cats1 undup_cat; congr cat; apply: eq_filter => y /[1inE].
 Qed.
 
 (* Lookup *)
@@ -1988,7 +1988,7 @@ Lemma mem_subseq s1 s2 : subseq s1 s2 -> {subset s1 <= s2}.
 Proof. by case/subseqP=> m _ -> x; apply: mem_mask. Qed.
 
 Lemma sub1seq x s : subseq [:: x] s = (x \in s).
-Proof. by elim: s => //= y s; rewrite inE; case: ifP; rewrite ?sub0seq. Qed.
+Proof. by elim: s => //= y s /[1inE]; case: ifP; rewrite ?sub0seq. Qed.
 
 Lemma size_subseq s1 s2 : subseq s1 s2 -> size s1 <= size s2.
 Proof. by case/subseqP=> m sz_m ->; rewrite size_mask -sz_m ?count_size. Qed.
@@ -2176,7 +2176,7 @@ Proof.
 elim: m s => [|[] m ih] [|x s] //=.
 - by move=> _; elim: s.
 - case/andP => /negP x_notin_s /ih {1}->; rewrite inE eqxx /=; congr cons.
-  by apply/eq_in_filter => ?; rewrite inE; case: eqP => // ->.
+  by apply/eq_in_filter => ? /[1inE]; case: eqP => // ->.
 - by case: ifP => [/mem_mask -> // | _ /andP [] _ /ih].
 Qed.
 
@@ -2260,7 +2260,7 @@ Lemma nth_index_map s x0 x :
   {in s &, injective f} -> x \in s -> nth x0 s (index (f x) (map f s)) = x.
 Proof.
 elim: s => //= y s IHs inj_f s_x; rewrite (inj_in_eq inj_f) ?mem_head //.
-move: s_x; rewrite inE; have [-> // | _] := eqVneq; apply: IHs.
+move: s_x => /[1inE]; have [-> // | _] := eqVneq; apply: IHs.
 by apply: sub_in2 inj_f => z; apply: predU1r.
 Qed.
 
@@ -3088,7 +3088,7 @@ Proof.
 elim: s => [|x s IHs]; first by constructor.
 rewrite /= all_cat all_map /preim.
 apply/(iffP andP)=> [[/allP /= ? ? x' y x'_in_xs]|p_xs_t].
-  by move: x'_in_xs y; rewrite inE => /predU1P [-> //|? ?]; exact: IHs.
+  by move: x'_in_xs y => /[1inE] /predU1P [-> //|? ?]; exact: IHs.
 split; first by apply/allP => ?; exact/p_xs_t/mem_head.
 by apply/IHs => x' y x'_in_s; apply: p_xs_t; rewrite inE x'_in_s orbT.
 Qed.
@@ -3168,14 +3168,14 @@ move=> bs /andP[]; elim: bs => [|[x [|n]] bs IHbs] //= /andP[bs'x Ubs] bs'0.
 rewrite inE /tseq /tally /= -[n.+1]addn1 in bs'0 *.
 elim: n 1 => /= [|n IHn] m; last by rewrite eqxx IHn addnS.
 rewrite -{}[in RHS]IHbs {Ubs bs'0}// /tally /tally_seq add0n.
-elim: bs bs'x [::] => [|[y n] bs IHbs] //=; rewrite inE => /norP[y'x bs'x].
+elim: bs bs'x [::] => [|[y n] bs IHbs] //= /[1inE] /norP[y'x bs'x].
 by elim: n => [|n IHn] bs1 /=; [rewrite IHbs | rewrite eq_sym ifN // IHn].
 Qed.
 
 Lemma incr_tallyP x : {homo incr_tally^~ x : bs / bs \in wf_tally}.
 Proof.
 move=> bs /andP[]; rewrite unfold_in.
-elim: bs => [|[y [|n]] bs IHbs] //= /andP[bs'y Ubs]; rewrite inE /= => bs'0.
+elim: bs => [|[y [|n]] bs IHbs] //= /andP[bs'y Ubs] /[1inE]/= bs'0.
 rewrite eq_sym; case: ifP => [/eqP<- | y'x] /=; first by rewrite bs'y Ubs.
 rewrite -andbA {}IHbs {Ubs bs'0}// andbT.
 elim: bs bs'y => [|b bs IHbs] /=; rewrite inE ?y'x // => /norP[b'y bs'y].
@@ -3308,7 +3308,7 @@ rewrite {}IHbs; first 1 last; first by rewrite (perm_size (perm_tseq bsCA)).
 rewrite (map_inj_uniq (rcons_injl x)) {}IHn {Dn}//=.
 have: x \notin unzip1 bs by apply: contraL Ubs; rewrite map_cat mem_cat => ->.
 move: {bs2 m Ubs}(perms_rec n _ _ _) (_ :: bs2) => ts.
-elim: bs => [|[y [|m]] bs IHbs] //=; rewrite inE => bs2 /norP[x'y /IHbs//].
+elim: bs => [|[y [|m]] bs IHbs] //= /[1inE] bs2 /norP[x'y /IHbs//].
 rewrite cons_permsE has_cat negb_or has_map => ->.
 by apply/hasPn=> t _; apply: contra x'y => /mapP[t1 _ /rcons_inj[_ ->]].
 Qed.

--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -28,6 +28,22 @@ Global Set Bullet Behavior "None".
 (*        triggered by such evars under binders.                              *)
 (*  Import Deprecation.Silent :: turn off deprecation warning messages.       *)
 (*  Import Deprecation.Reject :: raise an error instead of only warning.      *)
+(*                                                                            *)
+(*   Intro pattern ltac views:                                                *)
+(*   - calling rewrite from an intro pattern, use with parsimony              *)
+(*     => /[1 rules]  := rewrite rules                                        *)
+(*     => /[-1 rules] := rewrite -rules                                       *)
+(*     => /[! rules]  := rewrite !rules                                       *)
+(*     => /[-! rules] := rewrite -!rules                                      *)
+(*     => /[? rules]  := rewrite ?rules                                       *)
+(*     => /[-? rules] := rewrite -?rules                                      *)
+(*     => /[/def]     := rewrite /def                                         *)
+(*   - top of the stack actions:                                              *)
+(*     => /apply      := => hyp {}/hyp                                        *)
+(*     => /swap       := => x y; move: y x                                    *)
+(*                       (also swap and perserves let bindings)               *)
+(*     => /dup        := => x; have copy := x; move: copy x                   *)
+(*                       (also copies and preserves let bindings)             *)
 (******************************************************************************)
 
 Module NonPropType.
@@ -94,3 +110,64 @@ End Exports.
 
 End Deprecation.
 Export Deprecation.Exports.
+
+Module Export ipat.
+
+Notation "'[' '1' rules ']'" :=
+  (ltac:(rewrite rules)) (at level 0) : ssripat_scope.
+Notation "'[' '-' '1' rules ']'" :=
+  (ltac:(rewrite -rules)) (at level 0) : ssripat_scope.
+Notation "'[' '!' rules ']'" :=
+  (ltac:(rewrite !rules)) (at level 0) : ssripat_scope.
+Notation "'[' '?' rules ']'" :=
+  (ltac:(rewrite ?rules)) (at level 0) : ssripat_scope.
+Notation "'[' '-' '!' rules ']'" :=
+  (ltac:(rewrite -!rules)) (at level 0) : ssripat_scope.
+Notation "'[' '-' '?' rules ']'" :=
+  (ltac:(rewrite -?rules)) (at level 0) : ssripat_scope.
+Notation "'[' '/' def ']'" :=
+  (ltac:(rewrite /def)) (at level 0, def at level 0) : ssripat_scope.
+
+Notation apply := (ltac:(let f := fresh "_top_" in move=> f {}/f)).
+
+(* we try to preserve the naming by matching the names from the goal *)
+(* we do move to perform a hnf before trying to match                *)
+Notation swap := (ltac:(move;
+  lazymatch goal with
+  | |- forall (x : _), _ => let x := fresh x in move=> x; move;
+    lazymatch goal with
+    | |- forall (y : _), _ => let y := fresh y in move=> y; move: y x
+    | |- let y := _ in _ => let y := fresh y in move=> y; move: @y x
+    | _ => let y := fresh "_top_" in move=> y; move: y x
+    end
+  | |- let x := _ in _ => let x := fresh x in move => x; move;
+    lazymatch goal with
+    | |- forall (y : _), _ => let y := fresh y in move=> y; move: y @x
+    | |- let y := _ in _ => let y := fresh y in move=> y; move: @y @x
+    | _ => let y := fresh "_top_" in move=> y; move: y x
+    end
+  | _ => let x := fresh "_top_" in let x := fresh x in move=> x; move;
+    lazymatch goal with
+    | |- forall (y : _), _ => let y := fresh y in move=> y; move: y @x
+    | |- let y := _ in _ => let y := fresh y in move=> y; move: @y @x
+    | _ => let y := fresh "_top_" in move=> y; move: y x
+    end
+  end)).
+
+(* we try to preserve the naming by matching the names from the goal *)
+(* we do move to perform a hnf before trying to match                *)
+Notation dup := (ltac:(move;
+  lazymatch goal with
+  | |- forall (x : _), _ =>
+    let x := fresh x in move=> x;
+    let copy := fresh x in have copy := x; move: copy x
+  | |- let x := _ in _ =>
+    let x := fresh x in move=> x;
+    let copy := fresh x in pose copy := x;
+    do [unfold x in (value of copy)]; move: @copy @x
+  | |- _ =>
+    let x := fresh "_top_" in move=> x;
+    let copy := fresh "_top" in have copy := x; move: copy x
+  end)).
+
+End ipat.

--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -44,6 +44,13 @@ Global Set Bullet Behavior "None".
 (*                       (also swap and perserves let bindings)               *)
 (*     => /dup        := => x; have copy := x; move: copy x                   *)
 (*                       (also copies and preserves let bindings)             *)
+(*   - discharge in intro pattern                                             *)
+(*     (limited to 3 variable names, local definitions or local assumptions)  *)
+(*     => /[: x @y z] := move: x @y z                                         *)
+(*   - rewrite an equation in up to 7 context hypothesis                      *)
+(*     (local definitions or local assumptions, that are not section hyps)    *)
+(*     => /[-> in x0 .. x6] := move=> e; rewrite  {}e in x0 .. x6 *           *)
+(*     => /[<- in x0 .. x6] := move=> e; rewrite -{}e in x0 .. x6 *           *)
 (******************************************************************************)
 
 Module NonPropType.
@@ -169,5 +176,100 @@ Notation dup := (ltac:(move;
     let x := fresh "_top_" in move=> x;
     let copy := fresh "_top" in have copy := x; move: copy x
   end)).
+
+
+Notation "'[' ':' x0 ']'" :=
+  (ltac:(move: x0)) (at level 0, x0 at level 0) : ssripat_scope.
+Notation "'[' ':' '@' x0 ']'" :=
+  (ltac:(move: @x0)) (at level 0, x0 at level 0) : ssripat_scope.
+
+
+Notation "'[' ':' x0 x1 ']'" :=
+  (ltac:(move: x0 x1)) (at level 0, x0, x1 at level 0) : ssripat_scope.
+Notation "'[' ':' x0 '@' x1 ']'" :=
+  (ltac:(move: x0 @x1)) (at level 0, x0, x1 at level 0) : ssripat_scope.
+Notation "'[' ':' '@' x0 x1 ']'" :=
+  (ltac:(move: @x0 x1)) (at level 0, x0, x1 at level 0) : ssripat_scope.
+Notation "'[' ':' '@' x0 '@' x1 ']'" :=
+  (ltac:(move: @x0 @x1)) (at level 0, x0, x1 at level 0) : ssripat_scope.
+
+Notation "'[' ':' x0 x1 x2 ']'" :=
+  (ltac:(move: x0 x1 x2)) (at level 0, x0, x1, x2 at level 0) : ssripat_scope.
+Notation "'[' ':' x0 x1 '@' x2 ']'" :=
+  (ltac:(move: x0 x1 @x2)) (at level 0, x0, x1, x2 at level 0) : ssripat_scope.
+Notation "'[' ':' x0 '@' x1 x2 ']'" :=
+  (ltac:(move: x0 @x1 x2)) (at level 0, x0, x1, x2 at level 0) : ssripat_scope.
+Notation "'[' ':' x0 '@' x1 '@' x2 ']'" :=
+  (ltac:(move: x0 @x1 @x2)) (at level 0, x0, x1, x2 at level 0) : ssripat_scope.
+Notation "'[' ':' '@' x0 x1 x2 ']'" :=
+  (ltac:(move: @x0 x1 x2)) (at level 0, x0, x1, x2 at level 0) : ssripat_scope.
+Notation "'[' ':' '@' x0 x1 '@' x2 ']'" :=
+  (ltac:(move: @x0 x1 @x2)) (at level 0, x0, x1, x2 at level 0) : ssripat_scope.
+Notation "'[' ':' '@' x0 '@' x1 x2 ']'" :=
+  (ltac:(move: @x0 @x1 x2)) (at level 0, x0, x1, x2 at level 0) : ssripat_scope.
+Notation "'[' ':' '@' x0 '@' x1 '@' x2 ']'" :=
+  (ltac:(move: @x0 @x1 @x2)) (at level 0, x0, x1, x2 at level 0) : ssripat_scope.
+
+Notation "[ '<-' 'in' x0 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> r; do [case: _ / r] in x0 *]))
+(at level 0, x0 ident) : ssripat_scope.
+Notation "[ '<-' 'in' x0 x1 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> r; do [case: _ / r] in x0 x1 *]))
+(at level 0, x0 ident, x1 ident) : ssripat_scope.
+Notation "[ '<-' 'in' x0 x1 x2 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> r; do [case: _ / r] in x0 x1 x2 *]))
+(at level 0, x0 ident, x1 ident, x2 ident) : ssripat_scope.
+Notation "[ '<-' 'in' x0 x1 x2 x3 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> r; do [case: _ / r] in x0 x1 x2 x3 *]))
+(at level 0, x0 ident, x1 ident, x2 ident, x3 ident) : ssripat_scope.
+Notation "[ '<-' 'in' x0 x1 x2 x3 x4 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> r; do [case: _ / r] in x0 x1 x2 x3 x4 *]))
+(at level 0, x0 ident, x1 ident, x2 ident, x3 ident, x4 ident) : ssripat_scope.
+Notation "[ '<-' 'in' x0 x1 x2 x3 x4 x5 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> r; do [case: _ / r] in x0 x1 x2 x3 x4 x5 *]))
+(at level 0, x0 ident, x1 ident, x2 ident, x3 ident, x4 ident,
+ x5 ident) : ssripat_scope.
+Notation "[ '<-' 'in' x0 x1 x2 x3 x4 x5 x6 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> r; do [case: _ / r] in x0 x1 x2 x3 x4 x5 x6 *]))
+(at level 0, x0 ident, x1 ident, x2 ident, x3 ident, x4 ident,
+ x5 ident, x6 ident) : ssripat_scope.
+
+Notation "[ '->' 'in' x0 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> /esym r; do [case: _ / r] in x0 *]))
+(at level 0, x0 ident) : ssripat_scope.
+Notation "[ '->' 'in' x0 x1 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> /esym r; do [case: _ / r] in x0 x1 *]))
+(at level 0, x0 ident, x1 ident) : ssripat_scope.
+Notation "[ '->' 'in' x0 x1 x2 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> /esym r; do [case: _ / r] in x0 x1 x2 *]))
+(at level 0, x0 ident, x1 ident, x2 ident) : ssripat_scope.
+Notation "[ '->' 'in' x0 x1 x2 x3 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> /esym r; do [case: _ / r] in x0 x1 x2 x3 *]))
+(at level 0, x0 ident, x1 ident, x2 ident, x3 ident) : ssripat_scope.
+Notation "[ '->' 'in' x0 x1 x2 x3 x4 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> /esym r; do [case: _ / r] in x0 x1 x2 x3 x4 *]))
+(at level 0, x0 ident, x1 ident, x2 ident, x3 ident, x4 ident) : ssripat_scope.
+Notation "[ '->' 'in' x0 x1 x2 x3 x4 x5 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> /esym r; do [case: _ / r] in x0 x1 x2 x3 x4 x5 *]))
+(at level 0, x0 ident, x1 ident, x2 ident, x3 ident, x4 ident,
+ x5 ident) : ssripat_scope.
+Notation "[ '->' 'in' x0 x1 x2 x3 x4 x5 x6 ]" :=
+  (ltac:(let r := fresh "_top" in
+         do [move=> /esym r; do [case: _ / r] in x0 x1 x2 x3 x4 x5 x6 *]))
+(at level 0, x0 ident, x1 ident, x2 ident, x3 ident, x4 ident,
+ x5 ident, x6 ident) : ssripat_scope.
 
 End ipat.


### PR DESCRIPTION
##### Motivation for this change

Adding to intro pattern: discharge in and rewrite **in**.
Working syntax  `/[: x @y z]`, (limited to three variables)
and `/[-> in x0 .. x6]`, and `/[<- in x0 .. x6]` (limited to seven variables).

(This is a sequel of #501, which should close #372)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
- [ ] merge of dependency #501 
- [ ] pull request in Coq with the final proposition.
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
