### PR TITLE
Refactor, reshuffle, and rename sorting lemmas in `path.v`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -276,6 +276,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `(path|sorted)_(mask|filter)_in`, `rev_cycle`, `cycle_map`,
   `(homo|mono)_cycle(_in)`.
 
+- in `path.v`, new lemma `sort_iota_stable`.
+
 - in `seq.v` new lemmas `index_pivot`, `take_pivot`, `rev_pivot`,
   `eqseq_pivot2l`, `eqseq_pivot2r`, `eqseq_pivotl`, `eqseq_pivotr`
   `uniq_eqseq_pivotl`, `uniq_eqseq_pivotr`, `mask_rcons`, `rev_mask`,
@@ -366,6 +368,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `path.v`, generalized lemmas `sub_path_in`, `sub_sorted_in`, and
   `eq_path_in` for non-`eqType`s.
 
+- in `path.v`, generalized lemmas `sorted_ltn_nth` and `sorted_leq_nth`
+  (formerly `sorted_lt_nth` and `sorted_le_nth`, cf Renamed section) for
+  non-`eqType`s.
+
 - in `order.v`, generalized `sort_le_id` for any `porderType`.
 
 ### Renamed
@@ -415,7 +421,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     (`allpairs_consr` and `allpairs_catr` are now deprecated alias,
     and will be attributed to the new `perm_allpairs_catr`).
 
-- in `path.v`, `eq_sorted(_irr)` -> `(irr_)sorted_eq`
+- in `path.v`,
+  + `eq_sorted(_irr)` -> `(irr_)sorted_eq`
+  + `sorted_(lt|le)_nth` -> `sorted_(ltn|leq)_nth`
+  + `(ltn|leq)_index` -> `sorted_(ltn|leq)_index`
 
 - in `div.v`
   + `coprime_mul(l|r)` -> `coprimeM(l|r)`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -425,6 +425,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + `eq_sorted(_irr)` -> `(irr_)sorted_eq`
   + `sorted_(lt|le)_nth` -> `sorted_(ltn|leq)_nth`
   + `(ltn|leq)_index` -> `sorted_(ltn|leq)_index`
+  + `subseq_order_path` -> `subseq_path`
 
 - in `div.v`
   + `coprime_mul(l|r)` -> `coprimeM(l|r)`

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -1648,7 +1648,7 @@ pose t0 := nth (F i0) s 0; have: t0 \in s by rewrite mem_nth.
 rewrite mem_sort => /mapP/sig2_eqW[it0]; rewrite mem_enum => it0P def_t0.
 have /negP[/=] := no_i it0; rewrite [P _]it0P/=; apply/'forall_implyP=> j Pj.
 have /(nthP (F i0))[k g_lt <-] : F j \in s by rewrite mem_sort map_f ?mem_enum.
-by rewrite -def_t0 sorted_le_nth.
+by rewrite -def_t0 sorted_leq_nth.
 Qed.
 
 End Extremum.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -989,7 +989,7 @@ Section Stability_iota.
 
 Variables (leN : rel nat) (leN_total : total leN) (leN_tr : transitive leN).
 
-Let le_lex := [rel n m | leN n m && (leN m n ==> (n < m))].
+Let lt_lex := [rel n m | leN n m && (leN m n ==> (n < m))].
 
 Local Arguments iota : simpl never.
 Local Arguments size : simpl never.
@@ -997,7 +997,7 @@ Local Arguments cat : simpl never.
 
 Let push_invariant := fix push_invariant (ss : seq (seq nat)) :=
   if ss is s :: ss' then
