### PR TITLE
Add `_in` variants of the sorting lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -54,6 +54,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `in_on1P`, `in_on1lP`, `in_on2P`, `on1W_in`, `on1lW_in`, `on2W_in`,
     `in_on1W`, `in_on1lW`, `in_on2W`, `on1S`, `on1lS`, `on2S`,
     `on1S_in`, `on1lS_in`, `on2S_in`, `in_on1S`, `in_on1lS`, `in_on2S`.
+  + lemmas about interaction between `{in _, _}` and `sig`:
+    `in1_sig`, `in2_sig`, and `in3_sig`.
 
 - Added a factory `distrLatticePOrderMixin` in order.v to build a
   `distrLatticeType` from a `porderType`.
@@ -270,13 +272,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   already deprecated in favor of `allpairs_rconsr`, cf renamed
   section).
 
-- in `seq.v`, new lemmas `allss` and `all_mask`.
+- in `seq.v`, new lemmas `allss`, `all_mask`, and `all_sigP`.
+  `allss` has also been declared as a hint.
 
 - in `path.v`, new lemmas `sub_cycle(_in)`, `eq_cycle_in`,
   `(path|sorted)_(mask|filter)_in`, `rev_cycle`, `cycle_map`,
   `(homo|mono)_cycle(_in)`.
 
 - in `path.v`, new lemma `sort_iota_stable`.
