### PR TITLE
lemmas for reasoning about "rot n (rot m s)"

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -251,6 +251,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `polydiv.v`, new lemma `dvdpNl`.
 
+- in `seq.v`, new definition `rot_add` and new lemmas `rot_minn`, `leq_rot_add`, `rot_addC`, `rot_rot_add`.
+
 ### Changed
 
 - in ssrbool.v, use `Reserved Notation` for `[rel _ _ : _ | _]` to avoid warnings with coq-8.12

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1854,17 +1854,33 @@ move=> Hn Hm; case: leqP => [/rotD // | /ltnW Hmn]; symmetry.
 by rewrite -{2}(rotK n s) /rotr -rotD size_rot addnBA ?subnK ?addnK.
 Qed.
 
-Lemma rot_rot m n s : rot m (rot n s) = rot n (rot m s).
+Lemma rot_minn n s : rot n s = rot (minn n (size s)) s.
 Proof.
-case: (ltnP (size s) m) => Hm.
-  by rewrite !(@rot_oversize T m) ?size_rot 1?ltnW.
-case: (ltnP (size s) n) => Hn.
-  by rewrite !(@rot_oversize T n) ?size_rot 1?ltnW.
-by rewrite !rot_add_mod 1?addnC.
+by case: (leqP n (size s)) => // /leqW ?; rewrite rot_size rot_oversize.
 Qed.
 
+Definition rot_add s n m (k := size s) (p := minn m k + minn n k) :=
+  locked (if p <= k then p else p - k).
+
+Lemma leq_rot_add n m s : rot_add s n m <= size s.
+Proof.
+by unlock rot_add; case: ifP; rewrite // leq_subLR leq_add // geq_minr.
+Qed.
+
+Lemma rot_addC n m s : rot_add s n m = rot_add s m n.
+Proof. by unlock rot_add; rewrite ![minn n _ + _]addnC. Qed.
+
+Lemma rot_rot_add n m s : rot m (rot n s) = rot (rot_add s n m) s.
+Proof.
+unlock rot_add.
+by rewrite (rot_minn n) (rot_minn m) rot_add_mod ?size_rot ?geq_minr.
+Qed.
+
+Lemma rot_rot m n s : rot m (rot n s) = rot n (rot m s).
+Proof. by rewrite rot_rot_add rot_addC -rot_rot_add. Qed.
+
 Lemma rot_rotr m n s : rot m (rotr n s) = rotr n (rot m s).
-Proof. by rewrite {2}/rotr size_rot rot_rot. Qed.
+Proof. by rewrite [RHS]/rotr size_rot rot_rot. Qed.
 
 Lemma rotr_rotr m n s : rotr m (rotr n s) = rotr n (rotr m s).
 Proof. by rewrite /rotr !size_rot rot_rot. Qed.


### PR DESCRIPTION
##### Motivation for this change

This is an attempt at easing the reasoning about compositions of the form `rot n (rot m s)`, where one does not have bounds on `n` and `m`, making `rotD` and `rot_add_mod` awkward to use. This is used in the formalization of subcycles (i.e., subsequences up to rotation). 

I'm reasonably sure that the names I chose are not optimal, so I'd be happy for feedback, I'll add the `CHANGELOG` entries once the names are decided upon. 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
