### PR TITLE
Adding allrel predicate

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -42,6 +42,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   coefficient.
 
 - in `poly.v`, new lemma `commr_horner`.
+- in `seq.v`, new lemma `mkseqP` to abstract a sequence `s` with
+  `mkseq f n`, where `f` and `n` are fresh variables.
+
+- in `seq.v`, new high-order predicate `allrel r s` which
+  asserts that a relation `r` holds on all pairs of elements of `s`, and
+  + lemmas `allrel_map`, `allrelP` and `allrel0`.
+  + lemmas `allrel1`, `allrel2` and `allrel_cons`,
+    under assumptions of reflexivity and symmetry of `r`.
 
 ### Changed
 


### PR DESCRIPTION
##### Motivation for this change

<!-- please explain your reason for doing this change -->

This predicate is useful in stating that a sequence of matrices all commute.
This is a part of #207.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.