### PR TITLE
erroneous deprecation warning

### DIFF
--- a/mathcomp/algebra/polydiv.v
+++ b/mathcomp/algebra/polydiv.v
@@ -3205,7 +3205,7 @@ Notation "@ 'divp_scalel'" :=
 Notation "@ 'divp_scaler'" :=
   (deprecate modp_scaler divpZr) (at level 10, only parsing) : fun_scope.
 Notation "@ 'divp_opp'" :=
-  (deprecate modp_opp divpN) (at level 10, only parsing) : fun_scope.
+  (deprecate divp_opp divpN) (at level 10, only parsing) : fun_scope.
 Notation "@ 'divp_add'" :=
   (deprecate modp_add divpD) (at level 10, only parsing) : fun_scope.
 Notation modp_scalel := (@modp_scalel _) (only parsing).


### PR DESCRIPTION
##### Motivation for this change

`divp_opp` warning erroneously reported as `modp_opp`

##### Things done/to do

<!-- please fill in the following checklist -->
~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~~
~~- [ ] added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
