### PR TITLE
Kernel lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -163,6 +163,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (e.g. with `raddf_eq0`), and lemma `inj_row_free` characterizing
   `row_free` matrices `A`  through `v *m A = 0 -> v = 0` for all `v`.
 
+- in `mxpoly.v`,
+  + new definitions `kermxpoly g p` (the kernel of polynomial $p(g)$).
+    * new elementary theorems: `kermxpolyC`, `kermxpoly1`,
+      `kermxpolyX`, `kermxpoly_min`
+    * kernel lemmas: `mxdirect_kermxpoly`, `kermxpolyM`,
+      `kermxpoly_prod`, and `mxdirect_sum_kermx`
+    * correspondance between `eigenspace` and `kermxpoly`: `eigenspace_poly`
+  + generalized eigenspace `geigenspace` and a generalization of eigenvalues
+    called `eigenpoly g` (i.e. polynomials such that `kermxpoly g p`
+    is nonzero, e.g. eigen polynomials of degree 1 are of the form
+    `'X - a%:P` where `a` are eigenvalues), and
+    * correspondance with `kermx`: `geigenspaceE`,
+    * application of kernel lemmas `mxdirect_sum_geigenspace`,
+    * new lemmas: `eigenpolyP`, `eigenvalue_poly`, `eigenspace_sub_geigen`,
+  + new `map_mx` lemmas: `map_kermxpoly`, `map_geigenspace`, `eigenpoly_map`.
 
 ### Changed
 


### PR DESCRIPTION
##### Motivation for this change

- new definitions `kermxpoly g p` (the kernel of polynomial $p(g)$).
  + new elementary theorems: `kermxpolyC`, `kermxpoly1`, `kermxpolyX`, `kermxpoly_min`
  + kernel lemmas: `mxdirect_kermxpoly`, `kermxpolyM`, `kermxpoly_prod`, and `mxdirect_sum_kermx`
  + correspondance between `eigenspace` and `kermxpoly`: `eigenspace_poly`
- generalized eigenspace `geigenspace` and a generalization of eigenvalues called `eigenpoly g` (i.e. polynomials such that `kermxpoly g p` is nonzero, e.g. eigen polynomials of degree 1 are of the form `'X - a%:P` where `a` are eigenvalues).
  + correspondance with `kermx`: `geigenspaceE`
  + application of kernel lemmas `mxdirect_sum_geigenspace`
  + new lemmas: `eigenpolyP`, `eigenvalue_poly`
- new `map_mx` lemmas: `map_kermxpoly`, `map_geigenspace`, `eigenpoly_map`.

Part of #207

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.