### PR TITLE
[DO NOT MERGE] Fix a coherence (ambiguous paths) issue of fieldExtType and a conversion issue of "regular" instances

### DIFF
--- a/mathcomp/Make.test-suite
+++ b/mathcomp/Make.test-suite
@@ -1,6 +1,7 @@
 test_suite/test_hierarchy_all.v
 test_suite/test_ssrAC.v
 test_suite/test_guard.v
+test_suite/test_regular_conv.v
 
 -I .
 

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -1407,7 +1407,7 @@ Variable R : unitRingType.
 
 Record class_of M :=
   Class { base : GRing.UnitAlgebra.class_of R M; mixin : mixin_of M base }.
-Definition base2 M (c : class_of M) := Algebra.Class (mixin c).
+Definition base2 M (c : class_of M) := @Algebra.Class _ _ (base c) (mixin c).
 Definition base3 M (c : class_of M) := @UnitRing.Class _ (base c) (mixin c).
 
 Local Coercion base : class_of >-> GRing.UnitAlgebra.class_of.

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -3323,13 +3323,14 @@ Section ClassDef.
 Variable R : ringType.
 
 Record class_of (T : Type) : Type := Class {
-  base : ComAlgebra.class_of R T;
-  mixin : GRing.UnitRing.mixin_of (ComRing.Pack base)
+  base : UnitAlgebra.class_of R T;
+  mixin : commutative (Ring.mul base)
 }.
-Definition base2 R m := UnitAlgebra.Class (@mixin R m).
-Definition base3 R m := ComUnitRing.Class (@mixin R m).
-Local Coercion base : class_of >-> ComAlgebra.class_of.
-Local Coercion base2 : class_of >-> UnitAlgebra.class_of.
+Definition base2 R m := ComAlgebra.Class (@mixin R m).
+Definition base3 R m :=
+  @ComUnitRing.Class _ (ComRing.Class (@mixin R m)) (UnitRing.mixin (base m)).
+Local Coercion base : class_of >-> UnitAlgebra.class_of.
+Local Coercion base2 : class_of >-> ComAlgebra.class_of.
 Local Coercion base3 : class_of >-> ComUnitRing.class_of.
 
 Structure type (phR : phant R) := Pack {sort; _ : class_of sort}.
@@ -3340,8 +3341,8 @@ Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of xT).
 
 Definition pack :=
-  fun bT b & phant_id (@ComAlgebra.class R phR bT) (b : ComAlgebra.class_of R T) =>
-  fun mT m & phant_id (UnitRing.mixin (UnitRing.class mT)) m =>
+  fun bT b & phant_id (@UnitAlgebra.class R phR bT) (b : UnitAlgebra.class_of R T) =>
+  fun mT m & phant_id (ComRing.mixin (ComRing.class mT)) m =>
   Pack (Phant R) (@Class T b m).
 
 Definition eqType := @Equality.Pack cT xclass.
@@ -3370,8 +3371,9 @@ Definition alg_comUnitRingType := @Algebra.Pack R phR comUnitRingType xclass.
 End ClassDef.
 
 Module Exports.
-Coercion base : class_of >-> ComAlgebra.class_of.
-Coercion base2 : class_of >-> UnitAlgebra.class_of.
+Coercion base : class_of >-> UnitAlgebra.class_of.
+Coercion base2 : class_of >-> ComAlgebra.class_of.
+Coercion base3 : class_of >-> ComUnitRing.class_of.
 Coercion sort : type >-> Sortclass.
 Bind Scope ring_scope with sort.
 Coercion eqType : type >-> Equality.type.

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -2724,12 +2724,15 @@ Section ClassDef.
 Variable R : ringType.
 
 Record class_of (T : Type) : Type := Class {
-  base : Algebra.class_of R T;
-  mixin : commutative (Ring.mul base)
+  base : ComRing.class_of T;
+  lmod_mixin : Lmodule.mixin_of R (Zmodule.Pack base);
+  lalg_mixin : @Lalgebra.axiom R (Lmodule.Pack _ (Lmodule.Class lmod_mixin))
+                               (Ring.mul base);
+  mixin : Algebra.axiom (Lalgebra.Pack _ (Lalgebra.Class lalg_mixin))
 }.
