### PR TITLE
[WIP] Make linear subspaces canonically a `tbLatticeType`

### DIFF
--- a/algebra/vector.v
+++ b/algebra/vector.v
@@ -2,7 +2,7 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import fintype tuple finfun bigop nmodule.
+From mathcomp Require Import fintype tuple finfun bigop nmodule order.
 From mathcomp Require Import rings_modules_and_algebras divalg matrix mxalgebra.
 
 (******************************************************************************)
@@ -129,7 +129,9 @@ Reserved Notation "\dim A" (at level 10, A at level 8, format "\dim  A").
 
 Delimit Scope vspace_scope with VS.
 
-Import GRing.Theory.
+Import Order.LTheory GRing.Theory.
+
+Fact vspace_display : Order.disp_t. Proof. exact: Order.Disp tt tt. Qed.
 
 (* Finite dimension vector space *)
 Record semivector_axiom_def (R : nzSemiRingType) n (V : lSemiModType R) := {
@@ -295,7 +297,6 @@ Implicit Types (u : vT) (X : seq vT) (U V : {vspace vT}).
 HB.instance Definition _ := [Choice of {vspace vT} by <:].
 
 Definition dimv U := \rank (vs2mx U).
-Definition subsetv U V := (vs2mx U <= vs2mx V)%MS.
 Definition vline u := mx2vs (v2r u).
 
 (* Vspace membership is defined as line inclusion. *)
@@ -303,9 +304,6 @@ Definition pred_of_vspace (U : space vT) : {pred vT} :=
   fun v => (vs2mx (vline v) <= vs2mx U)%MS.
 Canonical vspace_predType := @PredType _ (unkeyed {vspace vT}) pred_of_vspace.
 
-Definition fullv : {vspace vT} := mx2vs 1%:M.
-Definition addv U V := mx2vs (vs2mx U + vs2mx V).
-Definition capv U V := mx2vs (vs2mx U :&: vs2mx V).
 Definition complv U := mx2vs (vs2mx U)^C.
 Definition diffv U V := mx2vs (vs2mx U :\: vs2mx V).
 Definition vpick U := r2v (nz_row (vs2mx U)).
@@ -326,19 +324,61 @@ Definition basis_of U X := (span X == U) && free X.
 End VspaceDefs.
 
 Coercion pred_of_vspace : space >-> pred_sort.
+
+Prenex Implicits complv diffv span free basis_of.
+
+Module Import VspaceSyntax.
+
 Notation "\dim U" := (dimv U) : nat_scope.
-Notation "U <= V" := (subsetv U V) : vspace_scope.
-Notation "U <= V <= W" := (subsetv U V && subsetv V W) : vspace_scope.
 Notation "<[ v ] >" := (vline v) : vspace_scope.
 Notation "<< X >>" := (span X) : vspace_scope.
-Notation "0" := (vline 0) : vspace_scope.
-Arguments fullv {K vT}.
-Prenex Implicits subsetv addv capv complv diffv span free basis_of.
 
-Notation "U + V" := (addv U V) : vspace_scope.
-Notation "U :&: V" := (capv U V) : vspace_scope.
 Notation "U ^C" := (complv U) : vspace_scope.
 Notation "U :\: V" := (diffv U V) : vspace_scope.
+
+Notation subsetv := (@Order.le vspace_display _).
+Notation "@ 'subsetv' K vT" :=
+  (@Order.le vspace_display _ : rel {vspace (vT : vectType K)})
+  (at level 10, K at level 8, vT at level 8, only parsing) : function_scope.
+Notation properv := (@Order.lt vspace_display _).
+Notation "@ 'properv' K vT" :=
+  (@Order.lt vspace_display _ : rel {vspace (vT : vectType K)})
+  (at level 10, K at level 8, vT at level 8, only parsing) : function_scope.
+Notation capv := (@Order.meet vspace_display _).
+Notation "@ 'capv' K vT" :=
+  (@Order.meet vspace_display _ : {vspace (vT : vectType K)} -> _)
+  (at level 10, K at level 8, vT at level 8, only parsing) : function_scope.
+Notation addv := (@Order.join vspace_display _).
+Notation "@ 'addv' K vT" :=
+  (@Order.join vspace_display _ : {vspace (vT : vectType K)} -> _)
+  (at level 10, K at level 8, vT at level 8, only parsing) : function_scope.
+Notation fullv := (@Order.top vspace_display _).
+Notation "@ 'fullv' K vT" :=
+  (@Order.top vspace_display _ : {vspace (vT : vectType K)})
+  (at level 10, K at level 8, vT at level 8, only parsing) : function_scope.
+
+Notation "U <= V" := (subsetv U V) : vspace_scope.
+Notation "U <= V :> T" := ((U : T) <= (V : T))%VS (only parsing) : vspace_scope.
+Notation "U >= V" := (V <= U) (only parsing) : vspace_scope.
+Notation "U >= V :> T" := ((U : T) >= (V : T))%VS (only parsing) : vspace_scope.
+
+Notation "U < V"  := (properv U V) : vspace_scope.
+Notation "U < V :> T" := ((U : T) < (V : T))%VS (only parsing) : vspace_scope.
+Notation "U > V"  := (V < U) (only parsing) : vspace_scope.
+Notation "U > V :> T" := ((U : T) > (V : T))%VS (only parsing) : vspace_scope.
+
+Notation "U <= V <= W" := ((U <= V) && (V <= W))%VS : vspace_scope.
+Notation "U < V <= W" := ((U < V) && (V <= W))%VS : vspace_scope.
+Notation "U <= V < W" := ((U <= V) && (V < W))%VS : vspace_scope.
+Notation "U < V < W" := ((U < V) && (V < W))%VS : vspace_scope.
+
+Notation "U :&: V" := (capv U V) : vspace_scope.
+Notation "U + V" := (addv U V) : vspace_scope.
+
+Notation "0" := (@Order.bottom vspace_display _) : vspace_scope.
+(* Notation "0" := (@Order.bottom vspace_display _ : {vspace _}) *)
+(*   (only parsing) : vspace_scope. *)
+
 Notation "{ : vT }" := (@fullv _ vT) (only parsing) : vspace_scope.
 
 Notation "\sum_ ( i <- r | P ) U" :=
@@ -391,6 +431,75 @@ Notation "\bigcap_ ( i 'in' A | P ) U" :=
 Notation "\bigcap_ ( i 'in' A ) U" :=
   (\big[capv/fullv]_(i in A) U%VS) : vspace_scope.
 
+End VspaceSyntax.
+
+Module VspaceLattice.
+Section VspaceLattice.
+
+Variables (K : fieldType) (vT : vectType K).
+Implicit Types (u : vT) (X : seq vT) (U V : {vspace vT}).
+
+Let vs2mxP U V : reflect (U = V) (vs2mx U == vs2mx V)%MS.
+Proof. by rewrite (sameP genmxP eqP) !gen_vs2mx; apply: eqP. Qed.
+
+Fact subsetv_refl : reflexive (fun U V => vs2mx U <= vs2mx V)%MS.
+Proof. by move=> ?; exact: submx_refl. Qed.
+
+Fact subsetv_asym : antisymmetric (fun U V => vs2mx U <= vs2mx V)%MS.
+Proof. exact: vs2mxP. Qed.
+
+Fact subsetv_trans : transitive (fun U V => vs2mx U <= vs2mx V)%MS.
+Proof. by move=> ? ? ?; exact: submx_trans. Qed.
+
+#[export]
+HB.instance Definition _ := Order.Le_isPOrder.Build vspace_display {vspace vT}
+  subsetv_refl subsetv_asym subsetv_trans.
+
+Lemma subsetvE U V : (U <= V)%VS = (vs2mx U <= vs2mx V)%MS. Proof. by []. Qed.
+
+Local Notation capv := (fun U V => mx2vs (vs2mx U :&: vs2mx V)).
+Local Notation addv := (fun U V => mx2vs (vs2mx U + vs2mx V)).
+
+Fact capvP U V W : (U <= capv V W)%VS = (U <= V)%VS && (U <= W)%VS.
+Proof. by rewrite !subsetvE/= genmx_cap !gen_vs2mx sub_capmx. Qed.
+
+Fact addvP U V W : (addv U V <= W)%VS = (U <= W)%VS && (V <= W)%VS.
+Proof. by rewrite !subsetvE/= genmx_adds !gen_vs2mx addsmx_sub. Qed.
+
+#[export]
+HB.instance Definition _ :=
+  Order.POrder_MeetJoin_isLattice.Build vspace_display {vspace vT} capvP addvP.
+
+Fact sub0v U : (vline 0 <= U)%VS.
+Proof. by rewrite subsetvE /= genmxE linear0 sub0mx. Qed.
+
+Fact subsetv1 V : (V <= mx2vs 1%:M)%VS.
+Proof. by rewrite subsetvE /= mx2vsK; apply: submx1. Qed.
+
+#[export]
+HB.instance Definition _ :=
+  Order.hasBottom.Build vspace_display {vspace vT} sub0v.
+#[export]
+HB.instance Definition _ :=
+  Order.hasTop.Build vspace_display {vspace vT} subsetv1.
+
+Lemma capvE U V : (U :&: V)%VS = mx2vs (vs2mx U :&: vs2mx V). Proof. by []. Qed.
+Lemma addvE U V : (U + V)%VS = mx2vs (vs2mx U + vs2mx V). Proof. by []. Qed.
+Lemma v0E : 0%VS = vline 0. Proof. by []. Qed.
+Lemma fullvE : {: vT}%VS = mx2vs 1%:M. Proof. by []. Qed.
+
+End VspaceLattice.
+Module Exports.
+HB.reexport.
+Definition subsetvE := subsetvE.
+Definition capvE := capvE.
+Definition addvE := addvE.
+Definition v0E := v0E.
+Definition fullvE := fullvE.
+End Exports.
+End VspaceLattice.
+Export VspaceLattice.Exports.
+
 Section VectorTheory.
 
 Variables (K : fieldType) (vT : vectType K).
@@ -399,6 +508,8 @@ Implicit Types (a : K) (u v w : vT) (X Y : seq vT) (U V W : {vspace vT}).
 Local Notation subV := (@subsetv K vT) (only parsing).
 Local Notation addV := (@addv K vT) (only parsing).
 Local Notation capV := (@capv K vT) (only parsing).
+Local Notation "0" :=
+  (@Order.bottom _ {vspace vT}) (only parsing) : vspace_scope.
 
 (* begin hide *)
 
@@ -479,25 +590,25 @@ Proof. by apply/vlineP; exists 1; rewrite scale1r. Qed.
 Lemma subvP U V : reflect {subset U <= V} (U <= V)%VS.
 Proof.
 apply: (iffP rV_subP) => sU12 u.
-  by rewrite !memvE /subsetv !genmxE => /sU12.
-by have:= sU12 (r2v u); rewrite !memvE /subsetv !genmxE r2vK.
+  by rewrite !memvE !subsetvE !genmxE => /sU12.
+by have:= sU12 (r2v u); rewrite !memvE !subsetvE !genmxE r2vK.
 Qed.
 
-Lemma subvv U : (U <= U)%VS. Proof. exact/subvP. Qed.
-Hint Resolve subvv : core.
+#[deprecated(since="mathcomp 2.6.0", use=le_refl)]
+Lemma subvv U : (U <= U)%VS. Proof. exact: le_refl. Qed.
 
-Lemma subv_trans : transitive subV.
-Proof. by move=> U V W /subvP sUV /subvP sVW; apply/subvP=> u /sUV/sVW. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=le_trans)]
+Lemma subv_trans : transitive subV. Proof. exact: le_trans. Qed.
 
