### PR TITLE
fix "Nothing to inject" warnings

### DIFF
--- a/mathcomp/ssreflect/fingraph.v
+++ b/mathcomp/ssreflect/fingraph.v
@@ -621,8 +621,8 @@ Lemma fcard_gt1P (A : {pred T}) :
   reflect (exists2 x, x \in A & exists2 y, y \in A & ~~ fconnect f x y)
           (1 < fcard f A).
 Proof.
-move=> clAf; apply: (iffP card_gt1P) => [|[x] [xA [y yA not_xfy]]]. 
-  move=> [x] [y] [/andP [/= rfx xA]] [/andP[/= rfy yA] xDy].
+move=> clAf; apply: (iffP card_gt1P) => [|[x xA [y yA not_xfy]]].
+  move=> [x [y [/andP [/= rfx xA] /andP[/= rfy yA] xDy]]].
   by exists x; try exists y; rewrite // -root_connect // (eqP rfx) (eqP rfy).
 exists (froot f x), (froot f y); rewrite !inE !roots_root ?root_connect //=.
 by split => //; rewrite -(closed_connect clAf (connect_root _ _)).


### PR DESCRIPTION
##### Motivation for this change

This fixes two "Noting to inject" warnings introduced by #509 :disappointed: 

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
