### PR TITLE
Delaying the deprecation of `iter_add`

### DIFF
--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -2035,7 +2035,8 @@ Notation "@ 'odd_opp'" :=
 Notation "@ 'sqrn_sub'" :=
   (deprecate sqrn_sub sqrnB) (at level 10, only parsing) : fun_scope.
 
-#[deprecated(since="mathcomp 1.12.0", note="Use iterD instead.")]
+(* TODO: restore when Coq 8.10 is no longer supported                *)
+(* #[deprecated(since="mathcomp 1.13.0", note="Use iterD instead.")] *)
 Notation iter_add := iterD (only parsing).
 
 Notation maxn_mulr := (deprecate maxn_mulr maxnMr) (only parsing).

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -2030,13 +2030,14 @@ Notation "@ 'decr_inj_in'" :=
   (deprecate decr_inj_in decn_inj_in) (at level 10, only parsing) : fun_scope.
 Notation decr_inj_in := (@decr_inj_in _ _) (only parsing).
 
-Notation "@ 'iter_add'" :=
-  (deprecate iter_add iterD) (at level 10, only parsing) : fun_scope.
 Notation "@ 'odd_opp'" :=
   (deprecate odd_opp oddN) (at level 10, only parsing) : fun_scope.
 Notation "@ 'sqrn_sub'" :=
   (deprecate sqrn_sub sqrnB) (at level 10, only parsing) : fun_scope.
-Notation iter_add := (@iter_add _) (only parsing).
+
+#[deprecated(since="mathcomp 1.12.0", note="Use iterD instead.")]
+Notation iter_add := iterD (only parsing).
+
 Notation maxn_mulr := (deprecate maxn_mulr maxnMr) (only parsing).
 Notation maxn_mull := (deprecate maxn_mull maxnMl) (only parsing).
 Notation minn_mulr := (deprecate minn_mulr minnMr) (only parsing).


### PR DESCRIPTION
##### Motivation for this change

~~Switch `iter_add` to Coq's builtin deprecation mechanism.~~
Fixes #628 

If this succeeds, we should consider switching every single deprecation to Coq's builtin mechanism before the release.

EDIT:
Since Coq 8.10 is not deprecation ready for `Notation` (nor definitions or lemmas), we delay the deprecation of `iter_add` to support compilation of Coquelicot. (cf #628)

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