-Lemma subv_anti : antisymmetric subV.
-Proof. by move=> U V; apply/vs2mxP. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=le_anti)]
+Lemma subv_anti : antisymmetric subV. Proof. exact: le_anti. Qed.
 
-Lemma eqEsubv U V : (U == V) = (U <= V <= U)%VS.
-Proof. by apply/eqP/idP=> [-> | /subv_anti//]; rewrite subvv. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=eq_le)]
+Lemma eqEsubv U V : (U == V) = (U <= V <= U)%VS. Proof. exact: eq_le. Qed.
 
 Lemma vspaceP U V : U =i V <-> U = V.
 Proof.
-split=> [eqUV | -> //]; apply/subv_anti/andP.
+split=> [eqUV | -> //]; apply/le_anti/andP.
 by split; apply/subvP=> v; rewrite eqUV.
 Qed.
 
@@ -509,68 +620,70 @@ by exists (r2v vi); rewrite memvK r2vK ?row_sub.
 Qed.
 
 (* Empty space. *)
-Lemma sub0v U : (0 <= U)%VS.
-Proof. exact: mem0v. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=le0x)]
+Lemma sub0v U : (0 <= U)%VS. Proof. exact: le0x. Qed.
 
-Lemma subv0 U : (U <= 0)%VS = (U == 0%VS).
-Proof. by rewrite eqEsubv sub0v andbT. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=lex0)]
+Lemma subv0 U : (U <= 0)%VS = (U == 0%VS). Proof. exact: lex0. Qed.
 
 Lemma memv0 v : (v \in 0%VS) = (v == 0).
 Proof. by apply/idP/eqP=> [/vlineP[k ->] | ->]; rewrite (scaler0, mem0v). Qed.
 
 (* Full space *)
 
