### PR TITLE
Add more test cases for higher-order recursive functions in seq.v w.r.t. the guard condition

### DIFF
--- a/mathcomp/test_suite/test_guard.v
+++ b/mathcomp/test_suite/test_guard.v
@@ -1,6 +1,45 @@
 From mathcomp Require Import all_ssreflect.
 
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
 Inductive tree := Node { children : seq tree }.
 
+Inductive ptree (T : Type) := singleton of T | branch of list (ptree T).
+
+(* has *)
+Fixpoint tree_has (T : Type) (p : pred T) (t : ptree T) : bool :=
+  match t with
+    | singleton x => p x
+    | branch ts => has (tree_has p) ts
+  end.
+
+(* all *)
+Fixpoint tree_all (T : Type) (p : pred T) (t : ptree T) : bool :=
+  match t with
+    | singleton x => p x
+    | branch ts => all (tree_all p) ts
+  end.
+
+(* map *)
+Fixpoint traverse_id (t : tree) : tree :=
+  Node (map traverse_id (children t)).
+
+(* foldr *)
+Fixpoint tree_foldr (T R : Type) (f : T -> R -> R) (z : R) (t : ptree T) : R :=
+  match t with
+    | singleton x => f x z
+    | branch ts => foldr (fun t z' => tree_foldr f z' t) z ts
+  end.
+
+(* foldl *)
+Fixpoint tree_foldl (T R : Type) (f : R -> T -> R) (z : R) (t : ptree T) : R :=
+  match t with
+    | singleton x => f z x
+    | branch ts => foldl (tree_foldl f) z ts
+  end.
+
+(* all2 *)
 Fixpoint eq_tree (x y : tree) {struct x} : bool :=
   all2 eq_tree (children x) (children y).


### PR DESCRIPTION
##### Motivation for this change

This PR adds some test cases in `test_suite/test_guard.v` which I promised to do in https://github.com/math-comp/math-comp/pull/471#issuecomment-611521366. Currently, test cases for `find`, `filter`, `count`, `pmap`, `pairmap`, `scanl` are missing.

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
