### PR TITLE
Rework of PR #281: Archimedean structures on top of num/real domain/field/closedField

### DIFF
--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -35,27 +35,27 @@ with builtins; with (import <nixpkgs> {}).lib;
   bundles = let
     master = [
       "mathcomp-bigenough"
+      "mathcomp-finmap"
       "mathcomp-real-closed"
       "fourcolor"
       "odd-order"
       "coquelicot"
       "gaia"
+      "multinomials"
+      "mathcomp-zify"
+      "coqeal"
+      "interval"
+      "graph-theory"
       # "deriving"  # requires univ poly
       # "extructures"  # requires deriving
     ];
     hierarchy-builder = [
-      "coqeal"
-      "interval"
       "reglang"
-      "graph-theory"
       "coq-bits"
       "mathcomp-classical"
       "mathcomp-analysis"
     ];
     proux01-hierarchy-builder = [
-      "mathcomp-finmap"
-      "multinomials"
-      "mathcomp-zify"
       "mathcomp-abel"
       "mathcomp-tarjan"
     ];

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -45,13 +45,169 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `RealMonic.deg2_poly_le0m`, `deg_le2_poly_delta_ge0`,
     `deg_le2_poly_delta_le0`, `deg_le2_poly_ge0`, `deg_le2_poly_le0`
 
+- new file `archimedean.v`
+
+- in `archimedean.v`
+  + new structures `archiNumDomainType`, `archiNumFieldType`,
+    `archiClosedFieldType`, `archiDomainType`, `archiRcfType`
+  + structure `archiFieldType` (renamed from `archimedeanFieldType`
+    from `ssrnum.v`)
+  + notations `Num.trunc`, `Num.floor` `Num.ceil`, `Num.nat`,
+    `Num.int`
+  + notation `Num.bound` (moved from `ssrnum.v`)
+  + lemmas `trunc_itv`, `natrE`, `trunc_def`, `natrK`, `truncK`,
+    `trunc0`, `trunc1`, `natr_nat`, `natrP`, `truncD`, `truncM`,
+    `truncX`, `rpred_nat_num`, `nat_num0`, `nat_num1`,
+    `nat_num_semiring`, `Rreal_nat`, `natr_normK`, `trunc_gt0`,
+    `trunc0Pn`, `natrge0`, `natrgt0`, `norm_natr`, `natrsum_eq1`,
+    `natr_mul_eq1`, `natr_prod_eq1`, `floorP`, `intrE`, `floor_itv`,
+    `ge_floor`, `lt_succ_floor`, `floor_def`, `floor_ge_int`,
+    `floor_le`, `intrKfloor`, `intr_int`, `intrP`, `intrEfloor`,
+    `floorK`, `floor0`, `floor1`, `floorD`, `floorN`, `floorM`,
+    `floorX`, `ceil_itv`, `gt_pred_ceil`, `le_ceil`, `ceil_def`,
+    `ceil_le_int`, `ceil_le`, `intrKceil`, `intrEceil`, `ceilK`,
+    `ceil0`, `ceil1`, `ceilD`, `ceilN`, `ceilM`, `ceilX`,
+    `ceil_floor`, `rpred_int_num`, `int_num0`, `int_num1`,
+    `int_num_subring`, `intr_nat`, `Rreal_int`, `intr_normK`,
+    `intrEsign`, `natr_norm_int`, `natrEint`, `intrEge0`,
+    `natr_exp_even`, `norm_intr_ge1`, `sqr_intr_ge1`, `intr_ler_sqr`,
+    `floorpK`, `floorpP`, `trunc_floor`, `raddfZ_nat`, `rpredZ_nat`,
+    `raddfZ_int`, `rpredZ_int`, `aut_natr`, `aut_intr`, `natr_aut_nu`,
+    `intr_aut_nu`, `conj_natr`, `conj_intr`
+  + lemmas `archi_boundP`, `upper_nthrootP` (moved from `ssrnum.v`)
+  + lemmas `Znat_def`, `ZnatP` (moved from `ssrint.v`)
+  + instances of `SemiringClosed` for `Num.nat` and `Num.int`
+
+- in `rat.v`
+  + lemmas `floor_rat`, `ceil_rat`
+
+- in `ssrnum.v`
+  + structures `archiNumDomainType`, `archiNumFieldType`,
+    `archiCLosedFieldType`, `archiDomainType`, `archiFieldType`,
+    `archiRcfType`
+  + factory `NumDomain_bounded_isArchimedean` (renamed from
+    `RealDomain_isArchimedean`)
+  + lemmas `truncP`, `trunc_itv`
+
+- in `algC.v`
+  + lemma `Implementation.archimedean`
+  + instance of `archiClosedFieldType` on `Implementation.type`
+
 ### Changed
 
 ### Renamed
 
+- in `algC.v`
+  + `Cint` -> `Num.int`
+  + `Cnat` -> `Num.nat`
+  + `floorC` -> `Num.floor`
+  + `truncC` -> `Num.trunc`
+  + `Creal0` -> `real0`
+  + `Creal1` -> `real1`
+  + `floorC_itv` -> `floor_itv`
+  + `floorC_def` -> `floor_def`
+  + `intCK` -> `intrKfloor`
+  + `floorCK` -> `floorK`
+  + `floorC0` -> `floor0`
+  + `floorC1` -> `floor1`
+  + `floorCpK` -> `floorpK`
+  + `floorCpD` -> `floorpP`
+  + `Cint_int` -> `intr_int`
+  + `CintP` -> `intrP`
+  + `floorCD` -> `floorD`
+  + `floorCN` -> `floorN`
+  + `floorCM` -> `floorM`
+  + `floorCX` -> `floorX`
+  + `rpred_Cint` -> `rpred_int_num`
+  + `Cint0` -> `int_num0`
+  + `Cint1` -> `int_num1`
+  + `Creal_Cint` -> `Rreal_int`
+  + `conj_Cint` -> `conj_intr`
+  + `Cint_normK` -> `intr_normK`
+  + `CintEsign` -> `intrEsign`
+  + `truncC_itv` -> `trunc_itv`
+  + `truncC_def` -> `trunc_def`
+  + `natCK` -> `natRK`
+  + `CnatP` -> `natrP`
+  + `truncCK` -> `truncK`
+  + `truncC_gt0` -> `trunc_gt0`
+  + `truncC0Pn` -> `trunc0Pn`
+  + `truncC0` -> `trunc0`
+  + `truncC1` -> `trunc1`
+  + `truncCD` -> `truncD`
+  + `truncCM` -> `truncM`
+  + `truncCX` -> `truncX`
+  + `rpred_Cnat` -> `rpred_nat_num`
+  + `Cnat_nat` -> `natr_nat`
+  + `Cnat0` -> `nat_num0`
+  + `Cnat1` -> `nat_num1`
+  + `Cnat_ge0` -> `natr_ge0`
+  + `Cnat_gt0` -> `natr_gt0`
+  + `conj_Cnat` -> `conj_natr`
+  + `norm_Cnat` -> `norm_natr`
+  + `Creal_Cnat` -> `Rreal_nat`
+  + `Cnat_sum_eq1` -> `natr_sum_eq1`
+  + `Cnat_mul_eq1` -> `natr_mul_eq1`
+  + `Cnat_prod_eq1` -> `natr_prod_eq1`
+  + `Cint_Cnat` -> `intr_nat`
+  + `CintE` -> `intrE`
+  + `Cnat_norm_Cint` -> `natr_norm_int`
+  + `CnatEint` -> `natrEint`
+  + `CintEge0` -> `intrEge0`
+  + `Cnat_exp_even` -> `natr_exp_even`
+  + `norm_Cint_ge1` -> `norm_intr_ge1`
+  + `sqr_Cint_ge1` -> `sqr_intr_ge1`
+  + `Cint_ler_sqr` -> `intr_ler_sqr`
+  + `aut_Cnat` -> `aut_natr`
+  + `aut_Cint` -> `aut_intr`
+  + `Cnat_aut` -> `natr_aut`
+  + `Cint_aut` -> `intr_aut`
+  + `raddfZ_Cnat` -> `raddfZ_nat`
+  + `raddfZ_Cint` -> `raddfZ_int`
+  + `rpredZ_Cnat` -> `rpredZnat`
+  + `rpredZ_Cint` -> `rpredZint`
+
 ### Removed
 
+- in `ssrint.v`
+  + definition `Znat_pred`
+  + lemma `Znat_semiring_closed`
+
+- in `rat.v`
+  + definition `Qint_pred`, `Qnat_pred`
+  + lemmas `rat_archimedean`, `Qint_subring_closed`,
+    `Qnat_semiring_closed`
+
+- in `algC.v`
+  + lemma `floorC_subproof`, `Cnat_semiring`
+
 ### Deprecated
+
+- in `ssrint.v`
+  + definition `Znat` (require `archimedean.v` and use `Num.nat`)
+  + lemmas `Znat_def`, `ZnatP` (moved to `archimedean.v`)
+  + lemma `polyC_mulrz` (use `polyCMz`)
+
+- in `rat.v`
+  + definitions `Qint` and `Qnat` (require `archimedean.v` and use
+    `Num.int` and `Num.nat`)
+  + lemma `QintP` (require `archimedean.v` and use `intrP`)
+  + lemma `Qnat_def` (require `archimedean.v` and use `natrEint`)
+  + lemma `QnatP` (require `archimedean.v` and use `natrP`)
+
+- in `ssrnum.v`
+  + structure `archiFieldType` (renamed `archiFieldType` and moved to
+    `archimedean.v`)
+  + structures `archiNumDomainType`, `archiNumFieldType`,
+    `archiCLosedFieldType`, `archiDomainType`, `archiFieldType`,
+    `archiRcfType` (moved to `archimedean.v`)
+  + factory `RealField_isArchimedean` renamed
+    `NumDomain_bounded_isArchimedean` and moved to `archimedean.v`
+  + factory `NumDomain_bounded_isArchimedean` (moved to `archimedean.v`)
+  + notations `Num.Def.trunc`, `Num.trunc`, `Num.Def.nat_num`, `Num.nat`,
+    `Num.Def.int_num`, `Num.int`, `Num.bound` (moved to `archimedean.v`)
+  + lemmas `archi_boundP`, `upper_nthrootP`, `truncP`, `trunc_itv`
+    (moved to `archimedean.v`)
 
 ### Infrastructure
 

--- a/mathcomp/Make
+++ b/mathcomp/Make
@@ -1,6 +1,6 @@
 algebra/all_algebra.v
-algebra/finalg.v
 algebra/countalg.v
+algebra/finalg.v
 algebra/fraction.v
 algebra/intdiv.v
 algebra/interval.v
@@ -85,9 +85,9 @@ ssreflect/ssrAC.v
 ssreflect/ssrbool.v
 ssreflect/ssreflect.v
 ssreflect/ssrfun.v
+ssreflect/ssrmatching.v
 ssreflect/ssrnat.v
 ssreflect/ssrnotations.v
-ssreflect/ssrmatching.v
 ssreflect/tuple.v
 
 -I .

--- a/mathcomp/Make
+++ b/mathcomp/Make
@@ -1,4 +1,5 @@
 algebra/all_algebra.v
+algebra/archimedean.v
 algebra/countalg.v
 algebra/finalg.v
 algebra/fraction.v

--- a/mathcomp/algebra/Make
+++ b/mathcomp/algebra/Make
@@ -1,4 +1,5 @@
 all_algebra.v
+archimedean.v
 countalg.v
 finalg.v
 fraction.v