-Lemma subvf U : (U <= fullv)%VS. Proof. by rewrite /subsetv vs2mxF submx1. Qed.
-Lemma memvf v : v \in fullv. Proof. exact: subvf. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=lex1)]
+Lemma subvf U : (U <= {:vT})%VS. Proof. exact: lex1. Qed.
+Lemma memvf v : v \in {:vT}%VS. Proof. by rewrite memvE lex1. Qed.
 
 (* Picking a non-zero vector in a subspace. *)
 Lemma memv_pick U : vpick U \in U. Proof. by rewrite mem_r2v nz_row_sub. Qed.
 
 Lemma vpick0 U : (vpick U == 0) = (U == 0%VS).
-Proof. by  rewrite -memv0 mem_r2v -subv0 /subV vs2mx0 !submx0 nz_row_eq0. Qed.
+Proof. by rewrite -memv0 mem_r2v -lex0 !subsetvE vs2mx0 !submx0 nz_row_eq0. Qed.
 
 (* Sum of subspaces. *)
+#[deprecated(since="mathcomp 2.6.0", use=leUx)]
 Lemma subv_add U V W : (U + V <= W)%VS = (U <= W)%VS && (V <= W)%VS.
-Proof. by rewrite /subV vs2mxD addsmx_sub. Qed.
+Proof. exact: leUx. Qed.
 
+#[deprecated(since="mathcomp 2.6.0", use=leU2)]
 Lemma addvS U1 U2 V1 V2 : (U1 <= U2 -> V1 <= V2 -> U1 + V1 <= U2 + V2)%VS.
-Proof. by rewrite /subV !vs2mxD; apply: addsmxS. Qed.
+Proof. exact: leU2. Qed.
 
-Lemma addvSl U V : (U <= U + V)%VS.
-Proof. by rewrite /subV vs2mxD addsmxSl. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=leUl)]
+Lemma addvSl U V : (U <= U + V)%VS. Proof. exact: leUl. Qed.
 
-Lemma addvSr U V : (V <= U + V)%VS.
-Proof. by rewrite /subV vs2mxD addsmxSr. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=leUr)]
+Lemma addvSr U V : (V <= U + V)%VS. Proof. exact: leUr. Qed.
 
-Lemma addvC : commutative addV.
-Proof. by move=> U V; apply/vs2mxP; rewrite !vs2mxD addsmxC submx_refl. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=joinC)]
+Lemma addvC : commutative addV. Proof. exact: joinC. Qed.
 
-Lemma addvA : associative addV.
-Proof. by move=> U V W; apply/vs2mxP; rewrite !vs2mxD addsmxA submx_refl. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=joinA)]
+Lemma addvA : associative addV. Proof. exact: joinA. Qed.
 
+#[deprecated(since="mathcomp 2.6.0", use=join_idPl)]
 Lemma addv_idPl {U V}: reflect (U + V = U)%VS (V <= U)%VS.
-Proof. by rewrite /subV (sameP addsmx_idPl eqmxP) -vs2mxD; apply: vs2mxP. Qed.
+Proof. exact: join_idPl. Qed.
 
+#[deprecated(since="mathcomp 2.6.0", use=join_idPr)]
 Lemma addv_idPr {U V} : reflect (U + V = V)%VS (U <= V)%VS.
-Proof. by rewrite addvC; apply: addv_idPl. Qed.
+Proof. exact: join_idPr. Qed.
 
-Lemma addvv : idempotent_op addV.
-Proof. by move=> U; apply/addv_idPl. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=joinxx)]
+Lemma addvv : idempotent_op addV. Proof. exact: joinxx. Qed.
 
-Lemma add0v : left_id 0%VS addV.
-Proof. by move=> U; apply/addv_idPr/sub0v. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=join0x)]
+Lemma add0v : left_id 0%VS addV. Proof. exact: join0x. Qed.
 
-Lemma addv0 : right_id 0%VS addV.
-Proof. by move=> U; apply/addv_idPl/sub0v. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=joinx0)]
+Lemma addv0 : right_id 0%VS addV. Proof. exact: joinx0. Qed.
 
-Lemma sumfv : left_zero fullv addV.
-Proof. by move=> U; apply/addv_idPl/subvf. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=join1x)]
+Lemma sumfv : left_zero fullv addV. Proof. exact: join1x. Qed.
 
-Lemma addvf : right_zero fullv addV.
-Proof. by move=> U; apply/addv_idPr/subvf. Qed.
-
-HB.instance Definition _ := Monoid.isComLaw.Build {vspace vT} 0%VS addv
-  addvA addvC add0v.
+#[deprecated(since="mathcomp 2.6.0", use=joinx1)]
+Lemma addvf : right_zero fullv addV. Proof. exact: joinx1. Qed.
 
 Lemma memv_add u v U V : u \in U -> v \in V -> u + v \in (U + V)%VS.
 Proof. by rewrite !memvK genmxE linearD; apply: addmx_sub_adds. Qed.
@@ -589,26 +702,28 @@ Section BigSum.
 Variable I : finType.
 Implicit Type P : pred I.
 
+#[deprecated(since="mathcomp 2.6.0", use=joins_min)]
 Lemma sumv_sup i0 P U Vs :
   P i0 -> (U <= Vs i0)%VS -> (U <= \sum_(i | P i) Vs i)%VS.
-Proof. by move=> Pi0 /subv_trans-> //; rewrite (bigD1 i0) ?addvSl. Qed.
+Proof. exact: joins_min. Qed.
+
+#[warning="-deprecated"]
 Arguments sumv_sup i0 [P U Vs].
 
+#[deprecated(since="mathcomp 2.6.0", use=joinsP)]
 Lemma subv_sumP {P Us V} :
   reflect (forall i, P i -> Us i <= V)%VS  (\sum_(i | P i) Us i <= V)%VS.
-Proof.
-apply: (iffP idP) => [sUV i Pi | sUV].
-  by apply: subv_trans sUV; apply: sumv_sup Pi _.
-by elim/big_rec: _ => [|i W Pi sWV]; rewrite ?sub0v // subv_add sUV.
-Qed.
+Proof. exact: joinsP. Qed.
 
 Lemma memv_sumr P vs (Us : I -> {vspace vT}) :
     (forall i, P i -> vs i \in Us i) ->
   \sum_(i | P i) vs i \in (\sum_(i | P i) Us i)%VS.
-Proof. by move=> Uv; apply/rpred_sum=> i Pi; apply/(sumv_sup i Pi)/Uv. Qed.
+Proof.
+by move=> Uv; apply/rpred_sum=> i Pi; rewrite memvE; apply/(joins_min Pi)/Uv.
+Qed.
 
 Lemma memv_sumP {P} {Us : I -> {vspace vT}} {v} :
