### PR TITLE
Use predicators even extensively

### DIFF
--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -89,10 +89,8 @@ Proof.
 by rewrite {3}[d]intEsign !mulr_sign; case: ifP => -> //; rewrite divzN opprK.
 Qed.
 
-Lemma div0z d : (0 %/ d)%Z = 0.
-Proof.
-by rewrite -(canLR (signrMK _) (divz_abs _ _)) (divz_nat 0) div0n mulr0.
-Qed.
+Lemma div0z : left_zero 0 divz.
+Proof. by move=> d; rewrite /divz /= div0n mulr0. Qed.
 
 Lemma divNz_nat m d : (d > 0)%N -> (Negz m %/ d)%Z = - (m %/ d).+1%:Z.
 Proof. by case: d => // d _; apply: mul1r. Qed.
@@ -126,7 +124,10 @@ by rewrite lez_nat ltn_mod.
 Qed.
 
 Lemma divz0 m : (m %/ 0)%Z = 0. Proof. by case: m. Qed.
-Lemma mod0z d : (0 %% d)%Z = 0. Proof. by rewrite /modz div0z mul0r subrr. Qed.
+
+Lemma mod0z : left_zero 0 modz.
+Proof. by move=> d; rewrite /modz div0z mul0r subrr. Qed.
+
 Lemma modz0 m : (m %% 0)%Z = m. Proof. by rewrite /modz mulr0 subr0. Qed.
 
 Lemma divz_small m d : 0 <= m < `|d|%:Z -> (m %/ d)%Z = 0.
@@ -271,8 +272,8 @@ Proof. by rewrite -{1}[d]mul1r modzMDl. Qed.
 Lemma modzDr m d : (m + d = m %[mod d])%Z.
 Proof. by rewrite addrC modzDl. Qed.
 
-Lemma modzz d : (d %% d)%Z = 0.
-Proof. by rewrite -{1}[d]addr0 modzDl mod0z. Qed.
+Lemma modzz : self_inverse 0 modz.
+Proof. by move=> d; rewrite -{1}[d]addr0 modzDl mod0z. Qed.
 
 Lemma modzMl p d : (p * d %% d)%Z = 0.
 Proof. by rewrite -[p * d]addr0 modzMDl mod0z. Qed.

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -767,14 +767,14 @@ Definition dsubmx (A : 'M[R]_(m1 + m2, n)) :=
 Lemma row_mxEl A1 A2 i j : row_mx A1 A2 i (lshift n2 j) = A1 i j.
 Proof. by rewrite mxE (unsplitK (inl _ _)). Qed.
 
-Lemma row_mxKl A1 A2 : lsubmx (row_mx A1 A2) = A1.
-Proof. by apply/matrixP=> i j; rewrite mxE row_mxEl. Qed.
+Lemma row_mxKl A2 : cancel (row_mx^~ A2) lsubmx.
+Proof. by move=> A1; apply/matrixP=> i j; rewrite mxE row_mxEl. Qed.
 
 Lemma row_mxEr A1 A2 i j : row_mx A1 A2 i (rshift n1 j) = A2 i j.
 Proof. by rewrite mxE (unsplitK (inr _ _)). Qed.
 
-Lemma row_mxKr A1 A2 : rsubmx (row_mx A1 A2) = A2.
-Proof. by apply/matrixP=> i j; rewrite mxE row_mxEr. Qed.
+Lemma row_mxKr A1 : cancel (row_mx A1) rsubmx.
+Proof. by move=> A2; apply/matrixP=> i j; rewrite mxE row_mxEr. Qed.
 
 Lemma hsubmxK A : row_mx (lsubmx A) (rsubmx A) = A.
 Proof. by apply/matrixP=> i j /[!mxE]; case: split_ordP => k -> /[!mxE]. Qed.
@@ -782,14 +782,14 @@ Proof. by apply/matrixP=> i j /[!mxE]; case: split_ordP => k -> /[!mxE]. Qed.
 Lemma col_mxEu A1 A2 i j : col_mx A1 A2 (lshift m2 i) j = A1 i j.
 Proof. by rewrite mxE (unsplitK (inl _ _)). Qed.
 
-Lemma col_mxKu A1 A2 : usubmx (col_mx A1 A2) = A1.
-Proof. by apply/matrixP=> i j; rewrite mxE col_mxEu. Qed.
+Lemma col_mxKu A2 : cancel (col_mx^~ A2) usubmx.
+Proof. by move=> A1; apply/matrixP=> i j; rewrite mxE col_mxEu. Qed.
 
 Lemma col_mxEd A1 A2 i j : col_mx A1 A2 (rshift m1 i) j = A2 i j.
 Proof. by rewrite mxE (unsplitK (inr _ _)). Qed.
 
-Lemma col_mxKd A1 A2 : dsubmx (col_mx A1 A2) = A2.
-Proof. by apply/matrixP=> i j; rewrite mxE col_mxEd. Qed.
+Lemma col_mxKd A1 : cancel (col_mx A1) dsubmx.
+Proof. by move=> A2; apply/matrixP=> i j; rewrite mxE col_mxEd. Qed.
 
 Lemma lsubmxEsub : lsubmx = colsub (lshift _).
 Proof. by rewrite /lsubmx /mxsub !unlock. Qed.
@@ -1808,8 +1808,8 @@ Proof. by apply/matrixP=> i j; rewrite !mxE mul1r. Qed.
 Lemma scalemxDl A x y : (x + y) *m: A = x *m: A + y *m: A.
 Proof. by apply/matrixP=> i j; rewrite !mxE mulrDl. Qed.
 
-Lemma scalemxDr x A B : x *m: (A + B) = x *m: A + x *m: B.
-Proof. by apply/matrixP=> i j; rewrite !mxE mulrDr. Qed.
+Lemma scalemxDr : right_distributive scalemx +%R.
+Proof. by move=> x A B; apply/matrixP=> i j; rewrite !mxE mulrDr. Qed.
 
 Lemma scalemxA x y A : x *m: (y *m: A) = (x * y) *m: A.
 Proof. by apply/matrixP=> i j; rewrite !mxE mulrA. Qed.
@@ -2203,12 +2203,13 @@ Qed.
 Lemma scalar_mxM n a b : (a * b)%:M = a%:M *m b%:M :> 'M_n.
 Proof. by rewrite mul_scalar_mx scale_scalar_mx. Qed.
 
-Lemma mul1mx m n (A : 'M_(m, n)) : 1%:M *m A = A.
-Proof. by rewrite mul_scalar_mx scale1r. Qed.
+Lemma mul1mx m n : left_id 1%:M (@mulmx m m n).
+Proof. by move=> A; rewrite mul_scalar_mx scale1r. Qed.
 
-Lemma mulmx1 m n (A : 'M_(m, n)) : A *m 1%:M = A.
+Lemma mulmx1 m n : right_id 1%:M (@mulmx m n n).
 Proof.
-by rewrite -diag_const_mx mul_mx_diag; apply/matrixP=> i j; rewrite !mxE mulr1.
+move=> A; rewrite -diag_const_mx mul_mx_diag.
+by apply/matrixP=> i j; rewrite !mxE mulr1.
 Qed.
 
 Lemma rowsubE m m' n f (A : 'M_(m, n)) :

--- a/mathcomp/algebra/polydiv.v
+++ b/mathcomp/algebra/polydiv.v
@@ -140,10 +140,10 @@ Definition rdvdp p q := rmodp q p == 0.
 Lemma redivp_def p q : redivp p q = (rscalp p q, rdivp p q, rmodp p q).
 Proof. by rewrite /rscalp /rdivp /rmodp; case: (redivp p q) => [[]] /=. Qed.
 
-Lemma rdiv0p p : rdivp 0 p = 0.
+Lemma rdiv0p : left_zero 0 rdivp.
 Proof.
-rewrite /rdivp unlock; case: ifP => // Hp; rewrite /redivp_rec !size_poly0.
-by rewrite polySpred ?Hp.
+move=> p; rewrite /rdivp unlock; case: ifP => // Hp.
+by rewrite /redivp_rec !size_poly0 polySpred ?Hp.
 Qed.
 
 Lemma rdivp0 p : rdivp p 0 = 0. Proof. by rewrite /rdivp unlock eqxx. Qed.
@@ -190,10 +190,10 @@ apply: leq_trans (size_scale_leq _ _) _.
 by rewrite size_polyXn -subSn // leq_subLR -add1n leq_add.
 Qed.
 
-Lemma rmod0p p : rmodp 0 p = 0.
+Lemma rmod0p : left_zero 0 rmodp.
 Proof.
-rewrite /rmodp unlock; case: ifP => // Hp; rewrite /redivp_rec !size_poly0.
-by rewrite polySpred ?Hp.
+move=> p; rewrite /rmodp unlock; case: ifP => // Hp.
+by rewrite /redivp_rec !size_poly0 polySpred ?Hp.
 Qed.
 
 Lemma rmodp0 p : rmodp p 0 = p. Proof. by rewrite /rmodp unlock eqxx. Qed.
@@ -995,8 +995,8 @@ Qed.
 
 Lemma modp_mulr d p : (d * p) %% d = 0. Proof. by rewrite mulrC modp_mull. Qed.
 
-Lemma modpp d : d %% d = 0.
-Proof. by rewrite -[d in d %% _]mul1r modp_mull. Qed.
+Lemma modpp : self_inverse 0 (@modp R).
+Proof. by move=> d; rewrite -[d in d %% _]mul1r modp_mull. Qed.
 
 Lemma ltn_modp p q : (size (p %% q) < size q) = (q != 0).
 Proof.

--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -95,9 +95,9 @@ Definition fracq (x : int * int) := nosimpl (@Rat (_, _) (fracq_subproof x)).
 Fact ratz_frac n : ratz n = fracq (n, 1).
 Proof. by apply: val_inj; rewrite /= gcdn1 !divn1 abszE mulr_sign_norm. Qed.
 
-Fact valqK x : fracq (valq x) = x.
+Fact valqK : cancel valq fracq.
 Proof.
-move: x => [[n d] /= Pnd]; apply: val_inj=> /=.
+move=> [[n d] /= Pnd]; apply: val_inj=> /=.
 move: Pnd; rewrite /coprime /fracq /= => /andP[] hd -/eqP hnd.
 by rewrite lt_gtF ?gt_eqF //= hnd !divn1 mulz_sign_abs abszE gtr0_norm.
 Qed.

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -801,23 +801,19 @@ Proof. by rewrite addrC mulrS. Qed.
 Lemma mulrb x (b : bool) : x *+ b = (if b then x else 0).
 Proof. by case: b. Qed.
 
-Lemma mul0rn n : 0 *+ n = 0 :> V.
-Proof. by elim: n => // n IHn; rewrite mulrS add0r. Qed.
+Lemma mul0rn : left_zero 0%R (@natmul V).
+Proof. by elim=> //= n IHn; rewrite mulrS add0r. Qed.
 
 Lemma mulNrn x n : (- x) *+ n = x *- n.
 Proof. by elim: n => [|n IHn]; rewrite ?oppr0 // !mulrS opprD IHn. Qed.
 
 Lemma mulrnDl n : {morph (fun x => x *+ n) : x y / x + y}.
 Proof.
-move=> x y; elim: n => [|n IHn]; rewrite ?addr0 // !mulrS.
-by rewrite addrCA -!addrA -IHn -addrCA.
+by move=> x y; elim: n => [|n IHn]; rewrite ?addr0 // !mulrS addrACA IHn.
 Qed.
 
-Lemma mulrnDr x m n : x *+ (m + n) = x *+ m + x *+ n.
-Proof.
-elim: m => [|m IHm]; first by rewrite add0r.
-by rewrite !mulrS IHm addrA.
-Qed.
+Lemma mulrnDr x : {morph natmul x : x y / (x + y)%N >-> x + y}.
+Proof. by elim=> [|m IHm] n; rewrite ?add0r // !mulrS IHm addrA. Qed.
 
 Lemma mulrnBl n : {morph (fun x => x *+ n) : x y / x - y}.
 Proof.
@@ -836,8 +832,8 @@ Proof.
 by rewrite mulnC; elim: n => //= n IHn; rewrite mulrS mulrnDr IHn.
 Qed.
 
-Lemma mulrnAC x m n : x *+ m *+ n = x *+ n *+ m.
-Proof. by rewrite -!mulrnA mulnC. Qed.
+Lemma mulrnAC : right_commutative (@natmul V).
+Proof. by move=> x m n; rewrite -!mulrnA mulnC. Qed.
 
 Lemma iter_addr n x y : iter n (+%R x) y = x *+ n + y.
 Proof. by elim: n => [|n ih]; rewrite ?add0r //= ih mulrS addrA. Qed.
@@ -1086,8 +1082,8 @@ Proof. by case: n => //; rewrite mulr1. Qed.
 Lemma expr0n n : 0 ^+ n = (n == 0%N)%:R :> R.
 Proof. by case: n => // n; rewrite exprS mul0r. Qed.
 
-Lemma expr1n n : 1 ^+ n = 1 :> R.
-Proof. by elim: n => // n IHn; rewrite exprS mul1r. Qed.
+Lemma expr1n : left_zero 1 (@exp R).
+Proof. by elim=> // n IHn; rewrite exprS mul1r. Qed.
 
 Lemma exprD x m n : x ^+ (m + n) = x ^+ m * x ^+ n.
 Proof. by elim: m => [|m IHm]; rewrite ?mul1r // !exprS -mulrA -IHm. Qed.
@@ -1171,8 +1167,8 @@ elim: m => [|m IHm]; first by rewrite expr1n.
 by rewrite mulSn exprD IHm exprS exprMn_comm //; apply: commrX.
 Qed.
 
-Lemma exprAC x m n : (x ^+ m) ^+ n = (x ^+ n) ^+ m.
-Proof. by rewrite -!exprM mulnC. Qed.
+Lemma exprAC : right_commutative (@exp R).
+Proof. by move=> x m n; rewrite -!exprM mulnC. Qed.
 
 Lemma expr_mod n x i : x ^+ n = 1 -> x ^+ (i %% n) = x ^+ i.
 Proof.
@@ -1444,7 +1440,8 @@ Section Char2.
 
 Hypothesis charR2 : 2 \in [char R].
 
-Lemma addrr_char2 x : x + x = 0. Proof. by rewrite -mulr2n mulrn_char. Qed.
+Lemma addrr_char2 : self_inverse (0 : R) +%R.
+Proof. by move=> x; rewrite -mulr2n mulrn_char. Qed.
 
 Lemma oppr_char2 x : - x = x.
 Proof. by apply/esym/eqP; rewrite -addr_eq0 addrr_char2. Qed.
@@ -1630,8 +1627,8 @@ Proof. by case: V v => ? [] ? []. Qed.
 Lemma scale0r v : 0 *: v = 0.
 Proof. by apply: (addIr (1 *: v)); rewrite -scalerDl !add0r. Qed.
 
-Lemma scaler0 a : a *: 0 = 0 :> V.
-Proof. by rewrite -{1}(scale0r 0) scalerA mulr0 scale0r. Qed.
+Lemma scaler0 : right_zero 0 *:%R.
+Proof. by move=> a; rewrite -{1}(scale0r 0) scalerA mulr0 scale0r. Qed.
 
 Lemma scaleNr a v : - a *: v = - (a *: v).
 Proof. by apply: (addIr (a *: v)); rewrite -scalerDl !addNr scale0r. Qed.

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -540,10 +540,10 @@ rewrite ?(muln0, mulr0n, mul0rn, oppr0, mulNrn, opprK) //;
 * by rewrite -mulrnA.
 Qed.
 
-Fact mulrzAC m n x : (x *~ n) *~ m = (x *~ m) *~ n.
-Proof. by rewrite !mulrzA_C mulrC. Qed.
+Fact mulrzAC : right_commutative (@intmul M).
+Proof. by move=> x m n; rewrite !mulrzA_C mulrC. Qed.
 
-Fact mulr1z (x : M) : x *~ 1 = x. Proof. by []. Qed.
+Fact mulr1z : right_id 1%R (@intmul M). Proof. by []. Qed.
 
 Fact mulrzDr m : {morph ( *~%R^~ m : M -> M) : x y / x + y}.
 Proof.
@@ -583,8 +583,8 @@ Proof. by rewrite -!scalezrE scalerA mulrC. Qed.
 
 Lemma mulr0z x : x *~ 0 = 0. Proof. by []. Qed.
 
-Lemma mul0rz n : 0 *~ n = 0 :> M.
-Proof. by rewrite -scalezrE scaler0. Qed.
+Lemma mul0rz : left_zero 0 (@intmul M).
+Proof. by move=> n; rewrite -scalezrE scaler0. Qed.
 
 Lemma mulrNz x n : x *~ (- n) = - (x *~ n).
 Proof. by rewrite -scalezrE scaleNr. Qed.
@@ -1016,8 +1016,8 @@ Proof. by case: (intP n)=> // [|m]; rewrite ?opprK ?expr0z ?invr1 // invrK. Qed.
 Lemma exprz_inv x n : (x^-1) ^ n = x ^ (- n).
 Proof. by case: (intP n)=> // m; rewrite -[_ ^ (- _)]exprVn ?opprK ?invrK. Qed.
 
-Lemma exp1rz n : 1 ^ n = 1 :> R.
-Proof. by case: (intP n)=> // m; rewrite -?exprz_inv ?invr1; apply: expr1n. Qed.
+Lemma exp1rz : left_zero 1 (@exprz R).
+Proof. by case/intP => // m; rewrite -?exprz_inv ?invr1; apply: expr1n. Qed.
 
 Lemma exprSz x (n : nat) : x ^ n.+1 = x * x ^ n. Proof. exact: exprS. Qed.
 
@@ -1093,8 +1093,8 @@ rewrite exprSz ihn // intS mulrDr mulr1 exprzD_ss //.
 by case: (intP m)=> // m'; rewrite ?oppr_le0 //.
 Qed.
 
-Lemma exprzAC x m n : (x ^ m) ^ n = (x ^ n) ^ m.
-Proof. by rewrite !exprz_exp mulrC. Qed.
+Lemma exprzAC : right_commutative (@exprz R).
+Proof. by move=> x m n; rewrite !exprz_exp mulrC. Qed.
 
 Lemma exprz_out x n (nux : x \isn't a GRing.unit) (hn : 0 <= n) :
   x ^ (- n) = x ^ n.

--- a/mathcomp/algebra/vector.v
+++ b/mathcomp/algebra/vector.v
@@ -681,9 +681,9 @@ apply/vs2mxP; rewrite vs2mxD -gen_vs2mx -genmx_adds !genmxE submx1 sub1mx.
 exact: addsmx_compl_full.
 Qed.
 
-Lemma capv_compl U : (U :&: U^C = 0)%VS.
+Lemma capv_compl : right_inverse (0 : {vspace vT})%VS complv capv.
 Proof.
-apply/val_inj; rewrite [val]/= vs2mx0 vs2mxI -gen_vs2mx -genmx_cap.
+move=> U; apply/val_inj; rewrite [val]/= vs2mx0 vs2mxI -gen_vs2mx -genmx_cap.
 by rewrite capmx_compl genmx0.
 Qed.
 

--- a/mathcomp/field/falgebra.v
+++ b/mathcomp/field/falgebra.v
@@ -473,8 +473,8 @@ Proof. by case: n => //; rewrite prodv1. Qed.
 Lemma expv0n n : (0 ^+ n = if n is _.+1 then 0 else 1)%VS.
 Proof. by case: n => // n; rewrite expvSl prod0v. Qed.
 
-Lemma expv1n n : (1 ^+ n = 1)%VS.
-Proof. by elim: n => // n IHn; rewrite expvSl IHn prodv1. Qed.
+Lemma expv1n : left_zero 1%VS expv.
+Proof. by elim=> // n IHn; rewrite expvSl IHn prodv1. Qed.
 
 Lemma expvD U m n : (U ^+ (m + n) = U ^+ m * U ^+ n)%VS.
 Proof. by elim: m => [|m IHm]; rewrite ?prod1v // !expvSl IHm prodvA. Qed.

--- a/mathcomp/fingroup/fingroup.v
+++ b/mathcomp/fingroup/fingroup.v
@@ -440,8 +440,8 @@ Lemma expg1 x : x ^+ 1 = x. Proof. by []. Qed.
 Lemma expgS x n : x ^+ n.+1 = x * x ^+ n.
 Proof. by case: n => //; rewrite mulg1. Qed.
 
-Lemma expg1n n : 1 ^+ n = 1 :> T.
-Proof. by elim: n => // n IHn; rewrite expgS mul1g. Qed.
+Lemma expg1n : left_zero (1 : T) expgn.
+Proof. by elim=> // n IHn; rewrite expgS mul1g. Qed.
 
 Lemma expgD x n m : x ^+ (n + m) = x ^+ n * x ^+ m.
 Proof. by elim: n => [|n IHn]; rewrite ?mul1g // !expgS IHn mulgA. Qed.
@@ -455,8 +455,8 @@ elim: m => [|m IHm]; first by rewrite muln0 expg0.
 by rewrite mulnS expgD IHm expgS.
 Qed.
 
-Lemma expgAC x m n : x ^+ m ^+ n = x ^+ n ^+ m.
-Proof. by rewrite -!expgM mulnC. Qed.
+Lemma expgAC : right_commutative (@expgn T).
+Proof. by move=> x m n; rewrite -!expgM mulnC. Qed.
 
 Definition commute x y := x * y = y * x.
 
@@ -545,14 +545,14 @@ Proof. by rewrite mulKVg. Qed.
 Lemma conjgCV x y : x * y = y ^ x^-1 * x.
 Proof. by rewrite -mulgA mulgKV invgK. Qed.
 
-Lemma conjg1 x : x ^ 1 = x.
-Proof. by rewrite conjgE commute1 mulKg. Qed.
+Lemma conjg1 : right_id (1 : T) conjg.
+Proof. by move=> x; rewrite conjgE commute1 mulKg. Qed.
 
-Lemma conj1g x : 1 ^ x = 1.
-Proof. by rewrite conjgE mul1g mulVg. Qed.
+Lemma conj1g : left_zero (1 : T) conjg.
+Proof. by move=> x; rewrite conjgE mul1g mulVg. Qed.
 
-Lemma conjMg x y z : (x * y) ^ z = x ^ z * y ^ z.
-Proof. by rewrite !conjgE !mulgA mulgK. Qed.
+Lemma conjMg : left_distributive (@conjg T) mulg.
+Proof. by move=> x y z; rewrite !conjgE !mulgA mulgK. Qed.
 
 Lemma conjgM x y z : x ^ (y * z) = (x ^ y) ^ z.
 Proof. by rewrite !conjgE invMg !mulgA. Qed.
@@ -560,8 +560,8 @@ Proof. by rewrite !conjgE invMg !mulgA. Qed.
 Lemma conjVg x y : x^-1 ^ y = (x ^ y)^-1.
 Proof. by rewrite !conjgE !invMg invgK mulgA. Qed.
 
-Lemma conjJg x y z : (x ^ y) ^ z = (x ^ z) ^ y ^ z.
-Proof. by rewrite 2!conjMg conjVg. Qed.
+Lemma conjJg : left_distributive (@conjg T) conjg.
+Proof. by move=> x y z; rewrite 2!conjMg conjVg. Qed.
 
 Lemma conjXg x y n : (x ^+ n) ^ y = (x ^ y) ^+ n.
 Proof. by elim: n => [|n IHn]; rewrite ?conj1g // !expgS conjMg IHn. Qed.
@@ -595,8 +595,8 @@ Proof. by rewrite -mulgA !mulKVg. Qed.
 Lemma commgCV x y : x * y = [~ x^-1, y^-1] * (y * x).
 Proof. by rewrite commgEl !mulgA !invgK !mulgKV. Qed.
 
-Lemma conjRg x y z : [~ x, y] ^ z = [~ x ^ z, y ^ z].
-Proof. by rewrite !conjMg !conjVg. Qed.
+Lemma conjRg : left_distributive (@conjg T) commg.
+Proof. by move=> x y z; rewrite !conjMg !conjVg. Qed.
 
 Lemma invg_comm x y : [~ x, y]^-1 = [~ y, x].
 Proof. by rewrite commgEr conjVg invMg invgK. Qed.
@@ -610,11 +610,11 @@ Proof. by rewrite -eq_mulVg1 eq_sym; apply: eqP. Qed.
 Lemma commg1_sym x y : ([~ x, y] == 1 :> T) = ([~ y, x] == 1 :> T).
 Proof. by rewrite -invg_comm (inv_eq invgK) invg1. Qed.
 
-Lemma commg1 x : [~ x, 1] = 1.
-Proof. exact/eqP/commgP. Qed.
+Lemma commg1 : right_zero (1 : T) commg.
+Proof. by move=> x; exact/eqP/commgP. Qed.
 
-Lemma comm1g x : [~ 1, x] = 1.
-Proof. by rewrite -invg_comm commg1 invg1. Qed.
+Lemma comm1g : left_zero (1 : T) commg.
+Proof. by move=> x; rewrite -invg_comm commg1 invg1. Qed.
 
 Lemma commgg x : [~ x, x] = 1.
 Proof. exact/eqP/commgP. Qed.
@@ -622,8 +622,8 @@ Proof. exact/eqP/commgP. Qed.
 Lemma commgXg x n : [~ x, x ^+ n] = 1.
 Proof. exact/eqP/commgP/commuteX. Qed.
 
-Lemma commgVg x : [~ x, x^-1] = 1.
-Proof. exact/eqP/commgP/commuteV. Qed.
+Lemma commgVg : right_inverse (1 : T) invg commg.
+Proof. move=> x; exact/eqP/commgP/commuteV. Qed.
 
 Lemma commgXVg x n : [~ x, x ^- n] = 1.
 Proof. exact/eqP/commgP/commuteV/commuteX. Qed.
@@ -895,10 +895,10 @@ Proof. by move=> B1; rewrite -{1}(mulg1 A) mulgS ?sub1set. Qed.
 Lemma mulg_subr A B : 1 \in A -> B \subset A * B.
 Proof. by move=> A1; rewrite -{1}(mul1g B) mulSg ?sub1set. Qed.
 
-Lemma mulUg A B C : (A :|: B) * C = (A * C) :|: (B * C).
+Lemma mulUg : left_distributive mulg (@setU gT).
 Proof. exact: imset2Ul. Qed.
 
-Lemma mulgU A B C : A * (B :|: C) = (A * B) :|: (A * C).
+Lemma mulgU : right_distributive mulg (@setU gT).
 Proof. exact: imset2Ur. Qed.
 
 (* Set (pointwise) inverse. *)
@@ -1099,17 +1099,17 @@ Proof. by rewrite -(conjSg _ B x) conjsgKV. Qed.
 Lemma conjg_set1 x y : [set x] :^ y = [set x ^ y].
 Proof. by rewrite [_ :^ _]imset_set1. Qed.
 
-Lemma conjs1g x : 1 :^ x = 1.
-Proof. by rewrite conjg_set1 conj1g. Qed.
+Lemma conjs1g : left_zero 1 (@conjugate gT).
+Proof. by move=> x; rewrite conjg_set1 conj1g. Qed.
 
 Lemma conjsg_eq1 A x : (A :^ x == 1%g) = (A == 1%g).
 Proof. by rewrite (canF_eq (conjsgK x)) conjs1g. Qed.
 
-Lemma conjsMg A B x : (A * B) :^ x = A :^ x * B :^ x.
-Proof. by rewrite !conjsgE !mulgA rcosetK. Qed.
+Lemma conjsMg : left_distributive (@conjugate gT) mulg.
+Proof. by move=> A B x; rewrite !conjsgE !mulgA rcosetK. Qed.
 
-Lemma conjIg A B x : (A :&: B) :^ x = A :^ x :&: B :^ x.
-Proof. by rewrite !conjg_preim preimsetI. Qed.
+Lemma conjIg : left_distributive conjugate (@setI gT).
+Proof. by move=> A B x; rewrite !conjg_preim preimsetI. Qed.
 
 Lemma conj0g x : set0 :^ x = set0.
 Proof. exact: imset0. Qed.
@@ -2201,8 +2201,8 @@ Proof.
 by apply/eqP; rewrite eqEsubset sub_conjg !gen_subG conjSg -?sub_conjg !sub_gen.
 Qed.
 
-Lemma conjYg A B z : (A <*> B) :^z = A :^ z <*> B :^ z.
-Proof. by rewrite -genJ conjUg. Qed.
+Lemma conjYg : left_distributive conjugate (@joing gT).
+Proof. by move=> A B z; rewrite -genJ conjUg. Qed.
 
 Lemma genD1 A x : x \in <<A :\ x>> -> <<A :\ x>> = <<A>>.
 Proof.
@@ -2351,16 +2351,16 @@ Proof.
 by move=> sAG sBG; apply: subset_trans (der1_subG G); apply: commgSS.
 Qed.
 
-Lemma commGC A B : [~: A, B] = [~: B, A].
+Lemma commGC : commutative (@commutator gT).
 Proof.
-rewrite -[[~: A, B]]genV; congr <<_>>; apply/setP=> z; rewrite inE.
+move=> A B; rewrite -[[~: A, B]]genV; congr <<_>>; apply/setP=> z; rewrite inE.
 by apply/imset2P/imset2P=> [] [x y Ax Ay]; last rewrite -{1}(invgK z);
   rewrite -invg_comm => /invg_inj->; exists y x.
 Qed.
 
-Lemma conjsRg A B x : [~: A, B] :^ x = [~: A :^ x, B :^ x].
+Lemma conjsRg : left_distributive conjugate (@commutator gT).
 Proof.
-wlog suffices: A B x / [~: A, B] :^ x \subset [~: A :^ x, B :^ x].
+move=> A B x; wlog suffices: A B x / [~: A, B] :^ x \subset [~: A :^ x, B :^ x].
   move=> subJ; apply/eqP; rewrite eqEsubset subJ /= -sub_conjgV.
   by rewrite -{2}(conjsgK x A) -{2}(conjsgK x B).
 rewrite -genJ gen_subG; apply/subsetP=> _ /imsetP[_ /imset2P[y z Ay Bz ->] ->].

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -248,8 +248,8 @@ Proof. by case: tpermP. Qed.
 Lemma tpermD x y z : x != z -> y != z -> tperm x y z = z.
 Proof. by case: tpermP => // ->; rewrite eqxx. Qed.
 
-Lemma tpermC x y : tperm x y = tperm y x.
-Proof. by apply/permP => z; do 2![case: tpermP => //] => ->. Qed.
+Lemma tpermC : commutative tperm.
+Proof. by move=> x y; apply/permP => z; do 2![case: tpermP => //] => ->. Qed.
 
 Lemma tperm1 x : tperm x x = 1.
 Proof. by apply/permP => z; rewrite perm1; case: tpermP. Qed.

--- a/mathcomp/ssreflect/div.v
+++ b/mathcomp/ssreflect/div.v
@@ -84,9 +84,9 @@ Proof. by rewrite /divn modn_def; case: (edivn m d). Qed.
 Lemma divn_eq m d : m = m %/ d * d + m %% d.
 Proof. by rewrite /divn modn_def; case: edivnP. Qed.
 
-Lemma div0n d : 0 %/ d = 0. Proof. by case: d. Qed.
+Lemma div0n : left_zero 0 divn. Proof. by case. Qed.
 Lemma divn0 m : m %/ 0 = 0. Proof. by []. Qed.
-Lemma mod0n d : 0 %% d = 0. Proof. by case: d. Qed.
+Lemma mod0n : left_zero 0 modn. Proof. by case. Qed.
 Lemma modn0 m : m %% 0 = m. Proof. by []. Qed.
 
 Lemma divn_small m d : m < d -> m %/ d = 0.
@@ -245,8 +245,8 @@ rewrite [in RHS](divn_eq m (n.+1 * p.+1)) mulnA mulnAC !divnMDl //.
 by rewrite [_ %/ p.+1]divn_small ?addn0 // ltn_divLR // mulnC ltn_mod.
 Qed.
 
-Lemma divnAC m n p : m %/ n %/ p =  m %/ p %/ n.
-Proof. by rewrite -!divnMA mulnC. Qed.
+Lemma divnAC : right_commutative divn.
+Proof. by move=> m n p; rewrite -!divnMA mulnC. Qed.
 
 Lemma modn_small m d : m < d -> m %% d = m.
 Proof. by move=> lt_md; rewrite [RHS](divn_eq m d) divn_small. Qed.
@@ -260,14 +260,14 @@ have [->|d_gt0] := posnP d; first by rewrite muln0.
 by rewrite [in LHS](divn_eq m d) addnA -mulnDl modn_def edivn_eq // ltn_mod.
 Qed.
 
-Lemma muln_modr p m d : p * (m %% d) = (p * m) %% (p * d).
+Lemma muln_modr : right_distributive muln modn.
 Proof.
-have [->//|p_gt0] := posnP p; apply: (@addnI (p * (m %/ d * d))).
+move=> p m d; have [->//|p_gt0] := posnP p; apply: (@addnI (p * (m %/ d * d))).
 by rewrite -mulnDr -divn_eq mulnCA -(divnMl p_gt0) -divn_eq.
 Qed.
 
-Lemma muln_modl p m d : (m %% d) * p = (m * p) %% (d * p).
-Proof. by rewrite -!(mulnC p); apply: muln_modr. Qed.
+Lemma muln_modl : left_distributive muln modn.
+Proof. by move=> m d p; rewrite -!(mulnC p); apply: muln_modr. Qed.
 
 Lemma modn_divl m n d : (m %/ d) %% n = m %% (n * d) %/ d.
 Proof.
@@ -282,7 +282,8 @@ Proof. by rewrite -[m %% _](modnMDl 1) mul1n. Qed.
 
 Lemma modnDr m d : m + d = m %[mod d]. Proof. by rewrite addnC modnDl. Qed.
 
-Lemma modnn d : d %% d = 0. Proof. by rewrite [d %% d](modnDr 0) mod0n. Qed.
+Lemma modnn : self_inverse 0 modn.
+Proof. by move=> d; rewrite [d %% d](modnDr 0) mod0n. Qed.
 
 Lemma modnMl p d : p * d %% d = 0.
 Proof. by rewrite -[p * d]addn0 modnMDl mod0n. Qed.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -3718,8 +3718,8 @@ Proof. by move=> x y z; rewrite !meetA [X in X `&` _]meetC. Qed.
 Lemma meetACA : interchange (@meet _ L) (@meet _ L).
 Proof. by move=> x y z t; rewrite !meetA [X in X `&` _]meetAC. Qed.
 
-Lemma meetxx x : x `&` x = x.
-Proof. by rewrite -[X in _ `&` X](meetKU x) joinKI. Qed.
+Lemma meetxx : idempotent (@meet _ L).
+Proof. by move=> x; rewrite -[X in _ `&` X](meetKU x) joinKI. Qed.
 
 Lemma meetKI y x : x `&` (x `&` y) = x `&` y.
 Proof. by rewrite meetA meetxx. Qed.
@@ -3792,7 +3792,7 @@ Proof. exact: (@meetCA _ [latticeType of L^d]). Qed.
 Lemma joinACA : interchange (@join _ L) (@join _ L).
 Proof. exact: (@meetACA _ [latticeType of L^d]). Qed.
 
-Lemma joinxx x : x `|` x = x.
+Lemma joinxx : idempotent (@join _ L).
 Proof. exact: (@meetxx _ [latticeType of L^d]). Qed.
 
 Lemma joinKU y x : x `|` (x `|` y) = x `|` y.
@@ -4603,7 +4603,8 @@ Lemma leBx x y : x `\` y <= x.
 Proof. by rewrite -{2}[x](joinIB y) lexU2 // lexx orbT. Qed.
 Hint Resolve leBx : core.
 
-Lemma subxx x : x `\` x = 0. Proof. by have := subKI x x; rewrite meet_r. Qed.
+Lemma subxx : self_inverse (0 : L) sub.
+Proof. by move=> x; have := subKI x x; rewrite meet_r. Qed.
 
 Lemma leBl z x y : x <= y -> x `\` z <= y `\` z.
 Proof.
@@ -4632,9 +4633,9 @@ apply/idP/idP; first by move=> /join_r <-; rewrite joinA subKU joinAC leUr.
 by rewrite -{1}[x](joinIB y) => /(leU2r_le (subIK _ _)).
 Qed.
 
-Lemma subUx x y z : (x `|` y) `\` z = (x `\` z) `|` (y `\` z).
+Lemma subUx : @left_distributive L L sub join.
 Proof.
-apply/eqP; rewrite eq_le leUx !leBl ?leUr ?leUl ?andbT //.
+move=> x y z; apply/eqP; rewrite eq_le leUx !leBl ?leUr ?leUl ?andbT //.
 by rewrite leBLR joinA subKU joinAC subKU joinAC -joinA leUr.
 Qed.
 
@@ -4675,15 +4676,15 @@ rewrite leBRL leIx2 ?leBx //= meetUr meetAC subIK -meetA subIK.
 by rewrite meet0x meetx0 joinx0.
 Qed.
 
-Lemma subx0 x : x `\` 0 = x.
-Proof. by apply/eqP; rewrite eq_sub join0x meetx0 lexx eqxx. Qed.
+Lemma subx0 : right_id (0 : L) sub.
+Proof. by move=> x; apply/eqP; rewrite eq_sub join0x meetx0 lexx eqxx. Qed.
 
-Lemma sub0x x : 0 `\` x = 0.
-Proof. by apply/eqP; rewrite eq_sub joinx0 meet0x lexx eqxx le0x. Qed.
+Lemma sub0x : left_zero (0 : L) sub.
+Proof. by move=> x; apply/eqP; rewrite eq_sub joinx0 meet0x lexx eqxx le0x. Qed.
 
-Lemma subIx x y z : (x `&` y) `\` z = (x `\` z) `&` (y `\` z).
+Lemma subIx : @left_distributive L L sub meet.
 Proof.
-apply/eqP; rewrite eq_sub joinIr ?leI2 ?subKU ?leUr ?leBx //=.
+move=> x y z; apply/eqP; rewrite eq_sub joinIr ?leI2 ?subKU ?leUr ?leBx //=.
 by rewrite -meetA subIK meetx0.
 Qed.
 
@@ -4774,17 +4775,17 @@ Proof. by rewrite !complE subxU. Qed.
 Lemma complI  x y : ~` (x `&` y) = ~` x `|` ~` y.
 Proof. by rewrite !complE subxI. Qed.
 
