### PR TITLE
Add `pairwise` predicate and some missing lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,9 +10,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- in `seq.v`,
+  + new higher-order predicate `pairwise r xs` which asserts that the relation
+    `r` holds for any i-th and j-th element of `xs` such that i < j.
+  + new lemmas `allrel_mask(l|r)`, `allrel_filter(l|r)`, `sub(_in)_allrel`,
+    `pairwise_cons`, `pairwise_cat`, `pairwise_rcons`, `pairwise2`,
+    `pairwise_mask`, `pairwise_filter`, `pairwiseP`, `pairwise_all2rel`,
+    `sub(_in)_pairwise`, `eq(_in)_pairwise`, `pairwise_map`, `subseq_pairwise`,
+    `uniq_pairwise`, `pairwise_uniq`, and `pairwise_eq`.
+
+- in `path.v`, new lemmas: `sorted_pairwise(_in)`, `path_pairwise(_in)`,
+  `cycle_all2rel(_in)`, `pairwise_sort`, and `sort_pairwise_stable`.
+
 ### Changed
 
 ### Renamed
+
+- in `path.v`,
+  + `sub_(path|cycle|sorted)_in` -> `sub_in_(path|cycle|sorted)`
+  + `eq_(path|cycle)_in` -> `eq_in_(path|cycle)`
 
 ### Removed
 


### PR DESCRIPTION
##### Motivation for this change

This PR introduces a higher-order predicate `pairwise r xs` which asserts that the relation `r` holds for any i-th and j-th element of `xs` such that i < j.

Closes #639
Closes #676

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
