### PR TITLE
lemmas on `subseq` and `rot`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -270,6 +270,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `(homo|mono)_cycle(_in)`.
 - in `seq.v` new lemmas `eqseq_pivot`, `rev_mask`, `subseq_rev`, `subseq_cat2l`, `subseq_cat2r`, `subseq_rot`, `subseq_pivot`.
 
+- in `seq.v` new lemmas `eqseq_pivot`, `eqseq_pivot_uniql`, `eqseq_pivot_uniqr`,
+  `mask_rcons, `rev_mask`, `subseq_rev`, `subseq_cat2l`, `subseq_cat2r`, `subseq_rot`, and
+  `uniq_subseq_pivot`.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -274,7 +274,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `mask_rcons, `rev_mask`, `subseq_rev`, `subseq_cat2l`, `subseq_cat2r`, `subseq_rot`, and
 - in `seq.v` new lemmas `index_pivot`, `take_pivot`, `rev_pivot`,
   `eqseq_pivot2l`, `eqseq_pivot2r`, `eqseq_pivotl`, `eqseq_pivotr`
-  `uniq_eqseq_pivotl`, `uniq_eqseq_pivotr`, `mask_rcons, `rev_mask`,
+  `uniq_eqseq_pivotl`, `uniq_eqseq_pivotr`, `mask_rcons`, `rev_mask`,
   `subseq_rev`, `subseq_cat2l`, `subseq_cat2r`, `subseq_rot`, and
   `uniq_subseq_pivot`.
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -268,6 +268,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `path.v`, new lemmas `sub_cycle(_in)`, `eq_cycle_in`,
   `(path|sorted)_(mask|filter)_in`, `rev_cycle`, `cycle_map`,
   `(homo|mono)_cycle(_in)`.
+- in `seq.v` new lemmas `eqseq_pivot`, `rev_mask`, `subseq_rev`, `subseq_cat2l`, `subseq_cat2r`, `subseq_rot`, `subseq_pivot`.
+
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -272,6 +272,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `seq.v` new lemmas `eqseq_pivot`, `eqseq_pivot_uniql`, `eqseq_pivot_uniqr`,
   `mask_rcons, `rev_mask`, `subseq_rev`, `subseq_cat2l`, `subseq_cat2r`, `subseq_rot`, and
