### PR TITLE
Adding [row|col]_[udlr]submx lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -83,6 +83,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     * `mxOver S` is a subring for square matrices if `S` is.
 - in `matrix.v` new lemmas about `map_mx`: `map_mx_id`, `map_mx_comp`,
   `eq_in_map_mx`, `eq_map_mx` and `map_mx_id_in`.
+- in `matrix.v`, new lemmas `row_usubmx`, `row_dsubmx`, `col_lsubmx`,
+  and `col_rsubmx`.
 
 ### Changed
 

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -607,6 +607,18 @@ Proof. by split_mxE. Qed.
 Lemma col_mx_const a : col_mx (const_mx a) (const_mx a) = const_mx a.
 Proof. by split_mxE. Qed.
 
+Lemma row_usubmx A i : row i (usubmx A) = row (lshift m2 i) A.
+Proof. by apply/rowP=> j; rewrite !mxE; congr (A _ _); apply/val_inj. Qed.
+
+Lemma row_dsubmx A i : row i (dsubmx A) = row (rshift m1 i) A.
+Proof. by apply/rowP=> j; rewrite !mxE; congr (A _ _); apply/val_inj. Qed.
+
+Lemma col_lsubmx A i : col i (lsubmx A) = col (lshift n2 i) A.
+Proof. by apply/colP=> j; rewrite !mxE; congr (A _ _); apply/val_inj. Qed.
+
+Lemma col_rsubmx A i : col i (rsubmx A) = col (rshift n1 i) A.
+Proof. by apply/colP=> j; rewrite !mxE; congr (A _ _); apply/val_inj. Qed.
+
 End CutPaste.
 
 Lemma trmx_lsub m n1 n2 (A : 'M_(m, n1 + n2)) : (lsubmx A)^T = usubmx A^T.


### PR DESCRIPTION
##### Motivation for this change

Combining `row` and `col` with block submatrices.
Part of #207.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.