### PR TITLE
fix notation-incompatible-format warnings

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- in ssrbool.v, use `Reserved Notation` for `[rel _ _ : _ | _]` to avoid warnings with coq-8.12
+
 ### Renamed
 
 ### Removed

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -38,10 +38,14 @@ Definition SimplRel {T} (r : rel T) : simpl_rel T := fun x => SimplPred (r x).
 Coercion rel_of_simpl_rel T (sr : simpl_rel T) : rel T := sr.
 Arguments rel_of_simpl_rel {T} sr x / y : rename.
 
+(* Required to avoid an incompatible format warning with coq-8.12 *)
+Reserved Notation "[ 'rel' x y : T | E ]" (at level 0, x ident, y ident,
+  format "'[hv' [ 'rel'  x  y  :  T  | '/ '  E ] ']'").
+
 Notation "[ 'rel' x y | E ]" := (SimplRel (fun x y => E%B)) (at level 0,
   x ident, y ident, format "'[hv' [ 'rel'  x  y  | '/ '  E ] ']'") : fun_scope.
-Notation "[ 'rel' x y : T | E ]" := (SimplRel (fun x y : T => E%B)) (at level 0,
-  x ident, y ident, only parsing) : fun_scope.
+Notation "[ 'rel' x y : T | E ]" := (SimplRel (fun x y : T => E%B)) 
+  (only parsing) : fun_scope.
 Notation "[ 'rel' x y 'in' A & B | E ]" :=
   [rel x y | (x \in A) && (y \in B) && E] (at level 0, x ident, y ident,
   format "'[hv' [ 'rel'  x  y  'in'  A  &  B  | '/ '  E ] ']'") : fun_scope.


### PR DESCRIPTION
##### Motivation for this change

[notation-incompatible-format warnings are everywhere in 8.12](https://coq.zulipchat.com/#narrow/stream/237665-math-comp-devs/topic/notation-incompatible-format.20warnings.20are.20everywhere.20in.208.2E12) (Zulip conversation)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
