### PR TITLE
Missing homo/mono lemmas in the presence of cancellation

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -62,6 +62,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `fintype.v`, new lemmas: `seq_sub_default`, `seq_subE`
 - in `order.v`, new "unfolding" lemmas: `minEnat` and `maxEnat`
 
+- in `ssrbool.v`
+  + lemmas about the `cancel` predicate and `{in _, _}`/`{on _, _}` notations:
+    * `onW_can`, `onW_can_in`, `in_onW_can`, `onT_can`, `onT_can_in`, `in_onT_can`
+  + lemmas about monotone functions and the `{in _, _}` notation:
+    * `homoRL_in`, `homoLR_in`, `homo_mono_in`, `monoLR_in`, `monoRL_in`,
+      `can_mono_in`
+  + lemmas about the `cancel` predicate and injective functions:
+    * `inj_can_sym_in_on`, `inj_can_sym_on`, `inj_can_sym_in`
+
 ### Changed
 
 - in `order.v`, `le_xor_gt`, `lt_xor_ge`, `compare`, `incompare`, `lel_xor_gt`,

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -65,9 +65,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `ssrbool.v`
   + lemmas about the `cancel` predicate and `{in _, _}`/`{on _, _}` notations:
     * `onW_can`, `onW_can_in`, `in_onW_can`, `onT_can`, `onT_can_in`, `in_onT_can`
-  + lemmas about monotone functions and the `{in _, _}` notation:
-    * `homoRL_in`, `homoLR_in`, `homo_mono_in`, `monoLR_in`, `monoRL_in`,
-      `can_mono_in`
   + lemmas about the `cancel` predicate and injective functions:
     * `inj_can_sym_in_on`, `inj_can_sym_on`, `inj_can_sym_in`
 
@@ -106,6 +103,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + `lexU` -> `le_maxr`
   + `ltxU` -> `lt_maxr`
   + `lexU` -> `le_maxr`
+
+- in `ssrbool.v`
+  + lemmas about monotone functions and the `{in _, _}` notation:
+    * `homoRL_in`, `homoLR_in`, `homo_mono_in`, `monoLR_in`, `monoRL_in`, `can_mono_in`
 
 ### Renamed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -64,7 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `ssrbool.v`
   + lemmas about the `cancel` predicate and `{in _, _}`/`{on _, _}` notations:
-    * `onW_can`, `onW_can_in`, `in_onW_can`, `onT_can`, `onT_can_in`, `in_onT_can`
+    * `onW_can`, `onW_can_in`, `in_onW_can`, `onS_can`, `onS_can_in`, `in_onS_can`
   + lemmas about the `cancel` predicate and injective functions:
     * `inj_can_sym_in_on`, `inj_can_sym_on`, `inj_can_sym_in`
 

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -86,7 +86,7 @@ Arguments mono_sym_in {aT rT} [aR rR f aD].
 Arguments homo_sym_in11 {aT rT} [aR rR f aD aD'].
 Arguments mono_sym_in11 {aT rT} [aR rR f aD aD'].
 
-Section onW_can.
+Section CancelOn.
 
 Variables (aT rT : predArgType) (aD : {pred aT}) (rD : {pred rT}).
 Variables (f : aT -> rT) (g : rT -> aT).
@@ -100,24 +100,24 @@ Proof. by move=> fgK x xrD xaD; apply: fgK. Qed.
 Lemma in_onW_can : cancel g f -> {in rD, {on aD, cancel g & f}}.
 Proof. by move=> fgK x xrD xaD; apply: fgK. Qed.
 
-Lemma onT_can : (forall x, g x \in aD) -> {on aD, cancel g & f} -> cancel g f.
+Lemma onS_can : (forall x, g x \in aD) -> {on aD, cancel g & f} -> cancel g f.
 Proof. by move=> mem_g fgK x; apply: fgK. Qed.
 
-Lemma onT_can_in : {homo g : x / x \in rD >-> x \in aD} ->
+Lemma onS_can_in : {homo g : x / x \in rD >-> x \in aD} ->
   {in rD, {on aD, cancel g & f}} -> {in rD, cancel g f}.
 Proof. by move=> mem_g fgK x x_rD; apply/fgK/mem_g. Qed.
 
-Lemma in_onT_can : (forall x, g x \in aD) ->
+Lemma in_onS_can : (forall x, g x \in aD) ->
   {in rT, {on aD, cancel g & f}} -> cancel g f.
 Proof. by move=> mem_g fgK x; apply/fgK. Qed.
 
-End onW_can.
+End CancelOn.
 Arguments onW_can {aT rT} aD {f g}.
 Arguments onW_can_in {aT rT} aD {rD f g}.
 Arguments in_onW_can {aT rT} aD rD {f g}.
-Arguments onT_can {aT rT} aD {f g}.
-Arguments onW_can_in {aT rT} aD {rD f g}.
-Arguments in_onT_can {aT rT} aD {f g}.
+Arguments onS_can {aT rT} aD {f g}.
+Arguments onS_can_in {aT rT} aD {rD f g}.
+Arguments in_onS_can {aT rT} aD {f g}.
 
 Section MonoHomoMorphismTheory_in.
 
@@ -173,18 +173,17 @@ Section inj_can_sym_in_on.
 Variables (aT rT : predArgType) (aD : {pred aT}) (rD : {pred rT}).
 Variables (f : aT -> rT) (g : rT -> aT).
 
-Lemma inj_can_sym_in_on : {homo f : x / x \in aD >-> x \in rD} ->
-  {in aD, {on rD, cancel f & g}} ->
-  {in [pred x | x \in rD & g x \in aD], injective g} ->
-  {in rD, {on aD, cancel g & f}}.
+Lemma inj_can_sym_in_on :
+    {homo f : x / x \in aD >-> x \in rD} -> {in aD, {on rD, cancel f & g}} ->
+  {in rD &, {on aD &, injective g}} -> {in rD, {on aD, cancel g & f}}.
 Proof. by move=> fD fK gI x x_rD gx_aD; apply: gI; rewrite ?inE ?fK ?fD. Qed.
 
 Lemma inj_can_sym_on : {in aD, cancel f g} ->
-  {in [pred x | g x \in aD], injective g} -> {on aD, cancel g & f}.
+  {on aD &, injective g} -> {on aD, cancel g & f}.
 Proof. by move=> fK gI x gx_aD; apply: gI; rewrite ?inE ?fK. Qed.
 
 Lemma inj_can_sym_in : {homo f \o g : x / x \in rD} -> {on rD, cancel f & g} ->
-  {in rD, injective g} ->  {in rD, cancel g f}.
+  {in rD &, injective g} ->  {in rD, cancel g f}.
 Proof. by move=> fgD fK gI x x_rD; apply: gI; rewrite ?fK ?fgD. Qed.
 
 End inj_can_sym_in_on.

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -85,3 +85,110 @@ Arguments homo_sym_in {aT rT} [aR rR f aD].
 Arguments mono_sym_in {aT rT} [aR rR f aD].
 Arguments homo_sym_in11 {aT rT} [aR rR f aD aD'].
 Arguments mono_sym_in11 {aT rT} [aR rR f aD aD'].
+
+Section onW_can.
+
+Variables (aT rT : predArgType) (aD : {pred aT}) (rD : {pred rT}).
+Variables (f : aT -> rT) (g : rT -> aT).
+
+Lemma onW_can : cancel g f -> {on aD, cancel g & f}.
+Proof. by move=> fgK x xaD; apply: fgK. Qed.
+
+Lemma onW_can_in : {in rD, cancel g f} -> {in rD, {on aD, cancel g & f}}.
+Proof. by move=> fgK x xrD xaD; apply: fgK. Qed.
+
+Lemma in_onW_can : cancel g f -> {in rD, {on aD, cancel g & f}}.
+Proof. by move=> fgK x xrD xaD; apply: fgK. Qed.
+
+Lemma onT_can : (forall x, g x \in aD) -> {on aD, cancel g & f} -> cancel g f.
+Proof. by move=> mem_g fgK x; apply: fgK. Qed.
+
+Lemma onT_can_in : {homo g : x / x \in rD >-> x \in aD} ->
+  {in rD, {on aD, cancel g & f}} -> {in rD, cancel g f}.
+Proof. by move=> mem_g fgK x x_rD; apply/fgK/mem_g. Qed.
+
+Lemma in_onT_can : (forall x, g x \in aD) ->
+  {in rT, {on aD, cancel g & f}} -> cancel g f.
+Proof. by move=> mem_g fgK x; apply/fgK. Qed.
+
+End onW_can.
+Arguments onW_can {aT rT} aD {f g}.
+Arguments onW_can_in {aT rT} aD {rD f g}.
+Arguments in_onW_can {aT rT} aD rD {f g}.
+Arguments onT_can {aT rT} aD {f g}.
+Arguments onW_can_in {aT rT} aD {rD f g}.
+Arguments in_onT_can {aT rT} aD {f g}.
+
+Section MonoHomoMorphismTheory_in.
+
+Variables (aT rT : predArgType) (aD : {pred aT}) (rD : {pred rT}).
+Variables (f : aT -> rT) (g : rT -> aT) (aR : rel aT) (rR : rel rT).
+
+Hypothesis fgK : {in rD, {on aD, cancel g & f}}.
+Hypothesis mem_g : {homo g : x / x \in rD >-> x \in aD}.
+
+Lemma homoRL_in :
+    {in aD &, {homo f : x y / aR x y >-> rR x y}} ->
+  {in rD & aD, forall x y, aR (g x) y -> rR x (f y)}.
+Proof. by move=> Hf x y hx hy /Hf; rewrite fgK ?mem_g// ?inE; apply. Qed.
+
+Lemma homoLR_in :
+    {in aD &, {homo f : x y / aR x y >-> rR x y}} ->
+  {in aD & rD, forall x y, aR x (g y) -> rR (f x) y}.
+Proof. by move=> Hf x y hx hy /Hf; rewrite fgK ?mem_g// ?inE; apply. Qed.
+
+Lemma homo_mono_in :
+    {in aD &, {homo f : x y / aR x y >-> rR x y}} ->
+    {in rD &, {homo g : x y / rR x y >-> aR x y}} ->
+  {in rD &, {mono g : x y / rR x y >-> aR x y}}.
+Proof.
+move=> mf mg x y hx hy; case: (boolP (rR _ _))=> [/mg //|]; first exact.
+by apply: contraNF=> /mf; rewrite !fgK ?mem_g//; apply.
+Qed.
+
+Lemma monoLR_in :
+    {in aD &, {mono f : x y / aR x y >-> rR x y}} ->
+  {in aD & rD, forall x y, rR (f x) y = aR x (g y)}.
+Proof. by move=> mf x y hx hy; rewrite -{1}[y]fgK ?mem_g// mf ?mem_g. Qed.
+
+Lemma monoRL_in :
+    {in aD &, {mono f : x y / aR x y >-> rR x y}} ->
+  {in rD & aD, forall x y, rR x (f y) = aR (g x) y}.
+Proof. by move=> mf x y hx hy; rewrite -{1}[x]fgK ?mem_g// mf ?mem_g. Qed.
+
+Lemma can_mono_in :
+    {in aD &, {mono f : x y / aR x y >-> rR x y}} ->
+  {in rD &, {mono g : x y / rR x y >-> aR x y}}.
+Proof. by move=> mf x y hx hy; rewrite -mf ?mem_g// !fgK ?mem_g. Qed.
+
+End MonoHomoMorphismTheory_in.
+Arguments homoRL_in {aT rT aD rD f g aR rR}.
+Arguments homoLR_in {aT rT aD rD f g aR rR}.
+Arguments homo_mono_in {aT rT aD rD f g aR rR}.
+Arguments monoLR_in {aT rT aD rD f g aR rR}.
+Arguments monoRL_in {aT rT aD rD f g aR rR}.
+Arguments can_mono_in {aT rT aD rD f g aR rR}.
+
+Section inj_can_sym_in_on.
+Variables (aT rT : predArgType) (aD : {pred aT}) (rD : {pred rT}).
+Variables (f : aT -> rT) (g : rT -> aT).
+
+Lemma inj_can_sym_in_on : {homo f : x / x \in aD >-> x \in rD} ->
+  {in aD, {on rD, cancel f & g}} ->
+  {in [pred x | x \in rD & g x \in aD], injective g} ->
+  {in rD, {on aD, cancel g & f}}.
+Proof. by move=> fD fK gI x x_rD gx_aD; apply: gI; rewrite ?inE ?fK ?fD. Qed.
+
+Lemma inj_can_sym_on : {in aD, cancel f g} ->
+  {in [pred x | g x \in aD], injective g} -> {on aD, cancel g & f}.
+Proof. by move=> fK gI x gx_aD; apply: gI; rewrite ?inE ?fK. Qed.
+
+Lemma inj_can_sym_in : {homo f \o g : x / x \in rD} -> {on rD, cancel f & g} ->
+  {in rD, injective g} ->  {in rD, cancel g f}.
+Proof. by move=> fgD fK gI x x_rD; apply: gI; rewrite ?fK ?fgD. Qed.
+
+End inj_can_sym_in_on.
+Arguments inj_can_sym_in_on {aT rT aD rD f g}.
+Arguments inj_can_sym_on {aT rT aD f g}.
+Arguments inj_can_sym_in {aT rT rD f g}.
+

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -11,7 +11,15 @@ From Coq Require Export ssrbool.
 (* This file also anticipates a v8.11 change in the definition of simpl_pred  *)
 (* to T -> simpl_pred T. This change ensures that inE expands the definition  *)
 (* of r : simpl_rel along with the \in, when rewriting in y \in r x.          *)
+(*                                                                            *)
+(* This file also anticipates v8.13 additions as well as a generalization in  *)
+(* the statments of `homoRL_in`, `homoLR_in`, `homo_mono_in`, `monoLR_in`,    *)
+(* monoRL_in, and can_mono_in.                                                *)
 (******************************************************************************)
+
+(******************)
+(* v8.11 addtions *)
+(******************)
 
 Notation "{ 'pred' T }" := (pred_sort (predPredType T)) (at level 0,
   format "{ 'pred'  T }") : type_scope.
@@ -49,6 +57,10 @@ Notation "[ 'rel' x y 'in' A ]" := [rel x y in A & A] (at level 0,
 Notation xrelpre := (fun f (r : rel _) x y => r (f x) (f y)).
 Definition relpre {T rT} (f : T -> rT)  (r : rel rT) :=
   [rel x y | r (f x) (f y)].
+
+(******************)
+(* v8.13 addtions *)
+(******************)
 
 Section HomoMonoMorphismFlip.
 Variables (aT rT : Type) (aR : rel aT) (rR : rel rT) (f : aT -> rT).
@@ -190,4 +202,3 @@ End inj_can_sym_in_on.
 Arguments inj_can_sym_in_on {aT rT aD rD f g}.
 Arguments inj_can_sym_on {aT rT aD f g}.
 Arguments inj_can_sym_in {aT rT rD f g}.
-


### PR DESCRIPTION
##### Motivation for this change

The current section  `MonoHomoMorphismTheory_in` from [`coq/theories/ssr/ssrbool.v`](https://github.com/coq/coq/blob/master/theories/ssr/ssrbool.v#L1981-L2035) is completely unusable because it's `rD` is too specific, and the cancellation hypothesis is too restrictive `{on D, cancel f a g}` which barely covers the use cases (e.g. in [mathcomp/analysis](https://github.com/math-comp/analysis/blob/d38d70a1d224ca4b895375bb6f32639c4545bf32/theories/normedtype.v#L1047-L1048)).

Fixes #518 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- ~added corresponding documentation in the headers~
- [x] backport to `coq/theories/ssr/ssrbool.v`
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