-Definition base2 R m := ComRing.Class (@mixin R m).
-Local Coercion base : class_of >-> Algebra.class_of.
-Local Coercion base2 : class_of >-> ComRing.class_of.
+Definition base2 R m := Algebra.Class (@mixin R m).
+Local Coercion base : class_of >-> ComRing.class_of.
+Local Coercion base2 : class_of >-> Algebra.class_of.
 
 Structure type (phR : phant R) := Pack {sort; _ : class_of sort}.
 Local Coercion sort : type >-> Sortclass.
@@ -2739,9 +2742,12 @@ Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of xT).
 
 Definition pack :=
-  fun bT b & phant_id (@Algebra.class R phR bT) (b : Algebra.class_of R T) =>
-  fun mT m & phant_id (ComRing.mixin (ComRing.class mT)) m =>
-  Pack (Phant R) (@Class T b m).
+  fun bT b & phant_id (@ComRing.class bT) b =>
+  fun mT Mm Am m
+    & phant_id (Lalgebra.mixin (@Algebra.class R phR mT)) Mm
+    & phant_id (@Lalgebra.ext R _ (@Algebra.class R phR mT)) Am
+    & phant_id (@Algebra.mixin R _ (@Algebra.class R phR mT)) m =>
+  Pack (Phant R) (@Class T b Mm Am m).
 
 Definition eqType := @Equality.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
@@ -2758,8 +2764,8 @@ Definition alg_comRingType := @Algebra.Pack R phR comRingType xclass.
 End ClassDef.
 
 Module Exports.
-Coercion base : class_of >-> Algebra.class_of.
-Coercion base2 : class_of >-> ComRing.class_of.
+Coercion base : class_of >-> ComRing.class_of.
+Coercion base2 : class_of >-> Algebra.class_of.
 Coercion sort : type >-> Sortclass.
 Bind Scope ring_scope with sort.
 Coercion eqType : type >-> Equality.type.
@@ -2783,7 +2789,8 @@ Canonical lalg_comRingType.
 Canonical alg_comRingType.
 
 Notation comAlgType R := (type (Phant R)).
-Notation "[ 'comAlgType' R 'of' T ]" := (@pack _ (Phant R) T _ _ id _ _ id)
+Notation "[ 'comAlgType' R 'of' T ]" :=
+  (@pack _ (Phant R) T _ _ id _ _ _ _ id id id)
   (at level 0, format "[ 'comAlgType'  R  'of'  T ]") : form_scope.
 End Exports.
 
@@ -3251,12 +3258,15 @@ Section ClassDef.
 Variable R : ringType.
 
 Record class_of (T : Type) : Type := Class {
-  base : Algebra.class_of R T;
-  mixin : GRing.UnitRing.mixin_of (Ring.Pack base)
+  base : UnitRing.class_of T;
+  lmod_mixin : Lmodule.mixin_of R (Zmodule.Pack base);
+  lalg_mixin : @Lalgebra.axiom R (Lmodule.Pack _ (Lmodule.Class lmod_mixin))
+                               (Ring.mul base);
+  mixin : Algebra.axiom (Lalgebra.Pack _ (Lalgebra.Class lalg_mixin))
 }.
-Definition base2 R m := UnitRing.Class (@mixin R m).
-Local Coercion base : class_of >-> Algebra.class_of.
-Local Coercion base2 : class_of >-> UnitRing.class_of.
+Definition base2 R m := Algebra.Class (@mixin R m).
+Local Coercion base : class_of >-> UnitRing.class_of.
+Local Coercion base2 : class_of >-> Algebra.class_of.
 
 Structure type (phR : phant R) := Pack {sort; _ : class_of sort}.
 Local Coercion sort : type >-> Sortclass.
@@ -3266,9 +3276,12 @@ Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of xT).
 
 Definition pack :=
-  fun bT b & phant_id (@Algebra.class R phR bT) (b : Algebra.class_of R T) =>
-  fun mT m & phant_id (UnitRing.mixin (UnitRing.class mT)) m =>
-  Pack (Phant R) (@Class T b m).
+  fun bT b & phant_id (@UnitRing.class bT) b =>
+  fun mT Mm Am m
+    & phant_id (Lalgebra.mixin (@Algebra.class R phR mT)) Mm
+    & phant_id (@Lalgebra.ext R _ (@Algebra.class R phR mT)) Am
+    & phant_id (@Algebra.mixin R _ (@Algebra.class R phR mT)) m =>
+  Pack (Phant R) (@Class T b Mm Am m).
 
 Definition eqType := @Equality.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
