### PR TITLE
Submatrix theory

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -137,6 +137,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   dual lattices.
 - in `finset.v` new lemma `disjoints1`
 - in `fintype.v` new lemmas: `disjointFr`, `disjointFl`, `disjointWr`, `disjointW`
+- in `fintype.v`, new (pigeonhole) lemmas `leq_card_in`, `leq_card`,
+  and `inj_leq`.
+
+- in `matrix.v`, new definition `mxsub`, `rowsub` and `colsub`,
+  corresponding to arbitrary submatrices/reindexation of a matrix.
+  + We provide the theorems `x?(row|col)(_perm|')?Esub`, `t?permEsub`
+    `[lrud]submxEsub`, `(ul|ur|dl|dr)submxEsub` for compatibility with
+    ad-hoc submatrices/permutations.
+  + We provide a new, configurable, induction lemma `mxsub_ind`.
+  + We provide the basic theory `mxsub_id`, `eq_mxsub`, `eq_rowsub`,
+    `eq_colsub`, `mxsub_eq_id`, `mxsub_eq_colsub`, `mxsub_eq_rowsub`,
+    `mxsub_ffunl`, `mxsub_ffunr`, `mxsub_ffun`, `mxsub_const`,
+    `mxsub_comp`, `rowsub_comp`, `colsub_comp`, `mxsubrc`, `mxsubcr`,
+    `trmx_mxsub`, `row_mxsub`, `col_mxsub`, `row_rowsub`,
+    `col_colsub`, and `map_mxsub`, `pid_mxErow` and `pid_mxEcol`.
+  + Interaction with `castmx` through lemmas `rowsub_cast`,
+    `colsub_cast`, `mxsub_cast`, and `castmxEsub`.
+  + `(mx|row|col)sub` are canonically additive and linear.
+  + Interaction with `mulmx` through lemmas `mxsub_mul`,
+    `mul_rowsub_mx`, `mulmx_colsub`, and `rowsubE`.
+
+- in `mxalgebra.v`, new lemma `rowsub_sub`, `eq_row_full`,
+  `row_full_castmx`, `row_free_castmx`, `rowsub_comp_sub`,
+  `submx_rowsub`, `eqmx_rowsub_comp_perm`, `eqmx_rowsub_comp`,
+  `eqmx_rowsub`, `row_freePn`, and `negb_row_free`.
+
 
 - in `interval.v`:
   + Intervals and their bounds of `T` now have canonical ordered type instances

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -1281,6 +1281,9 @@ apply: (iffP eqP) => [eqfA |]; last exact: card_in_image.
 by apply/dinjectiveP; apply/card_uniqP; rewrite size_map -cardE.
 Qed.
 
+Lemma leq_card_in A : {in A &, injective f} -> #|A| <= #|T'|.
+Proof. by move=> /card_in_image <-; rewrite max_card. Qed.
+
 Hypothesis injf : injective f.
 
 Lemma card_image A : #|image f A| = #|A|.
@@ -1295,6 +1298,8 @@ rewrite -card_image /=; apply: eq_card => y.
 by rewrite [y \in _]image_pre !inE andbC.
 Qed.
 
+Lemma leq_card : #|T| <= #|T'|. Proof. exact: (leq_card_in (in2W _)). Qed.
+
 Hypothesis card_range : #|T| = #|T'|.
 
 Lemma inj_card_onto y : y \in codom f.
@@ -1308,6 +1313,8 @@ Qed.
 End CardFunImage.
 
 Arguments image_injP {T T' f A}.
+Arguments leq_card_in [T T'] f.
+Arguments leq_card [T T'] f.
 
 Section FinCancel.
 
@@ -1865,6 +1872,10 @@ Qed.
 
 Lemma rev_ord_inj {n} : injective (@rev_ord n).
 Proof. exact: inv_inj rev_ordK. Qed.
+
+Lemma inj_leq m n (f : 'I_m -> 'I_n) : injective f -> m <= n.
+Proof. by move=> /leq_card; rewrite !card_ord. Qed.
+Arguments inj_leq [m n] f _.
 
 (* bijection between any finType T and the Ordinal finType of its cardinal *)
 Section EnumRank.


### PR DESCRIPTION
##### Motivation for this change

This PR introduces arbitrary sub/reindexed - matrices, and provides a correspondance to all other specific instances in the library (`row`, `row'`, `xrow`, ...). This is an important prerequisite to the theory of minors. We also provide lemma `row_freePn` which states that in a row non-free matrix, one line is a linear combination of the others (i.e. `(row i A <= row' i A)%MS`).

Part of #207.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] Merge dependency: #569
- [x] Merge dependency: #570
- [x] Merge dependency: #572
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.