### PR TITLE
Fix big meet and join notations for dual_display

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -133,6 +133,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   deprecated and will be removed two releases from now.
 
 - in `eqtype.v` new lemmas `contra_not_neq`, `contra_eq_not`.
+- in `order.v`, new notations `0^d` and `1^d` for bottom and top elements of
+  dual lattices.
 
 ### Changed
 
@@ -157,6 +159,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `big_uncond` (cf Added) but it will be renamed `big_mkcond` in the
   next release.
 
+- in `order.v`, `\join^d_` and `\meet^d_` notations are now properly specialized
+  for `dual_display`.
 
 ### Renamed
 

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -468,6 +468,9 @@ Reserved Notation "A `|^d` B" (at level 52, left associativity).
 Reserved Notation "A `\^d` B" (at level 50, left associativity).
 Reserved Notation "~^d` A" (at level 35, right associativity).
 
+Reserved Notation "0^d" (at level 0).
+Reserved Notation "1^d" (at level 0).
+
 (* Reserved notations for product ordering of prod or seq *)
 Reserved Notation "x <=^p y" (at level 70, y at next level).
 Reserved Notation "x >=^p y" (at level 70, y at next level).
@@ -2550,6 +2553,16 @@ Notation "x ><^d y" := (~~ (><^d%O x y)) : order_scope.
 
 Notation "x `&^d` y" := (dual_meet x y) : order_scope.
 Notation "x `|^d` y" := (dual_join x y) : order_scope.
+
+Notation "0^d" := dual_bottom : order_scope.
+Notation "1^d" := dual_top : order_scope.
+
+(* The following Local Notations are here to define the \join^d_ and \meet^d_ *)
+(* notations later. Do not remove them.                                       *)
+Local Notation "0" := dual_bottom.
+Local Notation "1" := dual_top.
+Local Notation join := dual_join.
+Local Notation meet := dual_meet.
 
 Notation "\join^d_ ( i <- r | P ) F" :=
   (\big[join/0]_(i <- r | P%B) F%O) : order_scope.


### PR DESCRIPTION
##### Motivation for this change

These `Local Notation`s were removed in #454 and this removal broke the following `\join^d_` and `\meet^d_` notations.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