@@ -3285,8 +3298,8 @@ Definition alg_unitRingType := @Algebra.Pack R phR unitRingType xclass.
 End ClassDef.
 
 Module Exports.
-Coercion base : class_of >-> Algebra.class_of.
-Coercion base2 : class_of >-> UnitRing.class_of.
+Coercion base : class_of >-> UnitRing.class_of.
+Coercion base2 : class_of >-> Algebra.class_of.
 Coercion sort : type >-> Sortclass.
 Bind Scope ring_scope with sort.
 Coercion eqType : type >-> Equality.type.
@@ -3309,7 +3322,8 @@ Canonical lmod_unitRingType.
 Canonical lalg_unitRingType.
 Canonical alg_unitRingType.
 Notation unitAlgType R := (type (Phant R)).
-Notation "[ 'unitAlgType' R 'of' T ]" := (@pack _ (Phant R) T _ _ id _ _ id)
+Notation "[ 'unitAlgType' R 'of' T ]" :=
+  (@pack _ (Phant R) T _ _ id _ _ _ _ id id id)
   (at level 0, format "[ 'unitAlgType'  R  'of'  T ]") : form_scope.
 End Exports.
 
@@ -3323,15 +3337,18 @@ Section ClassDef.
 Variable R : ringType.
 
 Record class_of (T : Type) : Type := Class {
-  base : UnitAlgebra.class_of R T;
-  mixin : commutative (Ring.mul base)
+  base : ComUnitRing.class_of T;
+  lmod_mixin : Lmodule.mixin_of R (Zmodule.Pack base);
+  lalg_mixin : @Lalgebra.axiom R (Lmodule.Pack _ (Lmodule.Class lmod_mixin))
+                               (Ring.mul base);
+  mixin : Algebra.axiom (Lalgebra.Pack _ (Lalgebra.Class lalg_mixin))
 }.
 Definition base2 R m := ComAlgebra.Class (@mixin R m).
 Definition base3 R m :=
-  @ComUnitRing.Class _ (ComRing.Class (@mixin R m)) (UnitRing.mixin (base m)).
-Local Coercion base : class_of >-> UnitAlgebra.class_of.
+  @UnitAlgebra.Class _ _ (base m) (lmod_mixin m) _ (@mixin R m).
+Local Coercion base : class_of >-> ComUnitRing.class_of.
 Local Coercion base2 : class_of >-> ComAlgebra.class_of.
-Local Coercion base3 : class_of >-> ComUnitRing.class_of.
+Local Coercion base3 : class_of >-> UnitAlgebra.class_of.
 
 Structure type (phR : phant R) := Pack {sort; _ : class_of sort}.
 Local Coercion sort : type >-> Sortclass.
@@ -3341,9 +3358,12 @@ Let xT := let: Pack T _ := cT in T.
 Notation xclass := (class : class_of xT).
 
 Definition pack :=
-  fun bT b & phant_id (@UnitAlgebra.class R phR bT) (b : UnitAlgebra.class_of R T) =>
-  fun mT m & phant_id (ComRing.mixin (ComRing.class mT)) m =>
-  Pack (Phant R) (@Class T b m).
+  fun bT b & phant_id (@ComUnitRing.class bT) b =>
+  fun mT Mm Am m
+    & phant_id (Lalgebra.mixin (@Algebra.class R phR mT)) Mm
+    & phant_id (@Lalgebra.ext R _ (@Algebra.class R phR mT)) Am
+    & phant_id (@Algebra.mixin R _ (@Algebra.class R phR mT)) m =>
+  Pack (Phant R) (@Class T b Mm Am m).
 
 Definition eqType := @Equality.Pack cT xclass.
 Definition choiceType := @Choice.Pack cT xclass.
@@ -3371,9 +3391,9 @@ Definition alg_comUnitRingType := @Algebra.Pack R phR comUnitRingType xclass.
 End ClassDef.
 
 Module Exports.
-Coercion base : class_of >-> UnitAlgebra.class_of.
+Coercion base : class_of >-> ComUnitRing.class_of.
 Coercion base2 : class_of >-> ComAlgebra.class_of.
