### PR TITLE
Fix some hierarchy.ml related issues

### DIFF
--- a/mathcomp/Make.test-suite
+++ b/mathcomp/Make.test-suite
@@ -1,4 +1,4 @@
-test_suite/hierarchy_test.v
+test_suite/test_hierarchy_all.v
 test_suite/test_ssrAC.v
 test_suite/test_guard.v
 

--- a/mathcomp/Makefile.common
+++ b/mathcomp/Makefile.common
@@ -56,11 +56,10 @@ Makefile.coq: pre-makefile $(COQPROJECT) Makefile
 
 # Test suite ---------------------------------------------------------
 
-test_suite/hierarchy_test.v: build
-	mkdir -p test_suite
-	COQBIN=$(COQBIN) ocaml ../etc/utils/hierarchy.ml -verify -R . mathcomp -lib all.all > test_suite/hierarchy_test.v
+test_suite/test_hierarchy_all.v: build
+	COQBIN=$(COQBIN) ocaml ../etc/utils/hierarchy.ml -verify -R . mathcomp -lib all.all > test_suite/test_hierarchy_all.v
 
-Makefile.test-suite.coq: test_suite/hierarchy_test.v
+Makefile.test-suite.coq: test_suite/test_hierarchy_all.v
 	$(COQMAKEFILE) $(COQMAKEFILEOPTIONS) -f Make.test-suite -o Makefile.test-suite.coq
 
 # Global config, build, clean and distclean --------------------------
@@ -127,6 +126,9 @@ endif
 # Make of individual .vo ---------------------------------------------
 %.vo: __always__ Makefile.coq
 	+$(COQMAKE) $@
+
+test_suite/%.vo: __always__ Makefile.test-suite.coq
+	+$(COQMAKE_TESTSUITE) $@
 
 doc: __always__ Makefile.coq
 	mkdir -p _build_doc/


### PR DESCRIPTION
##### Motivation for this change

- Fix some issues reported by @strub:
  - pass `Unix.environment ()` to `coqtop` to preserve the parent process environment,
  - check the exit status of `coqtop` and report an error if it is wrong.
- Fix some `Makefile` issues:
  - rename `hierarchy_test.v` to `test_hierarchy_all.v` because other test cases are named `test_*.v` and we may also have `test_hierarchy_ssreflect.v`, `test_hierarchy_fingroup.v`, etc. (but I actually had some issues to implement this feature in the `Makefile`),
  - since the `test_suite` directory exists from the beginning, we do not need to do `mkdir -p test_suite`,
  - ~the `build` prerequisite of `test_suite/test_hierarchy_all.v` should be order only (right?),~
  - fix `make test_suite/*.vo` by adding a rule.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
