### PR TITLE
Maximal rank and full rank row submatrices

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -279,6 +279,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `subseq_rev`, `subseq_cat2l`, `subseq_cat2r`, `subseq_rot`, and
   `uniq_subseq_pivot`.
 
+- in `mxalgebra.v`, new definitions `maxrankfun`, `fullrankfun` which
+  are "subset function" to be plugged in `rowsub`, with lemmas:
+  `maxrowsub_free`, `eq_maxrowsub`, `maxrankfun_inj`,
+  `maxrowsub_full`, `fullrowsub_full`, `fullrowsub_unit`,
+  `fullrowsub_free`, `mxrank_fullrowsub`, `eq_fullrowsub`, and
+  `fullrankfun_inj`.
+
 ### Changed
 
 - in `ssrbool.v`, use `Reserved Notation` for `[rel _ _ : _ | _]` to avoid warnings with coq-8.12


### PR DESCRIPTION
##### Motivation for this change

Taking a submatrix of maximal rank, and even a square matrix of full
rank when given a proof that the rank was already full.
Part of #207

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
- [x] merge of #574
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.