+- in `seq.v` new lemmas `index_pivot`, `take_pivot`, `rev_pivot`,
+  `eqseq_pivot2l`, `eqseq_pivot2r`, `eqseq_pivotl`, `eqseq_pivotr`
+  `uniq_eqseq_pivotl`, `uniq_eqseq_pivotr`, `mask_rcons, `rev_mask`,
+  `subseq_rev`, `subseq_cat2l`, `subseq_cat2r`, `subseq_rot`, and
   `uniq_subseq_pivot`.
 
 ### Changed

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2382,10 +2382,10 @@ rewrite uniq_perm ?filter_uniq ?(subseq_uniq ss12) // => x.
 by rewrite mem_filter; apply: andb_idr; apply: (mem_subseq ss12).
 Qed.
 
-Lemma uniq_subseq_pivot (s1 s2 s3 s4 : seq T) x (s := s3 ++ x :: s4) :
+Lemma uniq_subseq_pivot x (s1 s2 s3 s4 : seq T) (s := s3 ++ x :: s4) :
   uniq s -> subseq (s1 ++ x :: s2) s = (subseq s1 s3 && subseq s2 s4).
 Proof.
-move=> uniq_s; apply/idP/idP => [sub_s'_s|/andP[? ?]]; last first. 
+move=> uniq_s; apply/idP/idP => [sub_s'_s|/andP[? ?]]; last first.
   by rewrite cat_subseq //= eqxx.
 have uniq_s' := subseq_uniq sub_s'_s uniq_s.
 have/eqP {sub_s'_s uniq_s} := subseq_uniqP _ uniq_s sub_s'_s.

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1395,12 +1395,13 @@ Proof. by move=> x; rewrite -[s in RHS](cat_take_drop n0) !mem_cat /= orbC. Qed.
 Lemma eqseq_rot s1 s2 : (rot n0 s1 == rot n0 s2) = (s1 == s2).
 Proof. exact/inj_eq/rot_inj. Qed.
 
+(* lemmas about the pivot pattern [_ ++ _ :: _] *)
 
-Lemma index_pivot x s1 s2 (s := s1 ++ x :: s2) : x \notin s1 -> 
+Lemma index_pivot x s1 s2 (s := s1 ++ x :: s2) : x \notin s1 ->
   index x s = size s1.
 Proof. by rewrite index_cat/= eqxx addn0; case: ifPn. Qed.
 
-Lemma take_pivot x s2 s1 (s := s1 ++ x :: s2) : x \notin s1 -> 
+Lemma take_pivot x s2 s1 (s := s1 ++ x :: s2) : x \notin s1 ->
   take (index x s) s = s1.
 Proof. by move=> /index_pivot->; rewrite take_size_cat. Qed.
 
@@ -1419,7 +1420,7 @@ Lemma eqseq_pivot2r x s1 s2 s3 s4 : x \notin s2 -> x \notin s4 ->
   (s1 ++ x :: s2 == s3 ++ x :: s4) = (s1 == s3) && (s2 == s4).
 Proof.
 move=> xNs2 xNs4; rewrite -(can_eq revK) !rev_pivot.
-by rewrite eqseq_pivot2l ?mem_rev// !(can_eq revK) andbC.
+by rewrite eqseq_pivot2l ?mem_rev // !(can_eq revK) andbC.
 Qed.
 
 Lemma eqseq_pivotl x s1 s2 s3 s4 : x \notin s1 -> x \notin s2 ->
@@ -2394,7 +2395,7 @@ Proof.
 move => uniq_s sub_s'_s; have uniq_s' := subseq_uniq sub_s'_s uniq_s.
 have/eqP {sub_s'_s uniq_s} := subseq_uniqP _ uniq_s sub_s'_s.
 rewrite !filter_cat /= mem_cat inE eqxx orbT /=.
-rewrite eqseq_pivot_uniql // => /andP [/eqP -> /eqP ->].
+rewrite uniq_eqseq_pivotl // => /andP [/eqP -> /eqP ->].
 by rewrite !filter_subseq.
 Qed.
 

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2185,7 +2185,7 @@ Proof. by rewrite -subseq_rev !rev_cat subseq_cat2l subseq_rev. Qed.
 Lemma subseq_rot p s n :
   subseq p s -> exists2 k, k <= n & subseq (rot k p) (rot n s).
 Proof.
-move => /subseqP [m size_m ->].
+move=> /subseqP[m size_m ->].
 exists (count id (take n m)); last by rewrite -mask_rot // mask_subseq.
 by rewrite (leq_trans (count_size _ _))// size_take; case: ltnP.
 Qed.
@@ -2383,9 +2383,11 @@ by rewrite mem_filter; apply: andb_idr; apply: (mem_subseq ss12).
 Qed.
 
 Lemma uniq_subseq_pivot (s1 s2 s3 s4 : seq T) x (s := s3 ++ x :: s4) :
-  uniq s -> subseq (s1 ++ x :: s2) s -> subseq s1 s3 /\ subseq s2 s4.
+  uniq s -> subseq (s1 ++ x :: s2) s = (subseq s1 s3 && subseq s2 s4).
 Proof.
-move => uniq_s sub_s'_s; have uniq_s' := subseq_uniq sub_s'_s uniq_s.
+move=> uniq_s; apply/idP/idP => [sub_s'_s|/andP[? ?]]; last first. 
+  by rewrite cat_subseq //= eqxx.
+have uniq_s' := subseq_uniq sub_s'_s uniq_s.
 have/eqP {sub_s'_s uniq_s} := subseq_uniqP _ uniq_s sub_s'_s.
 rewrite !filter_cat /= mem_cat inE eqxx orbT /=.
 rewrite uniq_eqseq_pivotl // => /andP [/eqP -> /eqP ->].

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1434,9 +1434,7 @@ Qed.
 
 Lemma eqseq_pivotr x s1 s2 s3 s4 : x \notin s3 -> x \notin s4 ->
   (s1 ++ x :: s2 == s3 ++ x :: s4) = (s1 == s3) && (s2 == s4).
-Proof.
-by move=> *; rewrite eq_sym eqseq_pivotl// [s3 == _]eq_sym [s4 == _]eq_sym.
-Qed.
+Proof. by move=> *; rewrite eq_sym eqseq_pivotl//; case: eqVneq => /=. Qed.
 
 Lemma uniq_eqseq_pivotl x s1 s2 s3 s4 : uniq (s1 ++ x :: s2) ->
   (s1 ++ x :: s2 == s3 ++ x :: s4) = (s1 == s3) && (s2 == s4).
@@ -1446,9 +1444,7 @@ Qed.
 
 Lemma uniq_eqseq_pivotr x s1 s2 s3 s4 : uniq (s3 ++ x :: s4) ->
   (s1 ++ x :: s2 == s3 ++ x :: s4) = (s1 == s3) && (s2 == s4).
-Proof.
-by move=> ?; rewrite eq_sym uniq_eqseq_pivotl// [s3 == _]eq_sym [s4 == _]eq_sym.
-Qed.
+Proof. by move=> ?; rewrite eq_sym uniq_eqseq_pivotl//; case: eqVneq => /=. Qed.
 
 End EqSeq.
 
@@ -2177,16 +2173,13 @@ Lemma subseq_rev s1 s2 : subseq (rev s1) (rev s2) = subseq s1 s2.
 Proof.
 wlog suff W : s1 s2 / subseq s1 s2 -> subseq (rev s1) (rev s2).
   by apply/idP/idP => /W //; rewrite !revK.
-move/subseqP => [m size_m mask_m]; apply/subseqP.
-by exists (rev m); rewrite ?size_rev // -rev_mask // -mask_m.
+by case/subseqP => m size_m ->; rewrite rev_mask // mask_subseq.
 Qed.
 
-Lemma subseq_cat2l (s s1 s2 : seq T) :
-  subseq (s ++ s1) (s ++ s2) = subseq s1 s2.
+Lemma subseq_cat2l s s1 s2 : subseq (s ++ s1) (s ++ s2) = subseq s1 s2.
 Proof. by elim: s => // x s IHs; rewrite !cat_cons /= eqxx. Qed.
 
-Lemma subseq_cat2r (s s1 s2 : seq T) :
-  subseq (s1 ++ s) (s2 ++ s) = subseq s1 s2.
+Lemma subseq_cat2r s s1 s2 : subseq (s1 ++ s) (s2 ++ s) = subseq s1 s2.
 Proof. by rewrite -subseq_rev !rev_cat subseq_cat2l subseq_rev. Qed.
 
 Lemma subseq_rot p s n :


### PR DESCRIPTION
##### Motivation for this change

Lemmas for reasoning about `subseq`, in particular subsequences of duplicate free sequences and rotations of sequences. These turned out to be useful when formalizing subcycles (i.e., subsequences up to rotation).

@CohenCyril I chose `_pivot` for the `s1 ++ x :: s2` pattern, but I am open to suggestions. I would favor this pattern over `rcons s1 x ++ s2`, because the former arises naturally when using `rot_to_arc` (`x` being the beginning of the second arc). 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
