### PR TITLE
Adding Order.enum and related definitions and theorems

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -20,12 +20,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `pairwise_mask`, `pairwise_filter`, `pairwiseP`, `pairwise_all2rel`,
     `sub(_in)_pairwise`, `eq(_in)_pairwise`, `pairwise_map`, `subseq_pairwise`,
     `uniq_pairwise`, `pairwise_uniq`, and `pairwise_eq`.
+  + new lemmas `zip_map`, `eqseq_all`, and `eq_map_all`.
 
 - in `path.v`, new lemmas: `sorted_pairwise(_in)`, `path_pairwise(_in)`,
   `cycle_all2rel(_in)`, `pairwise_sort`, and `sort_pairwise_stable`.
 
 - in `interval.v`, new lemmas: `ge_pinfty`, `le_ninfty`, `gt_pinfty`, `lt_ninfty`.
 
+- in `order.v`
+  + we provide a canonical total order on ordinals and lemmas
+    `leEord`, `ltEord`, `botEord`, and `topEord` to translate generic
+    symbols to the concrete ones. Because of a shortcoming of the
+    current interface, which requires `finOrderType` structures to be
+    nonempty, the `finOrderType` is only defined for ordinal which are
+    manifestly nonempty (i.e. `'I_n.+1`).
+  + new notation `Order.enum A` for `sort <=%O (enum A)`, with new
+    lemmas in module `Order`: `cardE`, `mem_enum`, `enum_uniq`,
+    `cardT`, `enumT`, `enum0`, `enum1`, `eq_enum`, `eq_cardT`,
+    `set_enum`, `enum_set0`, `enum_setT`, `enum_set1`, `enum_ord`,
+    `val_enum_ord`, `size_enum_ord`, `nth_enum_ord`, `nth_ord_enum`,
+    `index_enum_ord`, `mono_sorted_enum`, and `mono_unique`.
+  + a new module `Order.EnumVal` (which can be imported locally), with
+    definitions `enum_rank_in`, `enum_rank`, `enum_val` on a finite
+    partially ordered type `T`, which are the same as the one from
+    `fintype.v`, except they are monotonous when `Order.le T` is
+    total. We provide the following lemmas: `enum_valP`,
+    `enum_val_nth`, `nth_enum_rank_in`, `nth_enum_rank`,
+    `enum_rankK_in`, `enum_rankK`, `enum_valK_in`, `enum_valK`,
+    `enum_rank_inj`, `enum_val_inj`, `enum_val_bij_in`,
+    `eq_enum_rank_in`, `enum_rank_in_inj`, `enum_rank_bij`,
+    `enum_val_bij`, `le_enum_val`, `le_enum_rank_in`, and
+    `le_enum_rank`.  They are all accessible via module `Order` if one
+    chooses not to import `Order.EnumVal`.
 ### Changed
 
 - In `ssralg.v` and `ssrint.v`, the nullary ring notations `-%R`, `+%R`, `*%R`,

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2996,9 +2996,20 @@ Lemma all2E s t :
   all2 s t = (size s == size t) && all [pred xy | r xy.1 xy.2] (zip s t).
 Proof. by elim: s t => [|x s IHs] [|y t] //=; rewrite IHs andbCA. Qed.
 
+Lemma zip_map I f g (s : seq I) :
+  zip (map f s) (map g s) = [seq (f i, g i) | i <- s].
+Proof. by elim: s => //= i s ->. Qed.
+
 End Zip.
 
 Prenex Implicits zip unzip1 unzip2 all2.
+
+Lemma eqseq_all (T : eqType) (s t : seq T) : (s == t) = all2 eq_op s t.
+Proof. by elim: s t => [|x s +] [|y t]//= => <-. Qed.
+
+Lemma eq_map_all I (T : eqType) (f g : I -> T) (s : seq I) :
+  (map f s == map g s) = all [pred xy | xy.1 == xy.2] [seq (f i, g i) | i <- s].
+Proof. by rewrite eqseq_all all2E !size_map eqxx zip_map. Qed.
 
 Section Flatten.
 


### PR DESCRIPTION
##### Motivation for this change

<!-- please explain your reason for doing this change -->

We complete some theory missing in `order.v` in order to deal with
block matrices. This is part of #207.

This was the first part of #703.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.