-  reflect (exists2 vs, forall i, P i ->  vs i \in Us i
+  reflect (exists2 vs, forall i, P i -> vs i \in Us i
                      & v = \sum_(i | P i) vs i)
           (v \in \sum_(i | P i) Us i)%VS.
 Proof.
@@ -622,50 +737,51 @@ End BigSum.
 
 (* Intersection *)
 
+#[deprecated(since="mathcomp 2.6.0", use=lexI)]
 Lemma subv_cap U V W : (U <= V :&: W)%VS = (U <= V)%VS && (U <= W)%VS.
-Proof. by rewrite /subV vs2mxI sub_capmx. Qed.
+Proof. exact: lexI. Qed.
 
+#[deprecated(since="mathcomp 2.6.0", use=leI2)]
 Lemma capvS U1 U2 V1 V2 : (U1 <= U2 -> V1 <= V2 -> U1 :&: V1 <= U2 :&: V2)%VS.
-Proof. by rewrite /subV !vs2mxI; apply: capmxS. Qed.
+Proof. exact: leI2. Qed.
 
-Lemma capvSl U V : (U :&: V <= U)%VS.
-Proof. by rewrite /subV vs2mxI capmxSl. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=leIl)]
+Lemma capvSl U V : (U :&: V <= U)%VS. Proof. exact: leIl. Qed.
 
-Lemma capvSr U V : (U :&: V <= V)%VS.
-Proof. by rewrite /subV vs2mxI capmxSr. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=leIr)]
+Lemma capvSr U V : (U :&: V <= V)%VS. Proof. exact: leIr. Qed.
 
-Lemma capvC : commutative capV.
-Proof. by move=> U V; apply/vs2mxP; rewrite !vs2mxI capmxC submx_refl. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=meetC)]
+Lemma capvC : commutative capV. Proof. exact: meetC. Qed.
 
-Lemma capvA : associative capV.
-Proof. by move=> U V W; apply/vs2mxP; rewrite !vs2mxI capmxA submx_refl. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=meetA)]
+Lemma capvA : associative capV. Proof. exact: meetA. Qed.
 
+#[deprecated(since="mathcomp 2.6.0", use=meet_idPl)]
 Lemma capv_idPl {U V} : reflect (U :&: V = U)%VS (U <= V)%VS.
-Proof. by rewrite /subV(sameP capmx_idPl eqmxP) -vs2mxI; apply: vs2mxP. Qed.
+Proof. exact: meet_idPl. Qed.
 
+#[deprecated(since="mathcomp 2.6.0", use=meet_idPr)]
 Lemma capv_idPr {U V} : reflect (U :&: V = V)%VS (V <= U)%VS.
-Proof. by rewrite capvC; apply: capv_idPl. Qed.
+Proof. exact: meet_idPr. Qed.
 
-Lemma capvv : idempotent_op capV.
-Proof. by move=> U; apply/capv_idPl. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=meetxx)]
+Lemma capvv : idempotent_op capV. Proof. exact: meetxx. Qed.
 
-Lemma cap0v : left_zero 0%VS capV.
-Proof. by move=> U; apply/capv_idPl/sub0v. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=meet0x)]
+Lemma cap0v : left_zero 0%VS capV. Proof. exact: meet0x. Qed.
 
-Lemma capv0 : right_zero 0%VS capV.
-Proof. by move=> U; apply/capv_idPr/sub0v. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=meetx0)]
+Lemma capv0 : right_zero 0%VS capV. Proof. exact: meetx0. Qed.
 
-Lemma capfv : left_id fullv capV.
-Proof. by move=> U; apply/capv_idPr/subvf. Qed.
+#[deprecated(since="mathcomp 2.6.0", use=meet1x)]
+Lemma capfv : left_id fullv capV. Proof. exact: meet1x. Qed.
 
-Lemma capvf : right_id fullv capV.
-Proof. by move=> U; apply/capv_idPl/subvf. Qed.
-
-HB.instance Definition _ := Monoid.isComLaw.Build {vspace vT} fullv capv
-  capvA capvC capfv.
+#[deprecated(since="mathcomp 2.6.0", use=meetx1)]
+Lemma capvf : right_id fullv capV. Proof. exact: meetx1. Qed.
 
 Lemma memv_cap w U V : (w \in U :&: V)%VS = (w \in U) && (w \in V).
-Proof. by rewrite !memvE subv_cap. Qed.
+Proof. by rewrite !memvE lexI. Qed.
 
 Lemma memv_capP {w U V} : reflect (w \in U /\ w \in V) (w \in U :&: V)%VS.
 Proof. by rewrite memv_cap; apply: andP. Qed.
@@ -676,23 +792,21 @@ by move=> sUV; apply/vs2mxP; rewrite !(vs2mxD, vs2mxI); apply/eqmxP/matrix_modl.
 Qed.
 
 Lemma vspace_modr  U V W : (W <= U -> (U :&: V) + W = U :&: (V + W))%VS.
-Proof. by rewrite -!(addvC W) !(capvC U); apply: vspace_modl. Qed.
+Proof. by rewrite -!(joinC W) !(meetC U); apply: vspace_modl. Qed.
 
 Section BigCap.
 Variable I : finType.
 Implicit Type P : pred I.
 
+#[deprecated(since="mathcomp 2.6.0", use=meets_max)]
 Lemma bigcapv_inf i0 P Us V :
   P i0 -> (Us i0 <= V -> \bigcap_(i | P i) Us i <= V)%VS.
-Proof. by move=> Pi0; apply: subv_trans; rewrite (bigD1 i0) ?capvSl. Qed.
+Proof. exact: meets_max. Qed.
 
+#[deprecated(since="mathcomp 2.6.0", use=meetsP)]
 Lemma subv_bigcapP {P U Vs} :
   reflect (forall i, P i -> U <= Vs i)%VS (U <= \bigcap_(i | P i) Vs i)%VS.
-Proof.
-apply: (iffP idP) => [sUV i Pi | sUV].
-  by rewrite (subv_trans sUV) ?(bigcapv_inf Pi).
-by elim/big_rec: _ => [|i W Pi]; rewrite ?subvf // subv_cap sUV.
-Qed.
+Proof. exact: meetsP. Qed.
 
 End BigCap.
 
@@ -711,7 +825,7 @@ Qed.
 
 (* Difference *)
 Lemma diffvSl U V : (U :\: V <= U)%VS.
-Proof. by rewrite /subV genmxE diffmxSl. Qed.
+Proof. by rewrite subsetvE genmxE diffmxSl. Qed.
 
 Lemma capv_diff U V : ((U :\: V) :&: V = 0)%VS.
 Proof.
@@ -726,7 +840,7 @@ exact/eqmxP/addsmx_diff_cap_eq.
 Qed.
 
 Lemma addv_diff U V : (U :\: V + V = U + V)%VS.
