### PR TITLE
Removing unused cpo_sort scope

### DIFF
--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -408,7 +408,6 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Declare Scope order_scope.
-Declare Scope cpo_sort.
 
 Delimit Scope order_scope with O.
 Local Open Scope order_scope.
@@ -1057,7 +1056,6 @@ End Exports.
 
 End POrder.
 Import POrder.Exports.
-Bind Scope cpo_sort with POrder.sort.
 
 Section POrderDef.
 
@@ -2072,7 +2070,6 @@ End Exports.
 
 End FinPOrder.
 Import FinPOrder.Exports.
-Bind Scope cpo_sort with FinPOrder.sort.
 
 Module FinLattice.
 Section ClassDef.


### PR DESCRIPTION
##### Motivation for this change

The scope `cpo_sort` is unused and is probably a leftover of previous versions of `order.v`.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.