### PR TITLE
Reorganize, generalize, and add lemmas about `path`, `cycle`, and `sorted`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -257,8 +257,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `seq.v`, new lemmas `allss` and `all_mask`.
 
 - in `path.v`, new lemmas `sub_cycle(_in)`, `eq_cycle_in`,
-  `(path|cycle|sorted)_(mask|filter)_in`, `cycle_(mask|filter)_in`, `rev_cycle`,
-  `cycle_map`, `(homo|mono)_cycle(_in)`.
+  `(path|sorted)_(mask|filter)_in`, `rev_cycle`, `cycle_map`,
+  `(homo|mono)_cycle(_in)`.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -254,6 +254,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `seq.v`, new definition `rot_add` and new lemmas `rot_minn`, `leq_rot_add`, `rot_addC`, `rot_rot_add`.
 
+- in `seq.v`, new lemmas `allss` and `all_mask`.
+
+- in `path.v`, new lemmas `sub_cycle(_in)`, `eq_cycle_in`,
+  `(path|cycle|sorted)_(mask|filter)_in`, `cycle_(mask|filter)_in`, `rev_cycle`,
+  `cycle_map`, `(homo|mono)_cycle(_in)`.
+
 ### Changed
 
 - in `ssrbool.v`, use `Reserved Notation` for `[rel _ _ : _ | _]` to avoid warnings with coq-8.12
@@ -324,6 +330,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - In `fintype.v`, lemmas `inj_card_onto` and `inj_card_bij` take a
   weaker hypothesis (i.e. `#|T| >= #|T'|` instead of `#|T| = #|T'|`
   thanks to `leq_card` under injectivity assumption).
+
+- in `path.v`, generalized lemmas `sub_path_in`, `sub_sorted_in`, and
+  `eq_path_in` for non-`eqType`s.
 
 ### Renamed
 

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -227,7 +227,7 @@ Proof. by move=> Pxs; rewrite filter_mask; exact: path_mask_in. Qed.
 Lemma cycle_mask_in m s : all P s -> cycle leT s -> cycle leT (mask m s).
 Proof.
 case: (resize_mask m s) => {m} m sizeE ->.
-elim: m s sizeE => [|[]m ih] [|x s] //= [sizeE] /andP [Px Ps].
+elim: m s sizeE => [|[] m ih] [|x s] //= [sizeE] /andP[Px Ps].
 - rewrite -!cats1 -(mask_cat [:: true] [:: x]) //.
   by apply: path_mask_in; rewrite /= all_cat /= Px Ps.
 - move=> xsx; apply: ih => // {sizeE}; case: s xsx Ps => //= y s.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -224,21 +224,6 @@ Lemma path_filter_in x a s :
   all P (x :: s) -> path leT x s -> path leT x (filter a s).
 Proof. by move=> Pxs; rewrite filter_mask; exact: path_mask_in. Qed.
 
-Lemma cycle_mask_in m s : all P s -> cycle leT s -> cycle leT (mask m s).
-Proof.
-case: (resize_mask m s) => {m} m sizeE ->.
-elim: m s sizeE => [|[] m ih] [|x s] //= [sizeE] /andP[Px Ps].
-- rewrite -!cats1 -(mask_cat [:: true] [:: x]) //.
-  by apply: path_mask_in; rewrite /= all_cat /= Px Ps.
-- move=> xsx; apply: ih => // {sizeE}; case: s xsx Ps => //= y s.
-  rewrite !rcons_path => /and3P [xy -> sx] /andP [Py Ps] /=.
-  apply: leT_tr sx xy => //.
-  by elim: s y Ps Py => //= z s ih y /andP [Pz Ps] _; apply: ih.
-Qed.
-
-Lemma cycle_filter_in a s : all P s -> cycle leT s -> cycle leT (filter a s).
-Proof. move=> Ps; rewrite filter_mask; exact: cycle_mask_in. Qed.
-
 Lemma sorted_mask_in m s : all P s -> sorted leT s -> sorted leT (mask m s).
 Proof.
 elim: m s => [|[] m ih] [|x s] //= Pxs; first exact: path_mask_in.
@@ -263,12 +248,6 @@ Proof. exact/path_mask_in/all_predT. Qed.
 Lemma path_filter x a s : path leT x s -> path leT x (filter a s).
 Proof. by rewrite filter_mask; exact: path_mask. Qed.
 
