### PR TITLE
Generalize some interval lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -234,6 +234,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     and they respectively mean open and close bounds as right bounds.
     This change gives us the canonical "left to right" ordering of interval bounds.
 
+- in `interval.v`:
+  + Lemmas `mid_in_itv(|oo|cc)` have been generalized from `realFieldType` to
+    `numFieldType`.
+
 ### Renamed
 
 - `big_rmcond` -> `big_rmcond_in` (cf Changed section)

--- a/mathcomp/algebra/interval.v
+++ b/mathcomp/algebra/interval.v
@@ -582,7 +582,7 @@ Import GRing.Theory Num.Theory.
 
 Section IntervalNumDomain.
 
-Variable R : numFieldType.
+Variable R : numDomainType.
 Implicit Types x : R.
 
 Lemma mem0_itvcc_xNx x : (0 \in `[- x, x]) = (0 <= x).
@@ -614,7 +614,7 @@ End IntervalNumDomain.
 
 Section IntervalField.
 
-Variable R : realFieldType.
+Variable R : numFieldType.
 
 Local Notation mid x y := ((x + y) / 2%:R).
 


### PR DESCRIPTION
##### Motivation for this change

- Generalize `mem0_itv(cc|oo)_xNx` and `oppr_itv(|oo|co|oc|cc)` lemmas from `numFieldType` to `numDomainType`, which have been specialized in PR #458 accidentally.
- Generalize `mid_in_itv(|oo|cc)` lemmas from `realFieldType` to `numFieldType`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