--- a/mathcomp/algebra/archimedean.v
+++ b/mathcomp/algebra/archimedean.v
@@ -1,0 +1,580 @@
+(* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
+(* Distributed under the terms of CeCILL-B.                                  *)
+From HB Require Import structures.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype bigop order ssralg poly ssrnum ssrint.
+
+(******************************************************************************)
+(*                           Archimedean structures                           *)
+(*                                                                            *)
+(* NB: See CONTRIBUTING.md for an introduction to HB concepts and commands.   *)
+(*                                                                            *)
+(* This file defines some numeric structures extended with the Archimedean    *)
+(* axiom. To use this file, insert "Import Num.Theory." and optionally        *)
+(* "Import Num.Def." before your scripts as in the ssrnum library.            *)
+(* The modules provided by this library subsume those from ssrnum.            *)
+(*                                                                            *)
+(* NB: the Archimedean structures are actually defined in ssrnum, but they    *)
+(* are deprecated in ssrnum and will be relocated to this file in a future    *)
+(* release.                                                                   *)
+(*                                                                            *)
+(* This file defines the following structures:                                *)
+(*                                                                            *)
+(*      archiNumDomainType == numDomainType with the Archimedean axiom        *)
+(*                            The HB class is called ArchiNumDomain.          *)
+(*       archiNumFieldType == numFieldType with the Archimedean axiom         *)
+(*                            The HB class is called ArchiNumField.           *)
+(*    archiClosedFieldType == closedFieldType with the Archimedean axiom      *)
+(*                            The HB class is called ArchiClosedField.        *)
+(*         archiDomainType == realDomainType with the Archimedean axiom       *)
+(*                            The HB class is called ArchiDomain.             *)
+(*          archiFieldType == realFieldType with the Archimedean axiom        *)
+(*                            The HB class is called ArchiField.              *)
+(*            archiRcfType == rcfType with the Archimedean axiom              *)
+(*                            The HB class is called ArchiRealClosedField.    *)
+(*                                                                            *)
+(* Over these structures, we have the following operations:                   *)
+(*  x \is a Num.int <=> x is an integer, i.e., x = m%:~R for some m : int     *)
+(*  x \is a Num.nat <=> x is a natural number, i.e., x = m%:R for some m : nat*)
+(*      Num.floor x == the m : int such that m%:~R <= z < (m + 1)%:~R         *)
+(*                     when x \is a Num.real, otherwise 0%Z                   *)
+(*       Num.ceil x == the m : int such that (m - 1)%:~R < z <= m%:~R         *)
+(*                     when x \is a NUm.real, otherwise 0%Z                   *)
+(*      Num.trunc x == the n : nat such that n%:R <= z < n.+1%:R              *)
+(*                     when 0 <= n, otherwise 0%N                             *)
+(*      Num.bound x == an upper bound for x, i.e., an n such that `|x| < n%:R *)
+(******************************************************************************)
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Local Open Scope ring_scope.
+Import Order.TTheory GRing.Theory Num.Theory.
+
+Module Num.
+
+Module Import Exports.
+
+Notation archiNumDomainType := Num.ArchiNumDomain.type.
+Notation archiNumFieldType := Num.ArchiNumField.type.
+Notation archiClosedFieldType := Num.ArchiClosedField.type.
+Notation archiDomainType := Num.ArchiDomain.type.
+Notation archiFieldType := Num.ArchiField.type.
+Notation archiRcfType := Num.ArchiRealClosedField.type.
+
+End Exports.
+
+Module Import Internals.
+
+Section ArchiNumDomain.
+Variable R : archiNumDomainType.
+Implicit Types x y : R.
+
+Local Notation trunc := (@Num.Def.trunc R).
+
+Definition truncP x :
+  if 0 <= x then (trunc x)%:R <= x < (trunc x).+1%:R else trunc x == 0%N :=
+  Num.Internals.truncP x.
+
+Definition trunc_itv x : 0 <= x -> (trunc x)%:R <= x < (trunc x).+1%:R :=
+  @Num.Internals.trunc_itv R x.
+
+Fact floor_subproof x :
+  {m | if x \is Num.real then m%:~R <= x < (m + 1)%:~R else m == 0}.
+Proof.
+have [Rx | _] := boolP (x \is Num.real); last by exists 0.
+without loss x_ge0: x Rx / x >= 0.
+  have [x_ge0 | /ltW x_le0] := real_ge0P Rx; first exact.
+  case/(_ (- x)) => [||m]; rewrite ?rpredN ?oppr_ge0 //.
+  rewrite lerNr ltrNl -!rmorphN opprD /= le_eqVlt.
+  case: eqP => [-> _ | _ /andP[lt_x_m lt_m_x]].
+    by exists (- m); rewrite lexx rmorphD ltrDl ltr01.
+  by exists (- m - 1); rewrite (ltW lt_m_x) subrK.
+by exists (Posz (trunc x)); rewrite addrC -intS -!pmulrn trunc_itv.
+Qed.
+
+End ArchiNumDomain.
+
+End Internals.
+
+Module Import Def.
+Export ssrnum.Num.Def.
+Definition floor {R : archiNumDomainType} (x : R) := sval (floor_subproof x).
+Definition ceil {R : archiNumDomainType} (x : R) := - floor (- x).
+End Def.
+
+Notation trunc := trunc.
+Notation floor := floor.
+Notation ceil := ceil.
+Notation bound := Num.ExtraDef.archi_bound.
+
+Module Import Theory.
+Export ssrnum.Num.Theory.
+
+Section ArchiNumDomainTheory.
+
+Variable R : archiNumDomainType.
+Implicit Types x y z : R.
+
+Local Notation trunc := (@Num.trunc R).
+Local Notation floor := (@Num.floor R).
+Local Notation ceil := (@Num.ceil R).
+Local Notation nat_num := (@nat_num R).
+Local Notation int_num := (@int_num R).
+
+(* trunc and nat_num *)
+
+Definition trunc_itv x : 0 <= x -> (trunc x)%:R <= x < (trunc x).+1%:R :=
+  @trunc_itv R x.
+
+Definition natrE x : (x \is a nat_num) = ((trunc x)%:R == x) :=
+  @ssrnum.Num.Theory.mc_2_0.natrE R x.
+
+Definition archi_boundP x : 0 <= x -> x < (bound x)%:R :=
+  @ssrnum.Num.Theory.mc_2_0.archi_boundP R x.
+
+Definition trunc_def x n : n%:R <= x < n.+1%:R -> trunc x = n :=
+  @ssrnum.Num.Theory.mc_2_0.trunc_def R x n.
+
+Definition natrK : cancel (GRing.natmul 1) trunc :=
+  @ssrnum.Num.Theory.mc_2_0.natrK R.
+
+Lemma truncK : {in nat_num, cancel trunc (GRing.natmul 1)}.
+Proof. by move=> x; rewrite natrE => /eqP. Qed.
+
+Lemma trunc0 : trunc 0 = 0%N. Proof. exact: natrK 0%N. Qed.
+Lemma trunc1 : trunc 1 = 1%N. Proof. exact: natrK 1%N. Qed.
+#[local] Hint Resolve trunc0 trunc1 : core.
+
+Definition natr_nat n : n%:R \is a nat_num :=
+  @ssrnum.Num.Theory.mc_2_0.natr_nat R n.
+#[local] Hint Resolve natr_nat : core.
+
+Definition natrP x : reflect (exists n, x = n%:R) (x \is a nat_num) :=
+  @ssrnum.Num.Theory.mc_2_0.natrP R x.
+
+Lemma truncD : {in nat_num & Rnneg, {morph trunc : x y / x + y >-> (x + y)%N}}.
+Proof.
+move=> _ y /natrP[n ->] y_ge0; apply: trunc_def.
+by rewrite -addnS !natrD !natrK lerD2l ltrD2l trunc_itv.
+Qed.
+
+Lemma truncM : {in nat_num &, {morph trunc : x y / x * y >-> (x * y)%N}}.
+Proof. by move=> _ _ /natrP[n1 ->] /natrP[n2 ->]; rewrite -natrM !natrK. Qed.
+
+Lemma truncX n : {in nat_num, {morph trunc : x / x ^+ n >-> (x ^ n)%N}}.
+Proof. by move=> _ /natrP[n1 ->]; rewrite -natrX !natrK. Qed.
+
+Lemma rpred_nat_num (S : semiringClosed R) x : x \is a nat_num -> x \in S.
+Proof. by move=> /natrP[n ->]; apply: rpred_nat. Qed.
+
+Definition nat_num0 : 0 \is a nat_num := @ssrnum.Num.Theory.mc_2_0.nat_num0 R.
+Definition nat_num1 : 1 \is a nat_num := @ssrnum.Num.Theory.mc_2_0.nat_num1 R.
+#[local] Hint Resolve nat_num0 nat_num1 : core.
+
+Definition nat_num_semiring : semiring_closed nat_num :=
+  @ssrnum.Num.Theory.mc_2_0.nat_num_semiring R.
+#[export]
+HB.instance Definition _ := GRing.isSemiringClosed.Build R Num.nat_num_subdef
+  nat_num_semiring.
+
+Lemma Rreal_nat : {subset nat_num <= Rreal}.
+Proof. by move=> _ /natrP[m ->]. Qed.
+
+Lemma natr_normK x : x \is a nat_num -> `|x| ^+ 2 = x ^+ 2.
+Proof. by move/Rreal_nat/real_normK. Qed.
+
+Lemma trunc_gt0 x : (0 < trunc x)%N = (1 <= x).
+Proof.
+case: ifP (truncP x) => [le0x /andP[lemx ltxm1] | le0x /eqP ->]; last first.
+  by apply/esym; apply/contraFF/le_trans: le0x.
+apply/idP/idP => [m_gt0 | x_ge1]; first by apply: le_trans lemx; rewrite ler1n.
+by rewrite -ltnS -(ltr_nat R) (le_lt_trans x_ge1).
+Qed.
+
+Lemma trunc0Pn x : reflect (trunc x = 0%N) (~~ (1 <= x)).
+Proof. by rewrite -trunc_gt0 -eqn0Ngt; apply: eqP. Qed.
+
+Lemma natr_ge0 x : x \is a nat_num -> 0 <= x.
+Proof. by move=> /natrP[n ->]; apply: ler0n. Qed.
+
+Lemma natr_gt0 x : x \is a nat_num -> (0 < x) = (x != 0).
+Proof. by move=> /natrP[n ->]; rewrite pnatr_eq0 ltr0n lt0n. Qed.
+
+Lemma norm_natr x : x \is a nat_num -> `|x| = x.
+Proof. by move/natr_ge0/ger0_norm. Qed.
+
+Lemma natr_sum_eq1 (I : finType) (P : pred I) (F : I -> R) :
+     (forall i, P i -> F i \is a nat_num) -> \sum_(i | P i) F i = 1 ->
+   {i : I | [/\ P i, F i = 1 & forall j, j != i -> P j -> F j = 0]}.
+Proof.
+move=> natF sumF1; pose nF i := trunc (F i).
+have{natF} defF i: P i -> F i = (nF i)%:R by move/natF; rewrite natrE => /eqP.
+have{sumF1} /eqP sumF1: (\sum_(i | P i) nF i == 1)%N.
+  by rewrite -(@eqr_nat R) natr_sum -(eq_bigr _ defF) sumF1.
+have [i Pi nZfi]: {i : I | P i & nF i != 0%N}.
+  by apply/sig2W/exists_inP; rewrite -negb_forall_in -sum_nat_eq0 sumF1.
+have F'ge0 := (leq0n _, etrans (eq_sym _ _) (sum_nat_eq0 (predD1 P i) nF)).
+rewrite -lt0n in nZfi; have [_] := (leqif_add (leqif_eq nZfi) (F'ge0 _)).
+rewrite /= big_andbC -bigD1 // sumF1 => /esym/andP/=[/eqP Fi1 /forall_inP Fi'0].
+exists i; split=> // [|j neq_ji Pj]; first by rewrite defF // -Fi1.
+by rewrite defF // (eqP (Fi'0 j _)) // neq_ji.
+Qed.
+
+Lemma natr_mul_eq1 x y :
+  x \is a nat_num -> y \is a nat_num -> (x * y == 1) = (x == 1) && (y == 1).
+Proof. by do 2!move/truncK <-; rewrite -natrM !pnatr_eq1 muln_eq1. Qed.
+
+Lemma natr_prod_eq1 (I : finType) (P : pred I) (F : I -> R) :
+    (forall i, P i -> F i \is a nat_num) -> \prod_(i | P i) F i = 1 ->
+  forall i, P i -> F i = 1.
+Proof.
+move=> natF prodF1; apply/eqfun_inP; rewrite -big_andE.
+move: prodF1; elim/(big_load (fun x => x \is a nat_num)): _.
+elim/big_rec2: _ => // i all1x x /natF N_Fi [Nx x1all1].
+by split=> [|/eqP]; rewrite ?rpredM ?natr_mul_eq1 // => /andP[-> /eqP].
+Qed.
+
+(* floor and int_num *)
+
+Local Lemma floorP x :
+  if x \is Rreal then
+    (floor x)%:~R <= x < (floor x + 1)%:~R else floor x == 0%N.
+Proof. by rewrite /floor; case: (floor_subproof x). Qed.
+
+Definition intrE x : (x \is a int_num) = (x \is a nat_num) || (- x \is a nat_num) :=
+  @ssrnum.Num.Theory.mc_2_0.intrE R x.
+
+Lemma floor_itv x : x \is Rreal -> (floor x)%:~R <= x < (floor x + 1)%:~R.
+Proof. by case: (x \is _) (floorP x). Qed.
+
+Lemma ge_floor x : x \is Rreal -> (floor x)%:~R <= x.
+Proof. by move=> /floor_itv /andP[]. Qed.
+
+Lemma lt_succ_floor x : x \is Rreal -> x < (floor x + 1)%:~R.
+Proof. by move=> /floor_itv /andP[]. Qed.
+
+Lemma floor_def x m : m%:~R <= x < (m + 1)%:~R -> floor x = m.
+Proof.
+case/andP=> lemx ltxm1; apply/eqP; rewrite eq_le -!ltzD1.
+move: (ger_real lemx); rewrite realz => /floor_itv/andP[lefx ltxf1].
+by rewrite -!(ltr_int R) 2?(@le_lt_trans _ _ x).
+Qed.
+
+Lemma floor_ge_int x n : x \is Rreal -> n%:~R <= x = (n <= floor x).
+Proof.
+move=> /floor_itv /andP[lefx ltxf1]; apply/idP/idP => lenx.
+  by rewrite -ltzD1 -(ltr_int R); apply: le_lt_trans ltxf1.
+by apply: le_trans lefx; rewrite ler_int.
+Qed.
+
+Lemma floor_le : {homo floor : x y / x <= y}.
+Proof.
+move=> x y lexy; move: (floorP x) (floorP y); rewrite (ger_real lexy).
+case: ifP => [_ /andP[lefx _] /andP[_] | _ /eqP-> /eqP-> //].
+by move=> /(le_lt_trans lexy) /(le_lt_trans lefx); rewrite ltr_int ltzD1.
+Qed.
+
+Lemma intrKfloor : cancel intr floor.
+Proof. by move=> m; apply: floor_def; rewrite lexx rmorphD ltrDl ltr01. Qed.
+
+Lemma intr_int m : m%:~R \is a int_num.
+Proof. by rewrite intrE; case: m => n; rewrite ?opprK natr_nat ?orbT. Qed.
+#[local] Hint Resolve intr_int : core.
+
+Lemma intrP x : reflect (exists m, x = m%:~R) (x \is a int_num).
+Proof.
+apply: (iffP idP) => [x_int | [m -> //]].
+rewrite -[x]opprK; move: x_int; rewrite intrE.
+move=> /orP[] /natrP[n ->]; first by exists n; rewrite opprK.
+by exists (- n%:R); rewrite mulrNz mulrz_nat.
+Qed.
+
+Lemma intrEfloor x : x \is a int_num = ((floor x)%:~R == x).
+Proof.
+by apply/intrP/eqP => [[n ->] | <-]; [rewrite intrKfloor | exists (floor x)].
+Qed.
+
+Lemma floorK : {in int_num, cancel floor intr}.
+Proof. by move=> z; rewrite intrEfloor => /eqP. Qed.
+
+Lemma floor0 : floor 0 = 0. Proof. exact: intrKfloor 0. Qed.
+Lemma floor1 : floor 1 = 1. Proof. exact: intrKfloor 1. Qed.
+#[local] Hint Resolve floor0 floor1 : core.
+
+Lemma floorD : {in int_num & Rreal, {morph floor : x y / x + y}}.
+Proof.
+move=> _ y /intrP[m ->] Ry; apply: floor_def.
+by rewrite -addrA 2!rmorphD /= intrKfloor lerD2l ltrD2l floor_itv.
+Qed.
+
+Lemma floorN : {in int_num, {morph floor : x / - x}}.
+Proof. by move=> _ /intrP[m ->]; rewrite -rmorphN !intrKfloor. Qed.
+
+Lemma floorM : {in int_num &, {morph floor : x y / x * y}}.
+Proof.
+by move=> _ _ /intrP[m1 ->] /intrP[m2 ->]; rewrite -rmorphM !intrKfloor.
+Qed.
+
+Lemma floorX n : {in int_num, {morph floor : x / x ^+ n}}.
+Proof. by move=> _ /intrP[m ->]; rewrite -rmorphXn !intrKfloor. Qed.
+
+(* ceil and int_num *)
+
+Lemma ceil_itv x : x \is Rreal -> (ceil x - 1)%:~R < x <= (ceil x)%:~R.
+Proof.
+by move=> Rx; rewrite -opprD !mulrNz ltrNl lerNr andbC floor_itv ?realN.
+Qed.
+
+Lemma gt_pred_ceil x : x \is Rreal -> (ceil x - 1)%:~R < x.
+Proof. by move=> /ceil_itv /andP[]. Qed.
+
+Lemma le_ceil x : x \is Rreal -> x <= (ceil x)%:~R.
+Proof. by move=> /ceil_itv /andP[]. Qed.
+
+Lemma ceil_def x m : (m - 1)%:~R < x <= m%:~R -> ceil x = m.
+Proof.
+move=> Hx; apply/eqP; rewrite eqr_oppLR; apply/eqP/floor_def.
+by rewrite lerNr ltrNl andbC -!mulrNz opprD opprK.
+Qed.
+
+Lemma ceil_le_int x n : x \is Rreal -> x <= n%:~R = (ceil x <= n).
+Proof.
+rewrite -realN; move=> /(floor_ge_int (- n)).
+by rewrite mulrNz lerNl opprK => ->; rewrite lerNl.
+Qed.
+
+Lemma ceil_le : {homo ceil : x y / x <= y}.
+Proof. by move=> x y lexy; rewrite /ceil lerN2 floor_le ?lerN2. Qed.
+
+Lemma intrKceil : cancel intr ceil.
+Proof. by move=> m; apply/eqP; rewrite eqr_oppLR -mulrNz intrKfloor. Qed.
+
+Lemma intrEceil x : x \is a int_num = ((ceil x)%:~R == x).
+Proof. by rewrite mulrNz eqr_oppLR -intrEfloor !intrE opprK orbC. Qed.
+
+Lemma ceilK : {in int_num, cancel ceil intr}.
+Proof. by move=> z; rewrite intrEceil => /eqP. Qed.
+
+Lemma ceil0 : ceil 0 = 0. Proof. exact: intrKceil 0. Qed.
+Lemma ceil1 : ceil 1 = 1. Proof. exact: intrKceil 1. Qed.
+#[local] Hint Resolve ceil0 ceil1 : core.
+
+Lemma ceilD : {in int_num & Rreal, {morph ceil : x y / x + y}}.
+Proof.
+move=> _ y /intrP[m ->] Ry; apply: ceil_def.
+by rewrite -addrA 3!rmorphD /= intrKceil lerD2l ltrD2l -rmorphD ceil_itv.
+Qed.
+
+Lemma ceilN : {in int_num, {morph ceil : x / - x}}.
+Proof. by move=> _ /intrP[m ->]; rewrite -rmorphN !intrKceil. Qed.
+
+Lemma ceilM : {in int_num &, {morph ceil : x y / x * y}}.
+Proof.
+by move=> _ _ /intrP[m1 ->] /intrP[m2 ->]; rewrite -rmorphM !intrKceil.
+Qed.
+
+Lemma ceilX n : {in int_num, {morph ceil : x / x ^+ n}}.
+Proof. by move=> _ /intrP[m ->]; rewrite -rmorphXn !intrKceil. Qed.
+
+Lemma ceil_floor x : x \is Rreal -> ceil x = floor x + (~~ (x \is a int_num)).
+Proof.
+case Ix: (x \is a int_num) => Rx /=.
+  by apply/eqP; rewrite addr0 eqr_oppLR floorN.
+apply/ceil_def; rewrite addrK; move: (floor_itv Rx).
+by rewrite le_eqVlt -intrEfloor Ix /= => /andP[-> /ltW].
+Qed.
+
+Lemma rpred_int_num (S : subringClosed R) x : x \is a int_num -> x \in S.
+Proof. by move=> /intrP[n ->]; rewrite rpred_int. Qed.
+
+Lemma int_num0 : 0 \is a int_num. Proof. by rewrite intrE nat_num0. Qed.
+Definition int_num1 : 1 \is a int_num := @ssrnum.Num.Theory.mc_2_0.int_num1 R.
+#[local] Hint Resolve int_num0 int_num1 : core.
+
+Fact int_num_subring : subring_closed int_num.
+Proof.
+by split=> // _ _ /intrP[n ->] /intrP[m ->]; rewrite -?mulrzBr -?intrM intr_int.
+Qed.
+#[export]
+HB.instance Definition _ := GRing.isSubringClosed.Build R Num.int_num_subdef
+  int_num_subring.
+
+Lemma intr_nat : {subset nat_num <= int_num}.
+Proof. by move=> ?; rewrite intrE => ->. Qed.
+
+Lemma Rreal_int : {subset int_num <= Rreal}. Proof. exact: rpred_int_num. Qed.
+
+Lemma intr_normK x : x \is a int_num -> `|x| ^+ 2 = x ^+ 2.
+Proof. by move/Rreal_int/real_normK. Qed.
+
+Lemma intrEsign x : x \is a int_num -> x = (-1) ^+ (x < 0)%R * `|x|.
+Proof. by move/Rreal_int/realEsign. Qed.
+
+Lemma natr_norm_int x : x \is a int_num -> `|x| \is a nat_num.
+Proof. by move=> /intrP[m ->]; rewrite -intr_norm rpred_nat_num ?natr_nat. Qed.
+
+Lemma natrEint x : (x \is a nat_num) = (x \is a int_num) && (0 <= x).
+Proof.
+apply/idP/andP=> [Nx | [Zx x_ge0]]; first by rewrite intr_nat ?natr_ge0.
+by rewrite -(ger0_norm x_ge0) natr_norm_int.
+Qed.
+
+Lemma intrEge0 x : 0 <= x -> (x \is a int_num) = (x \is a nat_num).
+Proof. by rewrite natrEint andbC => ->. Qed.
+
+Lemma natr_exp_even x n : ~~ odd n -> x \is a int_num -> x ^+ n \is a nat_num.
+Proof.
+move=> n_oddF x_intr.
+by rewrite natrEint rpredX //= real_exprn_even_ge0 // Rreal_int.
+Qed.
+
+Lemma norm_intr_ge1 x : x \is a int_num -> x != 0 -> 1 <= `|x|.
+Proof.
+rewrite -normr_eq0 => /natr_norm_int/natrP[n ->].
+by rewrite pnatr_eq0 ler1n lt0n.
+Qed.
+
+Lemma sqr_intr_ge1 x : x \is a int_num -> x != 0 -> 1 <= x ^+ 2.
+Proof.
+by move=> Zx nz_x; rewrite -intr_normK // expr_ge1 ?normr_ge0 ?norm_intr_ge1.
+Qed.
+
+Lemma intr_ler_sqr x : x \is a int_num -> x <= x ^+ 2.
+Proof.
+move=> Zx; have [-> | nz_x] := eqVneq x 0; first by rewrite expr0n.
+apply: le_trans (_ : `|x| <= _); first by rewrite real_ler_norm ?Rreal_int.
+by rewrite -intr_normK // ler_eXnr // norm_intr_ge1.
+Qed.
+
+Lemma floorpK : {in polyOver int_num, cancel (map_poly floor) (map_poly intr)}.
+Proof.
+move=> p /(all_nthP 0) Zp; apply/polyP=> i.
+rewrite coef_map coef_map_id0 //= -[p]coefK coef_poly.
+by case: ifP => [/Zp/floorK // | _]; rewrite floor0.
+Qed.
+
+Lemma floorpP (p : {poly R}) :
+  p \is a polyOver int_num -> {q | p = map_poly intr q}.
+Proof. by exists (map_poly floor p); rewrite floorpK. Qed.
+
+(* Relating Cnat and oldCnat. *)
+
+Lemma trunc_floor x : trunc x = if 0 <= x then `|floor x|%N else 0%N.
+Proof.
+case: ifP => [x_ge0 | x_ge0F]; last first.
+  by apply/trunc0Pn; apply/contraFN: x_ge0F; apply/le_trans.
+apply/trunc_def; rewrite !pmulrn intS addrC abszE; have/floor_le := x_ge0.
+by rewrite floor0 => /normr_idP ->; exact/floor_itv/ger0_real.
+Qed.
+
+(* predCmod *)
+Variables (U V : lmodType R) (f : {additive U -> V}).
+
+Lemma raddfZ_nat a u : a \is a nat_num -> f (a *: u) = a *: f u.
+Proof. by move=> /natrP[n ->]; apply: raddfZnat. Qed.
+
+Lemma rpredZ_nat (S : addrClosed V) :
+  {in nat_num & S, forall z u, z *: u \in S}.
+Proof. by move=> _ u /natrP[n ->]; apply: rpredZnat. Qed.
+
+Lemma raddfZ_int a u : a \is a int_num -> f (a *: u) = a *: f u.
+Proof. by move=> /intrP[m ->]; rewrite !scaler_int raddfMz. Qed.
+
+Lemma rpredZ_int (S : zmodClosed V) :
+  {in int_num & S, forall z u, z *: u \in S}.
+Proof. by move=> _ u /intrP[m ->] ?; rewrite scaler_int rpredMz. Qed.
+
+(* autC *)
+Implicit Type nu : {rmorphism R -> R}.
+
+Lemma aut_natr nu : {in nat_num, nu =1 id}.
+Proof. by move=> _ /natrP[n ->]; apply: rmorph_nat. Qed.
+
+Lemma aut_intr nu : {in int_num, nu =1 id}.
+Proof. by move=> _ /intrP[m ->]; apply: rmorph_int. Qed.
+
+End ArchiNumDomainTheory.
+
+Arguments natrK {R} _%N.
+Arguments intrKfloor {R}.
+Arguments intrKceil {R}.
+Arguments natrP {R x}.
+Arguments intrP {R x}.
+#[global] Hint Resolve trunc0 trunc1 : core.
+#[global] Hint Resolve floor0 floor1 : core.
+#[global] Hint Resolve ceil0 ceil1 : core.
+#[global] Hint Extern 0 (is_true (_%:R \is a nat_num)) => apply: natr_nat : core.
+#[global] Hint Extern 0 (is_true (_%:R \in Num.nat_num_subdef)) => apply: natr_nat : core.
+#[global] Hint Extern 0 (is_true (_%:~R \is a int_num)) => apply: intr_int : core.
+#[global] Hint Extern 0 (is_true (_%:~R \in Num.int_num_subdef)) => apply: intr_int : core.
+#[global] Hint Extern 0 (is_true (0 \is a nat_num)) => apply: nat_num0 : core.
+#[global] Hint Extern 0 (is_true (0 \in Num.nat_num_subdef)) => apply: nat_num0 : core.
+#[global] Hint Extern 0 (is_true (1 \is a nat_num)) => apply: nat_num1 : core.
+#[global] Hint Extern 0 (is_true (1 \in Num.int_num_subdef)) => apply: nat_num1 : core.
+#[global] Hint Extern 0 (is_true (0 \is a int_num)) => apply: int_num0 : core.
+#[global] Hint Extern 0 (is_true (0 \in Num.int_num_subdef)) => apply: int_num0 : core.
+#[global] Hint Extern 0 (is_true (1 \is a int_num)) => apply: int_num1 : core.
+#[global] Hint Extern 0 (is_true (1 \in Num.int_num_subdef)) => apply: int_num1 : core.
+
+Section ArchiDomainTheory.
+
+Variables (R : archiDomainType).
+
+Definition upper_nthrootP (x : R) i : (bound x <= i)%N -> x < 2%:R ^+ i :=
+  @ssrnum.Num.Theory.mc_2_0.upper_nthrootP R x i.
+
+End ArchiDomainTheory.
+
+Section ArchiNumFieldTheory.
+
+Variable R : archiNumFieldType.
+
+(* autLmodC *)
+Implicit Type nu : {rmorphism R -> R}.
+
+Lemma natr_aut nu x : (nu x \is a nat_num) = (x \is a nat_num).
+Proof. by apply/idP/idP=> /[dup] ? /(aut_natr nu) => [/fmorph_inj <-| ->]. Qed.
+
+Lemma intr_aut nu x : (nu x \is a int_num) = (x \is a int_num).
+Proof. by rewrite !intrE -rmorphN !natr_aut. Qed.
+
+End ArchiNumFieldTheory.
+
+Section ArchiClosedFieldTheory.
+
+Variable R : archiClosedFieldType.
+
+Implicit Type x : R.
+
+Lemma conj_natr x : x \is a nat_num -> x^* = x.
+Proof. by move/Rreal_nat/CrealP. Qed.
+
+Lemma conj_intr x : x \is a int_num -> x^* = x.
+Proof. by move/Rreal_int/CrealP. Qed.
+
+End ArchiClosedFieldTheory.
+
+Section ZnatPred.
+
+Notation Znat_def := ssrint.mc_2_0.Znat_def.
+Notation ZnatP := ssrint.mc_2_0.ZnatP.
+
+End ZnatPred.
+
+End Theory.
+
+Module PredInstances.
+HB.reexport.
+End PredInstances.
+
+Notation nat := nat_num.
+Notation int := int_num.
+
+End Num.
+
+Export Num.ArchiNumDomain.Exports Num.ArchiNumField.Exports.
+Export Num.ArchiClosedField.Exports Num.ArchiDomain.Exports.
+Export Num.ArchiField.Exports Num.ArchiRealClosedField.Exports.
+Export Num.Exports Num.PredInstances.

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -456,14 +456,14 @@ Lemma divzDr m n d :
   (d %| n)%Z -> ((m + n) %/ d)%Z = (m %/ d)%Z + (n %/ d)%Z.
 Proof. by move=> dv_n; rewrite addrC divzDl // addrC. Qed.
 
-Lemma Qint_dvdz (m d : int) : (d %| m)%Z -> ((m%:~R / d%:~R : rat) \is a Qint).
+Lemma Qint_dvdz (m d : int) : (d %| m)%Z -> (m%:~R / d%:~R : rat) \is a Qint.
 Proof.
 case/dvdzP=> z ->; rewrite rmorphM /=; have [->|dn0] := eqVneq d 0.
   by rewrite mulr0 mul0r.
 by rewrite mulfK ?intr_eq0 // rpred_int.
 Qed.
 
-Lemma Qnat_dvd (m d : nat) : (d %| m)%N -> ((m%:R / d%:R : rat) \is a Qnat).
+Lemma Qnat_dvd (m d : nat) : (d %| m)%N -> (m%:R / d%:R : rat) \is a Qnat.
 Proof.
 move=> h; rewrite Qnat_def divr_ge0 ?ler0n // -[m%:R]/(m%:~R) -[d%:R]/(d%:~R).
 by rewrite Qint_dvdz.

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -3,7 +3,7 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq path.
 From mathcomp Require Import div choice fintype tuple finfun bigop prime order.
-From mathcomp Require Import ssralg poly ssrnum ssrint rat matrix.
+From mathcomp Require Import ssralg poly ssrnum ssrint archimedean rat matrix.
 From mathcomp Require Import polydiv perm zmodp mxalgebra vector.
 
 (******************************************************************************)
@@ -456,18 +456,15 @@ Lemma divzDr m n d :
   (d %| n)%Z -> ((m + n) %/ d)%Z = (m %/ d)%Z + (n %/ d)%Z.
 Proof. by move=> dv_n; rewrite addrC divzDl // addrC. Qed.
 
-Lemma Qint_dvdz (m d : int) : (d %| m)%Z -> (m%:~R / d%:~R : rat) \is a Qint.
+Lemma Qint_dvdz (m d : int) : (d %| m)%Z -> (m%:~R / d%:~R : rat) \is a Num.int.
 Proof.
 case/dvdzP=> z ->; rewrite rmorphM /=; have [->|dn0] := eqVneq d 0.
   by rewrite mulr0 mul0r.
-by rewrite mulfK ?intr_eq0 // rpred_int.
+by rewrite mulfK ?intr_eq0.
 Qed.
 
-Lemma Qnat_dvd (m d : nat) : (d %| m)%N -> (m%:R / d%:R : rat) \is a Qnat.
-Proof.
-move=> h; rewrite Qnat_def divr_ge0 ?ler0n // -[m%:R]/(m%:~R) -[d%:R]/(d%:~R).
-by rewrite Qint_dvdz.
-Qed.
+Lemma Qnat_dvd (m d : nat) : (d %| m)%N -> (m%:R / d%:R : rat) \is a Num.nat.
+Proof. by move=> h; rewrite natrEint divr_ge0 ?ler0n // !pmulrn Qint_dvdz. Qed.
 
 (* Greatest common divisor *)
 

--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -846,7 +846,7 @@ Lemma ratr_int z : ratr z%:~R = z%:~R.
 Proof. by rewrite /ratr numq_int denq_int divr1. Qed.
 
 Lemma ratr_nat n : ratr n%:R = n%:R.
-Proof. exact: (ratr_int n). Qed.
+Proof. exact: ratr_int n. Qed.
 
 Lemma rpred_rat (S : divringClosed R) a : ratr a \in S.
 Proof. by rewrite rpred_div ?rpred_int. Qed.

--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -3,7 +3,7 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
 From mathcomp Require Import fintype bigop order ssralg countalg div ssrnum.
-From mathcomp Require Import ssrint prime.
+From mathcomp Require Import ssrint prime archimedean.
 
 (******************************************************************************)
 (* This file defines a datatype for rational numbers and equips it with a     *)
@@ -16,9 +16,6 @@ From mathcomp Require Import ssrint prime.
 (*                 rationals of the generic ring morphism n%:~R               *)
 (*       numq r == numerator of (r : rat)                                     *)
 (*       denq r == denominator of (r : rat)                                   *)
-(* x \is a Qint == x is an element of rat whose denominator is equal to 1     *)
-(* x \is a Qnat == x is a non-negative element of rat whose denominator       *)
-(*                 is equal to 1                                              *)
 (*       ratr r == generic embedding of (r : rat) into an arbitrary unit ring.*)
 (* [rat x // y] == smart constructor for rationals, definitionally equal      *)
 (*                 to x / y for concrete values, intended for printing only   *)
@@ -764,74 +761,44 @@ Proof. by case: b; rewrite ?(mul1r, mulN1r) // denqN. Qed.
 Lemma denq_norm x : denq `|x| = denq x.
 Proof. by rewrite normrEsign denq_mulr_sign. Qed.
 
-Fact rat_archimedean : Num.archimedean_axiom rat.
+Module ratArchimedean.
+Section ratArchimedean.
+
+Implicit Types x : rat.
+
+Let trunc x : nat := if 0 <= x then (`|numq x| %/ `|denq x|)%N else 0%N.
+
+Lemma truncP x :
+  if 0 <= x then (trunc x)%:R <= x < (trunc x).+1%:R else trunc x == 0%N.
 Proof.
-move=> x; exists `|numq x|.+1; rewrite mulrS ltr_pwDl //.
-rewrite pmulrn abszE intr_norm numqE normrM ler_peMr //.
-by rewrite -intr_norm ler1n absz_gt0 denq_eq0.
+rewrite /trunc -numq_ge0; case: (ratP x) => -[] //= n d _.
+rewrite ler_pdivlMr ?ltr_pdivrMr ?ltr0z // -!natrM ler_nat ltr_nat.
+by rewrite leq_trunc_div ltn_ceil.
 Qed.
 
-HB.instance Definition _ :=
-  Num.RealField_isArchimedean.Build rat rat_archimedean.
+Let is_nat x := (0 <= x) && (denq x == 1).
 
-Section QintPred.
-
-Definition Qint_pred := fun x : rat => denq x == 1.
-Arguments Qint_pred _ /.
-Definition Qint := [qualify a x : rat | Qint_pred x].
-
-Lemma Qint_def x : (x \is a Qint) = (denq x == 1). Proof. by []. Qed.
-
-Lemma numqK : {in Qint, cancel (fun x => numq x) intr}.
-Proof. by move=> x /(_ =P 1 :> int) Zx; rewrite numqE Zx rmorph1 mulr1. Qed.
-
-Lemma QintP x : reflect (exists z, x = z%:~R) (x \in Qint).
+Lemma is_natE x : is_nat x = ((trunc x)%:R == x).
 Proof.
-apply: (iffP idP) => [/numqK <- | [z ->]]; first by exists (numq x).
-by rewrite Qint_def denq_int.
+rewrite /is_nat /trunc -numq_ge0 !rat_eq; case: (ratP x) => -[] //= n d pnd.
+rewrite pmulrn numq_int denq_int mulr1 -PoszM !eqz_nat -dvdn_eq.
+apply/eqP/idP => [->|/dvdnP[k nE]] //.
+by move/eqP: pnd; rewrite nE gcdnC gcdnMl.
 Qed.
 
-Fact Qint_subring_closed : subring_closed Qint.
-Proof.
-split=> // _ _ /QintP[x ->] /QintP[y ->]; apply/QintP.
-  by exists (x - y); rewrite -rmorphB.
-by exists (x * y); rewrite -rmorphM.
-Qed.
+Lemma is_intE x : (denq x == 1) = is_nat x || is_nat (- x).
+Proof. by rewrite /is_nat denqN oppr_ge0 -andb_orl le_total. Qed.
 
-HB.instance Definition _ := GRing.isSubringClosed.Build rat Qint_pred
-  Qint_subring_closed.
+End ratArchimedean.
+End ratArchimedean.
 
-End QintPred.
-Arguments Qint_pred _ /.
+HB.instance Definition _ := Num.NumDomain_isArchimedean.Build rat
+  ratArchimedean.truncP ratArchimedean.is_natE ratArchimedean.is_intE.
 
-Section QnatPred.
+Lemma Qint_def (x : rat) : (x \is a Num.int) = (denq x == 1). Proof. by []. Qed.
 
-Definition Qnat_pred := fun x : rat => (x \is a Qint) && (0 <= x).
-Arguments Qnat_pred _ /.
-Definition Qnat := [qualify a x | Qnat_pred x].
-
-Lemma Qnat_def x : (x \is a Qnat) = (x \is a Qint) && (0 <= x).
-Proof. by []. Qed.
-
-Lemma QnatP x : reflect (exists n : nat, x = n%:R) (x \in Qnat).
-Proof.
-rewrite Qnat_def; apply: (iffP idP) => [/andP []|[n ->]]; last first.
-  by rewrite Qint_def pmulrn denq_int eqxx ler0z.
-by move=> /QintP [] [] n ->; rewrite ?ler0z // => _; exists n.
-Qed.
-
-Fact Qnat_semiring_closed : semiring_closed Qnat.
-Proof.
-do 2?split; move=> // x y; rewrite !Qnat_def => /andP[xQ hx] /andP[yQ hy].
-  by rewrite rpredD // addr_ge0.
-by rewrite rpredM // mulr_ge0.
-Qed.
-
-HB.instance Definition _ := GRing.isSemiringClosed.Build rat Qnat_pred
-  Qnat_semiring_closed.
-
-End QnatPred.
-Arguments Qnat_pred _ /.
+Lemma numqK : {in Num.int, cancel (fun x => numq x) intr}.
+Proof. by move=> _ /intrP [x ->]; rewrite numq_int. Qed.
 
 Lemma natq_div m n : n %| m -> (m %/ n)%:R = m%:R / n%:R :> rat.
 Proof. exact/char0_natf_div/char_num. Qed.
@@ -954,6 +921,22 @@ Proof. by move=> x y; rewrite !maxEle ler_rat; case: leP. Qed.
 
 End InPrealField.
 
+Section InParchiField.
+
+Variable F : archiNumFieldType.
+
+Lemma floor_rat : {mono (@ratr F) : x / Num.floor x}.
+Proof.
+move=> x; apply: floor_def; apply/andP; split.
+- by rewrite -ratr_int ler_rat ge_floor // num_real.
+- by rewrite -ratr_int ltr_rat lt_succ_floor // num_real.
+Qed.
+
+Lemma ceil_rat : {mono (@ratr F) : x / Num.ceil x}.
+Proof. by move=> x; rewrite /Num.ceil -rmorphN floor_rat. Qed.
+
+End InParchiField.
+
 Arguments ratr {R}.
 
 (* Connecting rationals to the ring and field tactics *)
@@ -997,3 +980,30 @@ Notation "[ 'rat' x // y ]" :=
 (* A specialization of vm_compute rewrite rule for pattern _%:Q *)
 Lemma rat_vm_compute n (x : rat) : vm_compute_eq n%:Q x -> n%:Q = x.
 Proof. exact. Qed.
+
+Module mc_2_0.
+
+Local Notation Qint := (Num.int : qualifier 1 rat) (only parsing).
+Local Notation Qnat := (Num.nat : qualifier 1 rat) (only parsing).
+
+Local Lemma QintP (x : rat) : reflect (exists z, x = z%:~R) (x \in Qint).
+Proof. exact: intrP. Qed.
+
+Local Lemma Qnat_def (x : rat) : (x \is a Qnat) = (x \is a Qint) && (0 <= x).
+Proof. exact: natrEint. Qed.
+
+Local Lemma QnatP x : reflect (exists n : nat, x = n%:R) (x \in Qnat).
+Proof. exact: natrP. Qed.
+
+End mc_2_0.
+
+#[deprecated(since="mathcomp 2.1.0", note="Use Num.int instead.")]
+Notation Qint := (Num.int : qualifier 1 rat) (only parsing).
+#[deprecated(since="mathcomp 2.1.0", note="Use Num.nat instead.")]
+Notation Qnat := (Num.nat : qualifier 1 rat) (only parsing).
+#[deprecated(since="mathcomp 2.1.0", note="Use intrP instead.")]
+Notation QintP := mc_2_0.QintP (only parsing).
+#[deprecated(since="mathcomp 2.1.0", note="Use natrEint instead.")]
+Notation Qnat_def := mc_2_0.Qnat_def (only parsing).
+#[deprecated(since="mathcomp 2.1.0", note="Use natrP instead.")]
+Notation QnatP := mc_2_0.QnatP (only parsing).

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -1554,7 +1554,7 @@ Lemma sgzP x :
   (sgz x == 0)  (sgz x == -1) (sgz x == 1) `|x| (sgr x) (sgz x).
 Proof.
 rewrite ![_ == sgz _]eq_sym ![_ == sgr _]eq_sym !sgr_cp0 !sgz_cp0.
-by rewrite /sgr /sgz !leNgt; case: ltrgt0P; constructor.
+by rewrite /sgz; case: sgrP; constructor.
 Qed.
 
 Lemma sgzN x : sgz (- x) = - sgz x.
@@ -1576,15 +1576,11 @@ Proof. by rewrite -eqr_oppLR -mulrN -sgzN mulz_sg_eq1. Qed.
 (*   (sgr y * sgr z == sgr x) = ((sgr y * sgr x == sgr z) && (sgr z != 0)). *)
 (* Proof. by do 3!case: sgrP=> _. Qed. *)
 
-Lemma sgzM x y : sgz (x * y) = sgz x  * sgz y.
+Lemma sgzM x y : sgz (x * y) = sgz x * sgz y.
 Proof.
-case: (sgzP x)=> hx; first by rewrite hx ?mul0r sgz0.
-  case: (sgzP y)=> hy; first by rewrite hy !mulr0 sgz0.
-    by apply/eqP; rewrite mul1r sgz_cp0 pmulr_rgt0.
-  by apply/eqP; rewrite mul1r sgz_cp0 nmulr_llt0.
-case: (sgzP y)=> hy; first by rewrite hy !mulr0 sgz0.
-  by apply/eqP; rewrite mulr1 sgz_cp0 nmulr_rlt0.
-by apply/eqP; rewrite mulN1r opprK sgz_cp0 nmulr_rgt0.
+rewrite -sgz_sgr -(sgz_sgr x) -(sgz_sgr y) sgrM.
+by case: sgrP; case: sgrP; rewrite /sgz ?(mulNr, mul0r, mul1r);
+  rewrite ?(oppr_eq0, oppr_cp0, eqxx, ltxx, ltr01, ltr10, oner_eq0).
 Qed.
 
 Lemma sgzX (n : nat) x : sgz (x ^+ n) = (sgz x) ^+ n.

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -1853,22 +1853,28 @@ Proof. by rewrite -mul_polyC polyCMz polyC1 mulrzl. Qed.
 
 End PolyZintRing.
 
-Section ZnatPred.
+Module intArchimedean.
+Section intArchimedean.
 
-Definition Znat_pred := fun n : int => 0 <= n.
-Definition Znat := [qualify a n : int | Znat_pred n].
+Implicit Types n : int.
 
-Lemma Znat_def n : (n \is a Znat) = (0 <= n). Proof. by []. Qed.
+Let trunc n : nat := if n is Posz n' then n' else 0%N.
 
-Lemma Znat_semiring_closed : semiring_closed Znat.
-Proof. by do 2?split => //; [apply: addr_ge0 | apply: mulr_ge0]. Qed.
-HB.instance Definition _ := GRing.isSemiringClosed.Build int Znat_pred
-  Znat_semiring_closed.
+Lemma truncP n :
+  if 0 <= n then (trunc n)%:R <= n < (trunc n).+1%:R else trunc n == 0%N.
+Proof. by case: n => //= n; rewrite !natz intS ltz1D lexx. Qed.
 
-Lemma ZnatP (m : int) : reflect (exists n : nat, m = n) (m \is a Znat).
-Proof. by apply: (iffP idP) => [|[n -> //]]; case: m => // n; exists n. Qed.
+Lemma is_natE n : (0 <= n) = ((trunc n)%:R == n).
+Proof. by case: n => //= n; rewrite natz eqxx. Qed.
 
-End ZnatPred.
+Lemma is_intE n : true = (0 <= n) || (0 <= - n).
+Proof. by case: n. Qed.
+
+End intArchimedean.
+End intArchimedean.
+
+HB.instance Definition _ := Num.NumDomain_isArchimedean.Build int
+  intArchimedean.truncP intArchimedean.is_natE intArchimedean.is_intE.
 
 Section rpred.
 
@@ -1893,4 +1899,23 @@ Proof. by rewrite -signr_odd; case: (odd n); rewrite ?rpredV. Qed.
 
 End rpred.
 
-Arguments Znat_pred _ /.
+Module mc_2_0.
+
+Local Lemma Znat_def (n : int) : (n \is a Num.Def.nat_num) = (0 <= n).
+Proof. by []. Qed.
+
+Local Lemma ZnatP (m : int) :
+  reflect (exists n : nat, m = n) (m \is a Num.Def.nat_num).
+Proof. by case: m => m; constructor; [exists m | case]. Qed.
+
+End mc_2_0.
+
+#[deprecated(since="mathcomp 2.1.0", note="Use polyCMz instead.")]
+Notation polyC_mulrz := polyCMz (only parsing).
+#[deprecated(since="mathcomp 2.1.0",
+             note="Require archimedean.v and use Num.nat instead.")]
+Notation Znat := (Num.Def.nat_num : qualifier 1 int) (only parsing).
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation Znat_def := mc_2_0.Znat_def (only parsing).
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation ZnatP := mc_2_0.ZnatP (only parsing).

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -32,8 +32,6 @@ From mathcomp Require Import ssralg poly.
 (*                    The HB class is called RealDomain.                      *)
 (*   realFieldType == Num Field where all elements are positive or negative   *)
 (*                    The HB class is called RealField.                       *)
-(*  archiFieldType == A Real Field with the archimedean axiom                 *)
-(*                    The HB class is called ArchimedeanField.                *)
 (*         rcfType == A Real Field with the real closed axiom                 *)
 (*                    The HB class is called RealClosedField.                 *)
 (*                                                                            *)
@@ -51,8 +49,6 @@ From mathcomp Require Import ssralg poly.
 (*  x \is a Num.neg <=> x is negative (:= x < 0)                              *)
 (* x \is a Num.nneg <=> x is positive or 0 (:= x >= 0)                        *)
 (* x \is a Num.real <=> x is real (:= x >= 0 or x < 0)                        *)
-(*      Num.bound x == in archimedean fields, and upper bound for x, i.e.,    *)
-(*                     and n such that `|x| < n%:R                            *)
 (*       Num.sqrt x == in a real-closed field, a positive square root of x if *)
 (*                     x >= 0, or 0 otherwise                                 *)
 (* For numeric algebraically closed fields we provide the generic definitions *)
@@ -162,6 +158,30 @@ Notation "[ 'numDomainType' 'of' T ]" := (NumDomain.clone T%type _)
 End NumDomainExports.
 HB.export NumDomainExports.
 
+HB.mixin Record NumDomain_isArchimedean R of NumDomain R := {
+  trunc_subdef : R -> nat;
+  nat_num_subdef : pred R;
+  int_num_subdef : pred R;
+  trunc_subproof :
+    forall x,
+      if 0 <= x then (trunc_subdef x)%:R <= x < (trunc_subdef x).+1%:R
+      else trunc_subdef x == 0%N;
+  nat_num_subproof : forall x, nat_num_subdef x = ((trunc_subdef x)%:R == x);
+  int_num_subproof :
+    forall x, int_num_subdef x = nat_num_subdef x || nat_num_subdef (- x);
+}.
+
+#[short(type="archiNumDomainType")]
+HB.structure Definition ArchiNumDomain :=
+  { R of NumDomain_isArchimedean R & NumDomain R }.
+
+Module ArchiNumDomainExports.
+Bind Scope ring_scope with ArchiNumDomain.sort.
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation archiNumDomainType := archiNumDomainType (only parsing).
+End ArchiNumDomainExports.
+HB.export ArchiNumDomainExports.
+
 Module Import Def.
 
 Notation normr := norm.
@@ -194,7 +214,7 @@ Notation minr := (@Order.min ring_display _).
 Notation "@ 'minr' R" := (@Order.min ring_display R)
   (at level 10, R at level 8, only parsing) : fun_scope.
 
-Section Def.
+Section NumDomainDef.
 Context {R : numDomainType}.
 
 Definition sgr (x : R) : R := if x == 0 then 0 else if x < 0 then -1 else 1.
@@ -207,12 +227,27 @@ Definition Rnneg : qualifier 0 R := [qualify x : R | Rnneg_pred x].
 Definition Rreal_pred := fun x : R => (0 <= x) || (x <= 0).
 Definition Rreal : qualifier 0 R := [qualify x : R | Rreal_pred x].
 
-End Def. End Def.
+End NumDomainDef.
+
+Section ArchiNumDomainDef.
+Context {R : ArchiNumDomain.type}.
+
+Definition trunc : R -> nat := @trunc_subdef R.
+Definition nat_num : qualifier 1 R := [qualify a x : R | nat_num_subdef x].
+Definition int_num : qualifier 1 R := [qualify a x : R | int_num_subdef x].
+
+End ArchiNumDomainDef.
+
+End Def.
 
 Arguments Rpos_pred _ _ /.
 Arguments Rneg_pred _ _ /.
 Arguments Rnneg_pred _ _ /.
 Arguments Rreal_pred _ _ /.
+
+Arguments trunc {R} : simpl never.
+Arguments nat_num {R} : simpl never.
+Arguments int_num {R} : simpl never.
 
 (* Shorter qualified names, when Num.Def is not imported. *)
 Notation le := ler (only parsing).
@@ -229,6 +264,9 @@ Notation pos := Rpos.
 Notation neg := Rneg.
 Notation nneg := Rnneg.
 Notation real := Rreal.
+(* Not to pollute the local namespace, Num.nat and Num.int are defined later. *)
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation trunc := trunc (only parsing).
 
 (* (Exported) symbolic syntax. *)
 Module Import Syntax.
@@ -368,27 +406,6 @@ Notation "[ 'realFieldType' 'of' T ]" := (RealField.clone T%type _)
 End RealFieldExports.
 HB.export RealFieldExports.
 
-HB.mixin Record RealField_isArchimedean R of RealField R := {
-  archi_bound_subproof : archimedean_axiom R
-}.
-
-#[short(type="archiFieldType")]
-HB.structure Definition ArchimedeanField :=
-  { R of RealField_isArchimedean R & RealField R }.
-
-Module ArchimedeanFieldExports.
-Bind Scope ring_scope with ArchimedeanField.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use Num.ArchimedeanField.clone instead.")]
-Notation "[ 'archiFieldType' 'of' T 'for' cT ]" := (ArchimedeanField.clone T%type cT)
-  (at level 0, format "[ 'archiFieldType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use Num.ArchimedeanField.clone instead.")]
-Notation "[ 'archiFieldType' 'of' T ]" := (ArchimedeanField.clone T%type _)
-  (at level 0, format "[ 'archiFieldType'  'of'  T ]") : form_scope.
-End ArchimedeanFieldExports.
-HB.export ArchimedeanFieldExports.
-
 HB.mixin Record RealField_isClosed R of RealField R := {
   poly_ivt_subproof : real_closed_axiom R
 }.
@@ -409,6 +426,81 @@ Notation "[ 'rcfType' 'of' T ]" :=  (RealClosedField.clone T%type _)
   (at level 0, format "[ 'rcfType'  'of'  T ]") : form_scope.
 End RealClosedFieldExports.
 HB.export RealClosedFieldExports.
+
+#[short(type="archiNumFieldType")]
+HB.structure Definition ArchiNumField :=
+  { R of NumDomain_isArchimedean R & NumField R }.
+
+Module ArchiNumFieldExports.
+Bind Scope ring_scope with ArchiNumField.sort.
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation archiNumFieldType := archiNumFieldType (only parsing).
+End ArchiNumFieldExports.
+HB.export ArchiNumFieldExports.
+
+#[short(type="archiClosedFieldType")]
+HB.structure Definition ArchiClosedField :=
+  { R of NumDomain_isArchimedean R & ClosedField R }.
+
+Module ArchiClosedFieldExports.
+Bind Scope ring_scope with ArchiClosedField.sort.
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation archiClosedFieldType := archiClosedFieldType (only parsing).
+End ArchiClosedFieldExports.
+HB.export ArchiClosedFieldExports.
+
+#[short(type="archiDomainType")]
+HB.structure Definition ArchiDomain :=
+  { R of NumDomain_isArchimedean R & RealDomain R }.
+
+Module ArchiDomainExports.
+Bind Scope ring_scope with ArchiDomain.sort.
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation archiDomainType := archiDomainType (only parsing).
+End ArchiDomainExports.
+HB.export ArchiDomainExports.
+
+#[short(type="archiFieldType")]
+HB.structure Definition ArchiField :=
+  { R of NumDomain_isArchimedean R & RealField R }.
+
+Module ArchiFieldExports.
+Bind Scope ring_scope with ArchiField.sort.
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation archiFieldType := archiFieldType (only parsing).
+#[deprecated(since="mathcomp 2.0.0",
+  note="Use Num.ArchiField.clone instead.")]
+Notation "[ 'archiFieldType' 'of' T 'for' cT ]" := (ArchiField.clone T%type cT)
+  (at level 0, format "[ 'archiFieldType'  'of'  T  'for'  cT ]") : form_scope.
+#[deprecated(since="mathcomp 2.0.0",
+  note="Use Num.ArchiField.clone instead.")]
+Notation "[ 'archiFieldType' 'of' T ]" := (ArchiField.clone T%type _)
+  (at level 0, format "[ 'archiFieldType'  'of'  T ]") : form_scope.
+End ArchiFieldExports.
+HB.export ArchiFieldExports.
+
+Module ArchimedeanField.
+#[deprecated(since="mathcomp 2.1.0",
+  note="Require archimedean.v and use archiFieldType instead.")]
+Notation sort := ArchiField.sort (only parsing).
+#[deprecated(since="mathcomp 2.1.0",
+  note="Require archimedean.v and use archiFieldType.on instead.")]
+Notation on R := (ArchiField.on R) (only parsing).
+End ArchimedeanField.
+#[deprecated(since="mathcomp 2.1.0",
+  note="Require archimedean.v and use ArchiField instead.")]
+Notation ArchimedeanField R := (ArchiField R) (only parsing).
+
+#[short(type="archiRcfType")]
+HB.structure Definition ArchiRealClosedField :=
+  { R of NumDomain_isArchimedean R & RealClosedField R }.
+
+Module ArchiRealClosedFieldExports.
+Bind Scope ring_scope with ArchiRealClosedField.sort.
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation archiRcfType := archiRcfType (only parsing).
+End ArchiRealClosedFieldExports.
+HB.export ArchiRealClosedFieldExports.
 
 (* The elementary theory needed to support the definition of the derived      *)
 (* operations for the extensions described above.                             *)
@@ -540,6 +632,20 @@ Qed.
 
 End RealClosed.
 
+Section ArchiNumDomain.
+Variable R : ArchiNumDomain.type.
+Implicit Types x y : R.
+
+Lemma truncP x :
+  if 0 <= x then (Def.trunc x)%:R <= x < (Def.trunc x).+1%:R
+  else Def.trunc x == 0%N.
+Proof. exact: trunc_subproof. Qed.
+
+Lemma trunc_itv x : 0 <= x -> (Def.trunc x)%:R <= x < (Def.trunc x).+1%:R.
+Proof. by move=> x_ge0; move: (truncP x); rewrite x_ge0. Qed.
+
+End ArchiNumDomain.
+
 Module Exports. HB.reexport. End Exports.
 
 End Internals.
@@ -552,13 +658,14 @@ End PredInstances.
 
 Module Import ExtraDef.
 
-Definition archi_bound {R} x := sval (sigW (@archi_bound_subproof R x)).
+Definition archi_bound {R : ArchiNumDomain.type} (x : R) := (Def.trunc `|x|).+1.
 
 Definition sqrtr {R} x := s2val (sig2W (@sqrtr_subproof R x)).
 
 End ExtraDef.
 
-Notation bound := archi_bound.
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation bound := archi_bound (only parsing).
 Notation sqrt := sqrtr.
 
 Module Import Theory.
@@ -3937,22 +4044,6 @@ Proof. by apply: real_leif_AGM2; apply: num_real. Qed.
 
 End RealField.
 
-Section ArchimedeanFieldTheory.
-
-Variables (F : archiFieldType) (x : F).
-
-Lemma archi_boundP : 0 <= x -> x < (bound x)%:R.
-Proof. by move/ger0_norm=> {1}<-; rewrite /bound; case: (sigW _). Qed.
-
-Lemma upper_nthrootP i : (bound x <= i)%N -> x < 2 ^+ i.
-Proof.
-rewrite /bound; case: (sigW _) => /= b le_x_b le_b_i.
-apply: le_lt_trans (ler_norm x) (lt_trans le_x_b _ ).
-by rewrite -natrX ltr_nat (leq_ltn_trans le_b_i) // ltn_expl.
-Qed.
-
-End ArchimedeanFieldTheory.
-
 Section RealClosedFieldTheory.
 
 Variable R : rcfType.
@@ -4816,6 +4907,100 @@ Arguments sqrCK_P {C x}.
 #[global] Hint Extern 0 (is_true (in_mem ('Im _) _)) =>
   solve [apply: Creal_Im] : core.
 
+Module mc_2_0.
+
+Local Lemma archi_boundP (R : ArchiNumDomain.type) (x : R) :
+  0 <= x -> x < (archi_bound x)%:R.
+Proof.
+move=> x_ge0; case/trunc_itv/andP: (normr_ge0 x) => _.
+exact/le_lt_trans/real_ler_norm/ger0_real.
+Qed.
+
+Local Lemma upper_nthrootP (R : ArchiDomain.type) (x : R) i :
+  (archi_bound x <= i)%N -> x < 2%:R ^+ i.
+Proof.
+case/trunc_itv/andP: (normr_ge0 x) => _ /ltr_normlW xlt le_b_i.
+by rewrite (lt_le_trans xlt) // -natrX ler_nat (ltn_trans le_b_i) // ltn_expl.
+Qed.
+
+Section ArchiNumDomainTheory.
+
+Variable R : ArchiNumDomain.type.
+Implicit Type x : R.
+
+Local Notation nat_num := (@nat_num R).
+Local Notation int_num := (@int_num R).
+
+Lemma natrE x : (x \is a nat_num) = ((Def.trunc x)%:R == x).
+Proof. exact: Num.nat_num_subproof. Qed.
+
+Lemma trunc_def x n : n%:R <= x < n.+1%:R -> Def.trunc x = n.
+Proof.
+case/andP=> lemx ltxm1; apply/eqP; rewrite eqn_leq -ltnS -[(n <= _)%N]ltnS.
+have/trunc_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lemx; apply: ler0n.
+by rewrite -!(ltr_nat R) 2?(@le_lt_trans _ _ x).
+Qed.
+
+Lemma natrK : cancel (GRing.natmul 1) (@Def.trunc R).
+Proof. by move=> m; apply: trunc_def; rewrite ler_nat ltr_nat ltnS leqnn. Qed.
+
+Lemma natr_nat n : n%:R \is a nat_num. Proof. by rewrite natrE natrK. Qed.
+#[local] Hint Resolve natr_nat : core.
+
+Lemma natrP x : reflect (exists n, x = n%:R) (x \is a nat_num).
+Proof.
+apply: (iffP idP) => [|[n ->]]; rewrite // natrE => /eqP <-.
+by exists (Def.trunc x).
+Qed.
+
+Lemma nat_num0 : 0 \is a nat_num. Proof. exact: (natr_nat 0). Qed.
+Lemma nat_num1 : 1 \is a nat_num. Proof. exact: (natr_nat 1). Qed.
+#[local] Hint Resolve nat_num0 nat_num1 : core.
+
+Fact nat_num_semiring : semiring_closed nat_num.
+Proof.
+by do 2![split] => //= _ _ /natrP[n ->] /natrP[m ->]; rewrite -(natrD, natrM).
+Qed.
+#[export]
+HB.instance Definition _ := GRing.isSemiringClosed.Build R nat_num_subdef
+  nat_num_semiring.
+
+Lemma intrE x : (x \is a int_num) = (x \is a nat_num) || (- x \is a nat_num).
+Proof. exact: Num.int_num_subproof. Qed.
+
+Lemma int_num1 : 1 \is a int_num. Proof. by rewrite intrE nat_num1. Qed.
+#[local] Hint Resolve int_num1 : core.
+
+Fact int_num_subring : subring_closed int_num.
+Proof.
+split=> // u v /[!intrE] /orP[]/natrP[n] + /orP[]/natrP[m]; rewrite ?opprB.
+- move=> -> ->.
+  by case: (leqP n m) => [|/ltnW] ?; apply/orP; [right|left]; rewrite -mulrnBr.
+- by move=> -> ->; rewrite -mulrnDr natr_nat.
+- by move=> -> ->; rewrite -mulrnDr natr_nat orbT.
+- rewrite -[u in u - v]opprK -[v in v - u]opprK => -> ->.
+  by case: (leqP n m) => [|/ltnW] ?;
+    apply/orP; [left|right]; rewrite addrC -mulrnBr.
+- by move=> -> ->; rewrite -natrM natr_nat.
+- by rewrite -mulrN => -> ->; rewrite -natrM natr_nat orbT.
+- by rewrite -mulNr => -> ->; rewrite -natrM natr_nat orbT.
+- by rewrite -mulrNN => -> ->; rewrite -natrM natr_nat.
+Qed.
+#[export]
+HB.instance Definition _ := GRing.isSubringClosed.Build R int_num_subdef
+  int_num_subring.
+
+End ArchiNumDomainTheory.
+
+Module Exports. HB.reexport. End Exports.
+
+End mc_2_0.
+
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation archi_boundP := mc_2_0.archi_boundP (only parsing).
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation upper_nthrootP := mc_2_0.upper_nthrootP (only parsing).
+
 Module Export Pdeg2.
 
 Module NumClosed.
@@ -5656,8 +5841,61 @@ HB.builders Context R of IntegralDomain_isLtReal R.
     le_total.
 HB.end.
 
+HB.factory Record NumDomain_bounded_isArchimedean R of NumDomain R := {
+  archi_bound_subproof : archimedean_axiom R
+}.
+
+HB.builders Context R of NumDomain_bounded_isArchimedean R.
+  Implicit Type x : R.
+
+  Definition bound x := sval (sigW (archi_bound_subproof x)).
+
+  Lemma boundP x : 0 <= x -> x < (bound x)%:R.
+  Proof. by move/ger0_norm=> {1}<-; rewrite /bound; case: (sigW _). Qed.
+
+  Fact trunc_subproof x : {m | 0 <= x -> m%:R <= x < m.+1%:R }.
+  Proof.
+  have [Rx | _] := boolP (0 <= x); last by exists 0%N.
+  have/ex_minnP[n lt_x_n1 min_n]: exists n, x < n.+1%:R.
+    by exists (bound x); rewrite (lt_trans (boundP Rx)) ?ltr_nat.
+  exists n => _; rewrite {}lt_x_n1 andbT; case: n min_n => //= n min_n.
+  rewrite real_leNgt ?rpred_nat ?ger0_real //; apply/negP => /min_n.
+  by rewrite ltnn.
+  Qed.
+
+  Definition trunc x := if 0 <= x then sval (trunc_subproof x) else 0%N.
+
+  Lemma truncP x :
+    if 0 <= x then (trunc x)%:R <= x < (trunc x).+1%:R else trunc x == 0%N.
+  Proof.
+  rewrite /trunc; case: trunc_subproof => // n hn.
+  by case: ifP => x_ge0; rewrite ?(ifT _ _ x_ge0) ?(ifF _ _ x_ge0) // hn.
+  Qed.
+
+  HB.instance Definition _ := NumDomain_isArchimedean.Build R
+    truncP (fun => erefl) (fun => erefl).
+HB.end.
+
+Module RealField_isArchimedean.
+#[deprecated(since="mathcomp 2.1.0",
+  note="NumDomain_bounded_isArchimedean.Build instead.")]
+Notation Build R p := (NumDomain_bounded_isArchimedean.Build R p).
+End RealField_isArchimedean.
+
+#[deprecated(since="mathcomp 2.1.0",
+  note="NumDomain_bounded_isArchimedean instead.")]
+Notation RealField_isArchimedean T := (NumDomain_bounded_isArchimedean T).
+
 Module Exports. HB.reexport. End Exports.