-Proof. by rewrite -{2}(addv_diff_cap U V) -addvA (addv_idPr (capvSr U V)). Qed.
+Proof. by rewrite -{2}(addv_diff_cap U V) -joinA meetUK. Qed.
 
 (* Subspace dimension. *)
 Lemma dimv0 : \dim (0%VS : {vspace vT}) = 0.
@@ -748,7 +862,7 @@ Lemma dimv_leqif_sup U V : (U <= V)%VS -> \dim U <= \dim V ?= iff (V <= U)%VS.
 Proof. exact: mxrank_leqif_sup. Qed.
 
 Lemma dimv_leqif_eq U V : (U <= V)%VS -> \dim U <= \dim V ?= iff (U == V).
-Proof. by rewrite eqEsubv; apply: mxrank_leqif_eq. Qed.
+Proof. by rewrite eq_le; apply: mxrank_leqif_eq. Qed.
 
 Lemma eqEdim U V : (U == V) = (U <= V)%VS && (\dim V <= \dim U).
 Proof. by apply/idP/andP=> [/eqP | [/dimv_leqif_eq/geq_leqif]] ->. Qed.
@@ -769,13 +883,13 @@ Proof. by move=> dxUV; rewrite -dimv_sum_cap dxUV dimv0 addn0. Qed.
 Lemma dimv_add_leqif U V :
   \dim (U + V) <= \dim U + \dim V ?= iff (U :&: V <= 0)%VS.
 Proof.
-by rewrite /dimv /subV !mxrank_gen vs2mx0 genmxE; apply: mxrank_adds_leqif.
+by rewrite /dimv subsetvE !mxrank_gen vs2mx0 genmxE; apply: mxrank_adds_leqif.
 Qed.
 
 Lemma diffv_eq0 U V : (U :\: V == 0)%VS = (U <= V)%VS.
 Proof.
 rewrite -dimv_eq0 -(eqn_add2l (\dim (U :&: V))) addn0 dimv_cap_compl eq_sym.
-by rewrite (dimv_leqif_eq (capvSl _ _)) (sameP capv_idPl eqP).
+by rewrite (dimv_leqif_eq (leIl _ _)) eq_meetl.
 Qed.
 
 Lemma dimv_leq_sum I r (P : pred I) (Us : I -> {vspace vT}) :
