### PR TITLE
removing CI for analysis-dev

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -432,11 +432,6 @@ ci-analysis-8.13:
   variables:
     COQ_VERSION: "8.13"
 
-ci-analysis-dev:
-  extends: .ci-analysis
-  variables:
-    COQ_VERSION: "dev"
-
 # The FCSL-PCM library
 .ci-fcsl-pcm:
   extends: .ci


### PR DESCRIPTION
##### Motivation for this change

Mathcomp analysis does not compile with Coq dev for now.
Removing a gitlab CI entry.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