+
+(* Not to pollute the local namespace, we define Num.nat and Num.int here. *)
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation nat := nat_num (only parsing).
+#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+Notation int := int_num (only parsing).
+
 End Num.
 Export Num.Exports.
+Export Num.Theory.mc_2_0.Exports.
 
 Export Num.Syntax Num.PredInstances.

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -1408,7 +1408,7 @@ apply/irrP/andP=> [[i ->] | [Nchi]]; first by rewrite irr_char cfnorm_irr.
 rewrite cfdot_sum_irr => /eqP/Cnat_sum_eq1[i _| i [_ ci1 cj0]].
   by rewrite rpredM // ?conj_Cnat ?Cnat_cfdot_char_irr.
 exists i; rewrite [chi]cfun_sum_cfdot (bigD1 i) //=.
-rewrite -(@normr_idP _ _ (@Cnat_ge0 _ (Cnat_cfdot_char_irr i Nchi))).
+rewrite -(normr_idP (Cnat_ge0 (Cnat_cfdot_char_irr i Nchi))).
 rewrite normC_def {}ci1 sqrtC1 scale1r big1 ?addr0 // => j neq_ji.
 by rewrite (('[_] =P 0) _) ?scale0r // -normr_eq0 normC_def cj0 ?sqrtC0.
 Qed.

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -7,6 +7,7 @@ From mathcomp Require Import ssralg poly finset fingroup morphism perm.
 From mathcomp Require Import automorphism quotient finalg action gproduct.
 From mathcomp Require Import zmodp commutator cyclic center pgroup sylow.
 From mathcomp Require Import matrix vector falgebra ssrnum algC algnum.
+From mathcomp Require Import archimedean.
 
 (******************************************************************************)
 (* This file contains the basic theory of class functions:                    *)
@@ -2413,11 +2414,11 @@ Local Notation "phi ^u" := (cfAut u phi) (at level 3, format "phi ^u").
 Lemma cfAutZ_nat n phi : (n%:R *: phi)^u = n%:R *: phi^u.
 Proof. exact: raddfZnat. Qed.
 
-Lemma cfAutZ_Cnat z phi : z \in Cnat -> (z *: phi)^u = z *: phi^u.
-Proof. exact: raddfZ_Cnat. Qed.
+Lemma cfAutZ_Cnat z phi : z \in Num.nat -> (z *: phi)^u = z *: phi^u.
+Proof. exact: raddfZ_nat. Qed.
 
-Lemma cfAutZ_Cint z phi : z \in Cint -> (z *: phi)^u = z *: phi^u.
-Proof. exact: raddfZ_Cint. Qed.
+Lemma cfAutZ_Cint z phi : z \in Num.int -> (z *: phi)^u = z *: phi^u.
+Proof. exact: raddfZ_int. Qed.
 
 Lemma cfAutK : cancel (@cfAut gT G u) (cfAut (algC_invaut u)).
 Proof. by move=> phi; apply/cfunP=> x; rewrite !cfunE /= algC_autK. Qed.

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -2342,8 +2342,8 @@ Lemma cfIndM phi psi:  H \subset G ->
 Proof.
 move=> HsG; apply/cfun_inP=> x Gx; rewrite !cfIndE // !cfunE !cfIndE // -mulrA.
 congr (_ * _); rewrite mulr_suml; apply: eq_bigr=> i iG; rewrite !cfunE.
-case: (boolP (x^i \in H))=> xJi; last by rewrite cfun0gen ?mul0r ?genGid.
-by rewrite !cfResE //; congr (_*_); rewrite cfunJgen ?genGid.
+case: (boolP (x ^ i \in H)) => xJi; last by rewrite cfun0gen ?mul0r ?genGid.
+by rewrite !cfResE //; congr (_ * _); rewrite cfunJgen ?genGid.
 Qed.
 
 End Induced.

--- a/mathcomp/character/inertia.v
+++ b/mathcomp/character/inertia.v
@@ -1235,9 +1235,9 @@ move=> nsNG iGN pr_p IGchi.
 have [t sGt] := constt_cfInd_irr s (normal_sub nsNG); exists t.
 have [e DtN]: exists e, 'Res 'chi_t = e%:R *: 'chi_s.
   rewrite constt_Ind_Res in sGt.
-  rewrite (Clifford_Res_sum_cfclass nsNG sGt); set e := '[_, _].
-  rewrite cfclass_invariant // big_seq1.
-  by exists (truncC e); rewrite truncCK ?Cnat_cfdot_char ?cfRes_char ?irr_char.
+  rewrite (Clifford_Res_sum_cfclass nsNG sGt) cfclass_invariant // big_seq1.
+  set e := '[_, _]; exists (truncC e).
+  by rewrite truncCK ?Cnat_cfdot_char ?cfRes_char ?irr_char.
 have [/irrWnorm/eqP | [c injc DtNc]] := cfRes_prime_irr_cases t nsNG iGN pr_p.
   rewrite DtN cfnormZ cfnorm_irr normr_nat mulr1 -natrX pnatr_eq1.
   by rewrite muln_eq1 andbb => /eqP->; rewrite scale1r.

--- a/mathcomp/character/inertia.v
+++ b/mathcomp/character/inertia.v
@@ -8,6 +8,7 @@ From mathcomp Require Import automorphism quotient action zmodp cyclic center.
 From mathcomp Require Import gproduct commutator gseries nilpotent pgroup.
 From mathcomp Require Import sylow maximal frobenius matrix mxalgebra.
 From mathcomp Require Import mxrepresentation vector algC classfun character.
+From mathcomp Require Import archimedean.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -511,7 +512,7 @@ have{chiHk chiHj}: '['Res[H] ('Ind[G] 'chi_j), 'chi_k] != 0.
   rewrite !inE !cfdot_Res_l in chiHj chiHk *.
   apply: contraNneq chiHk; rewrite cfdot_sum_irr => /psumr_eq0P/(_ i isT)/eqP.
   rewrite -cfdotC cfdotC mulf_eq0 conjC_eq0 (negbTE chiHj) /= => -> // i1.
-  by rewrite -cfdotC Cnat_ge0 // rpredM ?Cnat_cfdot_char ?cfInd_char ?irr_char.
+  by rewrite -cfdotC natr_ge0 // rpredM ?Cnat_cfdot_char ?cfInd_char ?irr_char.
 rewrite cfResInd // cfdotZl mulf_eq0 cfdot_suml => /norP[_].
 apply: contraR => chiGk'j; rewrite big1 // => x Gx; apply: contraNeq chiGk'j.
 rewrite -conjg_IirrE cfdot_irr pnatr_eq0; case: (_ =P k) => // <- _.
@@ -544,7 +545,7 @@ Lemma dvdn_constt_Res1_irr1 i j :
 Proof.
 move=> nsHG chiHj; have [sHG nHG] := andP nsHG; rewrite -(cfResE _ sHG) //.
 rewrite {1}(Clifford_Res_sum_cfclass nsHG chiHj) cfunE sum_cfunE.
-have /CnatP[n ->]: '['Res[H] 'chi_i, 'chi_j] \in Cnat.
+have /natrP[n ->]: '['Res[H] 'chi_i, 'chi_j] \in Num.nat.
   by rewrite Cnat_cfdot_char ?cfRes_char ?irr_char.
 exists (n * size ('chi_j ^: G)%CF)%N; rewrite natrM -mulrA; congr (_ * _).
 rewrite mulr_natl -[size _]card_ord big_tnth -sumr_const; apply: eq_bigr => k _.
@@ -966,7 +967,7 @@ have part_c: {in calA, forall s (chi := 'Ind[G] 'chi_s),
     by rewrite mulrb ifN_eqC ?subr0.
   rewrite -(cfResRes chi sHT sTG) DchiT Dphi !rmorphD !cfdotDl /=.
   rewrite -ltrBDl subrr ltr_wpDr ?lt_def //;
-    rewrite Cnat_ge0 ?Cnat_cfdot_char ?cfRes_char ?irr_char //.
+    rewrite natr_ge0 ?Cnat_cfdot_char ?cfRes_char ?irr_char //.
   by rewrite andbT -irr_consttE -constt_Ind_Res.
 do [split=> //; try by move=> s /AtoB_P[]] => [s1 s2 As1 As2 | r].
   have [[irr_s1G _ _] [irr_s2G _ _]] := (AtoB_P _ As1, AtoB_P _ As2).
@@ -1023,8 +1024,8 @@ move=> IGphi irr_psi calS.
 have IGpsi: G \subset 'I[psi].
   by rewrite (subset_trans _ (inertia_mul _ _)) // subsetI IGphi.
 pose e b := '['Ind[G] phi, 'chi_b]; pose d b g := '['chi_b * chi, 'chi_g * chi].
-have Ne b: e b \in Cnat by rewrite Cnat_cfdot_char ?cfInd_char ?irr_char.
-have egt0 b: b \in calS -> e b > 0 by rewrite Cnat_gt0.
+have Ne b: e b \in Num.nat by rewrite Cnat_cfdot_char ?cfInd_char ?irr_char.
+have egt0 b: b \in calS -> e b > 0 by rewrite natr_gt0.
 have DphiG: 'Ind phi = \sum_(b in calS) e b *: 'chi_b := cfun_sum_constt _.
 have DpsiG: 'Ind psi = \sum_(b in calS) e b *: 'chi_b * chi.
   by rewrite /psi -cNt cfIndM // DphiG mulr_suml.
@@ -1035,15 +1036,15 @@ have [_]: '['Ind[G] phi] <= '['Ind[G] psi] ?= iff d_delta.
   pose sum_d := \sum_(b in calS) e b * \sum_(g in calS) e g * d b g.
   have ->: '['Ind[G] phi] = sum_delta.
     rewrite DphiG cfdot_suml; apply: eq_bigr => b _; rewrite cfdotZl cfdot_sumr.
-    by congr (_ * _); apply: eq_bigr => g; rewrite cfdotZr cfdot_irr conj_Cnat.
+    by congr (_ * _); apply: eq_bigr => g; rewrite cfdotZr cfdot_irr conj_natr.
   have ->: '['Ind[G] psi] = sum_d.
     rewrite DpsiG cfdot_suml; apply: eq_bigr => b _.
     rewrite -scalerAl cfdotZl cfdot_sumr; congr (_ * _).
