### PR TITLE
Fix `@maxr` and `@minr`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -386,6 +386,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   constructors, the case `mask [::] s` can be dealt with using
   `mask0s` or explicit conversion.
 
+- in `ssrnum.v`, fixed notations `@minr` and `@maxr` to point `Order.min` and
+  `Order.max` respectively.
+
 ### Renamed
 
 - `big_rmcond` -> `big_rmcond_in` (cf Changed section)

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -383,10 +383,10 @@ Notation comparabler := (@Order.comparable ring_display _) (only parsing).
 Notation "@ 'comparabler' R" := (@Order.comparable ring_display R)
   (at level 10, R at level 8, only parsing) : fun_scope.
 Notation maxr := (@Order.max ring_display _).
-Notation "@ 'maxr' R" := (@Order.join ring_display R)
+Notation "@ 'maxr' R" := (@Order.max ring_display R)
     (at level 10, R at level 8, only parsing) : fun_scope.
 Notation minr := (@Order.min ring_display _).
-Notation "@ 'minr' R" := (@Order.meet ring_display R)
+Notation "@ 'minr' R" := (@Order.min ring_display R)
   (at level 10, R at level 8, only parsing) : fun_scope.
 
 Section Def.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -129,15 +129,6 @@ Local Open Scope order_scope.
 Local Open Scope ring_scope.
 Import Order.TTheory GRing.Theory.
 
-Reserved Notation "<= y" (at level 35).
-Reserved Notation ">= y" (at level 35).
-Reserved Notation "< y" (at level 35).
-Reserved Notation "> y" (at level 35).
-Reserved Notation "<= y :> T" (at level 35, y at next level).
-Reserved Notation ">= y :> T" (at level 35, y at next level).
-Reserved Notation "< y :> T" (at level 35, y at next level).
-Reserved Notation "> y :> T" (at level 35, y at next level).
-
 Fact ring_display : unit. Proof. exact: tt. Qed.
 
 Module Num.


### PR DESCRIPTION
##### Motivation for this change

- This PR fixes `@maxr` and `@minr` notations which wrongly pointed `Order.join` and `Order.meet`.
- This PR also removes `Reserved Notation`s in `ssrnum.v` which are already declared in `order.v`. https://github.com/math-comp/math-comp/blob/676a9266ad77232ab198c86a6a3a3f3f6ba53cc0/mathcomp/ssreflect/order.v#L415-L422

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
