### PR TITLE
Switching `ident` -> `name` in notations

### DIFF
--- a/mathcomp/field/closed_field.v
+++ b/mathcomp/field/closed_field.v
@@ -86,7 +86,7 @@ Definition sizeT : polyF -> cps nat := (fix loop p :=
 Definition qf_red_cps T (x : cps T) (y : _ -> T) :=
    forall e k, qf_eval e (x k) = qf_eval e (k (y e)).
 Notation "x ->_ e y" := (qf_red_cps x (fun e => y))
-  (e ident, at level 90, format "x  ->_ e  y").
+  (e name, at level 90, format "x  ->_ e  y").
 
 Definition qf_cps T D (x : cps T) :=
   forall k, (forall y, D y -> qf (k y)) -> qf (x k).

--- a/mathcomp/ssreflect/eqtype.v
+++ b/mathcomp/ssreflect/eqtype.v
@@ -504,12 +504,12 @@ Arguments app_fdelta {aT rT%type} df%FUN_DELTA f z.
 Notation "[ 'fun' z : T => F 'with' d1 , .. , dn ]" :=
   (SimplFunDelta (fun z : T =>
      app_fdelta d1%FUN_DELTA .. (app_fdelta dn%FUN_DELTA  (fun _ => F)) ..))
-  (at level 0, z ident, only parsing) : fun_scope.
+  (at level 0, z name, only parsing) : fun_scope.
 
 Notation "[ 'fun' z => F 'with' d1 , .. , dn ]" :=
   (SimplFunDelta (fun z =>
      app_fdelta d1%FUN_DELTA .. (app_fdelta dn%FUN_DELTA (fun _ => F)) ..))
-  (at level 0, z ident, format
+  (at level 0, z name, format
    "'[hv' [ '[' 'fun'  z  => '/ '  F ']' '/'  'with'  '[' d1 , '/'  .. , '/'  dn ']' ] ']'"
    ) : fun_scope.
 

--- a/mathcomp/ssreflect/finfun.v
+++ b/mathcomp/ssreflect/finfun.v
@@ -124,10 +124,10 @@ Canonical finfun_unlock := Unlockable FinfunDef.finfunE.
 Arguments finfun {aT rT} g.
 
 Notation "[ 'ffun' x : aT => E ]" := (finfun (fun x : aT => E))
-  (at level 0, x ident) : fun_scope.
+  (at level 0, x name) : fun_scope.
 
 Notation "[ 'ffun' x => E ]" := (@finfun _ (fun=> _) (fun x => E))
-  (at level 0, x ident, format "[ 'ffun'  x  =>  E ]") : fun_scope.
+  (at level 0, x name, format "[ 'ffun'  x  =>  E ]") : fun_scope.
 
 Notation "[ 'ffun' => E ]" := [ffun _ => E]
   (at level 0, format "[ 'ffun' =>  E ]") : fun_scope.

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -281,37 +281,37 @@ Notation enum A := (enum_mem (mem A)).
 Definition pick (T : finType) (P : pred T) := ohead (enum P).
 
 Notation "[ 'pick' x | P ]" := (pick (fun x => P%B))
-  (at level 0, x ident, format "[ 'pick'  x  |  P  ]") : form_scope.
+  (at level 0, x name, format "[ 'pick'  x  |  P  ]") : form_scope.
 Notation "[ 'pick' x : T | P ]" := (pick (fun x : T => P%B))
-  (at level 0, x ident, only parsing) : form_scope.
+  (at level 0, x name, only parsing) : form_scope.
 Definition pick_true T (x : T) := true.
 Reserved Notation "[ 'pick' x : T ]"
-  (at level 0, x ident, format "[ 'pick'  x : T ]").
+  (at level 0, x name, format "[ 'pick'  x : T ]").
 Notation "[ 'pick' x : T ]" := [pick x : T | pick_true x]
   (only parsing) : form_scope.
 Notation "[ 'pick' x : T ]" := [pick x : T | pick_true _]
   (only printing) : form_scope.
 Notation "[ 'pick' x ]" := [pick x : _]
-  (at level 0, x ident, only parsing) : form_scope.
+  (at level 0, x name, only parsing) : form_scope.
 Notation "[ 'pick' x | P & Q ]" := [pick x | P && Q ]
-  (at level 0, x ident,
+  (at level 0, x name,
    format "[ '[hv ' 'pick'  x  |  P '/ '   &  Q ] ']'") : form_scope.
 Notation "[ 'pick' x : T | P & Q ]" := [pick x : T | P && Q ]
-  (at level 0, x ident, only parsing) : form_scope.
+  (at level 0, x name, only parsing) : form_scope.
 Notation "[ 'pick' x 'in' A ]" := [pick x | x \in A]
-  (at level 0, x ident, format "[ 'pick'  x  'in'  A  ]") : form_scope.
+  (at level 0, x name, format "[ 'pick'  x  'in'  A  ]") : form_scope.
 Notation "[ 'pick' x : T 'in' A ]" := [pick x : T | x \in A]
-  (at level 0, x ident, only parsing) : form_scope.
+  (at level 0, x name, only parsing) : form_scope.
 Notation "[ 'pick' x 'in' A | P ]" := [pick x | x \in A & P ]
-  (at level 0, x ident,
+  (at level 0, x name,
    format "[ '[hv ' 'pick'  x  'in'  A '/ '   |  P ] ']'") : form_scope.
 Notation "[ 'pick' x : T 'in' A | P ]" := [pick x : T | x \in A & P ]
-  (at level 0, x ident, only parsing) : form_scope.
+  (at level 0, x name, only parsing) : form_scope.
 Notation "[ 'pick' x 'in' A | P & Q ]" := [pick x in A | P && Q]
-  (at level 0, x ident, format
+  (at level 0, x name, format
   "[ '[hv ' 'pick'  x  'in'  A '/ '   |  P '/ '  &  Q ] ']'") : form_scope.
 Notation "[ 'pick' x : T 'in' A | P & Q ]" := [pick x : T in A | P && Q]
-  (at level 0, x ident, only parsing) : form_scope.
+  (at level 0, x name, only parsing) : form_scope.
 
 (* We lock the definitions of card and subset to mitigate divergence of the   *)
 (* Coq term comparison algorithm.                                             *)
@@ -362,8 +362,8 @@ Definition ex_in C B x y :=  let: F^* := B in (C && F)^*.
 
 End Definitions.
 
-Notation "[ x | B ]" := (quant0b (fun x => B x)) (at level 0, x ident).
-Notation "[ x : T | B ]" := (quant0b (fun x : T => B x)) (at level 0, x ident).
+Notation "[ x | B ]" := (quant0b (fun x => B x)) (at level 0, x name).
+Notation "[ x : T | B ]" := (quant0b (fun x : T => B x)) (at level 0, x name).
 
 Module Exports.
 
@@ -1129,16 +1129,16 @@ End Injectiveb.
 Definition image_mem T T' f mA : seq T' := map f (@enum_mem T mA).
 Notation image f A := (image_mem f (mem A)).
 Notation "[ 'seq' F | x 'in' A ]" := (image (fun x => F) A)
-  (at level 0, F at level 99, x ident,
+  (at level 0, F at level 99, x name,
    format "'[hv' [ 'seq'  F '/ '  |  x  'in'  A ] ']'") : seq_scope.
 Notation "[ 'seq' F | x : T 'in' A ]" := (image (fun x : T => F) A)
-  (at level 0, F at level 99, x ident, only parsing) : seq_scope.
+  (at level 0, F at level 99, x name, only parsing) : seq_scope.
 Notation "[ 'seq' F | x : T ]" :=
   [seq F | x : T in pred_of_simpl (@pred_of_argType T)]
-  (at level 0, F at level 99, x ident,
+  (at level 0, F at level 99, x name,
    format "'[hv' [ 'seq'  F '/ '  |  x  :  T ] ']'") : seq_scope.
 Notation "[ 'seq' F , x ]" := [seq F | x : _ ]
-  (at level 0, F at level 99, x ident, only parsing) : seq_scope.
+  (at level 0, F at level 99, x name, only parsing) : seq_scope.
 
 Definition codom T T' f := @image_mem T T' f (mem T).
 

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2369,32 +2369,32 @@ Proof. by move=> injf; elim=> [|y1 s1 IHs] [|y2 s2] //= [/injf-> /IHs->]. Qed.
 End Map.
 
 Notation "[ 'seq' E | i <- s ]" := (map (fun i => E) s)
-  (at level 0, E at level 99, i ident,
+  (at level 0, E at level 99, i name,
    format "[ '[hv' 'seq'  E '/ '  |  i  <-  s ] ']'") : seq_scope.
 
 Notation "[ 'seq' E | i <- s & C ]" := [seq E | i <- [seq i <- s | C]]
-  (at level 0, E at level 99, i ident,
+  (at level 0, E at level 99, i name,
    format "[ '[hv' 'seq'  E '/ '  |  i  <-  s '/ '  &  C ] ']'") : seq_scope.
 
 Notation "[ 'seq' E | i : T <- s ]" := (map (fun i : T => E) s)
-  (at level 0, E at level 99, i ident, only parsing) : seq_scope.
+  (at level 0, E at level 99, i name, only parsing) : seq_scope.
 
 Notation "[ 'seq' E | i : T <- s & C ]" :=
   [seq E | i : T <- [seq i : T <- s | C]]
-  (at level 0, E at level 99, i ident, only parsing) : seq_scope.
+  (at level 0, E at level 99, i name, only parsing) : seq_scope.
 
 Notation "[ 'seq' E : R | i <- s ]" := (@map _ R (fun i => E) s)
-  (at level 0, E at level 99, i ident, only parsing) : seq_scope.
+  (at level 0, E at level 99, i name, only parsing) : seq_scope.
 
 Notation "[ 'seq' E : R | i <- s & C ]" := [seq E : R | i <- [seq i <- s | C]]
-  (at level 0, E at level 99, i ident, only parsing) : seq_scope.
+  (at level 0, E at level 99, i name, only parsing) : seq_scope.
 
 Notation "[ 'seq' E : R | i : T <- s ]" := (@map T R (fun i : T => E) s)
-  (at level 0, E at level 99, i ident, only parsing) : seq_scope.
+  (at level 0, E at level 99, i name, only parsing) : seq_scope.
 
 Notation "[ 'seq' E : R | i : T <- s & C ]" :=
   [seq E : R | i : T <- [seq i : T <- s | C]]
-  (at level 0, E at level 99, i ident, only parsing) : seq_scope.
+  (at level 0, E at level 99, i name, only parsing) : seq_scope.
 
 Lemma filter_mask T a (s : seq T) : filter a s = mask (map a s) s.
 Proof. by elim: s => //= x s <-; case: (a x). Qed.
@@ -3231,18 +3231,18 @@ Arguments flatten_mapP {S T A s y}.
 
 Notation "[ 'seq' E | x <- s , y <- t ]" :=
   (flatten [seq [seq E | y <- t] | x <- s])
-  (at level 0, E at level 99, x ident, y ident,
+  (at level 0, E at level 99, x name, y name,
    format "[ '[hv' 'seq'  E '/ '  |  x  <-  s , '/   '  y  <-  t ] ']'")
    : seq_scope.
 Notation "[ 'seq' E | x : S <- s , y : T <- t ]" :=
   (flatten [seq [seq E | y : T <- t] | x : S  <- s])
-  (at level 0, E at level 99, x ident, y ident, only parsing) : seq_scope.
+  (at level 0, E at level 99, x name, y name, only parsing) : seq_scope.
 Notation "[ 'seq' E : R | x : S <- s , y : T <- t ]" :=
   (flatten [seq [seq E : R | y : T <- t] | x : S  <- s])
-  (at level 0, E at level 99, x ident, y ident, only parsing) : seq_scope.
+  (at level 0, E at level 99, x name, y name, only parsing) : seq_scope.
 Notation "[ 'seq' E : R | x <- s , y <- t ]" :=
   (flatten [seq [seq E : R | y <- t] | x  <- s])
-  (at level 0, E at level 99, x ident, y ident, only parsing) : seq_scope.
+  (at level 0, E at level 99, x name, y name, only parsing) : seq_scope.
 
 Section AllPairsDep.
 

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -39,24 +39,24 @@ Coercion rel_of_simpl_rel T (sr : simpl_rel T) : rel T := sr.
 Arguments rel_of_simpl_rel {T} sr x / y : rename.
 
 (* Required to avoid an incompatible format warning with coq-8.12 *)
-Reserved Notation "[ 'rel' x y : T | E ]" (at level 0, x ident, y ident,
+Reserved Notation "[ 'rel' x y : T | E ]" (at level 0, x name, y name,
   format "'[hv' [ 'rel'  x  y  :  T  | '/ '  E ] ']'").
 
 Notation "[ 'rel' x y | E ]" := (SimplRel (fun x y => E%B)) (at level 0,
-  x ident, y ident, format "'[hv' [ 'rel'  x  y  | '/ '  E ] ']'") : fun_scope.
+  x name, y name, format "'[hv' [ 'rel'  x  y  | '/ '  E ] ']'") : fun_scope.
 Notation "[ 'rel' x y : T | E ]" := (SimplRel (fun x y : T => E%B)) 
   (only parsing) : fun_scope.
 Notation "[ 'rel' x y 'in' A & B | E ]" :=
-  [rel x y | (x \in A) && (y \in B) && E] (at level 0, x ident, y ident,
+  [rel x y | (x \in A) && (y \in B) && E] (at level 0, x name, y name,
   format "'[hv' [ 'rel'  x  y  'in'  A  &  B  | '/ '  E ] ']'") : fun_scope.
 Notation "[ 'rel' x y 'in' A & B ]" := [rel x y | (x \in A) && (y \in B)]
-  (at level 0, x ident, y ident,
+  (at level 0, x name, y name,
   format "'[hv' [ 'rel'  x  y  'in'  A  &  B ] ']'") : fun_scope.
 Notation "[ 'rel' x y 'in' A | E ]" := [rel x y in A & A | E]
-  (at level 0, x ident, y ident,
+  (at level 0, x name, y name,
   format "'[hv' [ 'rel'  x  y  'in'  A  | '/ '  E ] ']'") : fun_scope.
 Notation "[ 'rel' x y 'in' A ]" := [rel x y in A & A] (at level 0,
-  x ident, y ident, format "'[hv' [ 'rel'  x  y  'in'  A ] ']'") : fun_scope.
+  x name, y name, format "'[hv' [ 'rel'  x  y  'in'  A ] ']'") : fun_scope.
 
 Notation xrelpre := (fun f (r : rel _) x y => r (f x) (f y)).
 Definition relpre {T rT} (f : T -> rT)  (r : rel rT) :=


### PR DESCRIPTION
Fixes #704

EDIT: This fails because `name` is unsupported for Coq 8.11 and 8.12.
Cf #707 for a quick fix. This PR should probably be reactivated in one or two releases.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.