### PR TITLE
Generated opam packages allow coq-dev again

### DIFF
--- a/etc/utils/packager
+++ b/etc/utils/packager
@@ -80,7 +80,6 @@ do pkgdir="$PKGPREFIX/coq-mathcomp-$pkg/coq-mathcomp-$pkg.$VERSION"
    echo $URLLINE >> $pkgdir/opam
    if [ $VERSION != "dev" ]
    then echo $CHECKSUMLINE >> $pkgdir/opam
-        sed -r "s/\|[[:space:]]*\(=[[:space:]]*\"dev\"[[:space:]]*\)//" -i $pkgdir/opam
    fi
    echo "}" >> $pkgdir/opam
 done


### PR DESCRIPTION
##### Motivation for this change

As a result of [a discussion on Zulip](https://coq.zulipchat.com/#narrow/stream/237665-math-comp-devs/topic/MathComp.201.2E11.2E0.20OPAM.20packages.20Coq.20compatibility)
Reverts "removing opam `| (= "dev")` for released packages"
(commit 313e44316177c918b363c118f15297e08d13eb4e).

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
