### PR TITLE
Generalize mulpz for any ringType

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -311,6 +311,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - In `srnum.v`,
   + `>=< y` stands for `[pred x | x >=< y]`
 
+- in `ssrint.v`, generalized `mulpz` for any `ringType`.
 
 ### Renamed
 

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -1708,31 +1708,25 @@ Implicit Types m n : int.
 Implicit Types i j k : nat.
 Implicit Types p q r : {poly R}.
 
-Lemma coefMrz : forall p n i, (p *~ n)`_i = (p`_i *~ n).
-Proof. by move=> p [] n i; rewrite ?NegzE (coefMNn, coefMn). Qed.
+Lemma coefMrz p n i : (p *~ n)`_i = (p`_i *~ n).
+Proof. by case: n => n; rewrite ?NegzE (coefMNn, coefMn). Qed.
 
-Lemma polyCMz : forall n, {morph (@polyC R) : c / c *~ n}.
-Proof. by case/intP => // n c; rewrite ?mulrNz -!pmulrn ?polyCN ?polyCMn. Qed.
+Lemma polyCMz n : {morph (@polyC R) : c / c *~ n}.
+Proof. by case: (intP n) => // n' c; rewrite ?mulrNz ?polyCN polyCMn. Qed.
 
-Lemma hornerMz : forall n (p : {poly R}) x, (p *~ n).[x] = p.[x] *~ n.
-Proof. by case=> *; rewrite ?NegzE ?mulNzr ?(hornerN, hornerMn). Qed.
+Lemma hornerMz n p x : (p *~ n).[x] = p.[x] *~ n.
+Proof. by case: n => n; rewrite ?NegzE ?mulNzr ?(hornerN, hornerMn). Qed.
 
-Lemma horner_int : forall n x, (n%:~R : {poly R}).[x] = n%:~R.
-Proof. by move=> n x; rewrite hornerMz hornerC. Qed.
+Lemma horner_int n x : (n%:~R : {poly R}).[x] = n%:~R.
+Proof. by rewrite hornerMz hornerC. Qed.
 
-Lemma derivMz : forall n p, (p *~ n)^`() = p^`() *~ n.
-Proof. by move=> [] n p; rewrite ?NegzE -?pmulrn (derivMn, derivMNn). Qed.
+Lemma derivMz n p : (p *~ n)^`() = p^`() *~ n.
+Proof. by case: n => n; rewrite ?NegzE -?pmulrn (derivMn, derivMNn). Qed.
+
+Lemma mulpz p n : p *~ n = n%:~R *: p.
+Proof. by rewrite -mul_polyC polyCMz polyC1 mulrzl. Qed.
 
 End PolyZintRing.
-
-Section PolyZintOIdom.
-
-Variable R : realDomainType.
-
-Lemma mulpz (p : {poly R}) (n : int) : p *~ n = n%:~R *: p.
-Proof. by rewrite -[p *~ n]mulrzl -mul_polyC polyCMz polyC1. Qed.
-
-End PolyZintOIdom.
 
 Section ZnatPred.
 


### PR DESCRIPTION
##### Motivation for this change

This PR generalizes the first argument `R` of `mulpz` from `realDomainType` to `ringType`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