+
+- in `path.v`, new lemmas `order_path_min_in`, `path_sorted_inE`,
+  `sorted_(leq|ltn)_nth_in`, `subseq_path_in`, `subseq_sorted_in`,
+  `sorted_(leq|ltn)_index_in`, `sorted_uniq_in`, `sorted_eq_in`,
+  `irr_sorted_eq_in`, `sort_sorted_in`, `sorted_sort_in`, `perm_sort_inP`,
+  `all_sort`, `sort_stable_in`, `filter_sort_in`, `(sorted_)mask_sort_in`,
+  `(sorted_)subseq_sort_in`, and `mem2_sort_in`.
 
 - in `seq.v` new lemmas `index_pivot`, `take_pivot`, `rev_pivot`,
   `eqseq_pivot2l`, `eqseq_pivot2r`, `eqseq_pivotl`, `eqseq_pivotr`

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -882,7 +882,7 @@ Arguments sort_map {T T' f leT}.
 Section SortSeq_in.
 
 Variables (T : Type) (P : {pred T}) (leT : rel T).
-Notation le_sT := (relpre (val : sig P -> _) leT).
+Let le_sT := relpre (val : sig P -> _) leT.
 
 Hypothesis leT_total : {in P &, total leT}.
 Let le_sT_total : total le_sT := in2_sig leT_total.
@@ -1138,7 +1138,7 @@ Variables (T : Type) (P : {pred T}) (leT : rel T).
 Hypothesis leT_total : {in P &, total leT}.
 Hypothesis leT_tr : {in P & &, transitive leT}.
 
-Notation le_sT := (relpre (val : sig P -> _) leT).
+Let le_sT := relpre (val : sig P -> _) leT.
 Let le_sT_total : total le_sT := in2_sig leT_total.
 Let le_sT_tr : transitive le_sT := in3_sig leT_tr.
 

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -549,8 +549,8 @@ Lemma sorted_eq_in s1 s2 :
   {in s1 & &, transitive leT} -> {in s1 &, antisymmetric leT} ->
   sorted leT s1 -> sorted leT s2 -> perm_eq s1 s2 -> s1 = s2.
 Proof.
-move=> /in3_sig leT_tr /in2_sig/(_ _ _ _)/val_inj leT_anti ss1 ss2 s1s2.
-move: ss1 ss2 (s1s2); have /all_sigP[s1' ->] := allss s1.
+move=> /in3_sig leT_tr /in2_sig/(_ _ _ _)/val_inj leT_anti + + /[dup] s1s2.
+have /all_sigP[s1' ->] := allss s1.
 have /all_sigP[{s1s2}s2 ->] : all (mem s1) s2 by rewrite -(perm_all _ s1s2).
 by rewrite !sorted_map => ss1' ss2 /(perm_map_inj val_inj)/(sorted_eq leT_tr)->.
 Qed.
@@ -559,7 +559,7 @@ Lemma irr_sorted_eq_in s1 s2 :
   {in s1 & &, transitive leT} -> {in s1, irreflexive leT} ->
   sorted leT s1 -> sorted leT s2 -> s1 =i s2 -> s1 = s2.
 Proof.
-move=> /in3_sig leT_tr /in1_sig leT_irr ss1 ss2 s1s2; move: ss1 ss2 (s1s2).
+move=> /in3_sig leT_tr /in1_sig leT_irr + + /[dup] s1s2.
 have /all_sigP[s1' ->] := allss s1.
 have /all_sigP[s2' ->] : all (mem s1) s2 by rewrite -(eq_all_r s1s2).
 rewrite !sorted_map => ss1' ss2' {}s1s2; congr map.

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1500,6 +1500,16 @@ Arguments count_memPn {T x s}.
 Arguments uniqPn {T} x0 {s}.
 Arguments uniqP {T} x0 {s}.
 
+(* Since both `all (mem s) s` and `all (pred_of_seq s) s` may appear in       *)
+(* goals, the following hint has to be declared using the `Hint Extern`       *)
+(* command. Additionally, `mem` and `pred_of_seq` in the above terms do not   *)
+(* reduce to each other; thus, stating `allss` in the form of one of them     *)
+(* makes `apply: allss` failing for the other case. Since both `mem` and      *)
+(* `pred_of_seq` reduce to `mem_seq`, the following explicit type annotation  *)
+(* for `allss` makes it work for both cases.                                  *)
+Hint Extern 0 (is_true (all _ _)) =>
+  apply: (allss : forall T s, all (mem_seq s) s) : core.
+
 Section NthTheory.
 
 Lemma nthP (T : eqType) (s : seq T) x x0 :

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2385,9 +2385,9 @@ Notation "[ 'seq' E : R | i : T <- s & C ]" :=
 Lemma filter_mask T a (s : seq T) : filter a s = mask (map a s) s.
 Proof. by elim: s => //= x s <-; case: (a x). Qed.
 
-Lemma all_sigP T a (s : seq T) : all a s -> {s' : seq (sig a) | map sval s' = s}.
+Lemma all_sigP T a (s : seq T) : all a s -> {s' : seq (sig a) | s = map sval s'}.
 Proof.
-elim: s => /= [_|x s ihs /andP [ax /ihs [s' <-]]]; first by exists [::].
+elim: s => /= [_|x s ihs /andP [ax /ihs [s' ->]]]; first by exists [::].
 by exists (exist a x ax :: s').
 Qed.
 

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2385,6 +2385,12 @@ Notation "[ 'seq' E : R | i : T <- s & C ]" :=
 Lemma filter_mask T a (s : seq T) : filter a s = mask (map a s) s.
 Proof. by elim: s => //= x s <-; case: (a x). Qed.
 
+Lemma all_sigP T a (s : seq T) : all a s -> {s' : seq (sig a) | map sval s' = s}.
+Proof.
+elim: s => /= [_|x s ihs /andP [ax /ihs [s' <-]]]; first by exists [::].
+by exists (exist a x ax :: s').
+Qed.
+
 Section MiscMask.
 
 Lemma leq_count_mask T (P : {pred T}) m s : count P (mask m s) <= count P s.

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -349,3 +349,45 @@ Proof. by case: b => // /(_ isT). Qed.
 Lemma contra_notF P b : (b -> P) -> ~ P -> b = false.
 Proof. by case: b => // /(_ isT). Qed.
 End Contra.
+
+(******************)
+(* v8.14 addtions *)
+(******************)
+
+Section in_sig.
+Local Notation "{ 'all1' P }" := (forall x, P x : Prop) (at level 0).
+Local Notation "{ 'all2' P }" := (forall x y, P x y : Prop) (at level 0).
+Local Notation "{ 'all3' P }" := (forall x y z, P x y z : Prop) (at level 0).
+
+Variables T1 T2 T3 : Type.
+Variables (D1 : {pred T1}) (D2 : {pred T2})  (D3 : {pred T3}).
+Variable P1 : T1 -> Prop.
+Variable P11 : T1 -> T2 -> Prop.
+Variable P111 : T1 -> T2 -> T3 -> Prop.
+Variable P2 :  T1 -> T1 -> Prop.
+Variable P3 :  T1 -> T1 -> T1 -> Prop.
+
+Lemma in1_sig : {in D1, {all1 P1}} -> forall x : sig D1, P1 (sval x).
+Proof. by move=> DP [x Dx]; have := DP _ Dx. Qed.
+
+Lemma in11_sig : {in D1 & D2, {all2 P11}} ->
+  forall (x : sig D1) (y : sig D2), P11 (sval x) (sval y).
+Proof. by move=> DP [x Dx] [y Dy]; have := DP _ _ Dx Dy. Qed.
+
+Lemma in111_sig : {in D1 & D2 & D3, {all3 P111}} ->
+  forall (x : sig D1) (y : sig D2) (z : sig D3), P111 (sval x) (sval y) (sval z).
+Proof. by move=> DP [x Dx] [y Dy] [z Dz]; have := DP _ _ _ Dx Dy Dz. Qed.
+
+Lemma in2_sig : {in D1 &, {all2 P2}} -> forall x y : sig D1, P2 (sval x) (sval y).
+Proof. by move=> DP [x Dx] [y Dy]; have := DP _ _ Dx Dy. Qed.
+
+Lemma in3_sig : {in D1 & &, {all3 P3}} ->
+   forall x y z : sig D1, P3 (sval x) (sval y) (sval z).
+Proof. by move=> DP [x Dx] [y Dy] [z Dz]; have := DP _ _ _ Dx Dy Dz. Qed.
+
+End in_sig.
+Arguments in1_sig {T1 D1 P1}.
+Arguments in11_sig {T1 T2 D1 D2 P11}.
+Arguments in111_sig {T1 T2 T3 D1 D2 D3 P111}.
+Arguments in2_sig {T1 D1 P2}.
+Arguments in3_sig {T1 D1 P3}.

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -102,6 +102,10 @@ Arguments mono_sym_in {aT rT} [aR rR f aD].
 Arguments homo_sym_in11 {aT rT} [aR rR f aD aD'].
 Arguments mono_sym_in11 {aT rT} [aR rR f aD aD'].
 
+(******************)
+(* v8.14 addtions *)
+(******************)
+
 Section LocalGlobal.
 
 Local Notation "{ 'all1' P }" := (forall x, P x : Prop) (at level 0).
@@ -208,6 +212,10 @@ Arguments on2S_in  {T1 T2 D1} D2 {f Q2}.
 Arguments in_on1S  {T1 T2} D2 {f Q1}.
 Arguments in_on1lS {T1 T2 T3} D2 {f h Q1l}.
 Arguments in_on2S  {T1 T2} D2 {f Q2}.
+
+(******************)
+(* v8.13 addtions *)
+(******************)
 
 Section CancelOn.
 
@@ -362,32 +370,21 @@ Local Notation "{ 'all3' P }" := (forall x y z, P x y z : Prop) (at level 0).
 Variables T1 T2 T3 : Type.
 Variables (D1 : {pred T1}) (D2 : {pred T2})  (D3 : {pred T3}).
 Variable P1 : T1 -> Prop.
-Variable P11 : T1 -> T2 -> Prop.
-Variable P111 : T1 -> T2 -> T3 -> Prop.
-Variable P2 :  T1 -> T1 -> Prop.
-Variable P3 :  T1 -> T1 -> T1 -> Prop.
+Variable P2 : T1 -> T2 -> Prop.
+Variable P3 : T1 -> T2 -> T3 -> Prop.
 
 Lemma in1_sig : {in D1, {all1 P1}} -> forall x : sig D1, P1 (sval x).
 Proof. by move=> DP [x Dx]; have := DP _ Dx. Qed.
 
-Lemma in11_sig : {in D1 & D2, {all2 P11}} ->
-  forall (x : sig D1) (y : sig D2), P11 (sval x) (sval y).
+Lemma in2_sig : {in D1 & D2, {all2 P2}} ->
+  forall (x : sig D1) (y : sig D2), P2 (sval x) (sval y).
 Proof. by move=> DP [x Dx] [y Dy]; have := DP _ _ Dx Dy. Qed.
 
-Lemma in111_sig : {in D1 & D2 & D3, {all3 P111}} ->
-  forall (x : sig D1) (y : sig D2) (z : sig D3), P111 (sval x) (sval y) (sval z).
-Proof. by move=> DP [x Dx] [y Dy] [z Dz]; have := DP _ _ _ Dx Dy Dz. Qed.
-
-Lemma in2_sig : {in D1 &, {all2 P2}} -> forall x y : sig D1, P2 (sval x) (sval y).
-Proof. by move=> DP [x Dx] [y Dy]; have := DP _ _ Dx Dy. Qed.
-
-Lemma in3_sig : {in D1 & &, {all3 P3}} ->
-   forall x y z : sig D1, P3 (sval x) (sval y) (sval z).
+Lemma in3_sig : {in D1 & D2 & D3, {all3 P3}} ->
+  forall (x : sig D1) (y : sig D2) (z : sig D3), P3 (sval x) (sval y) (sval z).
 Proof. by move=> DP [x Dx] [y Dy] [z Dz]; have := DP _ _ _ Dx Dy Dz. Qed.
 
 End in_sig.
 Arguments in1_sig {T1 D1 P1}.
-Arguments in11_sig {T1 T2 D1 D2 P11}.
-Arguments in111_sig {T1 T2 T3 D1 D2 D3 P111}.
-Arguments in2_sig {T1 D1 P2}.
-Arguments in3_sig {T1 D1 P3}.
+Arguments in2_sig {T1 T2 D1 D2 P2}.
+Arguments in3_sig {T1 T2 T3 D1 D2 D3 P3}.


### PR DESCRIPTION
##### Motivation for this change

This PR adds `_in` variants of the sorting lemmas that restrict the domain where totality, transitivity, etc. hold by a predicate.
- [done] ~This generalization has not been done for the stability lemmas yet.~
- [postponed] ~This PR also attempts to add the `sort_map_in` lemma taken from PRs #328 and #358, but this is not general enough yet.~

CC: @CohenCyril

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] merge dependency: #632
- [x] merge dependency: #646
- [x] merge dependency: #650
- [ ]  backport to Coq (including ones from #521)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

##### PR overlays

- coq-community/lemma-overloading#63
- imdea-software/fcsl-pcm#24

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
