### PR TITLE
Intro pattern extensions for dup, swap and apply

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,9 +89,6 @@ make-coq-latest:
     variables:
       - $CRON_MODE == "nightly"
 
-coq-8.9:
-  extends: .opam-build-once
-
 coq-8.10:
   extends: .opam-build-once
 
@@ -173,11 +170,6 @@ test-coq-8.10:
   variables:
     COQ_VERSION: "8.10"
 
-test-coq-8.9:
-  extends: .test-once
-  variables:
-    COQ_VERSION: "8.9"
-
 # set CONTRIB_URL, script, COQ_VERSION, CONTRIB_VERSION when using
 .ci:
   stage: test
@@ -222,11 +214,6 @@ test-coq-8.9:
     - make -j "${NJOBS}"
     - make install
 
-ci-fourcolor-8.9:
-  extends: .ci-fourcolor
-  variables:
-    COQ_VERSION: "8.9"
-
 ci-fourcolor-8.10:
   extends: .ci-fourcolor
   variables:
@@ -256,11 +243,6 @@ ci-fourcolor-dev:
   script:
     - make -j "${NJOBS}"
     - make install
-
-ci-odd-order-8.9:
-  extends: .ci-odd-order
-  variables:
-    COQ_VERSION: "8.9"
 
 ci-odd-order-8.10:
   extends: .ci-odd-order
@@ -322,11 +304,6 @@ ci-lemma-overloading-dev:
     - opam pin add -n -k path coq-mathcomp-bigenough .
     - opam install -y -v -j "${NJOBS}" coq-mathcomp-bigenough
 
-ci-bigenough-8.9:
-  extends: .ci-bigenough
-  variables:
-    COQ_VERSION: "8.9"
-
 ci-bigenough-8.10:
   extends: .ci-bigenough
   variables:
@@ -358,11 +335,6 @@ ci-bigenough-dev:
 #     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-real-closed
 #     - opam install -y -v -j "${NJOBS}" coq-mathcomp-real-closed
 # 
-# ci-real-closed-8.9:
-#   extends: .ci-real-closed
-#   variables:
-#     COQ_VERSION: "8.9"
-# 
 # ci-real-closed-dev:
 #   extends: .ci-real-closed
 #   variables:
@@ -379,16 +351,6 @@ ci-bigenough-dev:
 #     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-analysis
 #     - opam install -y -v -j "${NJOBS}" coq-mathcomp-analysis
 # 
-# ci-analysis-8.8:
-#   extends: .ci-analysis
-#   variables:
-#     COQ_VERSION: "8.8"
-# 
-# ci-analysis-8.9:
-#   extends: .ci-analysis
-#   variables:
-#     COQ_VERSION: "8.9"
-# 
 # ci-analysis-dev:
 #   extends: .ci-analysis
 #   variables:
@@ -404,11 +366,6 @@ ci-bigenough-dev:
     - opam pin add -n -k path coq-mathcomp-finmap .
     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-finmap
     - opam install -y -v -j "${NJOBS}" coq-mathcomp-finmap
-
-ci-finmap-8.9:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "8.9"
 
 ci-finmap-8.10:
   extends: .ci-finmap
@@ -501,9 +458,6 @@ ci-fcsl-pcm-dev:
       - schedules
     variables:
       - $CRON_MODE == "nightly"
-
-mathcomp-dev_coq-8.9:
-  extends: .docker-deploy-once
 
 mathcomp-dev_coq-8.10:
   extends: .docker-deploy-once

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -58,6 +58,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added a factory `distrLatticePOrderMixin` in order.v to build a
   `distrLatticeType` from a `porderType`.
 
+- Added intro pattern ltac views for dup, swap, apply:
+  `/[apply]`, `/[swap]` and `/[dup]`.
+
 - in `bigop.v` new lemma `sig_big_dep`, analogous to `pair_big_dep`
   but with an additional dependency in the index types `I` and `J`.
 - in `fintype.v` adds lemma `split_ordP`, a variant of `splitP` which

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -1678,7 +1678,7 @@ Hint Resolve real1 : core.
 Lemma realn n : n%:R \is @real R. Proof. by rewrite ger0_real. Qed.
 
 Lemma ler_leVge x y : x <= 0 -> y <= 0 -> (x <= y) || (y <= x).
-Proof. by rewrite -!oppr_ge0 => /(ger_leVge _) h /h; rewrite !ler_opp2. Qed.
+Proof. by rewrite -!oppr_ge0 => /(ger_leVge _) /[apply]; rewrite !ler_opp2. Qed.
 
 Lemma real_leVge x y : x \is real -> y \is real -> (x <= y) || (y <= x).
 Proof. by rewrite -comparabler0 -comparable0r => /comparabler_trans P/P. Qed.

--- a/mathcomp/test_suite/test_intro_rw.v
+++ b/mathcomp/test_suite/test_intro_rw.v
@@ -1,0 +1,23 @@
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Lemma test_dup1 : forall n : nat, odd n.
+Proof. move=> /[dup] m n; suff: odd n by []. Abort.
+
+Lemma test_dup2 : let n := 1 in False.
+Proof. move=> /[dup] m n; have : m = n := erefl. Abort.
+
+Lemma test_swap1 : forall (n : nat) (b : bool), odd n = b.
+Proof. move=> /[swap] b n; suff: odd n = b by []. Abort.
+
+Lemma test_swap1 : let n := 1 in let b := true in False.
+Proof. move=> /[swap] b n; have : odd n = b := erefl. Abort.
+
+Lemma test_apply A B : forall (f : A -> B) (a : A), False.
+Proof.
+move=> /[apply] b.
+Check (b : B).
+Abort.


### PR DESCRIPTION
##### Motivation for this change

 Intro pattern ltac views (dup, swap, apply), top of the stack actions:
 - `=> /[apply]`      does `=> hyp {}/hyp`
 - `=> /[swap]`       does `=> x y; move: y x` (also swap and perserves let bindings)
 - `=> /[dup]`        does `=> x; have copy := x; move: copy x` (also copies and preserves let bindings)

This is the part of #501 that was not much subject to debate.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
- [x] **after merge** open corresponding PR in Coq to integrate changes from `ssreflect.v`

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.