### PR TITLE
[CI/CD] Deploy mathcomp/mathcomp-dev:coq-8.12 (with Coq 8.12+alpha)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -97,6 +97,10 @@ coq-8.10:
 coq-8.11:
   extends: .opam-build-once
 
+coq-8.12:
+  # to be replaced with .opam-build-once when 8.12.0 available
+  extends: .opam-build
+
 coq-dev:
   extends: .opam-build
 
@@ -232,6 +236,11 @@ ci-lemma-overloading-8.11:
   extends: .ci-lemma-overloading
   variables:
     COQ_VERSION: "8.11"
+
+ci-lemma-overloading-8.12:
+  extends: .ci-lemma-overloading
+  variables:
+    COQ_VERSION: "8.12"
 
 ci-lemma-overloading-dev:
   extends: .ci-lemma-overloading
@@ -437,6 +446,10 @@ mathcomp-dev:coq-8.10:
 
 mathcomp-dev:coq-8.11:
   extends: .docker-deploy-once
+
+mathcomp-dev:coq-8.12:
+  # to be replaced with .docker-deploy-once when 8.12.0 available
+  extends: .docker-deploy
 
 mathcomp-dev:coq-dev:
   extends: .docker-deploy

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -9,7 +9,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { ((>= "8.7" & < "8.12~") | (= "dev"))} ]
+depends: [ "coq" { ((>= "8.7" & < "8.13~") | (= "dev"))} ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
##### Motivation for this change

Coq 8.12+beta1 is not yet released (see [this wiki page](https://github.com/coq/coq/wiki/Release-Plan-for-Coq-8.12) for the roadmap) but as suggested by @palmskog on [Zulip](https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Docker.20image.20for.208.2E12/near/200030934), it can be useful to test projects with Coq 8.12+alpha in advance.

So a `coqorg/coq:8.12 = coqorg/coq:8.12-alpha` is now available and rebuilt every night from the [`v8.12` branch](https://github.com/coq/coq/tree/v8.12). Also, this PR will auto-deploy an accompanying version of mathcomp.dev in `mathcomp/mathcomp-dev:coq-8.12`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- [x] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.