### PR TITLE
Transpose `join_idP(l|r)` lemmas to follow the naming convention

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -371,21 +371,77 @@ ci-finmap-8.10:
   extends: .ci-finmap
   variables:
     COQ_VERSION: "8.10"
+  except:
+    - tags
+    - merge_requests
+    - schedules
+    - /^pr-671$/
 
 ci-finmap-8.11:
   extends: .ci-finmap
   variables:
     COQ_VERSION: "8.11"
+  except:
+    - tags
+    - merge_requests
+    - schedules
+    - /^pr-671$/
 
 ci-finmap-8.12:
   extends: .ci-finmap
   variables:
     COQ_VERSION: "8.12"
+  except:
+    - tags
+    - merge_requests
+    - schedules
+    - /^pr-671$/
 
 ci-finmap-dev:
   extends: .ci-finmap
   variables:
     COQ_VERSION: "dev"
+  except:
+    - tags
+    - merge_requests
+    - schedules
+    - /^pr-671$/
+
+ci-finmap-8.10-671:
+  extends: .ci-finmap
+  variables:
+    COQ_VERSION: "8.10"
+    CONTRIB_URL: "https://github.com/pi8027/finmap.git"
+    CONTRIB_VERSION: "join_idP"
+  only:
+    - /^pr-671$/
+
+ci-finmap-8.11-671:
+  extends: .ci-finmap
+  variables:
+    COQ_VERSION: "8.11"
+    CONTRIB_URL: "https://github.com/pi8027/finmap.git"
+    CONTRIB_VERSION: "join_idP"
+  only:
+    - /^pr-671$/
+
+ci-finmap-8.12-671:
+  extends: .ci-finmap
+  variables:
+    COQ_VERSION: "8.12"
+    CONTRIB_URL: "https://github.com/pi8027/finmap.git"
+    CONTRIB_VERSION: "join_idP"
+  only:
+    - /^pr-671$/
+
+ci-finmap-dev-671:
+  extends: .ci-finmap
+  variables:
+    COQ_VERSION: "dev"
+    CONTRIB_URL: "https://github.com/pi8027/finmap.git"
+    CONTRIB_VERSION: "join_idP"
+  only:
+    - /^pr-671$/
 
 # The FCSL-PCM library
 .ci-fcsl-pcm:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -371,77 +371,21 @@ ci-finmap-8.10:
   extends: .ci-finmap
   variables:
     COQ_VERSION: "8.10"
-  except:
-    - tags
-    - merge_requests
-    - schedules
-    - /^pr-671$/
 
 ci-finmap-8.11:
   extends: .ci-finmap
   variables:
     COQ_VERSION: "8.11"
-  except:
-    - tags
-    - merge_requests
-    - schedules
-    - /^pr-671$/
 
 ci-finmap-8.12:
   extends: .ci-finmap
   variables:
     COQ_VERSION: "8.12"
-  except:
-    - tags
-    - merge_requests
-    - schedules
-    - /^pr-671$/
 
 ci-finmap-dev:
   extends: .ci-finmap
   variables:
     COQ_VERSION: "dev"
-  except:
-    - tags
-    - merge_requests
-    - schedules
-    - /^pr-671$/
-
-ci-finmap-8.10-671:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "8.10"
-    CONTRIB_URL: "https://github.com/pi8027/finmap.git"
-    CONTRIB_VERSION: "join_idP"
-  only:
-    - /^pr-671$/
-
-ci-finmap-8.11-671:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "8.11"
-    CONTRIB_URL: "https://github.com/pi8027/finmap.git"
-    CONTRIB_VERSION: "join_idP"
-  only:
-    - /^pr-671$/
-
-ci-finmap-8.12-671:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "8.12"
-    CONTRIB_URL: "https://github.com/pi8027/finmap.git"
-    CONTRIB_VERSION: "join_idP"
-  only:
-    - /^pr-671$/
-
-ci-finmap-dev-671:
-  extends: .ci-finmap
-  variables:
-    COQ_VERSION: "dev"
-    CONTRIB_URL: "https://github.com/pi8027/finmap.git"
-    CONTRIB_VERSION: "join_idP"
-  only:
-    - /^pr-671$/
 
 # The FCSL-PCM library
 .ci-fcsl-pcm:

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -376,6 +376,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `order.v`, generalized `sort_le_id` for any `porderType`.
 
