### PR TITLE
Adding only parsing to notations in ssrAC

### DIFF
--- a/mathcomp/ssreflect/ssrAC.v
+++ b/mathcomp/ssreflect/ssrAC.v
@@ -227,11 +227,11 @@ Notation opAC op  p s := (opACof op (AC.pattern p%AC) s%AC).
 Notation opACl op s := (opAC op (AC.Leaf_of_nat (size (AC.serial s%AC))) s%AC).
 
 Notation "op .[ 'ACof' p s ]" := (opACof op p s)
-  (at level 2, p at level 1, left associativity).
+  (at level 2, p at level 1, left associativity, only parsing) : AC_scope.
 Notation "op .[ 'AC' p s ]" := (opAC op p s)
-  (at level 2, p at level 1, left associativity).
+  (at level 2, p at level 1, left associativity, only parsing) : AC_scope.
 Notation "op .[ 'ACl' s ]" := (opACl op s)
-  (at level 2, left associativity).
+  (at level 2, left associativity, only parsing) : AC_scope.
 
 Notation AC_strategy :=
   (ltac: (cbv -[Monoid.com_operator Monoid.operator]; reflexivity)).


### PR DESCRIPTION
##### Motivation for this change

Silence warning by declaring some notations `only parsing`.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
