### PR TITLE
Replace `exact:` with `apply:` in `Hint Extern` declarations

### DIFF
--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -1584,7 +1584,7 @@ Arguments ltr01 {R}.
 Arguments normr_idP {R x}.
 Arguments normr0P {R V v}.
 Hint Resolve ler01 ltr01 ltr0Sn ler0n : core.
-Hint Extern 0 (is_true (0 <= norm _)) => exact: normr_ge0 : core.
+Hint Extern 0 (is_true (0 <= norm _)) => apply: normr_ge0 : core.
 
 Section NumDomainOperationTheory.
 
@@ -2977,7 +2977,7 @@ Definition lter_nnormr := (ler_nnorml, ltr_nnorml).
 
 End NormedZmoduleTheory.
 
-Hint Extern 0 (is_true (norm _ \is real)) => exact: normr_real : core.
+Hint Extern 0 (is_true (norm _ \is real)) => apply: normr_real : core.
 
 Lemma real_ler_norml x y : x \is real -> (`|x| <= y) = (- y <= x <= y).
 Proof.


### PR DESCRIPTION
##### Motivation for this change

> However, it is forbidden to use `exact:` in a `Hint Extern`, since `exact` might call `ssrdone` which calls use of level 0 hints, potentially causing a loop in some weird cases. You may use `solve [apply: stuff]` instead.
(BTW I notice `exact:` is used in `ssrnum.v` which I accidentally let through...)

_Originally posted by @CohenCyril in https://github.com/math-comp/math-comp/pull/601#r521651941_

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
