### PR TITLE
Silencing Hint Locality warning

### DIFF
--- a/mathcomp/Make
+++ b/mathcomp/Make
@@ -100,3 +100,4 @@ ssreflect/tuple.v
 -arg -w -arg -ambiguous-paths
 -arg -w -arg +non-primitive-record
 -arg -w -arg +undeclared-scope
+-arg -w -arg -deprecated-hint-without-locality

--- a/mathcomp/_CoqProject
+++ b/mathcomp/_CoqProject
@@ -7,3 +7,4 @@
 -arg -w -arg +duplicate-clear
 -arg -w -arg +non-primitive-record
 -arg -w -arg +undeclared-scope
+-arg -w -arg -deprecated-hint-without-locality

--- a/mathcomp/algebra/Make
+++ b/mathcomp/algebra/Make
@@ -26,3 +26,4 @@ zmodp.v
 -arg -w -arg +duplicate-clear
 -arg -w -arg -ambiguous-paths
 -arg -w -arg +undeclared-scope
+-arg -w -arg -deprecated-hint-without-locality

--- a/mathcomp/character/Make
+++ b/mathcomp/character/Make
@@ -15,3 +15,4 @@ vcharacter.v
 -arg -w -arg +duplicate-clear
 -arg -w -arg -ambiguous-paths
 -arg -w -arg +undeclared-scope
+-arg -w -arg -deprecated-hint-without-locality

--- a/mathcomp/field/Make
+++ b/mathcomp/field/Make
@@ -18,3 +18,4 @@ separable.v
 -arg -w -arg +duplicate-clear
 -arg -w -arg -ambiguous-paths
 -arg -w -arg +undeclared-scope
+-arg -w -arg -deprecated-hint-without-locality

--- a/mathcomp/fingroup/Make
+++ b/mathcomp/fingroup/Make
@@ -16,3 +16,4 @@ quotient.v
 -arg -w -arg +duplicate-clear
 -arg -w -arg -ambiguous-paths
 -arg -w -arg +undeclared-scope
+-arg -w -arg -deprecated-hint-without-locality

--- a/mathcomp/solvable/Make
+++ b/mathcomp/solvable/Make
@@ -27,3 +27,4 @@ sylow.v
 -arg -w -arg +duplicate-clear
 -arg -w -arg -ambiguous-paths
 -arg -w -arg +undeclared-scope
+-arg -w -arg -deprecated-hint-without-locality

--- a/mathcomp/ssreflect/Make
+++ b/mathcomp/ssreflect/Make
@@ -32,3 +32,4 @@ order.v
 -arg -w -arg -ambiguous-paths
 -arg -w -arg +undeclared-scope
 -arg -w -arg -non-reversible-notation
+-arg -w -arg -deprecated-hint-without-locality


### PR DESCRIPTION
##### Motivation for this change

For now, the `#[global] Hint` attribute is only partially implemented
in Coq 8.13 and unimplemented in Coq 8.11 and Coq 8.12 so we have no
other choice than silencing it for the time being.

Does not really solve #705 in a convincing manner.

A cleanup issue must be open subsequent to the merge of this PR and
targetted to a milestone several versions (TBD) in the future in order to
reactivate the warning (and possibly turn it into a bug) with a proper fix.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.