+- in `order.v`, the names of lemmas `join_idPl` and `join_idPr` are transposed
+  to follow the naming convention.
+
 - the following constants have been tuned to only reduce when they do
   not expose a match: `subn_rec`, `decode_rec`, `nth` (thus avoiding a
   notorious problem of ``p`_0`` expanding too eagerly), `set_nth`,

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -3639,13 +3639,13 @@ Proof. exact: (@leIr _ [latticeType of L^d]). Qed.
 Lemma leUl x y : x <= x `|` y.
 Proof. exact: (@leIl _ [latticeType of L^d]). Qed.
 
-Lemma join_idPl {x y} : reflect (x `|` y = y) (x <= y).
+Lemma join_idPr {x y} : reflect (x `|` y = y) (x <= y).
 Proof. exact: (@meet_idPr _ [latticeType of L^d]). Qed.
-Lemma join_idPr {x y} : reflect (y `|` x = y) (x <= y).
+Lemma join_idPl {x y} : reflect (y `|` x = y) (x <= y).
 Proof. exact: (@meet_idPl _ [latticeType of L^d]). Qed.
 
-Lemma join_l x y : y <= x -> x `|` y = x. Proof. exact/join_idPr. Qed.
-Lemma join_r x y : x <= y -> x `|` y = y. Proof. exact/join_idPl. Qed.
+Lemma join_l x y : y <= x -> x `|` y = x. Proof. exact/join_idPl. Qed.
+Lemma join_r x y : x <= y -> x `|` y = y. Proof. exact/join_idPr. Qed.
 
 Lemma leUidl x y : (x `|` y <= y) = (x <= y).
 Proof. exact: (@leIidr _ [latticeType of L^d]). Qed.
@@ -3667,7 +3667,7 @@ Lemma lcomparableP x y : incomparel x y
 Proof.
 by case: (comparableP x) => [hxy|hxy|hxy|->]; do 1?have hxy' := ltW hxy;
    rewrite ?(meetxx, joinxx);
-   rewrite ?(meet_idPl hxy', meet_idPr hxy', join_idPl hxy', join_idPr hxy');
+   rewrite ?(meet_l hxy', meet_r hxy', join_l hxy', join_r hxy');
    constructor.
 Qed.
 
@@ -4378,8 +4378,7 @@ Lemma leBx x y : x `\` y <= x.
 Proof. by rewrite -{2}[x](joinIB y) lexU2 // lexx orbT. Qed.
 Hint Resolve leBx : core.
 
-Lemma subxx x : x `\` x = 0.
-Proof. by have := subKI x x; rewrite (meet_idPr _). Qed.
+Lemma subxx x : x `\` x = 0. Proof. by have := subKI x x; rewrite meet_r. Qed.
 
 Lemma leBl z x y : x <= y -> x `\` z <= y `\` z.
 Proof.
@@ -4390,21 +4389,21 @@ Qed.
 Lemma subKU y x : y `|` (x `\` y) = y `|` x.
 Proof.
 apply/eqP; rewrite eq_le leU2 //= leUx leUl.
-by apply/meet_idPl; have := joinIB y x; rewrite joinIl (join_idPr _).
+by apply/meet_idPl; have := joinIB y x; rewrite joinIl join_l.
 Qed.
 
 Lemma subUK y x : (x `\` y) `|` y = x `|` y.
 Proof. by rewrite joinC subKU joinC. Qed.
 
 Lemma leBKU y x : y <= x -> y `|` (x `\` y) = x.
-Proof. by move=> /join_idPl {2}<-; rewrite subKU. Qed.
+Proof. by move=> /join_r {2}<-; rewrite subKU. Qed.
 
 Lemma leBUK y x : y <= x -> (x `\` y) `|` y = x.
 Proof. by move=> leyx; rewrite joinC leBKU. Qed.
 
 Lemma leBLR x y z : (x `\` y <= z) = (x <= y `|` z).
 Proof.
-apply/idP/idP; first by move=> /join_idPl <-; rewrite joinA subKU joinAC leUr.
+apply/idP/idP; first by move=> /join_r <-; rewrite joinA subKU joinAC leUr.
 by rewrite -{1}[x](joinIB y) => /(leU2r_le (subIK _ _)).
 Qed.
 
@@ -4424,16 +4423,14 @@ Lemma joinBx x y z : (y `\` z) `|` x = ((y `|` x) `\` z) `|` (z `&` x).
 Proof. by rewrite ![_ `|` x]joinC ![_ `&` x]meetC joinxB. Qed.
 
 Lemma leBr z x y : x <= y -> z `\` y <= z `\` x.
-Proof.
-by move=> lexy; rewrite leBLR joinxB (meet_idPr _) ?leBUK ?leUr ?lexU2 ?lexy.
-Qed.
+Proof. by move=> lexy; rewrite leBLR joinxB meet_r ?leBUK ?leUr ?lexUl. Qed.
 
 Lemma leB2 x y z t : x <= z -> t <= y -> x `\` y <= z `\` t.
 Proof. by move=> /(@leBl t) ? /(@leBr x) /le_trans ->. Qed.
 
 Lemma meet_eq0E_sub z x y : x <= z -> (x `&` y == 0) = (x <= z `\` y).
 Proof.
-move=> xz; apply/idP/idP; last by move=> /meet_idPr <-; rewrite -meetA meetBI.
+move=> xz; apply/idP/idP; last by move=> /meet_r <-; rewrite -meetA meetBI.
 by move=> /eqP xIy_eq0; rewrite -[x](joinIB y) xIy_eq0 join0x leBl.
 Qed.
 
@@ -4474,22 +4471,20 @@ Proof. by rewrite ![_ `&` z]meetC meetxB. Qed.
 Lemma subxI x y z : x `\` (y `&` z) = (x `\` y) `|` (x `\` z).
 Proof.
 apply/eqP; rewrite eq_sub leUx !leBx //= joinIl joinA joinCA !subKU.
-rewrite joinCA -joinA [_ `|` x]joinC ![x `|` _](join_idPr _) //.
+rewrite joinCA -joinA [_ `|` x]joinC ![x `|` _]join_l //.
 by rewrite -joinIl leUr /= meetUl {1}[_ `&` z]meetC ?meetBI joinx0.
 Qed.
 
 Lemma subBx x y z : (x `\` y) `\` z = x `\` (y `|` z).
 Proof.
 apply/eqP; rewrite eq_sub leBr ?leUl //=.
-rewrite subxU joinIr subKU -joinIr (meet_idPl _) ?leUr //=.
-by rewrite -meetA subIK meetx0.
+by rewrite subxU joinIr subKU -joinIr meet_l ?leUr //= -meetA subIK meetx0.
 Qed.
 
 Lemma subxB x y z : x `\` (y `\` z) = (x `\` y) `|` (x `&` z).
 Proof.
-rewrite -[y in RHS](joinIB z) subxU joinIl subxI -joinA.
-rewrite joinBI (join_idPl _) // joinBx [x `|` _](join_idPr _) ?leIl //.
-by rewrite meetA meetAC subIK meet0x joinx0 (meet_idPr _).
+rewrite -[y in RHS](joinIB z) subxU joinIl subxI -joinA joinBI join_r //.
+by rewrite joinBx meetKU meetA meetAC subIK meet0x joinx0 meet_r.
 Qed.
 
 Lemma joinBK x y : (y `|` x) `\` x = (y `\` x).
@@ -4499,10 +4494,7 @@ Lemma joinBKC x y : (x `|` y) `\` x = (y `\` x).
 Proof. by rewrite subUx subxx join0x. Qed.
 
 Lemma disj_le x y : x `&` y == 0 -> x <= y = (x == 0).
-Proof.
-have [->|x_neq0] := eqVneq x 0; first by rewrite le0x.
-by apply: contraTF => lexy; rewrite (meet_idPl _).
-Qed.
+Proof. by rewrite [x == 0]eq_sym -eq_meetl => /eqP ->. Qed.
 
 Lemma disj_leC x y : y `&` x == 0 -> x <= y = (x == 0).
 Proof. by rewrite meetC => /disj_le. Qed.
@@ -4514,9 +4506,7 @@ Lemma disj_subr x y : x `&` y == 0 -> y `\` x = y.
 Proof. by rewrite meetC => /disj_subl. Qed.
 
 Lemma lt0B x y : x < y -> 0 < y `\` x.
-Proof.
-by move=> ?; rewrite lt_leAnge leBRL leBLR le0x meet0x eqxx joinx0 /= lt_geF.
-Qed.
+Proof. by move=> ?; rewrite lt_leAnge le0x leBLR joinx0 /= lt_geF. Qed.
 
 End CBDistrLatticeTheory.
 End CBDistrLatticeTheory.


### PR DESCRIPTION
##### Motivation for this change

If I understand correctly, suffixes `_idPl` and `_idPr` stand for `reflect (op x y = x) ...` and `reflect (op x y = y) ...` respectively. Lemmas `join_idP(l|r)` did not follow this naming convention.

```
$ grep -n 'Lemma [0-9a-zA-Z_]*_idPl' **/*.v
algebra/intdiv.v:511:Lemma gcdz_idPl {m n} : reflect (gcdz m n = `|m|%:Z) (m %| n)%Z.
algebra/mxalgebra.v:1042:Lemma addsmx_idPl : reflect (A + B :=: A)%MS (B <= A)%MS.
algebra/mxalgebra.v:1462:Lemma capmx_idPl n m1 m2 (A : 'M_(m1, n)) (B : 'M_(m2, n)) :
algebra/vector.v:529:Lemma addv_idPl {U V}: reflect (U + V = U)%VS (V <= U)%VS.
algebra/vector.v:621:Lemma capv_idPl {U V} : reflect (U :&: V = U)%VS (U <= V)%VS.
fingroup/fingroup.v:2245:Lemma joing_idPl G A : reflect (G <*> A = G) (A \subset G).
ssreflect/div.v:642:Lemma gcdn_idPl {m n} : reflect (gcdn m n = m) (m %| n).
ssreflect/div.v:851:Lemma lcmn_idPl {m n} : reflect (lcmn m n = m) (n %| m).
ssreflect/order.v:2955:Lemma min_idPl x y : reflect (min x y = x) (x <= y).
ssreflect/order.v:3003:Lemma comparable_max_idPl : reflect (max x y = x) (y <= x).
ssreflect/order.v:3577:Lemma meet_idPl {x y} : reflect (x `&` y = x) (x <= y).
ssreflect/order.v:3642:Lemma join_idPl {x y} : reflect (x `|` y = y) (x <= y).
ssreflect/order.v:3834:Lemma max_idPl x y : reflect (max x y = x) (y <= x).
ssreflect/ssrnat.v:659:Lemma maxn_idPl {m n} : reflect (maxn m n = m) (m >= n).
ssreflect/ssrnat.v:725:Lemma minn_idPl {m n} : reflect (minn m n = m) (m <= n).
$ grep -n 'Lemma [0-9a-zA-Z_]*_idPr' **/*.v
algebra/intdiv.v:514:Lemma gcdz_idPr {m n} : reflect (gcdz m n = `|n|%:Z) (n %| m)%Z.
algebra/mxalgebra.v:1036:Lemma addsmx_idPr : reflect (A + B :=: B)%MS (A <= B)%MS.
algebra/mxalgebra.v:1455:Lemma capmx_idPr n m1 m2 (A : 'M_(m1, n)) (B : 'M_(m2, n)) :
algebra/vector.v:532:Lemma addv_idPr {U V} : reflect (U + V = V)%VS (U <= V)%VS.
algebra/vector.v:624:Lemma capv_idPr {U V} : reflect (U :&: V = V)%VS (V <= U)%VS.
fingroup/fingroup.v:2251:Lemma joing_idPr A G : reflect (A <*> G = G) (A \subset G).
ssreflect/div.v:647:Lemma gcdn_idPr {m n} : reflect (gcdn m n = n) (n %| m).
ssreflect/div.v:846:Lemma lcmn_idPr {m n} : reflect (lcmn m n = n) (m %| n).
ssreflect/order.v:2958:Lemma max_idPr x y : reflect (max x y = y) (x <= y).
ssreflect/order.v:3000:Lemma comparable_min_idPr : reflect (min x y = y) (y <= x).
ssreflect/order.v:3579:Lemma meet_idPr {x y} : reflect (y `&` x = x) (x <= y).
ssreflect/order.v:3644:Lemma join_idPr {x y} : reflect (y `|` x = y) (x <= y).
ssreflect/order.v:3831:Lemma min_idPr x y : reflect (min x y = y) (y <= x).
ssreflect/ssrnat.v:662:Lemma maxn_idPr {m n} : reflect (maxn m n = n) (m <= n).
ssreflect/ssrnat.v:731:Lemma minn_idPr {m n} : reflect (minn m n = n) (m >= n).
```

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

##### CI overlays

- math-comp/finmap#77

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