-Coercion base3 : class_of >-> ComUnitRing.class_of.
+Coercion base3 : class_of >-> UnitAlgebra.class_of.
 Coercion sort : type >-> Sortclass.
 Bind Scope ring_scope with sort.
 Coercion eqType : type >-> Equality.type.
@@ -3410,7 +3430,8 @@ Canonical lalg_comUnitRingType.
 Canonical alg_comUnitRingType.
 
 Notation comUnitAlgType R := (type (Phant R)).
-Notation "[ 'comUnitAlgType' R 'of' T ]" := (@pack _ (Phant R) T _ _ id _ _ id)
+Notation "[ 'comUnitAlgType' R 'of' T ]" :=
+  (@pack _ (Phant R) T _ _ id _ _ _ _ id id id)
   (at level 0, format "[ 'comUnitAlgType'  R  'of'  T ]") : form_scope.
 End Exports.
 
@@ -3443,7 +3464,8 @@ Proof. by move=> Ux y Uy; rewrite /= invrM ?unitrV // invrK mulrC divrK. Qed.
 Lemma expr_div_n x y n : (x / y) ^+ n = x ^+ n / y ^+ n.
 Proof. by rewrite exprMn exprVn. Qed.
 
-Canonical regular_comUnitRingType := [comUnitRingType of R^o].
+Canonical regular_comUnitRingType :=
+  @ComUnitRing.Pack R^o (ComUnitRing.class R).
 Canonical regular_unitAlgType := [unitAlgType R of R^o].
 Canonical regular_comUnitAlgType := [comUnitAlgType R of R^o].
 

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -104,19 +104,13 @@ Local Coercion base : class_of >-> Falgebra.class_of.
 
 Section Bases.
 Variables (T : Type) (c : class_of T).
-Definition base1 := ComRing.Class (@comm_ext T c).
-Definition base2 := @ComUnitRing.Class T base1 c.
-Definition base3 := @IntegralDomain.Class T base2 (@idomain_ext T c).
-Definition base4 := @Field.Class T base3 (@field_ext T c).
-Definition base5 := @ComAlgebra.Class R T (@base T c) (@comm_ext T c).
-Definition base6 := @ComUnitAlgebra.Class R T base5 c.
+Definition base1 := @ComUnitAlgebra.Class R T (@base T c) (@comm_ext T c).
+Definition base2 := @IntegralDomain.Class T base1 (@idomain_ext T c).
+Definition base3 := @Field.Class T base2 (@field_ext T c).
 End Bases.
-Local Coercion base1 : class_of >-> ComRing.class_of.
-Local Coercion base2 : class_of >-> ComUnitRing.class_of.
-Local Coercion base3 : class_of >-> IntegralDomain.class_of.
-Local Coercion base4 : class_of >-> Field.class_of.
-Local Coercion base5 : class_of >-> ComAlgebra.class_of.
-Local Coercion base6 : class_of >-> ComUnitAlgebra.class_of.
+Local Coercion base1 : class_of >-> ComUnitAlgebra.class_of.
+Local Coercion base2 : class_of >-> IntegralDomain.class_of.
+Local Coercion base3 : class_of >-> Field.class_of.
 
 Structure type (phR : phant R) := Pack {sort; _ : class_of sort}.
 Local Coercion sort : type >-> Sortclass.
@@ -199,8 +193,8 @@ Module Exports.
 Coercion sort : type >-> Sortclass.
 Bind Scope ring_scope with sort.
 Coercion base : class_of >-> Falgebra.class_of.
