### PR TITLE
ssrnat: add subnA, addnCB, addnCAC, addnAl lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `finset.v`, new lemmas: `properC`, `properCr`, `properCl`
 - in `ssrnat.v`, new lemmas: `subn_minl`, `subn_maxl`
 - in `ssrnat.v`, new lemma: `oddS`
+- in `ssrnat.v`, new lemmas: `subnA`, `addnBn`, `addnCAC`, `addnACl`
 - in `finset.v`, new lemmas: `mem_imset_eq`, `mem_imset2_eq`.
   These lemmas will lose the `_eq` suffix in the next release, when the shortende names will become availabe (cf. Renamed section)
 

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -222,6 +222,12 @@ Proof. by move=> m n p; rewrite (addnC n) addnCA addnC. Qed.
 Lemma addnAC : right_commutative addn.
 Proof. by move=> m n p; rewrite -!addnA (addnC n). Qed.
 
+Lemma addnCAC m n p : m + n + p = p + n + m.
+Proof. by rewrite addnC addnA addnAC. Qed.
+
+Lemma addnACl m n p: m + n + p = n + (p + m).
+Proof. by rewrite (addnC m) addnC addnCA. Qed.
+
 Lemma addnACA : interchange addn addn.
 Proof. by move=> m n p q; rewrite -!addnA (addnCA n). Qed.
 
@@ -530,6 +536,9 @@ Proof. by rewrite ltnNge leq_subrR negb_or !lt0n. Qed.
 Lemma subnKC m n : m <= n -> m + (n - m) = n.
 Proof. by elim: m n => [|m IHm] [|n] // /(IHm n) {2}<-. Qed.
 
+Lemma addnBn m n : m + (n - m) = m - n + n.
+Proof. by elim: m n => [|m IHm] [|n] //; rewrite addSn addnS IHm. Qed.
+
 Lemma subnK m n : m <= n -> (n - m) + m = n.
 Proof. by rewrite addnC; apply: subnKC. Qed.
 
@@ -547,6 +556,9 @@ Proof. by move=> le_pm le_pn; rewrite addnBA // addnBAC. Qed.
 
 Lemma subnBA m n p : p <= n -> m - (n - p) = m + p - n.
 Proof. by move=> le_pn; rewrite -[in RHS](subnK le_pn) subnDr. Qed.
+
+Lemma subnA m n p : p <= n -> n <= m -> m - (n - p) = m - n + p.
+Proof. by move=> le_pn lr_nm; rewrite addnBAC // subnBA. Qed.
 
 Lemma subKn m n : m <= n -> n - (n - m) = m.
 Proof. by move/subnBA->; rewrite addKn. Qed.


### PR DESCRIPTION
##### Motivation for this change

This PR addresses issue #212 by adding some lemmas about natural numbers.

- `subnA`: the name was suggested by @CohenCyril in [this comment](https://github.com/math-comp/math-comp/issues/212#issuecomment-420657654);
- `addnCAC`: I call this "central commutativity", hence the name, but I'm happy to change it to anything else (this applies to any name in this PR);
- `addnAl`: "left cyclic associativity" (right cyclic associativity is just commutativity in this case);
- `addnCB`: can be proved also `by rewrite [RHS]addnC -!maxnE maxnC.`, but `maxn` is defined later in the file; I'd like to add this for the sake of completeness (I only needed it once) and because I've seen more ~five bright students to believe this wasn't provable (I'm not saying this should be a reason to include this lemma into the library, though).

I find `addnCAC` and `addnAl` sometimes convenient because having them in the library might save several rewrites once in a while.

I'm open to suggestions (including removing some of this PR's lemmas altogether). Thank you for your time.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
