### PR TITLE
Deprecation of iota_add delayed, and not the one of iter_add

### DIFF
--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -3654,7 +3654,9 @@ Notation uniq_perm_eq := (deprecate uniq_perm_eq uniq_perm _ _ _)
 Notation perm_eq_iotaP := (deprecate perm_eq_iotaP perm_iotaP) (only parsing).
 Notation perm_undup_count := (deprecate perm_undup_count perm_count_undup _ _)
   (only parsing).
-Notation iota_add := (deprecate iota_add iotaD) (only parsing).
+(* TODO: restore when Coq 8.10 is no longer supported                *)
+(* #[deprecated(since="mathcomp 1.13.0", note="Use iotaD instead.")] *)
+Notation iota_add := iotaD (only parsing).
 Notation iota_addl := (deprecate iota_addl iotaDl) (only parsing).
 
 Notation allpairs_catr :=

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -2030,15 +2030,13 @@ Notation "@ 'decr_inj_in'" :=
   (deprecate decr_inj_in decn_inj_in) (at level 10, only parsing) : fun_scope.
 Notation decr_inj_in := (@decr_inj_in _ _) (only parsing).
 
+Notation "@ 'iter_add'" :=
+  (deprecate iter_add iterD) (at level 10, only parsing) : fun_scope.
 Notation "@ 'odd_opp'" :=
   (deprecate odd_opp oddN) (at level 10, only parsing) : fun_scope.
 Notation "@ 'sqrn_sub'" :=
   (deprecate sqrn_sub sqrnB) (at level 10, only parsing) : fun_scope.
-
-(* TODO: restore when Coq 8.10 is no longer supported                *)
-(* #[deprecated(since="mathcomp 1.13.0", note="Use iterD instead.")] *)
-Notation iter_add := iterD (only parsing).
-
+Notation iter_add := (@iterD _) (only parsing).
 Notation maxn_mulr := (deprecate maxn_mulr maxnMr) (only parsing).
 Notation maxn_mull := (deprecate maxn_mull maxnMl) (only parsing).
 Notation minn_mulr := (deprecate minn_mulr minnMr) (only parsing).


### PR DESCRIPTION
##### Motivation for this change

Fixes #628
Reverts and replaces #633 which wrongfully changed `iter_add` instead of `iota_add`.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.