-Coercion base4 : class_of >-> Field.class_of.
-Coercion base6 : class_of >-> ComUnitAlgebra.class_of.
+Coercion base1 : class_of >-> ComUnitAlgebra.class_of.
+Coercion base3 : class_of >-> Field.class_of.
 Coercion eqType : type >-> Equality.type.
 Canonical eqType.
 Coercion choiceType : type >-> Choice.type.

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -261,8 +261,12 @@ Canonical primeChar_unitAlgType (R : unitRingType) charRp :=
   [unitAlgType 'F_p of type R charRp].
 Canonical primeChar_comRingType (R : comRingType) charRp :=
   [comRingType of type R charRp].
+Canonical primeChar_comAlgType (R : comRingType) charRp :=
+  [comAlgType 'F_p of type R charRp].
 Canonical primeChar_comUnitRingType (R : comUnitRingType) charRp :=
   [comUnitRingType of type R charRp].
+Canonical primeChar_comUnitAlgType (R : comUnitRingType) charRp :=
+  [comUnitAlgType 'F_p of type R charRp].
 Canonical primeChar_idomainType (R : idomainType) charRp :=
   [idomainType of type R charRp].
 Canonical primeChar_fieldType (F : fieldType) charFp :=
@@ -337,7 +341,7 @@ Local Notation F := (type _ charFp).
 Canonical primeChar_finFieldType := [finFieldType of F].
 (* We need to use the eta-long version of the constructor here as projections *)
 (* of the Canonical fieldType of F cannot be computed syntactically.          *)
-Canonical primeChar_fieldExtType := [fieldExtType 'F_p of F for F0].
+Canonical primeChar_fieldExtType := [fieldExtType 'F_p of F].
 Canonical primeChar_splittingFieldType := FinSplittingFieldType 'F_p F.
 
 End FinField.
@@ -500,7 +504,7 @@ suffices [L [ys Dp]]: {L : fieldExtType F & splits L p^%:A}.
   by case/memv_imgP=> v Lzs_v; rewrite memvf lfunE => /val_inj->.
 move: {2}_.+1 (ltnSn (size p)) => n; elim: n => // n IHn in F p nz_p * => lbn.
 have [Cp|C'p] := leqP (size p) 1.
-  pose L := [fieldExtType F of F^o for F]; exists L, [::].
+  pose L := [fieldExtType F of F^o]; exists L, [::].
   by rewrite big_nil -size_poly_eq1 size_map_poly eqn_leq Cp size_poly_gt0.
 have [r r_dv_p irr_r]: {r | r %| p & irreducible_poly r}.
   pose rVp (v : 'rV_n) (r := rVpoly v) := (1 < size r) && (r %| p).

--- a/mathcomp/test_suite/test_regular_conv.v
+++ b/mathcomp/test_suite/test_regular_conv.v
@@ -1,0 +1,30 @@
+From mathcomp Require Import all_ssreflect all_algebra all_field.
+
+Section regular.
+
+Import GRing.
+
+Let eq_ringType_of_regular_lalgType (R : ringType) :=
+  erefl : regular_lalgType R = Ring.Pack (Ring.class R) :> ringType.
+
+Let eq_ringType_of_regular_algType (R : comRingType) :=
+  erefl : regular_algType R = Ring.Pack (Ring.class R) :> ringType.
+
+Let eq_comRingType_of_regular_comAlgType (R : comRingType) :=
+  erefl : regular_comAlgType R = ComRing.Pack (ComRing.class R) :> ringType.
+
+Let eq_unitRingType_of_regular_unitAlgType (R : comUnitRingType) :=
+  erefl : regular_unitAlgType R =
+          UnitRing.Pack (UnitRing.class R) :> unitRingType.
+
+Let eq_comUnitRingType_of_regular_comUnitAlgType (R : comUnitRingType) :=
+  erefl : regular_comUnitAlgType R =
+          ComUnitRing.Pack (ComUnitRing.class R) :> comUnitRingType.
+
+Let eq_unitRingType_of_regular_FalgType (R : comUnitRingType) :=
+  erefl : regular_FalgType R = UnitRing.Pack (UnitRing.class R) :> unitRingType.
+
+Let eq_fieldType_of_regular_fieldExtType (K : fieldType) :=
+  erefl : regular_fieldExtType K = Field.Pack (Field.class K) :> fieldType.
+
+End regular.


### PR DESCRIPTION
##### Motivation for this change

- For `R : ringType`, `[lalgType R of R^o] : ringType` and `[ringType of R]` (≡ `GRing.Ring.Pack R (GRing.Ring.class R)`) were not convertible and other "regular" instances had the same issue, because every algebra structure had another algebra/module structure as their base. The algebra structures now take the closest ring/field structure as their base to avoid record eta expansion.
- The notation `[fieldExtType F of L for K]` is now removed. (Removing this notation is too aggressive and I have to put it back for compatibility reasons, but I don't get how to do that.)
- Some missing `comAlgType` and `comUnitAlgType` instances are added.
- Fixes #544: The coercion paths from `fieldExtType` to `unitAlgType` were ambiguous because the base of `FalgType` was `unitAlgType` but the base of `comUnitAlgType` was `comAlgType`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
