### PR TITLE
chore: refactor GitLab CI config a bit to lighten nightly builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,8 +98,12 @@ coq-8.11:
   extends: .opam-build-once
 
 coq-8.12:
-  # to be replaced with .opam-build-once when 8.12.0 available
-  extends: .opam-build
+  extends: .opam-build-once
+
+# to uncomment when 8.13+alpha available
+# coq-8.13:
+#   # to be replaced with .opam-build-once when 8.13.0 available
+#   extends: .opam-build
 
 coq-dev:
   extends: .opam-build
@@ -448,8 +452,12 @@ mathcomp-dev:coq-8.11:
   extends: .docker-deploy-once
 
 mathcomp-dev:coq-8.12:
-  # to be replaced with .docker-deploy-once when 8.12.0 available
-  extends: .docker-deploy
+  extends: .docker-deploy-once
+
+# to uncomment when 8.13+alpha available
+# mathcomp-dev:coq-8.13:
+#   # to be replaced with .docker-deploy-once when 8.13.0 available
+#   extends: .docker-deploy
 
 mathcomp-dev:coq-dev:
   extends: .docker-deploy


### PR DESCRIPTION
##### Motivation for this change

* jobs {coq-8.12, mathcomp-dev:coq-8.12} are unneeded in [this scheduled pipeline](https://gitlab.com/math-comp/math-comp/-/pipelines/182928354), now that 8.12.0 is tagged.

* Insert commented jobs for upcoming coq-8.13 as well.

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