-    by apply: eq_bigr => g _; rewrite -scalerAl cfdotZr conj_Cnat.
+    by apply: eq_bigr => g _; rewrite -scalerAl cfdotZr conj_natr.
   have eMmono := mono_leif (ler_pM2l (egt0 _ _)).
   apply: leif_sum => b /eMmono->; apply: leif_sum => g /eMmono->.
   split; last exact: eq_sym.
-  have /CnatP[n Dd]: d b g \in Cnat by rewrite Cnat_cfdot_char.
+  have /natrP[n Dd]: d b g \in Num.nat by rewrite Cnat_cfdot_char.
   have [Db | _] := eqP; rewrite Dd leC_nat // -ltC_nat -Dd Db cfnorm_gt0.
   by rewrite -char1_eq0 // cfunE mulf_neq0 ?irr1_neq0.
 rewrite -!cfdot_Res_l ?cfRes_Ind_invariant // !cfdotZl cfnorm_irr irrWnorm //.
@@ -1062,7 +1063,7 @@ apply/idP/idP=> [|/imageP[b Sb ->]].
   by apply: contraNneq N'i => ->; apply: image_f.
 rewrite gt_eqF // (bigD1 b) //= cfdotZl cfnorm_irr mulr1 ltr_wpDr ?egt0 //.
 apply: sumr_ge0 => g /andP[Sg _]; rewrite cfdotZl cfdot_irr.
