### PR TITLE
Be robust to a change in the default argument naming algorithm.

### DIFF
--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -1700,7 +1700,7 @@ Arguments rootP {R p x}.
 Arguments rootPf {R p x}.
 Arguments rootPt {R p x}.
 Arguments unity_rootP {R n z}.
-Arguments polyOverP {R S0 addS kS p}.
+Arguments polyOverP {R S0 addS kS p} : rename.
 Arguments polyC_inj {R} [x1 x2] eq_x12P.
 Arguments eq_poly {R n} [E1] E2 eq_E12.
 


### PR DESCRIPTION
##### Motivation for this change

Overlay for coq/coq#12756, in which the default argument name changes to just `S` from `S0`. This change preserves the old name; switching instead to use `S` may be preferable but introduces a potential impact on downstream users of mathcomp.
Should be entirely backwards compatible.

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