@@ -885,7 +999,7 @@ apply: (iffP directv_addP) => [dxUV u1 u2 v1 v2 Uu1 Uu2 Vv1 Vv2 | dxUV].
   apply/idP/idP=> [| /eqP[-> ->] //]; rewrite -subr_eq0 opprD addrACA addr_eq0.
   move/eqP=> eq_uv; rewrite xpair_eqE -subr_eq0 eq_uv oppr_eq0 subr_eq0 andbb.
   by rewrite -subr_eq0 -memv0 -dxUV memv_cap -memvN -eq_uv !memvB.
-apply/eqP; rewrite -subv0; apply/subvP=> v /memv_capP[U1v U2v].
+apply/eqP; rewrite -lex0; apply/subvP=> v /memv_capP[U1v U2v].
 by rewrite memv0 -[v == 0]andbb {1}eq_sym -xpair_eqE -dxUV ?mem0v // addrC.
 Qed.
 
@@ -920,7 +1034,7 @@ Proof.
 apply: (iffP directv_sumP) => [dxU us Uu u_0 i Pi | dxU i Pi].
   apply/eqP; rewrite -memv0 -(dxU i Pi) memv_cap Uu //= -memvN -sub0r -{1}u_0.
   by rewrite (bigD1 i) //= [_ - us i]addrC addKr memv_sumr // => j /andP[/Uu].
-apply/eqP; rewrite -subv0; apply/subvP=> v.
+apply/eqP; rewrite -lex0; apply/subvP=> v.
 rewrite memv_cap memv0 => /andP[Uiv /memv_sumP[us Uu Dv]].
 have: \sum_(j | P j) [eta us with i |-> - v] j = 0.
   rewrite (bigD1 i) //= eqxx {1}Dv addrC -sumrB big1 // => j /andP[_ i'j].
@@ -961,7 +1075,7 @@ Proof. by rewrite unlock /dimv genmxE rank_leq_row. Qed.
 
 Lemma span_subvP {X U} : reflect {subset X <= U} (<<X>> <= U)%VS.
 Proof.
-rewrite /subV [@span _ _]unlock genmxE.
+rewrite subsetvE [@span _ _]unlock genmxE.
 apply: (iffP row_subP) => /= [sXU | sXU i].
   by move=> _ /seq_tnthP[i ->]; have:= sXU i; rewrite rowK memvK.
 by rewrite rowK -memvK sXU ?mem_tnth.
@@ -972,14 +1086,14 @@ Proof. by move=> sXY; apply/span_subvP=> v /sXY/memv_span. Qed.
 
 Lemma eq_span X Y : X =i Y -> (<<X>> = <<Y>>)%VS.
 Proof.
-by move=> eqXY; apply: subv_anti; rewrite !sub_span // => u; rewrite eqXY.
+by move=> eqXY; apply: le_anti; rewrite !sub_span // => u; rewrite eqXY.
 Qed.
 
 Lemma span_def X : span X = (\sum_(u <- X) <[u]>)%VS.
 Proof.
-apply/subv_anti/andP; split.
-  by apply/span_subvP=> v Xv; rewrite (big_rem v) // memvE addvSl.
-by rewrite big_tnth; apply/subv_sumP=> i _; rewrite -memvE memv_span ?mem_tnth.
+apply/le_anti/andP; split.
+  by apply/span_subvP=> v Xv; rewrite (big_rem v) // memvE leUl.
+by rewrite big_tnth; apply/joinsP=> i _; rewrite -memvE memv_span ?mem_tnth.
 Qed.
 
 Lemma span_nil : (<<Nil vT>> = 0)%VS.
@@ -1078,7 +1192,7 @@ Lemma cat_free X Y :
 Proof.
 rewrite !free_directv mem_cat directvE /= !big_cat -directvE /= directv_addE /=.
 rewrite negb_or -!andbA; do !bool_congr; rewrite -!span_def.
-by rewrite (sameP eqP directv_addP).
+by apply/eqP/directv_addP.
 Qed.
 
 Lemma catl_free Y X : free (X ++ Y) -> free X.
@@ -1097,8 +1211,8 @@ Lemma free_cons v X : free (v :: X) = (v \notin <<X>>)%VS && free X.
 Proof.
 rewrite (cat_free [:: v]) seq1_free directvEgeq /= span_seq1 dim_vline.
 case: eqP => [-> | _] /=; first by rewrite mem0v.
-rewrite andbC ltnNge (geq_leqif (dimv_leqif_sup _)) ?addvSr //.
-by rewrite subv_add subvv andbT -memvE.
+rewrite andbC ltnNge (geq_leqif (dimv_leqif_sup _)) ?leUr //.
+by rewrite leUx lexx andbT.
 Qed.
 
 Lemma freeE n (X : n.-tuple vT) :
@@ -1250,19 +1364,19 @@ End BigSumBasis.
 
 End VectorTheory.
 
-#[global] Hint Resolve subvv : core.
+#[warning="-deprecated", global] Hint Resolve subvv : core.
 Arguments subvP {K vT U V}.
-Arguments addv_idPl {K vT U V}.
-Arguments addv_idPr {K vT U V}.
+#[warning="-deprecated"] Arguments addv_idPl {K vT U V}.
+#[warning="-deprecated"] Arguments addv_idPr {K vT U V}.
 Arguments memv_addP {K vT w U V }.
-Arguments sumv_sup [K vT I] i0 [P U Vs].
+#[warning="-deprecated"] Arguments sumv_sup [K vT I] i0 [P U Vs].
 Arguments memv_sumP {K vT I P Us v}.
-Arguments subv_sumP {K vT I P Us V}.
-Arguments capv_idPl {K vT U V}.
-Arguments capv_idPr {K vT U V}.
+#[warning="-deprecated"] Arguments subv_sumP {K vT I P Us V}.
+#[warning="-deprecated"] Arguments capv_idPl {K vT U V}.
+#[warning="-deprecated"] Arguments capv_idPr {K vT U V}.
 Arguments memv_capP {K vT w U V}.
-Arguments bigcapv_inf [K vT I] i0 [P Us V].
-Arguments subv_bigcapP {K vT I P U Vs}.
+#[warning="-deprecated"] Arguments bigcapv_inf [K vT I] i0 [P Us V].
+#[warning="-deprecated"] Arguments subv_bigcapP {K vT I P U Vs}.
 Arguments directvP {K vT S}.
 Arguments directv_addP {K vT U V}.
 Arguments directv_add_unique {K vT U V}.
@@ -1509,11 +1623,11 @@ Variables (K : fieldType) (aT rT : vectType K).
 Implicit Types (f g : 'Hom(aT, rT)) (U V : {vspace aT}) (W : {vspace rT}).
 
 Lemma limgS f U V : (U <= V)%VS -> (f @: U <= f @: V)%VS.
-Proof. by rewrite unlock /subsetv !genmxE; apply: submxMr. Qed.
+Proof. by rewrite unlock !subsetvE !genmxE; apply: submxMr. Qed.
 
 Lemma limg_line f v : (f @: <[v]> = <[f v]>)%VS.
 Proof.
-apply/eqP; rewrite 2!unlock eqEsubv /subsetv /= r2vK !genmxE.
+apply/eqP; rewrite 2!unlock eq_le !subsetvE /= r2vK !genmxE.
 by rewrite !(eqmxMr _ (genmxE _)) submx_refl.
 Qed.
 
@@ -1526,14 +1640,14 @@ Lemma memv_imgP f w U :
   reflect (exists2 u, u \in U & w = f u) (w \in f @: U)%VS.
 Proof.
 apply: (iffP idP) => [|[u Uu ->]]; last exact: memv_img.
-rewrite 2!unlock memvE /subsetv !genmxE => /submxP[ku Drw].
+rewrite 2!unlock memvE subsetvE !genmxE => /submxP[ku Drw].
 exists (r2v (ku *m vs2mx U)); last by rewrite /= r2vK -mulmxA -Drw v2rK.
-by rewrite memvE /subsetv !genmxE r2vK submxMl.
+by rewrite memvE subsetvE !genmxE r2vK submxMl.
 Qed.
 
 Lemma lim0g U : (0 @: U = 0 :> {vspace rT})%VS.
 Proof.
-apply/eqP; rewrite -subv0; apply/subvP=> _ /memv_imgP[u _ ->].
+apply/eqP; rewrite -lex0; apply/subvP=> _ /memv_imgP[u _ ->].
 by rewrite lfunE rpred0.
 Qed.
 
@@ -1545,7 +1659,7 @@ Qed.
 
 Lemma limgD f : {morph lfun_img f : U V / U + V}%VS.
 Proof.
-move=> U V; apply/eqP; rewrite unlock eqEsubv /subsetv /= -genmx_adds.
+move=> U V; apply/eqP; rewrite unlock eq_le !subsetvE /= -genmx_adds.
 by rewrite !genmxE !(eqmxMr _ (genmxE _)) !addsmxMr submx_refl.
 Qed.
 
@@ -1554,13 +1668,13 @@ Lemma limg_sum f I r (P : pred I) Us :
 Proof. exact: (big_morph _ (limgD f) (limg0 f)). Qed.
 
 Lemma limg_cap f U V : (f @: (U :&: V) <= f @: U :&: f @: V)%VS.
-Proof. by rewrite subv_cap !limgS ?capvSl ?capvSr. Qed.
+Proof. by rewrite lexI !limgS ?leIl ?leIr. Qed.
 
 Lemma limg_bigcap f I r (P : pred I) Us :
   (f @: (\bigcap_(i <- r | P i) Us i) <= \bigcap_(i <- r | P i) f @: Us i)%VS.
 Proof.
-elim/big_rec2: _ => [|i V U _ sUV]; first exact: subvf.
-by rewrite (subv_trans (limg_cap f _ U)) ?capvS.
+elim/big_rec2: _ => [|i V U _ sUV]; first exact: lex1.
+by rewrite (le_trans (limg_cap f _ U)) ?leI2.
 Qed.
 
 Lemma limg_span f X : (f @: <<X>> = <<map f X>>)%VS.
@@ -1597,12 +1711,12 @@ Proof. by move=> _ /memv_imgP[u _ ->]; rewrite -!comp_lfunE inv_lfun_def. Qed.
 
 Lemma lkerE f U : (U <= lker f)%VS = (f @: U == 0)%VS.
 Proof.
-rewrite unlock -dimv_eq0 /dimv /subsetv !genmxE mxrank_eq0.
+rewrite unlock -dimv_eq0 /dimv subsetvE !genmxE mxrank_eq0.
 by rewrite (sameP sub_kermxP eqP).
 Qed.
 
 Lemma memv_ker f v : (v \in lker f) = (f v == 0).
-Proof. by rewrite -memv0 !memvE subv0 lkerE limg_line. Qed.
+Proof. by rewrite -memv0 !memvE lex0 lkerE limg_line. Qed.
 
 Lemma eqlfunP f g v : reflect (f v = g v) (v \in lker (f - g)).
 Proof. by rewrite memv_ker !lfun_simp subr_eq0; apply: eqP. Qed.
@@ -1612,8 +1726,8 @@ Proof. by apply: (iffP subvP) => E x /E/eqlfunP. Qed.
 
 Lemma limg_ker_compl f U : (f @: (U :\: lker f) = f @: U)%VS.
 Proof.
-rewrite -{2}(addv_diff_cap U (lker f)) limgD; apply/esym/addv_idPl.
-by rewrite (subv_trans _ (sub0v _)) // subv0 -lkerE capvSr.
+rewrite -{2}(addv_diff_cap U (lker f)) limgD; apply/esym/join_l.
+by rewrite (le_trans _ (le0x _)) // lex0 -lkerE leIr.
 Qed.
 
 Lemma limg_ker_dim f U : (\dim (U :&: lker f) + \dim (f @: U) = \dim U)%N.
@@ -1634,7 +1748,7 @@ Qed.
 
 Lemma lker0P f : reflect (injective f) (lker f == 0%VS).
 Proof.
-rewrite -subv0; apply: (iffP subvP) => [injf u v eq_fuv | injf u].
+rewrite -lex0; apply: (iffP subvP) => [injf u v eq_fuv | injf u].
   apply/eqP; rewrite -subr_eq0 -memv0 injf //.
   by rewrite memv_ker linearB /= eq_fuv subrr.
 by rewrite memv_ker memv0 -(inj_eq injf) linear0.
@@ -1647,7 +1761,7 @@ by apply/subvP=> u Uu; have /memv_imgP[v Vv /injf->] := sfUV _ (memv_img f Uu).
 Qed.
 
 Lemma eq_limg_ker0 f U V : lker f == 0%VS -> (f @: U == f @: V)%VS = (U == V).
-Proof. by move=> injf; rewrite !eqEsubv !limg_ker0. Qed.
+Proof. by move=> injf; rewrite !eq_le !limg_ker0. Qed.
 
 Lemma lker0_lfunK f : lker f == 0%VS -> cancel f f^-1%VF.
 Proof.
@@ -1660,7 +1774,7 @@ Proof. by move/lker0_lfunK=> fK; apply/lfunP=> u; rewrite !lfunE /= fK. Qed.
 Lemma lker0_img_cap f U V : lker f == 0%VS ->
   (f @: (U :&: V) = f @: U :&: f @: V)%VS.
 Proof.
-move=> kf0; apply/eqP; rewrite eqEsubv limg_cap/=; apply/subvP => x.
+move=> kf0; apply/eqP; rewrite eq_le limg_cap/=; apply/subvP => x.
 rewrite memv_cap => /andP[/memv_imgP[u uU ->]] /memv_imgP[v vV].
 by move=> /(lker0P _ kf0) eq_uv; rewrite memv_img// memv_cap uU eq_uv vV.
 Qed.
@@ -1712,7 +1826,7 @@ Hypothesis kerf0 : lker f == 0%VS.
 
 Lemma lker0_limgf : limg f = fullv.
 Proof.
-by apply/eqP; rewrite eqEdim subvf limg_dim_eq //= (eqP kerf0) capv0.
+by apply/eqP; rewrite eqEdim lex1 limg_dim_eq //= (eqP kerf0) meetx0.
 Qed.
 
 Lemma lker0_lfunVK : cancel f^-1%VF f.
@@ -1760,19 +1874,19 @@ Variables (K : fieldType) (aT rT : vectType K).
 Implicit Types (f : 'Hom(aT, rT)) (U : {vspace aT}) (V W : {vspace rT}).
 
 Lemma lpreim_cap_limg f W : (f @^-1: (W :&: limg f))%VS = (f @^-1: W)%VS.
-Proof. by rewrite /lfun_preim -capvA capvv. Qed.
+Proof. by rewrite /lfun_preim meetIK. Qed.
 
 Lemma lpreim0 f : (f @^-1: 0)%VS = lker f.
-Proof. by rewrite /lfun_preim cap0v limg0 add0v. Qed.
+Proof. by rewrite /lfun_preim meet0x limg0 join0x. Qed.
 
 Lemma lpreimS f V W : (V <= W)%VS-> (f @^-1: V <= f @^-1: W)%VS.
-Proof. by move=> sVW; rewrite addvS // limgS // capvS. Qed.
+Proof. by move=> sVW; rewrite leU2 // limgS // leI2. Qed.
 
 Lemma lpreimK f W : (W <= limg f)%VS -> (f @: (f @^-1: W))%VS = W.
 Proof.
-move=> sWf; rewrite limgD (capv_idPl sWf) // -limg_comp.
+move=> sWf; rewrite limgD meet_l // -limg_comp.
 have /eqP->: (f @: lker f == 0)%VS by rewrite -lkerE.
-have /andP[/eqP defW _] := vbasisP W; rewrite addv0 -defW limg_span.
+have /andP[/eqP defW _] := vbasisP W; rewrite joinx0 -defW limg_span.
 rewrite map_id_in // => x Xx; rewrite lfunE /= limg_lfunVK //.
 by apply: span_subvP Xx; rewrite defW.
 Qed.
@@ -1780,7 +1894,7 @@ Qed.
 Lemma memv_preim f u W : (f u \in W) = (u \in f @^-1: W)%VS.
 Proof.
 apply/idP/idP=> [Wfu | /(memv_img f)]; last first.
-  by rewrite -lpreim_cap_limg lpreimK ?capvSr // => /memv_capP[].
+  by rewrite -lpreim_cap_limg lpreimK ?leIr // => /memv_capP[].
 rewrite -[u](addNKr (f^-1%VF (f u))) memv_add ?memv_img //.
   by rewrite memv_cap Wfu memv_img ?memvf.
 by rewrite memv_ker addrC linearB /= subr_eq0 limg_lfunVK ?memv_img ?memvf.
@@ -1867,7 +1981,7 @@ Definition addv_pi1 U V := daddv_pi (U :\: V) V.
 Definition addv_pi2 U V := daddv_pi V (U :\: V).
 
 Lemma memv_pi U V w : (daddv_pi U V) w \in U.
-Proof. by rewrite unlock memvE /subsetv genmxE /= r2vK proj_mx_sub. Qed.
+Proof. by rewrite unlock memvE subsetvE genmxE /= r2vK proj_mx_sub. Qed.
 
 Lemma memv_proj U w : projv U w \in U. Proof. exact: memv_pi. Qed.
 
@@ -1878,8 +1992,8 @@ Lemma memv_pi2 U V w : (addv_pi2 U V) w \in V. Proof. exact: memv_pi. Qed.
 
 Lemma daddv_pi_id U V u : (U :&: V = 0)%VS -> u \in U -> daddv_pi U V u = u.
 Proof.
-move/eqP; rewrite -dimv_eq0 memvE /subsetv /dimv !genmxE mxrank_eq0 => /eqP.
-by move=> dxUV Uu; rewrite unlock /= proj_mx_id ?v2rK.
+move/eqP; rewrite -dimv_eq0 memvE subsetvE /dimv !genmxE mxrank_eq0.
+by move=> /eqP dxUV Uu; rewrite unlock /= proj_mx_id ?v2rK.
 Qed.
 
 Lemma daddv_pi_proj U V w (pi := daddv_pi U V) :
@@ -1889,8 +2003,8 @@ Proof. by move/daddv_pi_id=> -> //; apply: memv_pi. Qed.
 Lemma daddv_pi_add U V w :
   (U :&: V = 0)%VS -> (w \in U + V)%VS -> daddv_pi U V w + daddv_pi V U w = w.
 Proof.
-move/eqP; rewrite -dimv_eq0 memvE /subsetv /dimv !genmxE mxrank_eq0 => /eqP.
-by move=> dxUW UVw; rewrite unlock /= -linearD /= add_proj_mx ?v2rK.
+move/eqP; rewrite -dimv_eq0 memvE subsetvE /dimv !genmxE mxrank_eq0.
+by move=> /eqP dxUW UVw; rewrite unlock /= -linearD /= add_proj_mx ?v2rK.
 Qed.
 
 Lemma projv_id U u : u \in U -> projv U u = u.
@@ -1914,7 +2028,7 @@ Qed.
 Lemma lker_proj U : lker (projv U) = (U^C)%VS.
 Proof.
 apply/eqP; rewrite eqEdim andbC; apply/andP; split.
-  by rewrite dimv_compl -(limg_ker_dim (projv U) fullv) limg_proj addnK capfv.
+  by rewrite dimv_compl -(limg_ker_dim (projv U) fullv) limg_proj addnK meet1x.
 by apply/subvP=> v; rewrite memv_ker -{2}[v]subr0 => /eqP <-; apply: memv_projC.
 Qed.
 
@@ -1922,7 +2036,7 @@ Lemma addv_pi1_proj U V w (pi1 := addv_pi1 U V) : pi1 (pi1 w) = pi1 w.
 Proof. by rewrite daddv_pi_proj // capv_diff. Qed.
 
 Lemma addv_pi2_id U V v : v \in V -> addv_pi2 U V v = v.
-Proof. by apply: daddv_pi_id; rewrite capvC capv_diff. Qed.
+Proof. by apply: daddv_pi_id; rewrite meetC capv_diff. Qed.
 
 Lemma addv_pi2_proj U V w (pi2 := addv_pi2 U V) : pi2 (pi2 w) = pi2 w.
 Proof. by rewrite addv_pi2_id ?memv_pi2. Qed.
@@ -2413,7 +2527,7 @@ by rewrite mul_mxof rVof_sub MsubV// memv_proj.
 Qed.
 
 Lemma vsofK M : (msof (vsof M) == M)%MS.
-Proof. by rewrite msof_sub -vsof_sub subvv. Qed.
+Proof. by rewrite msof_sub -vsof_sub le_refl. Qed.
 
 Lemma sub_msof : {mono msof : V V' / (V <= V')%VS >-> (V <= V')%MS}.
 Proof. by move=> V V'; rewrite msof_sub msofK. Qed.
@@ -2473,3 +2587,5 @@ Proof. by rewrite [LHS]lker_ker linearB linearZ/= mxof1// scalemx1. Qed.
 End eigen.
 End passmx.
 End passmx.
+
+Export VspaceSyntax.

--- a/field/falgebra.v
+++ b/field/falgebra.v
@@ -2,7 +2,7 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
-From mathcomp Require Import choice fintype div tuple finfun bigop ssralg.
+From mathcomp Require Import choice fintype div tuple finfun bigop order ssralg.
 From mathcomp Require Import finalg zmodp matrix vector poly.
 
 (******************************************************************************)
@@ -87,7 +87,7 @@ Reserved Notation "''AEnd' ( T )" (format "''AEnd' ( T )").
 Notation "\dim_ E V" := (divn (\dim V) (\dim E))
   (at level 10, E at level 2, V at level 8, format "\dim_ E  V") : nat_scope.
 
-Import GRing.Theory.
+Import Order.LTheory GRing.Theory.
 
 (* Finite dimensional algebra *)
 #[short(type="falgType")]
@@ -562,11 +562,11 @@ Notation "{ 'aspace' T }" := (aspace T) : type_scope.
 Notation "A * B" := (prodv A B) : vspace_scope.
 Notation "A ^+ n" := (expv A n) : vspace_scope.
 Notation "'C [ u ]" := (centraliser1_vspace u) : vspace_scope.
-Notation "'C_ U [ v ]" := (capv U 'C[v]) : vspace_scope.
-Notation "'C_ ( U ) [ v ]" := (capv U 'C[v]) (only parsing) : vspace_scope.
+Notation "'C_ U [ v ]" := (capv U 'C[v]%VS) : vspace_scope.
+Notation "'C_ ( U ) [ v ]" := (capv U 'C[v]%VS) (only parsing) : vspace_scope.
 Notation "'C ( V )" := (centraliser_vspace V) : vspace_scope.
-Notation "'C_ U ( V )" := (capv U 'C(V)) : vspace_scope.
-Notation "'C_ ( U ) ( V )" := (capv U 'C(V)) (only parsing) : vspace_scope.
+Notation "'C_ U ( V )" := (capv U 'C(V)%VS) : vspace_scope.
+Notation "'C_ ( U ) ( V )" := (capv U 'C(V)%VS) (only parsing) : vspace_scope.
 Notation "'Z ( V )" := (center_vspace V) : vspace_scope.
 
 Notation "1" := (aspace1 _) : aspace_scope.
@@ -635,7 +635,7 @@ Proof. by rewrite dim_vline algid_neq0. Qed.
 Lemma adim_gt0 A : (0 < \dim A)%N.
 Proof. by rewrite -(dim_algid A) dimvS // -memvE ?memv_algid. Qed.
 
-Lemma not_asubv0 A : ~~ (A <= 0)%VS.
+Lemma not_asubv0 A : ~~ (A <= 0 :> {vspace aT})%VS.
 Proof. by rewrite subv0 -dimv_eq0 -lt0n adim_gt0. Qed.
 
 Lemma adim1P {A} : reflect (A = <[algid A]>%VS :> {vspace aT}) (\dim A == 1%N).


### PR DESCRIPTION
##### Motivation for this change

<!-- please explain your reason for doing this change -->

This is my first attempt to make linear subspaces `{vspace vT}` canonically a `tbLatticeType`. In `vector.v`, some operators for linear subspace (`subsetv`, `fullv`, `addv`, and `capv`) have been redefined as notations for order operators. *The first obstacle is that `falgebra.v` does not compile since both `prodv` and `capv` (`Order.meet`) distributes over `addv` (`Order.join`) and so `addv_addoid` (in `falgebra.v`) is now redundant with `join_addoid` (in `order.v`).*

Closes #613

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
