### PR TITLE
change links to the wiki to links to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,17 @@ installation instructions in other scenarios.
 ## How to get help
 
 - The [website](http://math-comp.github.io/math-comp/) of the MathComp library
-  contains links to the HTML documentation of each file.
-- The [ssreflect mailing
-  list](https://sympa.inria.fr/sympa/info/ssreflect) is the primary
+  contains:
+  + links to the [HTML documentation of each file](https://math-comp.github.io/htmldoc/index.html)
+  + a list of [tutorials](https://math-comp.github.io/documentation.html)
+- The [ssreflect mailing list](https://sympa.inria.fr/sympa/info/ssreflect) is the primary
   venue for help and questions about the library.
 - The [Mathematical Components Book](https://math-comp.github.io/mcb/)
   provides a comprehensive introduction to the library.
-- The [MathComp wiki](https://github.com/math-comp/math-comp/wiki)
-  contains many useful information, including a list of
-  [tutorials](https://github.com/math-comp/math-comp/wiki/tutorials).
 - Experienced users hang around at
   [StackOverflow](https://stackoverflow.com/questions/tagged/ssreflect)
   listening to the `ssreflect` and `coq` tags.
 
 ## Publications and Tools using MathComp
 
-A collection of [papers](https://github.com/math-comp/math-comp/wiki/Publications) 
-using the Mathematical Components library can be found on the
-[wiki](https://github.com/math-comp/math-comp/wiki).
+[A collection of papers using the Mathematical Components library](https://math-comp.github.io/papers.html)


### PR DESCRIPTION
##### Motivation for this change

The README points to pages of the wiki that have not been updated while the website contains more up-to-date and better formatted information. 

##### Things done/to do

<!-- please fill in the following checklist -->
~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~
~- [ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