-Lemma joinxC  x :  x `|` ~` x = 1.
-Proof. by rewrite complE subKU joinx1. Qed.
+Lemma joinxC : right_inverse (1 : L) compl join.
+Proof. by move=> x; rewrite complE subKU joinx1. Qed.
 
-Lemma joinCx  x : ~` x `|` x = 1.
-Proof. by rewrite joinC joinxC. Qed.
+Lemma joinCx : left_inverse (1 : L) compl join.
+Proof. by move=> x; rewrite joinC joinxC. Qed.
 
-Lemma meetxC  x :  x `&` ~` x = 0.
-Proof. by rewrite complE subKI. Qed.
+Lemma meetxC : right_inverse (0 : L) compl meet.
+Proof. by move=> x; rewrite complE subKI. Qed.
 
-Lemma meetCx  x : ~` x `&` x = 0.
-Proof. by rewrite meetC meetxC. Qed.
+Lemma meetCx : left_inverse (0 : L) compl meet.
+Proof. by move=> x; rewrite meetC meetxC. Qed.
 
 Lemma compl1 : ~` 1 = 0 :> L.
 Proof. by rewrite complE subxx. Qed.
@@ -5918,8 +5919,8 @@ Section NatDvd.
 
 Implicit Types m n p : nat.
 
-Lemma lcmnn n : lcmn n n = n.
-Proof. by case: n => // n; rewrite /lcmn gcdnn mulnK. Qed.
+Lemma lcmnn : idempotent lcmn.
+Proof. by case=> // n; rewrite /lcmn gcdnn mulnK. Qed.
 
 Lemma le_def m n : m %| n = (gcdn m n == m)%N.
 Proof. by apply/gcdn_idPl/eqP. Qed.
@@ -7013,8 +7014,8 @@ Proof. by elim=> [|? ? ih] [|? ?] [|? ?] //=; rewrite meetA ih. Qed.
 Fact joinA : associative join.
 Proof. by elim=> [|? ? ih] [|? ?] [|? ?] //=; rewrite joinA ih. Qed.
 
-Fact meetss s : meet s s = s.
-Proof. by elim: s => [|? ? ih] //=; rewrite meetxx ih. Qed.
+Fact meetss : idempotent meet.
+Proof. by elim=> [|? ? ih] //=; rewrite meetxx ih. Qed.
 
 Fact joinKI y x : meet x (join x y) = x.
 Proof.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -1447,8 +1447,8 @@ Lemma traject_iteri x n :
   traject x n = iteri n (fun i => rcons^~ (iter i f x)) [::].
 Proof. by elim: n => //= n <-; rewrite -trajectSr. Qed.
 
-Lemma size_traject x n : size (traject x n) = n.
-Proof. by elim: n x => //= n IHn x //=; rewrite IHn. Qed.
+Lemma size_traject x : cancel (traject x) size.
+Proof. by move=> n; elim: n x => //= n IHn x; rewrite IHn. Qed.
 
 Lemma nth_traject i n : i < n -> forall x, nth x (traject x n) i = iter i f x.
 Proof.

--- a/mathcomp/ssreflect/prime.v
+++ b/mathcomp/ssreflect/prime.v
@@ -414,9 +414,9 @@ Qed.
 Lemma Euclid_dvd1 p : prime p -> (p %| 1) = false.
 Proof. by rewrite dvdn1; case: eqP => // ->. Qed.
 
-Lemma Euclid_dvdM m n p : prime p -> (p %| m * n) = (p %| m) || (p %| n).
+Lemma Euclid_dvdM p : prime p -> {morph dvdn p : x y / x * y >-> x || y}.
 Proof.
-move=> pr_p; case dv_pm: (p %| m); first exact: dvdn_mulr.
+move=> pr_p m n; case dv_pm: (p %| m); first exact: dvdn_mulr.
 by rewrite Gauss_dvdr // prime_coprime // dv_pm.
 Qed.
 
@@ -424,7 +424,7 @@ Lemma Euclid_dvd_prod (I : Type) (r : seq I) (P : pred I) (f : I -> nat) p :
   prime p ->  
   p %| \prod_(i <- r | P i) f i = \big[orb/false]_(i <- r | P i) (p %| f i).
 Proof.
-move=> pP; apply: big_morph=> [x y|]; [exact: Euclid_dvdM | exact: Euclid_dvd1].
+move=> pP; apply: big_morph; [exact: Euclid_dvdM | exact: Euclid_dvd1].
 Qed.
 
 Lemma Euclid_dvdX m n p : prime p -> (p %| m ^ n) = (p %| m) && (n > 0).

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -90,7 +90,7 @@ Require Export Ring.
 (*   V (infix) -- disjunction, as in                                          *)
 (*      leq_eqVlt : (m <= n) = (m == n) || (m < n).                           *)
 (*   X - exponentiation, as in lognX : logn p (m ^ n) = logn p m * n in       *)
-(*         file prime.v (the suffix is not used in this file).                 *)
+(*         file prime.v (the suffix is not used in this file).                *)
 (* Suffixes that abbreviate operations (D, B, M and X) are used to abbreviate *)
 (* second-rank operations in equational lemma names that describe left-hand   *)
 (* sides (e.g., mulnDl); they are not used to abbreviate the main operation   *)
@@ -1156,14 +1156,14 @@ Proof. by rewrite iter_muln muln1. Qed.
 
 Lemma exp0n n : 0 < n -> 0 ^ n = 0. Proof. by case: n => [|[]]. Qed.
 
-Lemma exp1n n : 1 ^ n = 1.
-Proof. by elim: n => // n; rewrite expnS mul1n. Qed.
+Lemma exp1n : left_zero 1 expn.
+Proof. by elim=> // n; rewrite expnS mul1n. Qed.
 
 Lemma expnD m n1 n2 : m ^ (n1 + n2) = m ^ n1 * m ^ n2.
 Proof. by elim: n1 => [|n1 IHn]; rewrite !(mul1n, expnS) // IHn mulnA. Qed.
 
-Lemma expnMn m1 m2 n : (m1 * m2) ^ n = m1 ^ n * m2 ^ n.
-Proof. by elim: n => // n IHn; rewrite !expnS IHn -!mulnA (mulnCA m2). Qed.
+Lemma expnMn : left_distributive expn muln.
+Proof. by move=> m1 m2; elim=> // n IHn; rewrite !expnS IHn mulnACA. Qed.
 
 Lemma expnM m n1 n2 : m ^ (n1 * n2) = (m ^ n1) ^ n2.
 Proof.
@@ -1171,8 +1171,8 @@ elim: n1 => [|n1 IHn]; first by rewrite exp1n.
 by rewrite expnD expnS expnMn IHn.
 Qed.
 
-Lemma expnAC m n1 n2 : (m ^ n1) ^ n2 = (m ^ n2) ^ n1.
-Proof. by rewrite -!expnM mulnC. Qed.
+Lemma expnAC : right_commutative expn.
+Proof. by move=> m n1 n2; rewrite -!expnM mulnC. Qed.
 
 Lemma expn_gt0 m n : (0 < m ^ n) = (0 < m) || (n == 0).
 Proof.
@@ -1376,8 +1376,7 @@ Proof. by elim=> //= n ->. Qed.
 Definition half_double := doubleK.
 Definition double_inj := can_inj doubleK.
 
-Lemma uphalf_double n : uphalf n.*2 = n.
-Proof. by elim: n => //= n ->. Qed.
+Lemma uphalf_double : cancel double uphalf. Proof. by elim=> //= n ->. Qed.
 
 Lemma uphalf_half n : uphalf n = odd n + n./2.
 Proof. by elim: n => //= n ->; rewrite addnA addn_negb. Qed.


### PR DESCRIPTION
##### Motivation for this change

This PR attempts to restate several lemmas using predicators such as `cancel`, `(left|right)_(id|zero|inverse|distributive)`, `idempotent`, `associative`, and `commutative`. Some of them are probably too aggressive and I would like to have comments on this point.

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  - If the ordering of arguments are changed, it has to be mentioned explicitly.
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
