### PR TITLE
simpler proof of sum_nat_const_nat in bigop.v

### DIFF
--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1823,7 +1823,7 @@ Lemma prod_nat_const n : \prod_(i in A) n = n ^ #|A|.
 Proof. by rewrite big_const -Monoid.iteropE. Qed.
 
 Lemma sum_nat_const_nat n1 n2 n : \sum_(n1 <= i < n2) n = (n2 - n1) * n.
-Proof. by rewrite big_const_nat; elim: (_ - _) => //= ? ->. Qed.
+Proof. by rewrite big_const_nat iter_addn_0 mulnC. Qed.
 
 Lemma prod_nat_const_nat n1 n2 n : \prod_(n1 <= i < n2) n = n ^ (n2 - n1).
 Proof. by rewrite big_const_nat -Monoid.iteropE. Qed.


### PR DESCRIPTION
##### Motivation for this change

While reviewing #537. I've noticed that we could take advantage of `iter_addn_0` to simplify the proof of `sum_nat_const_nat`

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