-Lemma cycle_mask m s : cycle leT s -> cycle leT (mask m s).
-Proof. exact/cycle_mask_in/all_predT. Qed.
-
-Lemma cycle_filter a s : cycle leT s -> cycle leT (filter a s).
-Proof. move=> Ps; rewrite filter_mask; exact: cycle_mask. Qed.
-
 Lemma sorted_mask m s : sorted leT s -> sorted leT (mask m s).
 Proof. exact/sorted_mask_in/all_predT. Qed.
 
@@ -284,14 +263,10 @@ Arguments path_sorted {T e x s}.
 Arguments path_min_sorted {T e x s}.
 Arguments path_mask_in {T P leT} leT_tr {x m s}.
 Arguments path_filter_in {T P leT} leT_tr {x a s}.
-Arguments cycle_mask_in {T P leT} leT_tr {m s}.
-Arguments cycle_filter_in {T P leT} leT_tr {a s}.
 Arguments sorted_mask_in {T P leT} leT_tr {m s}.
 Arguments sorted_filter_in {T P leT} leT_tr {a s}.
 Arguments path_mask {T leT} leT_tr {x} m {s}.
 Arguments path_filter {T leT} leT_tr {x} a {s}.
-Arguments cycle_mask {T leT} leT_tr m {s}.
-Arguments cycle_filter {T leT} leT_tr a {s}.
 Arguments sorted_mask {T leT} leT_tr m {s}.
 Arguments sorted_filter {T leT} leT_tr a {s}.
 

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1119,6 +1119,8 @@ Proof. by rewrite -all_predC; apply: allP. Qed.
 Lemma allPn a s : reflect (exists2 x, x \in s & ~~ a x) (~~ all a s).
 Proof. by rewrite -has_predC; apply: hasP. Qed.
 
+Lemma allss s : all (mem s) s. Proof. exact/allP. Qed.
+
 Lemma mem_filter a x s : (x \in filter a s) = a x && (x \in s).
 Proof.
 rewrite andbC; elim: s => //= y s IHs.
@@ -1920,15 +1922,17 @@ Lemma mask_cat m1 m2 s1 s2 :
   size m1 = size s1 -> mask (m1 ++ m2) (s1 ++ s2) = mask m1 s1 ++ mask m2 s2.
 Proof. by move: m1 s1; apply: seq_ind2 => // -[] m1 x1 s1 /= _ ->. Qed.
 
+Lemma all_mask a m s : all a s -> all a (mask m s).
+Proof.
+by elim: m s => [|[] m IHm] [|x s] //= /andP [? /IHm ->]; rewrite ?andbT.
+Qed.
+
 Lemma has_mask_cons a b m x s :
   has a (mask (b :: m) (x :: s)) = b && a x || has a (mask m s).
 Proof. by case: b. Qed.
 
 Lemma has_mask a m s : has a (mask m s) -> has a s.
-Proof.
-elim: m s => [|b m IHm] [|x s] //; rewrite has_mask_cons /= andbC.
-by case: (a x) => //= /IHm.
-Qed.
+Proof. by apply/contraTT; rewrite -!all_predC; apply: all_mask. Qed.
 
 Lemma mask_rot m s : size m = size s ->
    mask (rot n0 m) (rot n0 s) = rot (count id (take n0 m)) (mask m s).

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1923,9 +1923,7 @@ Lemma mask_cat m1 m2 s1 s2 :
 Proof. by move: m1 s1; apply: seq_ind2 => // -[] m1 x1 s1 /= _ ->. Qed.
 
 Lemma all_mask a m s : all a s -> all a (mask m s).
-Proof.
-by elim: m s => [|[] m IHm] [|x s] //= /andP [? /IHm ->]; rewrite ?andbT.
-Qed.
+Proof. by elim: s m => [|x s IHs] [|[] m]//= /andP[ax /IHs->]; rewrite ?ax. Qed.
 
 Lemma has_mask_cons a b m x s :
   has a (mask (b :: m) (x :: s)) = b && a x || has a (mask m s).


### PR DESCRIPTION
##### Motivation for this change

Part of #601.

- Add `allss` and `all_mask` lemmas in `seq.v`.
- Since `path`, `cycle`, and `sorted` share similar properties, these lemmas have been relocated in the same place to improve the visibility. Some missing lemmas have also been discovered and added.
- Generalize `sub_path_in`, `sub_sorted_in`, and `eq_path_in` for non-`eqType` `T` by introducing a predicate `P : {pred T}`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
