### PR TITLE
silencing warnings in individual packages

### DIFF
--- a/mathcomp/algebra/Make
+++ b/mathcomp/algebra/Make
@@ -19,3 +19,10 @@ vector.v
 zmodp.v
 
 -R . mathcomp.algebra
+
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -redundant-canonical-projection
+-arg -w -arg -notation-overridden
+-arg -w -arg -duplicate-clear
+-arg -w -arg -ambiguous-paths
+-arg -w -arg -undeclared-scope

--- a/mathcomp/character/Make
+++ b/mathcomp/character/Make
@@ -8,3 +8,10 @@ mxrepresentation.v
 vcharacter.v
 
 -R . mathcomp.character
+
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -redundant-canonical-projection
+-arg -w -arg -notation-overridden
+-arg -w -arg -duplicate-clear
+-arg -w -arg -ambiguous-paths
+-arg -w -arg -undeclared-scope

--- a/mathcomp/field/Make
+++ b/mathcomp/field/Make
@@ -11,3 +11,10 @@ galois.v
 separable.v
 
 -R . mathcomp.field
+
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -redundant-canonical-projection
+-arg -w -arg -notation-overridden
+-arg -w -arg -duplicate-clear
+-arg -w -arg -ambiguous-paths
+-arg -w -arg -undeclared-scope

--- a/mathcomp/fingroup/Make
+++ b/mathcomp/fingroup/Make
@@ -9,3 +9,10 @@ presentation.v
 quotient.v
 
 -R . mathcomp.fingroup
+
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -redundant-canonical-projection
+-arg -w -arg -notation-overridden
+-arg -w -arg -duplicate-clear
+-arg -w -arg -ambiguous-paths
+-arg -w -arg -undeclared-scope

--- a/mathcomp/solvable/Make
+++ b/mathcomp/solvable/Make
@@ -20,3 +20,10 @@ primitive_action.v
 sylow.v
 
 -R . mathcomp.solvable
+
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -redundant-canonical-projection
+-arg -w -arg -notation-overridden
+-arg -w -arg -duplicate-clear
+-arg -w -arg -ambiguous-paths
+-arg -w -arg -undeclared-scope

--- a/mathcomp/ssreflect/Make
+++ b/mathcomp/ssreflect/Make
@@ -24,3 +24,11 @@ order.v
 
 -I .
 -R . mathcomp.ssreflect
+
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -redundant-canonical-projection
+-arg -w -arg -notation-overridden
+-arg -w -arg -duplicate-clear
+-arg -w -arg -ambiguous-paths
+-arg -w -arg -undeclared-scope
+-arg -w -arg -non-reversible-notation


### PR DESCRIPTION
##### Motivation for this change

Subsumes and closes #447 
We opt for an aggressive silencing in package subdirectories `Make` in order for users of individual packages (through opam and nix mainly) to get no warnings.
We keep the current, light, silencing in the main `Make` to make sure we get some diagnostics.

We should open an issue for silencing in a better way (by fixing the code) from 1.12.0 is we support only Coq >= 8.10.0

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
