### PR TITLE
mulrIb

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -161,6 +161,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (e.g. with `raddf_eq0`), and lemma `inj_row_free` characterizing
   `row_free` matrices `A`  through `v *m A = 0 -> v = 0` for all `v`.
 
+- in `ssralg.v`, new lemma `mulrIb`.
 
 ### Changed
 

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -835,6 +835,9 @@ Qed.
 Lemma mulrnAC x m n : x *+ m *+ n = x *+ n *+ m.
 Proof. by rewrite -!mulrnA mulnC. Qed.
 
+Lemma mulrIb (x : V) : x != 0 -> injective (fun b : bool => x *+ b).
+Proof. by move=> x_neq0 [[]|[/esym|]]// /eqP; rewrite (negPf x_neq0). Qed.
+
 Lemma iter_addr_0 n (m : V) : iter n (+%R m) 0 = m *+ n.
 Proof. by elim: n => //= n ->; rewrite mulrS. Qed.
 


### PR DESCRIPTION
##### Motivation for this change

Adding `mulrIb` a specific injectivity case of `*+` when the lhs is a boolean.


##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.