-by rewrite mulr_ge0 ?ler0n ?Cnat_ge0.
+by rewrite mulr_ge0 ?ler0n ?natr_ge0.
 Qed.
 
 (* This is Isaacs, Corollary (6.17) (due to Gallagher). *)
@@ -1077,7 +1078,7 @@ have [] := constt_Ind_mul_ext IHchi0; rewrite irr0 ?mul1r ?mem_irr //.
 set psiG := 'Ind 1 => irrMchi injMchi constt_theta {2}->.
 have dot_psiG b: '[psiG, 'chi_(mod_Iirr b)] = 'chi[G / N]_b 1%g.
   rewrite mod_IirrE // -cfdot_Res_r cfRes_sub_ker ?cfker_mod //.
-  by rewrite cfdotZr cfnorm1 mulr1 conj_Cnat ?cfMod1 ?Cnat_irr1.
+  by rewrite cfdotZr cfnorm1 mulr1 conj_natr ?cfMod1 ?Cnat_irr1.
 have mem_psiG (b : Iirr (G / N)): mod_Iirr b \in irr_constt psiG.
   by rewrite irr_consttE dot_psiG irr1_neq0.
 have constt_psiG b: (b \in irr_constt psiG) = (N \subset cfker 'chi_b).
@@ -1128,7 +1129,8 @@ have nsKT_G: K :&: T <| G.
   exact: subset_trans (der1_min nLK abKbar) (sub_Inertia _ sLK).
 have [e DthL]: exists e, 'Res theta = e%:R *: \sum_(xi <- (phi ^: K)%CF) xi.
   rewrite (Clifford_Res_sum_cfclass nsLK sLp0) -/phi; set e := '[_, _].
-  by exists (truncC e); rewrite truncCK ?Cnat_cfdot_char ?cfRes_char ?irr_char.
+  exists (Num.trunc e).
+  by rewrite truncK ?Cnat_cfdot_char ?cfRes_char ?irr_char.
 have [defKT | ltKT_K] := eqVneq (K :&: T) K; last first.
   have defKT: K :&: T = L.
     apply: maxL; last by rewrite subsetI sLK sub_Inertia.
@@ -1174,7 +1176,7 @@ have [inj_Mphi | /injectivePn[i [j i'j eq_mm_ij]]] := boolP (injectiveb mmLth).
   rewrite -card_quotient // -card_Iirr_abelian // mulr_natl.
   rewrite ['Ind phi]cfun_sum_cfdot sum_cfunE (bigID [in codom mmLth]) /=.
   rewrite ler_wpDr ?sumr_ge0 // => [i _|].
-    by rewrite char1_ge0 ?rpredZ_Cnat ?Cnat_cfdot_char ?cfInd_char ?irr_char.
+    by rewrite char1_ge0 ?rpredZ_nat ?Cnat_cfdot_char ?cfInd_char ?irr_char.
   rewrite -big_uniq //= big_image -sumr_const ler_sum // => i _.
   rewrite cfunE -[in leRHS](cfRes1 L) -cfdot_Res_r mmLthL cfRes1.
   by rewrite DthL cfdotZr rmorph_nat cfnorm_irr mulr1.
@@ -1236,8 +1238,8 @@ have [t sGt] := constt_cfInd_irr s (normal_sub nsNG); exists t.
 have [e DtN]: exists e, 'Res 'chi_t = e%:R *: 'chi_s.
   rewrite constt_Ind_Res in sGt.
   rewrite (Clifford_Res_sum_cfclass nsNG sGt) cfclass_invariant // big_seq1.
-  set e := '[_, _]; exists (truncC e).
-  by rewrite truncCK ?Cnat_cfdot_char ?cfRes_char ?irr_char.
+  set e := '[_, _]; exists (Num.trunc e).
+  by rewrite truncK ?Cnat_cfdot_char ?cfRes_char ?irr_char.
 have [/irrWnorm/eqP | [c injc DtNc]] := cfRes_prime_irr_cases t nsNG iGN pr_p.
   rewrite DtN cfnormZ cfnorm_irr normr_nat mulr1 -natrX pnatr_eq1.
   by rewrite muln_eq1 andbb => /eqP->; rewrite scale1r.
@@ -1257,14 +1259,14 @@ Qed.
 (* This is Isaacs, Lemma (6.24). *)
 Lemma extend_to_cfdet G N s c0 u :
     let theta := 'chi_s in let lambda := cfDet theta in let mu := 'chi_u in
-    N <| G -> coprime #|G : N| (truncC (theta 1%g)) ->
+    N <| G -> coprime #|G : N| (Num.trunc (theta 1%g)) ->
     'Res[N, G] 'chi_c0 = theta -> 'Res[N, G] mu = lambda ->
   exists2 c, 'Res 'chi_c = theta /\ cfDet 'chi_c = mu
           & forall c1, 'Res 'chi_c1 = theta -> cfDet 'chi_c1 = mu -> c1 = c.
 Proof.
-move=> theta lambda mu nsNG; set e := #|G : N|; set f := truncC _.
+move=> theta lambda mu nsNG; set e := #|G : N|; set f := Num.trunc _.
 set eta := 'chi_c0 => co_e_f etaNth muNlam; have [sNG nNG] := andP nsNG.
-have fE: f%:R = theta 1%g by rewrite truncCK ?Cnat_irr1.
+have fE: f%:R = theta 1%g by rewrite truncK ?Cnat_irr1.
 pose nu := cfDet eta; have lin_nu: nu \is a linear_char := cfDet_lin_char _.
 have nuNlam: 'Res nu = lambda by rewrite -cfDetRes ?irr_char ?etaNth.
 have lin_lam: lambda \is a linear_char := cfDet_lin_char _.
@@ -1314,11 +1316,11 @@ Qed.
 (* This is Isaacs, Theorem (6.25). *)
 Theorem solvable_irr_extendible_from_det G N s (theta := 'chi[N]_s) :
     N <| G -> solvable (G / N) ->
-    G \subset 'I[theta] -> coprime #|G : N| (truncC (theta 1%g)) ->
+    G \subset 'I[theta] -> coprime #|G : N| (Num.trunc (theta 1%g)) ->
   [exists c, 'Res 'chi[G]_c == theta]
     = [exists u, 'Res 'chi[G]_u == cfDet theta].
 Proof.
-set e := #|G : N|; set f := truncC _ => nsNG solG IGtheta co_e_f.
+set e := #|G : N|; set f := Num.trunc _ => nsNG solG IGtheta co_e_f.
 apply/exists_eqP/exists_eqP=> [[c cNth] | [u uNdth]].
   have /lin_char_irr/irrP[u Du] := cfDet_lin_char 'chi_c.
   by exists u; rewrite -Du -cfDetRes ?irr_char ?cNth.
@@ -1418,10 +1420,10 @@ have [c vGc co_p_f]: exists2 c, c \in irr_constt nuG & ~~ (p %| 'chi_c 1%g)%C.
   rewrite prime_coprime // negbK -dvdC_nat -[rhs in (_ %| rhs)%C]mulr1.
   rewrite -(lin_char1 lin_v) -cfInd1 // ['Ind _]cfun_sum_constt /=.
   rewrite sum_cfunE rpred_sum // => i /p_dv_v1 p_dv_chi1i.
-  rewrite cfunE dvdC_mull // rpred_Cnat //.
+  rewrite cfunE dvdC_mull // intr_nat //.
   by rewrite Cnat_cfdot_char ?cfInd_char ?irr_char.
-pose f := truncC ('chi_c 1%g); pose b := (egcdn f m).1.
-have fK: f%:R = 'chi_c 1%g by rewrite truncCK ?Cnat_irr1.
+pose f := Num.trunc ('chi_c 1%g); pose b := (egcdn f m).1.
+have fK: f%:R = 'chi_c 1%g by rewrite truncK ?Cnat_irr1.
 have fb_mod_m: f * b = 1 %[mod m].
   have co_m_f: coprime m f.
     by rewrite (pnat_coprime p_m) ?p'natE // -dvdC_nat CdivE fK.
@@ -1507,13 +1509,13 @@ Qed.
 (* This is Isaacs, Corollary (6.28). *)
 Corollary extend_solvable_coprime_irr G N t (theta := 'chi[N]_t) :
     N <| G -> solvable (G / N) -> G \subset 'I[theta] ->
-    coprime #|G : N| ('o(theta)%CF * truncC (theta 1%g)) ->
+    coprime #|G : N| ('o(theta)%CF * Num.trunc (theta 1%g)) ->
   exists c, [/\ 'Res 'chi[G]_c = theta, 'o('chi_c)%CF = 'o(theta)%CF
               & forall d,
                   'Res 'chi_d = theta -> coprime #|G : N| 'o('chi_d)%CF ->
                 d = c].
 Proof.
-set e := #|G : N|; set f := truncC _ => nsNG solG IGtheta.
+set e := #|G : N|; set f := Num.trunc _ => nsNG solG IGtheta.
 rewrite coprimeMr => /andP[co_e_th co_e_f].
 have [sNG nNG] := andP nsNG; pose lambda := cfDet theta.
 have lin_lam: lambda \is a linear_char := cfDet_lin_char theta.

--- a/mathcomp/character/integral_char.v
+++ b/mathcomp/character/integral_char.v
@@ -6,8 +6,8 @@ From mathcomp Require Import div choice fintype tuple finfun bigop prime order.
 From mathcomp Require Import ssralg poly finset fingroup morphism perm.
 From mathcomp Require Import automorphism quotient action countalg finalg zmodp.
 From mathcomp Require Import commutator cyclic center pgroup sylow gseries.
-From mathcomp Require Import nilpotent abelian ssrnum ssrint polydiv rat.
-From mathcomp Require Import matrix mxalgebra intdiv mxpoly vector falgebra.
+From mathcomp Require Import nilpotent abelian ssrnum ssrint archimedean polydiv.
+From mathcomp Require Import rat matrix mxalgebra intdiv mxpoly vector falgebra.
 From mathcomp Require Import fieldext separable galois algC cyclotomic algnum.
 From mathcomp Require Import mxrepresentation classfun character.
 
@@ -262,12 +262,12 @@ Qed.
 
 (* This is Isaacs, Theorem (3.8). *)
 Theorem coprime_degree_support_cfcenter g :
-    coprime (truncC ('chi_i 1%g)) #|g ^: G| -> g \notin ('Z('chi_i))%CF ->
+    coprime (Num.trunc ('chi_i 1%g)) #|g ^: G| -> g \notin ('Z('chi_i))%CF ->
   'chi_i g = 0.
 Proof.
-set m := truncC _ => co_m_gG notZg.
+set m := Num.trunc _ => co_m_gG notZg.
 have [Gg | /cfun0-> //] := boolP (g \in G).
-have Dm: 'chi_i 1%g = m%:R by rewrite truncCK ?Cnat_irr1.
+have Dm: 'chi_i 1%g = m%:R by rewrite truncK ?Cnat_irr1.
 have m_gt0: (0 < m)%N by rewrite -ltC_nat -Dm irr1_gt0.
 have nz_m: m%:R != 0 :> algC by rewrite pnatr_eq0 -lt0n.
 pose alpha := 'chi_i g / m%:R.
@@ -296,14 +296,14 @@ pose beta := QnC (galNorm 1 {:Qn} a).
 have Dbeta: beta = \prod_(nu in 'Gal({:Qn} / 1)) sval (gQnC nu) alpha.
   rewrite /beta rmorph_prod. apply: eq_bigr => nu _.
   by case: (gQnC nu) => f /= ->; rewrite Da.
-have Zbeta: beta \in Cint.
+have Zbeta: beta \in Num.int.
   apply: Cint_rat_Aint; last by rewrite Dbeta rpred_prod.
   rewrite /beta; have /vlineP[/= c ->] := mem_galNorm galQn (memvf a).
   by rewrite alg_num_field fmorph_rat rpred_rat.
 have [|nz_a] := boolP (alpha == 0).
   by rewrite (can2_eq (divfK _) (mulfK _)) // mul0r => /eqP.
 have: beta != 0 by rewrite Dbeta; apply/prodf_neq0 => nu _; rewrite fmorph_eq0.
-move/(norm_Cint_ge1 Zbeta); rewrite lt_geF //; apply: le_lt_trans a_lt1.
+move/(norm_intr_ge1 Zbeta); rewrite lt_geF //; apply: le_lt_trans a_lt1.
 rewrite -[`|alpha|]mulr1 Dbeta (bigD1 1%g) ?group1 //= -Da.
 case: (gQnC _) => /= _ <-.
 rewrite gal_id normrM -subr_ge0 -mulrBr mulr_ge0 // Da subr_ge0.
@@ -340,7 +340,7 @@ have p_dvd_supp_g i: ~~ p_dv1 i && (i != 0) -> 'chi_i g = 0.
     rewrite fful_i subG1 -(isog_eq1 (isog_center (quotient1_isog G))) /=.
     by rewrite trivZ.
   rewrite coprime_degree_support_cfcenter ?trivZi ?inE //.
-  by rewrite -/m Dm irr1_degree natCK coprime_sym coprimeXl.
+  by rewrite -/m Dm irr1_degree natrK coprime_sym coprimeXl.
 pose alpha := \sum_(i | p_dv1 i && (i != 0)) 'chi_i 1%g / p%:R * 'chi_i g.
 have nz_p: p%:R != 0 :> algC by rewrite pnatr_eq0 -lt0n prime_gt0.
 have Dalpha: alpha = - 1 / p%:R.
@@ -403,7 +403,7 @@ Qed.
 Theorem dvd_irr1_cardG gT (G : {group gT}) i : ('chi[G]_i 1%g %| #|G|)%C.
 Proof.
 rewrite unfold_in -if_neg irr1_neq0 Cint_rat_Aint //=.
-  by rewrite rpred_div ?rpred_nat // rpred_Cnat ?Cnat_irr1.
+  by rewrite rpred_div ?rpred_nat // rpred_nat_num ?Cnat_irr1.
 rewrite -[n in n / _]/(_ *+ true) -(eqxx i) -mulr_natr.
 rewrite -first_orthogonality_relation mulVKf ?neq0CG //.
 rewrite sum_by_classes => [|x y Gx Gy]; rewrite -?conjVg ?cfunJ //.
@@ -441,7 +441,7 @@ have inj_lambda: {in 'Z(G) &, injective lambda}.
   rewrite Dlambda !cfunE lin_charM ?groupV // -eq_xy -lin_charM ?groupV //.
   by rewrite mulrC mulVg lin_char1 ?mul1r.
 rewrite unfold_in -if_neg irr1_neq0 Cint_rat_Aint //.
-  by rewrite rpred_div ?rpred_nat // rpred_Cnat ?Cnat_irr1.
+  by rewrite rpred_div ?rpred_nat // rpred_nat_num ?Cnat_irr1.
 rewrite (cfcenter_fful_irr fful) nCdivE natf_indexg ?center_sub //=.
 have ->: #|G|%:R = \sum_(x in G) 'chi_i x * 'chi_i (x^-1)%g.
   rewrite -[_%:R]mulr1; apply: canLR (mulVKf (neq0CG G)) _.
@@ -522,7 +522,7 @@ Proof.
 move=> sHG Nchi Hchi ZHG.
 suffices: (#|G : H| %| 'Res[H] chi 1%g)%C by rewrite cfResE ?group1.
 rewrite ['Res _]cfun_sum_cfdot sum_cfunE rpred_sum // => i _.
-rewrite cfunE dvdC_mulr ?Cint_Cnat ?Cnat_irr1 //.
+rewrite cfunE dvdC_mulr ?intr_nat ?Cnat_irr1 //.
 have [j ->]: exists j, 'chi_i = 'Res 'chi[G]_j.
   case/predU1P: ZHG => [-> | cGG] in i *.
     suffices ->: i = 0 by exists 0; rewrite !irr0 cfRes_cfun1 ?sub1G.
@@ -563,7 +563,7 @@ have [j ->]: exists j, 'chi_i = 'Res 'chi[G]_j.
   rewrite -DrQ; apply/cfun_inP=> x Hx; rewrite !cfResE // cfunE mulrC.
   by rewrite cfker1 ?linG1 ?mul1r ?(subsetP _ x Hx) // mod_IirrE ?cfker_mod.
 have: (#|G : H| %| #|G : H|%:R * '[chi, 'chi_j])%C.
-  by rewrite dvdC_mulr ?Cint_Cnat ?Cnat_cfdot_char_irr.
+  by rewrite dvdC_mulr ?intr_nat ?Cnat_cfdot_char_irr.
 congr (_ %| _)%C; rewrite (cfdotEl _ Hchi) -(Lagrange sHG) mulnC natrM.
 rewrite invfM -mulrA mulVKf ?neq0CiG //; congr (_ * _).
 by apply: eq_bigr => x Hx; rewrite !cfResE.
@@ -571,18 +571,18 @@ Qed.
 
 (* This is Isaacs, Theorem (3.13). *)
 Theorem faithful_degree_p_part gT (p : nat) (G P : {group gT}) i :
-    cfaithful 'chi[G]_i -> p.-nat (truncC ('chi_i 1%g)) ->
+    cfaithful 'chi[G]_i -> p.-nat (Num.trunc ('chi_i 1%g)) ->
     p.-Sylow(G) P -> abelian P ->
   'chi_i 1%g = (#|G : 'Z(G)|`_p)%:R.
 Proof.
 have [p_pr | pr'p] := boolP (prime p); last first.
   have p'n n: (n > 0)%N -> p^'.-nat n.
     by move/p'natEpi->; rewrite mem_primes (negPf pr'p).
-  rewrite irr1_degree natCK => _ /pnat_1-> => [_ _|].
+  rewrite irr1_degree natrK => _ /pnat_1-> => [_ _|].
     by rewrite part_p'nat ?p'n.
   by rewrite p'n ?irr_degree_gt0.
 move=> fful_i /p_natP[a Dchi1] sylP cPP.
-have Dchi1C: 'chi_i 1%g = (p ^ a)%:R by rewrite -Dchi1 irr1_degree natCK.
+have Dchi1C: 'chi_i 1%g = (p ^ a)%:R by rewrite -Dchi1 irr1_degree natrK.
 have pa_dv_ZiG: (p ^ a %| #|G : 'Z(G)|)%N.
   rewrite -dvdC_nat -[pa in (pa %| _)%C]Dchi1C -(cfcenter_fful_irr fful_i).
   exact: dvd_irr1_index_center.
@@ -668,12 +668,12 @@ have Qpi1: pi1 \in Crat.
   by rewrite lin_charX.
 clear I ItoS imItoS injItoS ItoQ inItoQ defItoQ imItoQ injItoQ.
 clear Qn galQn QnC gQnC eps pr_eps QnGg calG.
-have{Qpi1} Zpi1: pi1 \in Cint.
+have{Qpi1} Zpi1: pi1 \in Num.int.
   by rewrite Cint_rat_Aint // rpred_prod // => s _; apply: Aint_char.
 have{pi1 Zpi1} pi2_ge1: 1 <= pi2.
   have ->: pi2 = `|pi1| ^+ 2.
     by rewrite (big_morph Num.norm (@normrM _) (@normr1 _)) -prodrXl.
-  by rewrite Cint_normK // sqr_Cint_ge1 //; apply/prodf_neq0.
+  by rewrite intr_normK // sqr_intr_ge1 //; apply/prodf_neq0.
 have Sgt0: (#|S| > 0)%N by rewrite (cardD1 g) [g \in S]Sg.
 rewrite -mulr_natr -ler_pdivlMr ?ltr0n //.
 have n2chi_ge0 s: s \in S -> 0 <= `|chi s| ^+ 2 by rewrite exprn_ge0.
@@ -687,7 +687,7 @@ Theorem nonlinear_irr_vanish gT (G : {group gT}) i :
 Proof.
 move=> chi1gt1; apply/exists_eq_inP; apply: contraFT (lt_geF chi1gt1).
 move=> /exists_inPn-nz_chi.
-rewrite -(norm_Cnat (Cnat_irr1 i)) -(@expr_le1 _ 2)//.
+rewrite -(norm_natr (Cnat_irr1 i)) -(@expr_le1 _ 2)//.
 rewrite -(lerD2r (#|G|%:R * '['chi_i])) {1}cfnorm_irr mulr1.
 rewrite (cfnormE (cfun_onG _)) mulVKf ?neq0CG // (big_setD1 1%g) //=.
 rewrite addrCA lerD2l (cardsD1 1%g) group1 mulrS lerD2l.

--- a/mathcomp/character/vcharacter.v
+++ b/mathcomp/character/vcharacter.v
@@ -6,8 +6,8 @@ From mathcomp Require Import div choice fintype tuple finfun bigop prime order.
 From mathcomp Require Import ssralg poly finset fingroup morphism perm.
 From mathcomp Require Import automorphism quotient finalg action gproduct.
 From mathcomp Require Import zmodp commutator cyclic center pgroup sylow.
-From mathcomp Require Import frobenius vector ssrnum ssrint intdiv algC.
-From mathcomp Require Import algnum classfun character integral_char.
+From mathcomp Require Import frobenius vector ssrnum ssrint archimedean intdiv.
+From mathcomp Require Import algC algnum classfun character integral_char.
 
 (******************************************************************************)
 (* This file provides basic notions of virtual character theory:              *)
@@ -67,8 +67,8 @@ Qed.
 HB.instance Definition _ := GRing.isZmodClosed.Build (classfun B) Zchar
   Zchar_zmod.
 
-Lemma scale_zchar a phi : a \in Cint -> phi \in Zchar -> a *: phi \in Zchar.
-Proof. by case/CintP=> m -> Zphi; rewrite scaler_int rpredMz. Qed.
+Lemma scale_zchar a phi : a \in Num.int -> phi \in Zchar -> a *: phi \in Zchar.
+Proof. by case/intrP=> m -> Zphi; rewrite scaler_int rpredMz. Qed.
 
 End Basics.
 
@@ -129,26 +129,25 @@ Proof. by move=> Sphi; rewrite mem_zchar_on ?cfun_onT. Qed.
 
 Lemma zchar_nth_expansion S A phi :
     phi \in 'Z[S, A] ->
-  {z | forall i, z i \in Cint & phi = \sum_(i < size S) z i *: S`_i}.
+  {z | forall i, z i \in Num.int & phi = \sum_(i < size S) z i *: S`_i}.
 Proof.
-case/andP=> _ /sumboolP/sig_eqW[/= z ->].
-exists (intr \o z) => [i|]; first exact: Cint_int.
+case/andP=> _ /sumboolP/sig_eqW[/= z ->]; exists (intr \o z) => //=.
 by apply: eq_bigr => i _; rewrite scaler_int.
 Qed.
 
 Lemma zchar_tuple_expansion n (S : n.-tuple 'CF(G)) A phi :
     phi \in 'Z[S, A] ->
-  {z | forall i, z i \in Cint & phi = \sum_(i < n) z i *: S`_i}.
+  {z | forall i, z i \in Num.int & phi = \sum_(i < n) z i *: S`_i}.
 Proof. by move/zchar_nth_expansion; rewrite size_tuple. Qed.
 
 (* A pure seq version with the extra hypothesis of S's unicity.  *)
 Lemma zchar_expansion S A phi : uniq S ->
     phi \in 'Z[S, A] ->
-  {z | forall xi, z xi \in Cint & phi = \sum_(xi <- S) z xi *: xi}.
+  {z | forall xi, z xi \in Num.int & phi = \sum_(xi <- S) z xi *: xi}.
 Proof.
 move=> Suniq /zchar_nth_expansion[z Zz ->] /=.
 pose zS xi := oapp z 0 (insub (index xi S)).
-exists zS => [xi | ]; rewrite {}/zS; first by case: (insub _).
+exists zS => [xi | ]; rewrite {}/zS; first by case: (insub _) => /=.
 rewrite (big_nth 0) big_mkord; apply: eq_bigr => i _; congr (_ *: _).
 by rewrite index_uniq // valK.
 Qed.
@@ -220,11 +219,11 @@ apply: (iffP idP) => [| [a Na [b Nb ->]]]; last by rewrite rpredB ?char_vchar.
 case/zchar_tuple_expansion=> z Zz ->; rewrite (bigID (fun i => 0 <= z i)) /=.
 set chi1 := \sum_(i | _) _; set nchi2 := \sum_(i | _) _.
 exists chi1; last exists (- nchi2); last by rewrite opprK.
-  apply: rpred_sum => i zi_ge0; rewrite -tnth_nth rpredZ_Cnat ?irr_char //.
-  by rewrite CnatEint Zz.
+  apply: rpred_sum => i zi_ge0; rewrite -tnth_nth rpredZ_nat ?irr_char //.
+  by rewrite natrEint Zz.
 rewrite -sumrN rpred_sum // => i zi_lt0; rewrite -scaleNr -tnth_nth.
-rewrite rpredZ_Cnat ?irr_char // CnatEint rpredN Zz oppr_ge0 ltW //.
-by rewrite real_ltNge ?Creal_Cint.
+rewrite rpredZ_nat ?irr_char // natrEint rpredN Zz oppr_ge0 ltW //.
+by rewrite real_ltNge ?Rreal_int.
 Qed.
 
 Lemma Aint_vchar phi x : phi \in 'Z[irr G] -> phi x \in Aint.
@@ -233,33 +232,35 @@ case/vcharP=> [chi1 Nchi1 [chi2 Nchi2 ->]].
 by rewrite !cfunE rpredB ?Aint_char.
 Qed.
 
-Lemma Cint_vchar1 phi : phi \in 'Z[irr G] -> phi 1%g \in Cint.
+Lemma Cint_vchar1 phi : phi \in 'Z[irr G] -> phi 1%g \in Num.int.
 Proof.
 case/vcharP=> phi1 Nphi1 [phi2 Nphi2 ->].
-by rewrite !cfunE rpredB // rpred_Cnat ?Cnat_char1.
+by rewrite !cfunE rpredB // rpred_nat_num ?Cnat_char1.
 Qed.
 
-Lemma Cint_cfdot_vchar_irr i phi : phi \in 'Z[irr G] -> '[phi, 'chi_i] \in Cint.
+Lemma Cint_cfdot_vchar_irr i phi :
+  phi \in 'Z[irr G] -> '[phi, 'chi_i] \in Num.int.
 Proof.
 case/vcharP=> chi1 Nchi1 [chi2 Nchi2 ->].
-by rewrite cfdotBl rpredB // rpred_Cnat ?Cnat_cfdot_char_irr.
+by rewrite cfdotBl rpredB // rpred_nat_num ?Cnat_cfdot_char_irr.
 Qed.
 
 Lemma cfdot_vchar_r phi psi :
   psi \in 'Z[irr G] -> '[phi, psi] = \sum_i '[phi, 'chi_i] * '[psi, 'chi_i].
 Proof.
 move=> Zpsi; rewrite cfdot_sum_irr; apply: eq_bigr => i _; congr (_ * _).
-by rewrite aut_Cint ?Cint_cfdot_vchar_irr.
+by rewrite aut_intr ?Cint_cfdot_vchar_irr.
 Qed.
 
-Lemma Cint_cfdot_vchar : {in 'Z[irr G] &, forall phi psi, '[phi, psi] \in Cint}.
+Lemma Cint_cfdot_vchar :
+  {in 'Z[irr G] &, forall phi psi, '[phi, psi] \in Num.int}.
 Proof.
 move=> phi psi Zphi Zpsi; rewrite /= cfdot_vchar_r // rpred_sum // => k _.
 by rewrite rpredM ?Cint_cfdot_vchar_irr.
 Qed.
 
-Lemma Cnat_cfnorm_vchar : {in 'Z[irr G], forall phi, '[phi] \in Cnat}.
-Proof. by move=> phi Zphi; rewrite /= CnatEint cfnorm_ge0 Cint_cfdot_vchar. Qed.
+Lemma Cnat_cfnorm_vchar : {in 'Z[irr G], forall phi, '[phi] \in Num.nat}.
+Proof. by move=> phi Zphi; rewrite /= natrEint cfnorm_ge0 Cint_cfdot_vchar. Qed.
 
 Fact vchar_mulr_closed : mulr_closed 'Z[irr G].
 Proof.
@@ -422,8 +423,8 @@ apply/idP/mapP=> [Sxi | [i Ii ->{xi}]]; last first.
   by case b_i: (b i); rewrite (scale1r, scaleN1r).
 have: '[xi] = 1 by rewrite oSS ?eqxx.
 have vc_xi := vcS _ Sxi; rewrite cfdot_sum_irr.
-case/Cnat_sum_eq1 => [i _ | i [_ /eqP norm_xi_i xi_i'_0]].
-  by rewrite -normCK rpredX // Cnat_norm_Cint ?Cint_cfdot_vchar_irr.
+case/natr_sum_eq1 => [i _ | i [_ /eqP norm_xi_i xi_i'_0]].
+  by rewrite -normCK rpredX // natr_norm_int ?Cint_cfdot_vchar_irr.
 suffices def_xi: xi = (-1) ^+ b i *: 'chi_i.
   exists i; rewrite // mem_enum inE -/(b i) orbC.
   by case: (b i) def_xi Sxi => // ->; rewrite scale1r.
@@ -431,7 +432,7 @@ move: Sxi; rewrite [xi]cfun_sum_cfdot (bigD1 i) //.
 rewrite big1 //= ?addr0 => [|j ne_ji]; last first.
   apply/eqP; rewrite scaler_eq0 -normr_eq0 -[_ == 0](expf_eq0 _ 2) normCK.
   by rewrite xi_i'_0 ?eqxx.
-have:= norm_xi_i; rewrite (aut_Cint _ (Cint_cfdot_vchar_irr _ _)) //.
+have:= norm_xi_i; rewrite (aut_intr _ (Cint_cfdot_vchar_irr _ _)) //.
 rewrite -subr_eq0 subr_sqr_1 mulf_eq0 subr_eq0 addr_eq0 /b scaler_sign.
 case/pred2P=> ->; last by rewrite scaleN1r => ->.
 rewrite scale1r => Sxi; case: ifP => // SNxi.
@@ -466,7 +467,7 @@ have orthS: orthonormal S.
     by move/eqP; rewrite eq_scaled_irr (negbTE phi_i) => /andP[_ /= /eqP].
   rewrite eq_scaled_irr cfdotZl cfdotZr cfdot_irr mulrA mulr_natr mulrb.
   rewrite mem_enum in phi_i; rewrite (negbTE phi_i) andbC; case: eqP => // <-.
-  have /CnatP[m def_m] := Cnat_norm_Cint (Cint_cfdot_vchar_irr i Zphi).
+  have /natrP[m def_m] := natr_norm_int (Cint_cfdot_vchar_irr i Zphi).
   apply/eqP; rewrite eqxx /= -normCK def_m -natrX eqr_nat eqn_leq lt0n.
   rewrite expn_eq0 andbT -eqC_nat -def_m normr_eq0 [~~ _]phi_i andbT.
   rewrite (leq_exp2r _ 1) // -ltnS -(@ltn_exp2r _ _ 2) //.
@@ -530,7 +531,7 @@ Proof.
 move=> freeS [If Zf]; have [tau Dtau Itau] := isometry_of_free freeS If.
 exists tau => //; split; first by apply: sub_in2 Itau; apply: zchar_span.
 move=> _ /zchar_nth_expansion[a Za ->]; rewrite linear_sum rpred_sum // => i _.
-by rewrite linearZ rpredZ_Cint ?Dtau ?Zf ?mem_nth.
+by rewrite linearZ rpredZ_int ?Dtau ?Zf ?mem_nth.
 Qed.
 
 Lemma Zisometry_inj A nu :
@@ -542,7 +543,7 @@ Proof.
 move=> Inu _ _ /zchar_nth_expansion[u Zu ->] /zchar_nth_expansion[v Zv ->].
 rewrite !raddf_sum; apply: eq_bigr => j _ /=.
 rewrite !cfdot_suml; apply: eq_bigr => i _.
-by rewrite !raddfZ_Cint //= !cfdotZl !cfdotZr Inu ?mem_nth.
+by rewrite !raddfZ_int //= !cfdotZl !cfdotZr Inu ?mem_nth.
 Qed.
 
 End Isometries.
@@ -569,7 +570,7 @@ Lemma sub_aut_zchar S A psi :
   psi - psi^u \in 'Z[S, A^#].
 Proof.
 move=> Z_S Spsi Spsi_u; rewrite zcharD1 !cfunE subr_eq0 rpredB //=.
-by rewrite aut_Cint // Cint_vchar1 // (zchar_trans Z_S) ?(zcharW Spsi).
+by rewrite aut_intr // Cint_vchar1 // (zchar_trans Z_S) ?(zcharW Spsi).
 Qed.
 
 Lemma conjC_vcharAut chi x : chi \in 'Z[irr G] -> (u (chi x))^* = u (chi x)^*.
@@ -581,8 +582,7 @@ Qed.
 Lemma cfdot_aut_vchar phi chi :
   chi \in 'Z[irr G] -> '[phi^u , chi^u] = u '[phi, chi].
 Proof.
-case/vcharP=> chi1 Nchi1 [chi2 Nchi2 ->].
-by rewrite !raddfB /= !cfdot_aut_char.
+by case/vcharP=> chi1 Nchi1 [chi2 Nchi2 ->]; rewrite !raddfB /= !cfdot_aut_char.
 Qed.
 
 Lemma vchar_aut A chi : (chi^u \in 'Z[irr G, A]) = (chi \in 'Z[irr G, A]).
@@ -591,7 +591,7 @@ rewrite !(zchar_split _ A) cfAut_on; congr (_ && _).
 apply/idP/idP=> [Zuchi|]; last exact: cfAut_vchar.
 rewrite [chi]cfun_sum_cfdot rpred_sum // => i _.
 rewrite scale_zchar ?irr_vchar //.
-by rewrite -(Cint_aut u) -cfdot_aut_irr -aut_IirrE Cint_cfdot_vchar_irr.
+by rewrite -(intr_aut u) -cfdot_aut_irr -aut_IirrE Cint_cfdot_vchar_irr.
 Qed.
 
 End AutVchar.
@@ -659,7 +659,7 @@ case i0: (i == 0).
   exists 0 => [x Hx|]; last by rewrite irr0 cfker_cfun1 subsetDl.
   by rewrite (eqP i0) !irr0 !cfun1E // (subsetP sHG) ?Hx.
 have ochi1: '['chi_i, 1] = 0 by rewrite -irr0 cfdot_irr i0.
-pose a := 'chi_i 1%g; have Za: a \in Cint by rewrite CintE Cnat_irr1.
+pose a := 'chi_i 1%g; have Za: a \in Num.int by rewrite intrE Cnat_irr1.
 pose theta := 'chi_i - a%:A; pose phi := 'Ind[G] theta + a%:A.
 have /cfun_onP theta0: theta \in 'CF(H, H^#).
   by rewrite cfunD1E !cfunE cfun11 mulr1 subrr.
@@ -823,9 +823,9 @@ Lemma dirr_consttE (phi : 'CF(G)) (i : dIirr G) :
 Proof. by rewrite inE. Qed.
 
 Lemma Cnat_dirr (phi : 'CF(G)) i :
-  phi \in 'Z[irr G] -> i \in dirr_constt phi -> '[phi, dchi i] \in Cnat.
+  phi \in 'Z[irr G] -> i \in dirr_constt phi -> '[phi, dchi i] \in Num.nat.
 Proof.
-move=> PiZ; rewrite CnatEint dirr_consttE andbC => /ltW -> /=.
+move=> PiZ; rewrite natrEint dirr_consttE andbC => /ltW -> /=.
 by case: i => b i; rewrite cfdotZr rmorph_sign rpredMsign Cint_cfdot_vchar_irr.
 Qed.
 
@@ -856,7 +856,7 @@ Lemma irr_constt_to_dirr (phi: 'CF(G)) i : phi \in 'Z[irr G] ->
   (i \in irr_constt phi) = (to_dirr phi i \in dirr_constt phi).
 Proof.
 move=> Zphi; rewrite irr_consttE dirr_consttE cfdotZr rmorph_sign /=.
-by rewrite -real_normrEsign ?normr_gt0 ?Creal_Cint // Cint_cfdot_vchar_irr.
+by rewrite -real_normrEsign ?normr_gt0 ?Rreal_int // Cint_cfdot_vchar_irr.
 Qed.
 
 Lemma to_dirrK (phi: 'CF(G)) : cancel (to_dirr phi) (@of_irr G).
@@ -891,7 +891,7 @@ move=> PiZ; rewrite {1 2}(cfun_sum_dconstt PiZ).
 rewrite cfdot_suml; apply: eq_bigr=> i IiD.
 rewrite cfdot_sumr (bigD1 i) //= big1 ?addr0 => [|j /andP [JiD IdJ]].
   rewrite cfdotZr cfdotZl cfdot_dchi eqxx eq_sym (negPf (ndirr_diff i)).
-  by rewrite subr0 mulr1 aut_Cnat ?Cnat_dirr.
+  by rewrite subr0 mulr1 aut_natr ?Cnat_dirr.
 rewrite cfdotZr cfdotZl cfdot_dchi eq_sym (negPf IdJ) -natrB ?mulr0 //.
 by rewrite (negPf (contraNneq _ (dirr_constt_oppl JiD))) => // <-.
 Qed.
@@ -910,8 +910,8 @@ suffices Fd i: i \in dirr_constt phi -> '[phi, dchi i] = 1.
   by apply: eq_bigr => i /Fd->; rewrite scale1r.
 move=> IiD; apply: contraNeq Nl4 => phi_i_neq1.
 rewrite -Pln cnorm_dconstt // (bigD1 i) ?ler_wpDr ?sumr_ge0 //=.
-  by move=> j /andP[JiD _]; rewrite exprn_ge0 ?Cnat_ge0 ?Cnat_dirr.
-have /CnatP[m Dm] := Cnat_dirr PiZ IiD; rewrite Dm -natrX ler_nat (leq_sqr 2).
+  by move=> j /andP[JiD _]; rewrite exprn_ge0 ?natr_ge0 ?Cnat_dirr.
+have /natrP[m Dm] := Cnat_dirr PiZ IiD; rewrite Dm -natrX ler_nat (leq_sqr 2).
 by rewrite ltn_neqAle eq_sym -eqC_nat -ltC_nat -Dm phi_i_neq1 -dirr_consttE.
 Qed.
 

--- a/mathcomp/character/vcharacter.v
+++ b/mathcomp/character/vcharacter.v
@@ -259,9 +259,7 @@ by rewrite rpredM ?Cint_cfdot_vchar_irr.
 Qed.
 
 Lemma Cnat_cfnorm_vchar : {in 'Z[irr G], forall phi, '[phi] \in Cnat}.
-Proof.
-by move=> phi Zphi; rewrite /= CnatEint cfnorm_ge0 Cint_cfdot_vchar.
-Qed.
+Proof. by move=> phi Zphi; rewrite /= CnatEint cfnorm_ge0 Cint_cfdot_vchar. Qed.
 
 Fact vchar_mulr_closed : mulr_closed 'Z[irr G].
 Proof.

--- a/mathcomp/field/algC.v
+++ b/mathcomp/field/algC.v
@@ -473,9 +473,6 @@ Qed.
 
 HB.instance Definition _ := isComplex.Build type conjK conj_nt.
 
-Lemma normK u : `|u| ^+ 2 = u * conj u.
-Proof. by apply: (@normCK type). Qed.
-
 Definition conjMixin := Num.ClosedField.on type.
 
 Lemma algebraic : integralRange (@ratr type).
@@ -1101,7 +1098,7 @@ Qed.
 
 Lemma Crat0 : 0 \in Crat. Proof. by apply/CratP; exists 0; rewrite rmorph0. Qed.
 Lemma Crat1 : 1 \in Crat. Proof. by apply/CratP; exists 1; rewrite rmorph1. Qed.
-Hint Resolve Crat0 Crat1 : core.
+#[local] Hint Resolve Crat0 Crat1 : core.
 
 Fact Crat_divring_closed : divring_closed Crat.
 Proof.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -4,9 +4,9 @@ From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrbool ssrfun ssrnat eqtype seq choice.
 From mathcomp Require Import div fintype path tuple bigop finset prime order.
 From mathcomp Require Import ssralg poly polydiv mxpoly countalg closed_field.
-From mathcomp Require Import ssrnum ssrint rat intdiv fingroup finalg zmodp.
-From mathcomp Require Import cyclic pgroup sylow vector falgebra fieldext.
-From mathcomp Require Import separable galois.
+From mathcomp Require Import ssrnum ssrint archimedean rat intdiv fingroup.
+From mathcomp Require Import finalg zmodp cyclic pgroup sylow vector falgebra.
+From mathcomp Require Import fieldext separable galois.
 
 (******************************************************************************)
 (*   The main result in this file is the existence theorem that underpins the *)
@@ -598,7 +598,7 @@ have add_Rroot xR p c: {yR | extendsR xR yR & has_Rroot xR p c -> root_in yR p}.
   pose RyM := Num.IntegralDomain_isLtReal.Build (Q y) posD
                 posM posNneg posB posVneg absN absE (rrefl _).
   pose Ry : realFieldType := HB.pack (Q y) RyM.
-  have QisArchi : Num.RealField_isArchimedean Ry.
+  have QisArchi : Num.NumDomain_bounded_isArchimedean Ry.
     by constructor; apply: (@rat_algebraic_archimedean Ry _ alg_integral).
   exists (HB.pack_for archiFieldType _ QisArchi); apply: idfun.
 have some_realC: realC.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -461,11 +461,11 @@ have add_Rroot xR p c: {yR | extendsR xR yR & has_Rroot xR p c -> root_in yR p}.
     pose d := wid ab; pose dq := \poly_(i < (size q).-1) Mq i.+1.
     have d_ge0: 0 <= d by rewrite subr_ge0; case: xab.
     have [Mdq MdqP] := poly_disk_bound dq d.
-    pose n := Num.bound (Mu * Mdq * d); exists n => c /= /andP[].
+    pose n := Num.bound (Mu * Mdq * d); exists n => c /andP[].
     have{xab} [[]] := findP n _ _ xab; case: (find n q ab) => a1 b1 /=.
     rewrite -/d => qa1_le0 qb1_ge0 le_ab1 [/= le_aa1 le_b1b] Dab1 le_a1c le_cb1.
     have /MuP lbMu: c \in itv ab.
-      by rewrite !inE (le_trans le_aa1) ?(le_trans le_cb1).
+      by rewrite inE (le_trans le_aa1) ?(le_trans le_cb1).
     have Mu_ge0: 0 <= Mu by rewrite (le_trans _ lbMu).
     have Mdq_ge0: 0 <= Mdq.
       by rewrite (le_trans _ (MdqP 0 _)) ?normr0.

--- a/mathcomp/field/algnum.v
+++ b/mathcomp/field/algnum.v
@@ -564,8 +564,8 @@ Qed.
 Lemma Aint_int x : x%:~R \in Aint.
 Proof. by rewrite Aint_Cint ?Cint_int. Qed.
 
-Lemma Aint0 : 0 \in Aint. Proof. exact: (Aint_int 0). Qed.
-Lemma Aint1 : 1 \in Aint. Proof. exact: (Aint_int 1). Qed.
+Lemma Aint0 : 0 \in Aint. Proof. exact: Aint_int 0. Qed.
+Lemma Aint1 : 1 \in Aint. Proof. exact: Aint_int 1. Qed.
 #[global] Hint Resolve Aint0 Aint1 : core.
 
 Lemma Aint_unity_root n x : (n > 0)%N -> n.-unity_root x -> x \in Aint.

--- a/mathcomp/field/cyclotomic.v
+++ b/mathcomp/field/cyclotomic.v
@@ -3,8 +3,8 @@
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq path.
 From mathcomp Require Import div choice fintype tuple finfun bigop prime.
 From mathcomp Require Import ssralg poly finset fingroup finalg zmodp cyclic.
-From mathcomp Require Import ssrnum ssrint polydiv rat intdiv mxpoly.
-From mathcomp Require Import vector falgebra fieldext separable galois algC.
+From mathcomp Require Import ssrnum ssrint archimedean polydiv intdiv mxpoly.
+From mathcomp Require Import rat vector falgebra fieldext separable galois algC.
 
 (******************************************************************************)
 (* This file provides few basic properties of cyclotomic polynomials.         *)
@@ -117,6 +117,7 @@ Local Notation pQtoC := (map_poly ratr).
 
 Local Definition algC_intr_inj := @intr_inj algC.
 #[local] Hint Resolve algC_intr_inj : core.
+Local Notation intCK := (@intrKfloor algC).
 
 Lemma C_prim_root_exists n : (n > 0)%N -> {z : algC | n.-primitive_root z}.
 Proof.
@@ -133,7 +134,7 @@ Qed.
 
 Definition Cyclotomic n : {poly int} :=
   let: exist z _ := C_prim_root_exists (ltn0Sn n.-1) in
-  map_poly floorC (cyclotomic z n).
+  map_poly Num.floor (cyclotomic z n).
 
 Notation "''Phi_' n" := (Cyclotomic n)
   (at level 8, n at level 2, format "''Phi_' n").
@@ -141,7 +142,7 @@ Notation "''Phi_' n" := (Cyclotomic n)
 Lemma Cyclotomic_monic n : 'Phi_n \is monic.
 Proof.
 rewrite /'Phi_n; case: (C_prim_root_exists _) => z /= _.
-rewrite monicE lead_coefE coef_map_id0 ?(int_algC_K 0) ?getCint0 //.
+rewrite monicE lead_coefE coef_map_id0 ?(int_algC_K 0) ?floor0 //.
 by rewrite size_poly_eq -lead_coefE (monicP (cyclotomic_monic _ _)) (intCK 1).
 Qed.
 
@@ -177,7 +178,7 @@ have [r def_zn]: exists r, cyclotomic z n = pZtoC r.
     rewrite map_polyZ mapXn1 Dr0 Dr -scalerAl scalerKV ?intr_eq0 //.
     by rewrite rmorphM.
   by rewrite zprimitiveZ // zprimitive_monic ?monic_Xn_sub_1 ?mapXn1.
-rewrite floorCpK; last by apply/polyOverP=> i; rewrite def_zn coef_map Cint_int.
+rewrite floorpK; last by apply/polyOverP=> i; rewrite def_zn coef_map /=.
 pose f e (k : 'I_n) := Ordinal (ltn_pmod (k * e) n_gt0).
 have [e Dz0] := prim_rootP prim_z (prim_expr_order prim_z0).
 have co_e_n: coprime e n by rewrite -(prim_root_exp_coprime e prim_z) -Dz0.

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -6,7 +6,7 @@ From mathcomp Require Import fintype div tuple bigop prime finset fingroup.
 From mathcomp Require Import ssralg poly polydiv morphism action countalg.
 From mathcomp Require Import finalg zmodp cyclic center pgroup abelian matrix.
 From mathcomp Require Import mxpoly vector falgebra fieldext separable galois.
-From mathcomp Require ssrnum ssrint algC cyclotomic.
+From mathcomp Require ssrnum ssrint archimedean algC cyclotomic.
 
 (******************************************************************************)
 (*           Additional constructions and results on finite fields            *)
@@ -571,7 +571,7 @@ End FinFieldExists.
 
 Section FinDomain.
 
-Import order ssrnum ssrint algC cyclotomic Order.TTheory Num.Theory.
+Import order ssrnum ssrint archimedean algC cyclotomic Order.TTheory Num.Theory.
 Local Infix "%|" := dvdn. (* Hide polynomial divisibility. *)
 
 Variable R : finUnitRingType.
@@ -641,14 +641,14 @@ suffices: `|aq n| <= (q - 1)%:R.
   elim/big_ind: _ => // [|d _]; first exact: mulr_ege1.
   rewrite !hornerE; apply: le_trans (lerB_dist _ _).
   by rewrite normr_nat normrX n1z expr1n lerBDl (leC_nat 2).
-have Zaq d: d %| n -> aq d \in Cint.
+have Zaq d: d %| n -> aq d \in Num.int.
   move/(dvdn_prim_root z_prim)=> zd_prim.
   rewrite rpred_horner ?rpred_nat //= -Cintr_Cyclotomic //.
   by apply/polyOverP=> i; rewrite coef_map ?rpred_int.
 suffices: (aq n %| (q - 1)%:R)%C.
-  rewrite {1}[aq n]CintEsign ?Zaq // -(rpredMsign _ (aq n < 0)%R).
+  rewrite {1}[aq n]intrEsign ?Zaq // -(rpredMsign _ (aq n < 0)%R).
   rewrite dvdC_mul2l ?signr_eq0 //.
-  have /CnatP[m ->]: `|aq n| \in Cnat by rewrite Cnat_norm_Cint ?Zaq.
+  have /natrP[m ->]: `|aq n| \in Num.nat by rewrite natr_norm_int ?Zaq.
   by rewrite leC_nat dvdC_nat; apply: dvdn_leq; rewrite subn_gt0.
 have prod_aq m: m %| n -> \prod_(d < n.+1 | d %| m) aq d = (q ^ m - 1)%:R.
   move=> m_dv_n; transitivity ('X^m - 1).[q%:R : algC]; last first.
@@ -679,7 +679,7 @@ rewrite (bigD1 ord_max) //= [n %| m](contraNF _ Z'u) => [|n_dv_m]; last first.
   rewrite -sub_cent1 subEproper eq_sym eqEcard subsetT oG oCu leq_sub2r //.
   by rewrite leq_exp2l // dvdn_leq.
 rewrite divr1 dvdC_mulr //; apply/rpred_prod => d /andP[/Zaq-Zaqd _].
-have [-> | nz_aqd] := eqVneq (aq d) 0; first by rewrite mul0r.
+have [-> | nz_aqd] := eqVneq (aq d) 0; first by rewrite mul0r /=.
 by rewrite -[aq d]expr1 -exprB ?leq_b1 ?unitfE ?rpredX.
 Qed.
 


### PR DESCRIPTION
##### Motivation for this change

This PR renames the `archiFieldType` structure to `archiRealFieldType` and introduces 5 new Archimedean ring/field structures. These structures are currently defined in `ssrnum.v`, but will be relocated to a new file `archimedean.v` in a future release. We also generalize truncation (`truncC`), floor (`floorC`), the subset of natural integers (`Cnat`, `Qnat`, and `Znat`), and the subset of integers (`Cint` and `Qint`) to Archimedean rings, which are now `Num.trunc`, `Num.floor`, `Num.nat`, and `Num.int` respectively.

Closes #281

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
- [x] merge dependency: #686
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

##### CI overlays

- math-comp/fourcolor#27
- math-comp/odd-order#28

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