-    sorted le_lex s && perm_eq s (iota (size (flatten ss')) (size s)) &&
+    sorted lt_lex s && perm_eq s (iota (size (flatten ss')) (size s)) &&
     push_invariant ss'
   else
     true.
@@ -1014,7 +1014,7 @@ by rewrite mem_iota size_cat addnC => /andP [] /(leq_trans n_lt).
 Qed.
 
 Let pop_stable s1 ss :
-  push_invariant (s1 :: ss) -> sorted le_lex (merge_sort_pop leN s1 ss).
+  push_invariant (s1 :: ss) -> sorted lt_lex (merge_sort_pop leN s1 ss).
 Proof.
 elim: ss s1 => [s1 /andP [] /andP [] //|s2 ss ihss s1]; rewrite /= -2!andbA.
 move=> /and5P [sorted_s1 perm_s1 sorted_s2 perm_s2 hss]; apply: ihss.
@@ -1024,7 +1024,7 @@ rewrite mem_iota (perm_all _ perm_s1) => /andP [_ n_lt]; apply/allP => p.
 by rewrite mem_iota size_cat addnC => /andP [] /(leq_trans n_lt).
 Qed.
 
-Lemma sort_iota_stable n : sorted le_lex (sort leN (iota 0 n)).
+Lemma sort_iota_stable n : sorted lt_lex (sort leN (iota 0 n)).
 Proof.
 rewrite sortE -[0]/(size (@flatten nat [::])).
 have: push_invariant [::] by [].
@@ -1056,13 +1056,13 @@ Lemma filter_sort T (leT : rel T) :
 Proof.
 move=> leT_total leT_tr p s; case Ds: s => // [x s1].
 pose leN := relpre (nth x s) leT.
-pose le_lex := [rel n m | leN n m && (leN m n ==> (n < m))].
-have le_lex_tr: transitive le_lex.
-  rewrite /le_lex /leN => ? ? ? /= /andP [xy xy'] /andP [yz yz'].
+pose lt_lex := [rel n m | leN n m && (leN m n ==> (n < m))].
+have lt_lex_tr: transitive lt_lex.
+  rewrite /lt_lex /leN => ? ? ? /= /andP [xy xy'] /andP [yz yz'].
   rewrite (leT_tr _ _ _ xy yz); apply/implyP => zx; move: xy' yz'.
   by rewrite (leT_tr _ _ _ yz zx) (leT_tr _ _ _ zx xy); apply: ltn_trans.
 rewrite -{s1}Ds -(mkseq_nth x s) !(filter_map, sort_map); congr map.
-apply/(@irr_sorted_eq _ le_lex); rewrite /le_lex /leN //=.
+apply/(@irr_sorted_eq _ lt_lex); rewrite /lt_lex /leN //=.
 - by move=> ?; rewrite /= ltnn implybF andbN.
 - exact/sorted_filter/sort_iota_stable.
 - exact/sort_stable/sorted_filter/iota_ltn_sorted/ltn_trans/ltn_trans.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -1044,7 +1044,7 @@ Lemma sort_stable T (leT leT' : rel T) :
 Proof.
 move=> leT_total leT'_tr s sorted_s; case Ds: s => // [x s1].
 rewrite -{s1}Ds -(mkseq_nth x s) sort_map.
-have leN_total: total (xrelpre (nth x s) leT) by move=> n m; apply: leT_total.
+have leN_total: total (relpre (nth x s) leT) by move=> n m; apply: leT_total.
 apply: (homo_sorted_in _ (allss _)) (sort_iota_stable leN_total _) => /= y z.
 rewrite !mem_sort !mem_iota !leq0n add0n /= => ys zs /andP [->] /=.
 by case: (leT _ _); first apply: sorted_ltn_nth.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -419,7 +419,7 @@ Local Notation sorted := (sorted leT).
 
 Hypothesis leT_tr : transitive leT.
 
-Lemma subseq_order_path x s1 s2 : subseq s1 s2 -> path x s2 -> path x s1.
+Lemma subseq_path x s1 s2 : subseq s1 s2 -> path x s2 -> path x s1.
 Proof. by case/subseqP => m _ ->; apply/path_mask. Qed.
 
 Lemma subseq_sorted s1 s2 : subseq s1 s2 -> sorted s2 -> sorted s1.
@@ -1454,6 +1454,8 @@ Notation "@ 'ltn_index'" := (deprecate ltn_index sorted_ltn_index)
   (at level 10, only parsing) : fun_scope.
 Notation "@ 'leq_index'" := (deprecate leq_index sorted_leq_index)
   (at level 10, only parsing) : fun_scope.
+Notation "@ 'subseq_order_path'" := (deprecate subseq_order_path subseq_path)
+  (at level 10, only parsing) : fun_scope.
 
 Notation eq_sorted :=
   (fun le_tr le_asym => @eq_sorted _ _ le_tr le_asym _ _) (only parsing).
@@ -1470,3 +1472,5 @@ Notation ltn_index :=
 Notation leq_index :=
   (fun leT_tr leT_refl s_sorted =>
      @leq_index _ _ leT_tr leT_refl _ s_sorted _ _) (only parsing).
+Notation subseq_order_path :=
+  (fun leT_tr => @subseq_order_path _ _ leT_tr _ _ _) (only parsing).


### PR DESCRIPTION
##### Motivation for this change

<!-- please explain your reason for doing this change -->

Part of #601.

- Lemmas `sorted_(lt|le)_nth` have been renamed to `sorted_(ltn|leq)_nth`.
- Lemmas `(ltn|leq)_index` have been renamed to `sorted_(ltn|leq)_index` and generalized for non-`eqType`s.
- Lemmas `order_path_min`, `path_sortedE`, `subseq_order_path`, `subseq_sorted`, `sorted_uniq`, `sorted_eq`, `irr_sorted_eq`, `sorted_(ltn|leq)_nth`, and `sorted_(ltn|leq)_index` have been relocated since their proofs are independent from `merge` and `sort`.
- The stability proofs for `iota` sequences (`push_stable`, `pop_stable`, and `sort_iota_stable`) have been simplified by sorting out their hypotheses and by redefining `push_invariant` to include the `sorted` condition. Their main result `sort_iota_stable`, formerly a local `Let` to prove `sort_stable`, has been turned into a lemma.
- Some stability proofs for general sequences (`sort_stable` and `filter_sort`) have also been simplified, of which the former one uses the above `sorted_ltn_nth` lemma for a `Type` without decidable equality.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
