### PR TITLE
Adding some theory for `rem` and generalizing and renaming `subset_maskP`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -228,8 +228,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `commCmx`. The common arguments of these lemmas `R` and `n` are
   maximal implicits.
 
-  - in `seq.v`, added `in_mask`, `cons_subseq`, `undup_subseq`,
-    `subset_maskP`, `subset_subseqP`, `count_rem`, `count_mem_rem`,
+  - in `seq.v`, added `drop_index`, `in_mask`, `cons_subseq`, `undup_subseq`,
+    `count_maskP`, `count_subseqP`, `count_rem`, `count_mem_rem`,
     `rem_cons`, `remE`,  `subseq_rem` and `leq_count_uniq`.
   - in `fintype.v`, added `mask_enum_ord`.
   - in `bigop.v`, added `big_mask_tuple` and `big_mask`.

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -228,7 +228,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `commCmx`. The common arguments of these lemmas `R` and `n` are
   maximal implicits.
 
-  - in `seq.v`, added `in_mask`, `cons_subseq`, `undup_subseq`, `subset_maskP`.
+  - in `seq.v`, added `in_mask`, `cons_subseq`, `undup_subseq`,
+    `subset_maskP`, `subset_subseqP`, `count_rem`, `count_mem_rem`,
+    `rem_cons`, `remE`,  `subseq_rem` and `leq_count_uniq`.
   - in `fintype.v`, added `mask_enum_ord`.
   - in `bigop.v`, added `big_mask_tuple` and `big_mask`.
 - in `mxalgebra.v`, new notation `stablemx V f` asserting that `f`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -231,7 +231,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - in `seq.v`, added `drop_index`, `in_mask`, `cons_subseq`,
     `undup_subseq`, `leq_count_mask`, `leq_count_subseq`,
     `count_maskP`, `count_subseqP`, `count_rem`, `count_mem_rem`,
-    `rem_cons`, `remE`,  `subseq_rem` and `leq_count_uniq`.
+    `rem_cons`, `remE`, `subseq_rem`, `leq_uniq_countP`, and
+    `leq_uniq_count`.
   - in `fintype.v`, added `mask_enum_ord`.
   - in `bigop.v`, added `big_mask_tuple` and `big_mask`.
 - in `mxalgebra.v`, new notation `stablemx V f` asserting that `f`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -228,7 +228,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `commCmx`. The common arguments of these lemmas `R` and `n` are
   maximal implicits.
 
-  - in `seq.v`, added `drop_index`, `in_mask`, `cons_subseq`, `undup_subseq`,
+  - in `seq.v`, added `drop_index`, `in_mask`, `cons_subseq`,
+    `undup_subseq`, `leq_count_mask`, `leq_count_subseq`,
     `count_maskP`, `count_subseqP`, `count_rem`, `count_mem_rem`,
     `rem_cons`, `remE`,  `subseq_rem` and `leq_count_uniq`.
   - in `fintype.v`, added `mask_enum_ord`.


### PR DESCRIPTION
##### Motivation for this change

- Added helper lemmas about `rem`: `rem_cons` (to control unfolding), `remE`, `count_rem`, `count_mem_rem`, `subseq_rem`, `leq_count_mask`, and `leq_count_subseq`.  (New lemma `drop_index` briges the gap between `cat_take_drop` and `remE`).
- `subset_maskP`, which was not released yet is renamed to `count_maskP` and generalized as an equivalence with `(forall x, count_mem x s1 <= count_mem x s2)`, instead of an implication from `uniq s1` and `{subset s1 <= s2}`, the previous behaviour can be restored with helper lemma `leq_uniq_count`
- Its trivial consequence `count_subseqP` has been added too.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
