### PR TITLE
Make [fieldExtType F of L] work for abstract instances

### DIFF
--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -130,9 +130,11 @@ Definition pack :=
   fun (bT : Falgebra.type phR) b
     & phant_id (Falgebra.class bT : Falgebra.class_of R bT)
                (b : Falgebra.class_of R T) =>
-  fun mT Cm IDm Fm & phant_id (Field.class mT) (@Field.Class T
-        (@IntegralDomain.Class T (@ComUnitRing.Class T (@ComRing.Class T b
-          Cm) b) IDm) Fm) => Pack phR (@Class T b Cm IDm Fm).
+  fun mT Cm IDm Fm
+    & phant_id (GRing.ComRing.mixin (Field.class mT)) Cm
+    & phant_id (GRing.IntegralDomain.mixin (Field.class mT)) IDm
+    & phant_id (GRing.Field.mixin (Field.class mT)) Fm =>
+    Pack phR (@Class T b Cm IDm Fm).
 
 Definition pack_eta K :=
   let cK := Field.class K in let Cm := ComRing.mixin cK in
@@ -261,7 +263,7 @@ Canonical lmod_fieldType.
 Notation fieldExtType R := (type (Phant R)).
 
 Notation "[ 'fieldExtType' F 'of' L ]" :=
-  (@pack _ (Phant F) L _ _ id _ _ _ _ id)
+  (@pack _ (Phant F) L _ _ id _ _ _ _ id id id)
   (at level 0, format "[ 'fieldExtType'  F  'of'  L ]") : form_scope.
 
 Notation "[ 'fieldExtType' F 'of' L 'for' K ]" :=


### PR DESCRIPTION
##### Motivation for this change

If `L` is an abstract `fieldType`, this pack notation did not work as in https://github.com/math-comp/analysis/pull/205#discussion_r451832262. CC: @CohenCyril 

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
