### PR TITLE
Fixing [dup] and [swap] for Coq 8.12

### DIFF
--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -111,26 +111,12 @@ Notation "'[' 'apply' ']'" := (ltac:(let f := fresh "_top_" in move=> f {}/f))
 (* we try to preserve the naming by matching the names from the goal *)
 (* we do move to perform a hnf before trying to match                *)
 Notation "'[' 'swap' ']'" := (ltac:(move;
-  lazymatch goal with
-  | |- forall (x : _), _ => let x := fresh x in move=> x; move;
-    lazymatch goal with
-    | |- forall (y : _), _ => let y := fresh y in move=> y; move: y x
-    | |- let y := _ in _ => let y := fresh y in move=> y; move: @y x
-    | _ => let y := fresh "_top_" in move=> y; move: y x
-    end
-  | |- let x := _ in _ => let x := fresh x in move => x; move;
-    lazymatch goal with
-    | |- forall (y : _), _ => let y := fresh y in move=> y; move: y @x
-    | |- let y := _ in _ => let y := fresh y in move=> y; move: @y @x
-    | _ => let y := fresh "_top_" in move=> y; move: y x
-    end
-  | _ => let x := fresh "_top_" in let x := fresh x in move=> x; move;
-    lazymatch goal with
-    | |- forall (y : _), _ => let y := fresh y in move=> y; move: y @x
-    | |- let y := _ in _ => let y := fresh y in move=> y; move: @y @x
-    | _ => let y := fresh "_top_" in move=> y; move: y x
-    end
-  end))
+  let x := lazymatch goal with
+    | |- forall (x : _), _ => fresh x | |- let x := _ in _ => fresh x | _ => fresh "_top_"
+  end in intro x; move;
+  let y := lazymatch goal with
+    | |- forall (y : _), _ => fresh y | |- let y := _ in _ => fresh y | _ => fresh "_top_"
+  end in intro y; revert x; revert y))
   (at level 0, only parsing) : ssripat_scope.
 
 (* we try to preserve the naming by matching the names from the goal *)
@@ -138,15 +124,15 @@ Notation "'[' 'swap' ']'" := (ltac:(move;
 Notation "'[' 'dup' ']'" := (ltac:(move;
   lazymatch goal with
   | |- forall (x : _), _ =>
-    let x := fresh x in move=> x;
-    let copy := fresh x in have copy := x; move: copy x
+    let x := fresh x in intro x;
+    let copy := fresh x in have copy := x; revert x; revert copy
   | |- let x := _ in _ =>
-    let x := fresh x in move=> x;
+    let x := fresh x in intro x;
     let copy := fresh x in pose copy := x;
-    do [unfold x in (value of copy)]; move: @copy @x
+    do [unfold x in (value of copy)]; revert x; revert copy
   | |- _ =>
     let x := fresh "_top_" in move=> x;
-    let copy := fresh "_top" in have copy := x; move: copy x
+    let copy := fresh "_top" in have copy := x; revert x; revert copy
   end))
   (at level 0, only parsing) : ssripat_scope.
 

--- a/mathcomp/test_suite/test_intro_rw.v
+++ b/mathcomp/test_suite/test_intro_rw.v
@@ -21,3 +21,27 @@ Proof.
 move=> /[apply] b.
 Check (b : B).
 Abort.
+
+Lemma test_swap_plus P Q : P -> Q -> False.
+Proof.
+move=> + /[dup] q.
+suff: P -> Q -> False by [].
+Abort.
+
+Lemma test_dup_plus2 P : P -> let x := 0 in False.
+Proof.
+move=> + /[dup] y.
+suff: P -> let x := 0 in False by [].
+Abort.
+
+Lemma test_swap_plus P Q R : P -> Q -> R -> False.
+Proof.
+move=> + /[swap].
+suff: P -> R -> Q -> False by [].
+Abort.
+
+Lemma test_swap_plus2 P : P -> let x := 0 in let y := 1 in False.
+Proof.
+move=> + /[swap].
+suff: P -> let y := 1 in let x := 0 in False by [].
+Abort.


### PR DESCRIPTION
##### Motivation for this change

The former implementation of [dup] and [swap] was broken because of a bug introduced by Coq 8.12. We work around it.

- See https://github.com/coq/coq/pull/13459 for the same workaround in Coq
- and https://github.com/coq/coq/pull/13459 for the bug report.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.