### PR TITLE
Remove ci-fcsl-pcm-8.10

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -397,11 +397,6 @@ ci-finmap-dev:
     - opam pin add -n -k path coq-fcsl-pcm .
     - opam install -y -v -j "${NJOBS}" coq-fcsl-pcm
 
-ci-fcsl-pcm-8.10:
-  extends: .ci-fcsl-pcm
-  variables:
-    COQ_VERSION: "8.10"
-
 ci-fcsl-pcm-8.11:
   extends: .ci-fcsl-pcm
   variables:


### PR DESCRIPTION
##### Motivation for this change

Recently, fcsl-pcm dropped support for Coq 8.10 (https://github.com/imdea-software/fcsl-pcm/commit/c1efa62bd36f499eadbf2c43e82473331341a84b), and now CI fails, e.g., in #680.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
