### PR TITLE
Diagonalization of endormorphisms

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -156,6 +156,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - In `ssrnum.v`:
   + new lemma `eqNr`
 
+- In `mxpoly.v`: developed the theory of diagonalization. To that
+  effect, we define `conjmx`, `restrictmx`, and notations `A ~_P B`,
+  `A ~_P {in S'}`, `A ~_{in S} B`, `A ~_{in S} {in S'}`,
+  `all_simmx_in`, `diagonalizable_for`, `diagonalizable_in`,
+  `diagonalizable`, `codiagonalizable_in`, and `codiagonalizable`; and
+  their theory: `stablemx_comp`, `stablemx_restrict`, `conjmxM`,
+  `conjMmx`, `conjuMmx`, `conjMumx`, `conjuMumx`, `conjmx_scalar`,
+  `conj0mx`, `conjmx0`, `conjumx`, `conj1mx`, `conjVmx`, `conjmxK`,
+  `conjmxVK`, `horner_mx_conj`, `horner_mx_uconj`, `horner_mx_uconjC`,
+  `mxminpoly_conj`, `mxminpoly_uconj`, `sub_kermxpoly_conjmx`,
+  `sub_eigenspace_conjmx`, `eigenpoly_conjmx`, `eigenvalue_conjmx`,
+  `conjmx_eigenvalue`, `simmxPp`, `simmxW`, `simmxP`, `simmxRL`,
+  `simmxLR`, `simmx_minpoly`, `diagonalizable_for_row_base`,
+  `diagonalizable_forPp`, `diagonalizable_forP`,
+  `diagonalizable_forPex`, `diagonalizable_forLR`,
+  `diagonalizable_for_mxminpoly`, `diagonalizable_for_sum`,
+  `codiagonalizable1`, `codiagonalizable_on`, `diagonalizable_diag`,
+  `diagonalizable_scalar`, `diagonalizable0`, `diagonalizablePeigen`,
+  `diagonalizableP`, `diagonalizable_conj_diag`, and
+  `codiagonalizableP`.
+
 ### Changed
 
 - In `ssralg.v` and `ssrint.v`, the nullary ring notations `-%R`, `+%R`, `*%R`,

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -66,7 +66,7 @@ From mathcomp Require Import ssralg zmodp matrix mxalgebra poly polydiv.
 (*                  is a boolean predicate representing a set of matrices,    *)
 (*                  this states that conjmx P A is in S,                      *)
 (*                  which means A is similar to a matrix in S.                *)
-(* From the latter, we derive serveral related notions:                       *)
+(* From the latter, we derive several related notions:                        *)
 (*       A ~_P B := A ~_P {in pred1 B}                                        *)
 (*                  A is similar to B, with base change matrix P              *)
 (*  A ~_{in S} B := exists P, P \in S /\ A ~_P B                              *)

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -1,7 +1,7 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
-From mathcomp Require Import fintype tuple finfun bigop fingroup perm.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat choice seq.
+From mathcomp Require Import div fintype tuple finfun bigop fingroup perm.
 From mathcomp Require Import ssralg zmodp matrix mxalgebra poly polydiv.
 
 (******************************************************************************)
@@ -56,6 +56,52 @@ From mathcomp Require Import ssralg zmodp matrix mxalgebra poly polydiv.
 (*     row_env e == the flattening of a tensored environment e : seq 'rV_d.   *)
 (* row_var F d k == the term vector of width d such that for e : seq 'rV[F]_d *)
 (*                  we have eval e 'X_k = eval_mx (row_env e) (row_var d k).  *)
+(*    conjmx V f := V *m f *m pinvmx V                                        *)
+(*               == the conjugation of f by V, i.e. "the" matrix of f         *)
+(*                  in the basis of row vectors of V.                         *)
+(*                  Although this makes sense only when f stabilizes V,       *)
+(*                  the definition can be stated more generally.              *)
+(*  restrictmx V := conjmx (row_base V)                                       *)
+(* A ~_P {in S'} == where P is a base change matrix, A is a matrix, and S     *)
+(*                  is a boolean predicate representing a set of matrices,    *)
+(*                  this states that conjmx P A is in S,                      *)
+(*                  which means A is similar to a matrix in S.                *)
+(* From the latter, we derive serveral related notions:                       *)
+(*       A ~_P B := A ~_P {in pred1 B}                                        *)
+(*                  A is similar to B, with base change matrix P              *)
+(*  A ~_{in S} B := exists P, P \in S /\ A ~_P B                              *)
+(*               == A is similar to B,   with a base change matrix in S       *)
+(*   A ~_{in S} {in S'} := exists P, P \in S /\ A ~_P {in S'}                 *)
+(*                      == A is similar to a matrix in the class S',          *)
+(*                         with a base change matrix in S                     *)
+(* all_simmx_in S As S' == all the matrices in the sequence As are            *)
+(*                         similar to some matrix in the predicate S',        *)
+(*                         with a base change matrix in S.                    *)
+(*                                                                            *)
+(* We also specialize the class S' to diagonalizability:                      *)
+(*    diagonalizable_for P A := A ~_P {in is_diag_mx}.                        *)
+(*     diagonalizable_in S A := A ~_{in S} {in is_diag_mx}.                   *)
+(*          diagonalizable A := diagonalizable_in unitmx A.                   *)
+(*  codiagonalizable_in S As := all_simmx_in S As is_diag_mx.                 *)
+(*       codiagonalizable As := codiagonalizable_in unitmx As.                *)
+(*                                                                            *)
+(* The main results in diagnonalization theory are:                           *)
+(* - diagonalizablePeigen:                                                    *)
+(*     a matrix is diagonalizable iff there is a sequence                     *)
+(*     of scalars r, such that the sum of the associated                      *)
+(*     eigenspaces is full.                                                   *)
+(* - diagonalizableP:                                                         *)
+(*     a matrix is diagonalizable iff its minimal polynomial                  *)
+(*     divides a split polynomial with simple roots.                          *)
+(* - codiagonalizableP:                                                       *)
+(*     a sequence of matrices are diagonalizable in the same basis            *)
+(*     iff they are all diagonalizable and commute pairwize.                  *)
+(*                                                                            *)
+(* Naming conventions:                                                        *)
+(* - p, q are polynomials                                                     *)
+(* - A, B, C are matrices                                                     *)
+(* - f, g are matrices that are viewed as linear maps                         *)
+(* - V, W are matrices that are viewed as subspaces                           *)
 (******************************************************************************)
 
 Set Implicit Arguments.
@@ -1425,3 +1471,479 @@ End Env.
 End MatrixFormula.
 
 End MatrixFormula.
+
+Section ConjMx.
+Context {F : fieldType}.
+
+Definition conjmx (m n : nat)
+ (V : 'M_(m, n)) (f : 'M[F]_n) : 'M_m :=  V *m f *m pinvmx V.
+Notation restrictmx V := (conjmx (row_base V)).
+
+Lemma stablemx_comp (m n p : nat) (V : 'M[F]_(m, n)) (W : 'M_(n, p)) (f : 'M_p) :
+  stablemx W f -> stablemx V (conjmx W f) -> stablemx (V *m W) f.
+Proof. by move=> Wf /(submxMr W); rewrite -mulmxA mulmxKpV// mulmxA. Qed.
+
+Lemma stablemx_restrict m n (A : 'M[F]_n) (V : 'M_n) (W : 'M_(m, \rank V)):
+  stablemx V A -> stablemx W (restrictmx V A) = stablemx (W *m row_base V) A.
+Proof.
+move=> A_stabV; rewrite mulmxA -[in RHS]mulmxA.
+rewrite -(submxMfree _ W (row_base_free V)) mulmxKpV //.
+by rewrite mulmx_sub ?stablemx_row_base.
+Qed.
+
+Lemma conjmxM (m n : nat) (V : 'M[F]_(m, n)) :
+   {in [pred f | stablemx V f] &, {morph conjmx V : f g / f *m g}}.
+Proof.
+move=> f g; rewrite !inE => Vf Vg /=.
+by rewrite /conjmx 2!mulmxA mulmxA mulmxKpV ?stablemx_row_base.
+Qed.
+
+Lemma conjMmx (m n p : nat) (V : 'M[F]_(m, n)) (W : 'M_(n, p)) (f : 'M_p) :
+  row_free (V *m W) -> stablemx W f -> stablemx V (conjmx W f) ->
+  conjmx (V *m W) f = conjmx V (conjmx W f).
+Proof.
+move=> rfVW Wf VWf; apply: (row_free_inj rfVW); rewrite mulmxKpV ?stablemx_comp//.
+by rewrite mulmxA mulmxKpV// -[RHS]mulmxA mulmxKpV ?mulmxA.
+Qed.
+
+Lemma conjuMmx (m n : nat) (V : 'M[F]_m) (W : 'M_(m, n)) (f : 'M_n) :
+  V \in unitmx -> row_free W -> stablemx W f ->
+  conjmx (V *m W) f = conjmx V (conjmx W f).
+Proof.
+move=> Vu rfW Wf; rewrite conjMmx ?stablemx_unit//.
+by rewrite /row_free mxrankMfree// -/(row_free V) row_free_unit.
+Qed.
+
+Lemma conjMumx (m n : nat) (V : 'M[F]_(m, n)) (W f : 'M_n) :
+  W \in unitmx -> row_free V -> stablemx V (conjmx W f) ->
+  conjmx (V *m W) f = conjmx V (conjmx W f).
+Proof.
+move=> Wu rfW Wf; rewrite conjMmx ?stablemx_unit//.
+by rewrite /row_free mxrankMfree ?row_free_unit.
+Qed.
+
+Lemma conjuMumx (n : nat) (V W f : 'M[F]_n) :
+  V \in unitmx -> W \in unitmx ->
+  conjmx (V *m W) f = conjmx V (conjmx W f).
+Proof. by move=> Vu Wu; rewrite conjuMmx ?stablemx_unit ?row_free_unit. Qed.
+
+Lemma conjmx_scalar (m n : nat) (V : 'M[F]_(m, n)) (a : F) :
+  row_free V -> conjmx V a%:M = a%:M.
+Proof. by move=> rfV; rewrite /conjmx scalar_mxC mulmxKp. Qed.
+
+Lemma conj0mx (m n : nat) f : conjmx (0 : 'M[F]_(m, n)) f = 0.
+Proof. by rewrite /conjmx !mul0mx. Qed.
+
+Lemma conjmx0 (m n : nat) (V : 'M[F]_(m, n)) : conjmx V 0 = 0.
+Proof. by rewrite /conjmx mulmx0 mul0mx. Qed.
+
+Lemma conjumx (n : nat) (V : 'M_n) (f : 'M[F]_n) : V \in unitmx ->
+  conjmx V f = V *m f *m invmx V.
+Proof. by move=> uV; rewrite /conjmx pinvmxE. Qed.
+
+Lemma conj1mx (n : nat) (f : 'M[F]_n) : conjmx 1%:M f = f.
+Proof. by rewrite conjumx ?unitmx1// invmx1 mulmx1 mul1mx. Qed.
+
+Lemma conjVmx (n : nat) (V : 'M_n) (f : 'M[F]_n) : V \in unitmx ->
+  conjmx (invmx V) f = invmx V *m f *m V.
+Proof. by move=> Vunit; rewrite conjumx ?invmxK ?unitmx_inv. Qed.
+
+Lemma conjmxK (n : nat) (V f : 'M[F]_n) :
+  V \in unitmx -> conjmx (invmx V) (conjmx V f) = f.
+Proof. by move=> Vu; rewrite -conjuMumx ?unitmx_inv// mulVmx ?conj1mx. Qed.
+
+Lemma conjmxVK (n : nat) (V f : 'M[F]_n) :
+  V \in unitmx -> conjmx V (conjmx (invmx V) f) = f.
+Proof. by move=> Vu; rewrite -conjuMumx ?unitmx_inv// mulmxV ?conj1mx. Qed.
+
+Lemma horner_mx_conj m n p (V : 'M[F]_(n.+1, m.+1)) (f : 'M_m.+1) :
+   row_free V -> stablemx V f ->
+   horner_mx (conjmx V f) p = conjmx V (horner_mx f p).
+Proof.
+move=> V_free V_stab; rewrite/conjmx; elim/poly_ind: p => [|p c].
+  by rewrite !rmorph0 mulmx0 mul0mx.
+rewrite !(rmorphD, rmorphM)/= !(horner_mx_X, horner_mx_C) => ->.
+rewrite [_ * _]mulmxA [_ *m (V *m _)]mulmxA mulmxKpV ?horner_mx_stable//.
+apply: (row_free_inj V_free); rewrite [_ *m V]mulmxDl.
+pose stablemxE := (stablemxD, stablemxM, stablemxC, horner_mx_stable).
+by rewrite !mulmxKpV -?[V *m _ *m _]mulmxA ?stablemxE// mulmxDr -scalar_mxC.
+Qed.
+
+Lemma horner_mx_uconj n p (V : 'M[F]_(n.+1)) (f : 'M_n.+1) :
+   V \is a GRing.unit ->
+   horner_mx (V *m f *m invmx V) p = V *m horner_mx f p *m invmx V.
+Proof.
+move=> V_unit; rewrite -!conjumx//.
+by rewrite horner_mx_conj ?row_free_unit ?stablemx_unit.
+Qed.
+
+Lemma horner_mx_uconjC n p (V : 'M[F]_(n.+1)) (f : 'M_n.+1) :
+   V \is a GRing.unit ->
+   horner_mx (invmx V *m f *m V) p = invmx V *m horner_mx f p *m V.
+Proof.
+move=> V_unit; rewrite -[X in _ *m X](invmxK V).
+by rewrite horner_mx_uconj ?invmxK ?unitmx_inv.
+Qed.
+
+Lemma mxminpoly_conj m n (V : 'M[F]_(m.+1, n.+1)) (f : 'M_n.+1) :
+  row_free V -> stablemx V f -> mxminpoly (conjmx V f) %| mxminpoly f.
+Proof.
+by move=> *; rewrite mxminpoly_min// horner_mx_conj// mx_root_minpoly conjmx0.
+Qed.
+
+Lemma mxminpoly_uconj n (V : 'M[F]_(n.+1)) (f : 'M_n.+1) :
+  V \in unitmx -> mxminpoly (conjmx V f) = mxminpoly f.
+Proof.
+have simp := (row_free_unit, stablemx_unit, unitmx_inv, unitmx1).
+move=> Vu; apply/eqP; rewrite -eqp_monic ?mxminpoly_monic// /eqp.
+apply/andP; split; first by rewrite mxminpoly_conj ?simp.
+by rewrite -[f in X in X %| _](conjmxK _ Vu) mxminpoly_conj ?simp.
+Qed.
+
+Section fixed_stablemx_space.
+
+Variables (m n : nat).
+
+Implicit Types (V : 'M[F]_(m, n)) (A : 'M[F]_n).
+Implicit Types (a : F) (p : {poly F}).
+
+Section Sub.
+Variable (k : nat).
+Implicit Types (W : 'M[F]_(k, m)).
+
+Lemma sub_kermxpoly_conjmx V f p W : stablemx V f -> row_free V ->
+  (W <= kermxpoly (conjmx V f) p)%MS = (W *m V <= kermxpoly f p)%MS.
+Proof.
+case: n m => [|n'] [|m']// in V f W * => fV rfV; rewrite ?thinmx0//.
+   by rewrite mul0mx !sub0mx.
+apply/sub_kermxP/sub_kermxP; rewrite horner_mx_conj//; last first.
+  by move=> /(congr1 (mulmxr (pinvmx V)))/=; rewrite mul0mx !mulmxA.
+move=> /(congr1 (mulmxr V))/=; rewrite ![W *m _]mulmxA ?mul0mx mulmxKpV//.
+by rewrite -mulmxA mulmx_sub// horner_mx_stable//.
+Qed.
+
+Lemma sub_eigenspace_conjmx V f a W : stablemx V f -> row_free V ->
+  (W <= eigenspace (conjmx V f) a)%MS = (W *m V <= eigenspace f a)%MS.
+Proof. by move=> fV rfV; rewrite !eigenspace_poly sub_kermxpoly_conjmx. Qed.
+End Sub.
+
+Lemma eigenpoly_conjmx V f : stablemx V f -> row_free V ->
+  {subset eigenpoly (conjmx V f) <= eigenpoly f}.
+Proof.
+move=> fV rfV a /eigenpolyP [x]; rewrite sub_kermxpoly_conjmx//.
+move=> xV_le_fa x_neq0; apply/eigenpolyP.
+by exists (x *m V); rewrite ?mulmx_free_eq0.
+Qed.
+
+Lemma eigenvalue_conjmx V f : stablemx V f -> row_free V ->
+  {subset eigenvalue (conjmx V f) <= eigenvalue f}.
+Proof.
+by move=> fV rfV a; rewrite ![_ \in _]eigenvalue_poly; apply: eigenpoly_conjmx.
+Qed.
+
+Lemma conjmx_eigenvalue a V f : (V <= eigenspace f a)%MS -> row_free V ->
+  conjmx V f = a%:M.
+Proof.
+by move=> /eigenspaceP Vfa rfV; rewrite /conjmx Vfa -mul_scalar_mx mulmxKp.
+Qed.
+
+End fixed_stablemx_space.
+End ConjMx.
+Notation restrictmx V := (conjmx (row_base V)).
+
+Definition simmx_to_for {F : fieldType} {m n}
+  (P : 'M_(m, n)) A (S : {pred 'M[F]_m}) := S (conjmx P A).
+Notation "A ~_ P '{' 'in' S '}'" := (simmx_to_for P A S)
+  (at level 70, P at level 0, format "A  ~_ P  '{' 'in'  S '}'") :
+  ring_scope.
+
+Notation simmx_for P A B := (A ~_P {in PredOfSimpl.coerce (pred1 B)}).
+Notation "A ~_ P B" :=  (simmx_for P A B)
+  (at level 70, P at level 0, format "A  ~_ P  B").
+
+Notation simmx_in S A B := (exists2 P, P \in S & A ~_P B).
+Notation "A '~_{in' S '}' B" := (simmx_in S A B)
+  (at level 70, format "A '~_{in'  S '}'  B").
+
+Notation simmx_in_to S A S' := (exists2 P, P \in S & A ~_P {in S'}).
+Notation "A '~_{in' S '}' '{' 'in' S' '}'" := (simmx_in_to S A S')
+  (at level 70, format "A '~_{in'  S '}'  '{' 'in'  S' '}'").
+
+Notation all_simmx_in S As S' :=
+  (exists2 P, P \in S & all [pred A | A ~_P {in S'}] As).
+
+Notation diagonalizable_for P A := (A ~_P {in is_diag_mx}).
+Notation diagonalizable_in S A := (A ~_{in S} {in is_diag_mx}).
+Notation diagonalizable A := (diagonalizable_in unitmx A).
+Notation codiagonalizable_in S As := (all_simmx_in S As is_diag_mx).
+Notation codiagonalizable As := (codiagonalizable_in unitmx As).
+
+Section Simmxity.
+Context {F : fieldType}.
+
+Lemma simmxPp m n {P : 'M[F]_(m, n)} {A B} :
+  stablemx P A -> A ~_P B -> P *m A = B *m P.
+Proof. by move=> stablemxPA /eqP <-; rewrite mulmxKpV. Qed.
+
+Lemma simmxW m n {P : 'M[F]_(m, n)} {A B} : row_free P ->
+  P *m A = B *m P -> A ~_P B.
+Proof. by rewrite /(_ ~__ _)/= /conjmx => fP ->; rewrite mulmxKp. Qed.
+
+Section Simmx.
+
+Context {n : nat}.
+Implicit Types (A B P : 'M[F]_n) (As : seq 'M[F]_n) (d : 'rV[F]_n).
+
+Lemma simmxP {P A B} : P \in unitmx ->
+  reflect (P *m A = B *m P) (A ~_P B).
+Proof.
+move=> p_unit; apply: (iffP idP); first exact/simmxPp/stablemx_unit.
+by apply: simmxW; rewrite row_free_unit.
+Qed.
+
+Lemma simmxRL {P A B} : P \in unitmx ->
+  reflect (B = P *m A *m invmx P) (A ~_P B).
+Proof. by move=> ?; apply: (iffP eqP); rewrite conjumx. Qed.
+
+Lemma simmxLR {P A B} : P \in unitmx ->
+  reflect (A = conjmx (invmx P) B) (A ~_P B).
+Proof.
+by move=> Pu; rewrite conjVmx//; apply: (iffP (simmxRL Pu)) => ->;
+   rewrite !mulmxA ?(mulmxK, mulmxKV, mulVmx, mulmxV, mul1mx, mulmx1).
+Qed.
+
+End Simmx.
+
+Lemma simmx_minpoly {n} {P A B : 'M[F]_n.+1} : P \in unitmx ->
+  A ~_P B -> mxminpoly A = mxminpoly B.
+Proof. by move=> Pu /eqP<-; rewrite mxminpoly_uconj. Qed.
+
+Lemma diagonalizable_for_row_base m n (P : 'M[F]_(m, n)) (A : 'M_n) :
+  diagonalizable_for (row_base P) A = is_diag_mx (restrictmx P A).
+Proof. by []. Qed.
+
+Lemma diagonalizable_forPp m n (P : 'M[F]_(m, n)) A :
+  reflect (forall i j : 'I__, i != j :> nat -> conjmx P A i j = 0)
+          (diagonalizable_for P A).
+Proof. exact: @is_diag_mxP. Qed.
+
+Lemma diagonalizable_forP n (P : 'M[F]_n) A : P \in unitmx ->
+  reflect (forall i j : 'I__, i != j :> nat -> (P *m A *m invmx P) i j = 0)
+          (diagonalizable_for P A).
+Proof. by move=> Pu; rewrite -conjumx//; exact: is_diag_mxP. Qed.
+
+Lemma diagonalizable_forPex {m} {n} {P : 'M[F]_(m, n)} {A} :
+  reflect (exists D, A ~_P (diag_mx D)) (diagonalizable_for P A).
+Proof. by apply: (iffP (diag_mxP _)) => -[D]/eqP; exists D. Qed.
+
+Lemma diagonalizable_forLR n {P : 'M[F]_n} {A} : P \in unitmx ->
+  reflect (exists D, A = conjmx (invmx P) (diag_mx D)) (diagonalizable_for P A).
+Proof.
+by move=> Punit; apply: (iffP diagonalizable_forPex) => -[D /(simmxLR Punit)]; exists D.
+Qed.
+
+Lemma diagonalizable_for_mxminpoly {n} {P A : 'M[F]_n.+1}
+  (rs := undup [seq conjmx P A i i | i <- enum 'I_n.+1]) :
+  P \in unitmx -> diagonalizable_for P A ->
+  mxminpoly A = \prod_(r <- rs) ('X - r%:P).
+Proof.
+rewrite /rs => pu /(diagonalizable_forLR pu)[d {A rs}->].
+rewrite mxminpoly_uconj ?unitmx_inv// mxminpoly_diag.
+by rewrite (@eq_map _ _ _ (d 0))// => i; rewrite conjmxVK// mxE eqxx.
+Qed.
+
+End Simmxity.
+
+Lemma diagonalizable_for_sum (F : fieldType) (m n : nat) (p_ : 'I_n -> nat)
+      (V_ : forall i, 'M[F]_(p_ i, m)) (A : 'M[F]_m) :
+    mxdirect (\sum_i <<V_ i>>) ->
+    (forall i, stablemx (V_ i) A) ->
+    (forall i, row_free (V_ i)) ->
+  diagonalizable_for (\mxcol_i V_ i) A = [forall i, diagonalizable_for (V_ i) A].
+Proof.
+move=> Vd VA rAV; have aVA : stablemx (\mxcol_i V_ i) A.
+  rewrite (eqmx_stable _ (eqmx_col _)) stablemx_sums//.
+  by move=> i; rewrite (eqmx_stable _ (genmxE _)).
+apply/diagonalizable_forPex/'forall_diagonalizable_forPex => /=
+    [[D /(simmxPp aVA) +] i|/(_ _)/sigW DoA].
+  rewrite mxcol_mul -[D]submxrowK diag_mxrow mul_mxdiag_mxcol.
+  move=> /eq_mxcolP/(_ i); set D0 := (submxrow _ _) => VMeq.
+  by exists D0; apply/simmxW.
+exists (\mxrow_i tag (DoA i)); apply/simmxW.
+   rewrite -row_leq_rank eqmx_col (mxdirectP Vd)/=.
+   by under [X in (_ <= X)%N]eq_bigr do rewrite genmxE (eqP (rAV _)).
+rewrite mxcol_mul diag_mxrow mul_mxdiag_mxcol; apply: eq_mxcol => i.
+by case: DoA => /= k /(simmxPp); rewrite VA => /(_ isT) ->.
+Qed.
+
+Section Diag.
+Variable (F : fieldType).
+
+Lemma codiagonalizable1 n (A : 'M[F]_n) :
+  codiagonalizable [:: A] <-> diagonalizable A.
+Proof. by split=> -[P Punit PA]; exists P; move: PA; rewrite //= andbT. Qed.
+
+Definition codiagonalizablePfull n (As : seq 'M[F]_n) :
+  codiagonalizable As
+  <-> exists m, exists2 P : 'M_(m, n), row_full P &
+        all [pred A | diagonalizable_for P A] As.
+Proof.
+split => [[P Punit SPA]|[m [P Pfull SPA]]].
+  by exists n => //; exists P; rewrite ?row_full_unit.
+have Qfull := fullrowsub_unit Pfull.
+exists (rowsub (fullrankfun Pfull) P) => //; apply/allP => A AAs/=.
+have /allP /(_ _ AAs)/= /diagonalizable_forPex[d /simmxPp] := SPA.
+rewrite submx_full// => /(_ isT) PA_eq.
+apply/diagonalizable_forPex; exists (colsub (fullrankfun Pfull) d).
+apply/simmxP => //; apply/row_matrixP => i.
+rewrite !row_mul row_diag_mx -scalemxAl -rowE !row_rowsub !mxE.
+have /(congr1 (row (fullrankfun Pfull i))) := PA_eq.
+by rewrite !row_mul row_diag_mx -scalemxAl -rowE => ->.
+Qed.
+
+Lemma codiagonalizable_on m n (V_ : 'I_n -> 'M[F]_m) (As : seq 'M[F]_m) :
+    (\sum_i V_ i :=: 1%:M)%MS -> mxdirect (\sum_i V_ i) ->
+    (forall i, all (fun A => stablemx (V_ i) A) As) ->
+    (forall i, codiagonalizable (map (restrictmx (V_ i)) As)) ->
+  codiagonalizable As.
+Proof.
+move=> V1 Vdirect /(_ _)/allP AV /(_ _) /sig2W/= Pof.
+pose P_ i := tag (Pof i).
+have P_unit i : P_ i \in unitmx by rewrite /P_; case: {+}Pof.
+have P_diag i A : A \in As -> diagonalizable_for (P_ i *m row_base (V_ i)) A.
+  move=> AAs; rewrite /P_; case: {+}Pof => /= P Punit.
+  rewrite all_map => /allP/(_ A AAs); rewrite /= !/(diagonalizable_for _ _).
+  by rewrite conjuMmx ?row_base_free ?stablemx_row_base ?AV.
+pose P := \mxcol_i (P_ i *m row_base (V_ i)).
+have P_full i : row_full (P_ i) by rewrite row_full_unit.
+have PrV i : (P_ i *m row_base (V_ i) :=: V_ i)%MS.
+  exact/(eqmx_trans _ (eq_row_base _))/eqmxMfull.
+apply/codiagonalizablePfull; eexists _; last exists P; rewrite /=.
+- rewrite -sub1mx eqmx_col.
+  by under eq_bigr do rewrite (eq_genmx (PrV _)); rewrite -genmx_sums genmxE V1.
+apply/allP => A AAs /=; rewrite diagonalizable_for_sum.
+- by apply/forallP => i; apply: P_diag.
+- rewrite mxdirectE/=.
+  under eq_bigr do rewrite (eq_genmx (PrV _)); rewrite -genmx_sums genmxE V1.
+  by under eq_bigr do rewrite genmxE PrV; rewrite  -(mxdirectP Vdirect)//= V1.
+- by move=> i; rewrite (eqmx_stable _ (PrV _)) ?AV.
+- by move=> i; rewrite /row_free eqmxMfull ?eq_row_base ?row_full_unit.
+Qed.
+
+Lemma diagonalizable_diag {n} (d : 'rV[F]_n) : diagonalizable (diag_mx d).
+Proof.
+exists 1%:M; rewrite ?unitmx1// /(diagonalizable_for _ _).
+by rewrite conj1mx diag_mx_is_diag.
+Qed.
+Hint Resolve diagonalizable_diag : core.
+
+Lemma diagonalizable_scalar {n} (a : F) : diagonalizable (a%:M : 'M_n).
+Proof. by rewrite -diag_const_mx. Qed.
+Hint Resolve diagonalizable_scalar : core.
+
+Lemma diagonalizable0 {n} : diagonalizable (0 : 'M[F]_n).
+Proof.
+by rewrite (_ : 0 = 0%:M)//; apply/matrixP => i j; rewrite !mxE// mul0rn.
+Qed.
+Hint Resolve diagonalizable0 : core.
+
+Lemma diagonalizablePeigen {n} {A : 'M[F]_n} :
+  diagonalizable A <->
+  exists2 rs, uniq rs & (\sum_(r <- rs) eigenspace A r :=: 1%:M)%MS.
+Proof.
+split=> [df|[rs urs rsP]].
+  suff [rs rsP] : exists rs, (\sum_(r <- rs) eigenspace A r :=: 1%:M)%MS.
+    exists (undup rs); rewrite ?undup_uniq//; apply: eqmx_trans rsP.
+    elim: rs => //= r rs IHrs; rewrite big_cons.
+    case: ifPn => in_rs; rewrite ?big_cons; last exact: adds_eqmx.
+    apply/(eqmx_trans IHrs)/eqmx_sym/addsmx_idPr.
+    have rrs : (index r rs < size rs)%N by rewrite index_mem.
+    rewrite (big_nth 0) big_mkord (sumsmx_sup (Ordinal rrs)) ?nth_index//.
+  move: df => [P Punit /(diagonalizable_forLR Punit)[d ->]].
+  exists [seq d 0 i | i <- enum 'I_n]; rewrite big_image/=.
+  apply: (@eqmx_trans _ _ _ _ _ _ P); apply/eqmxP;
+    rewrite ?sub1mx ?submx1 ?row_full_unit//.
+  rewrite submx_full ?row_full_unit//=.
+  apply/row_subP => i; rewrite rowE (sumsmx_sup i)//.
+  apply/eigenspaceP; rewrite conjVmx// !mulmxA mulmxK//.
+  by rewrite -rowE row_diag_mx scalemxAl.
+have mxdirect_eigenspaces : mxdirect (\sum_(i < size rs) eigenspace A rs`_i).
+  apply: mxdirect_sum_eigenspace => i j _ _ rsij; apply/val_inj.
+  by apply: uniqP rsij; rewrite ?inE.
+rewrite (big_nth 0) big_mkord in rsP; rewrite -codiagonalizable1.
+apply/(codiagonalizable_on _ mxdirect_eigenspaces) => // i/=.
+  case: n => [|n] in A {mxdirect_eigenspaces} rsP *.
+    by rewrite thinmx0 sub0mx.
+  by rewrite comm_mx_stable_eigenspace.
+rewrite codiagonalizable1.
+by rewrite (@conjmx_eigenvalue _ _ _ rs`_i) ?eq_row_base ?row_base_free.
+Qed.
+
+Lemma diagonalizableP n' (n := n'.+1) (A : 'M[F]_n) :
+  diagonalizable A <->
+  exists2 rs, uniq rs & mxminpoly A %| \prod_(x <- rs) ('X - x%:P).
+Proof.
+split=> [[P Punit /diagonalizable_forPex[d /(simmxLR Punit)->]]|].
+  rewrite mxminpoly_uconj ?unitmx_inv// mxminpoly_diag.
+  by eexists; [|by []]; rewrite undup_uniq.
+rewrite diagonalizablePeigen => -[rs rsu rsP].
+exists rs; rewrite // !(big_nth 0) !big_mkord in rsP *.
+rewrite (eq_bigr _ (fun _ _ => eigenspace_poly _ _)).
+apply: (eqmx_trans (eqmx_sym (kermxpoly_prod _ _)) (kermxpoly_min _)) => //.
+by move=> i j _ _; rewrite coprimep_XsubC root_XsubC nth_uniq.
+Qed.
+
+Lemma diagonalizable_conj_diag m n (V : 'M[F]_(m, n)) (d : 'rV[F]_n) :
+  stablemx V (diag_mx d) -> row_free V -> diagonalizable (conjmx V (diag_mx d)).
+Proof.
+case: m n => [|m] [|n]// in V d * => Vd rdV; rewrite ?thinmx0//=.
+apply/diagonalizableP; pose u := undup [seq d 0 i | i <- enum 'I_n.+1].
+exists u; first by rewrite undup_uniq.
+by rewrite (dvdp_trans (mxminpoly_conj _ _))// mxminpoly_diag.
+Qed.
+
+Lemma codiagonalizableP n (As : seq 'M[F]_n) :
+  {in As &, forall A B, comm_mx A B} /\ {in As, forall A, diagonalizable A}
+  <-> codiagonalizable As.
+Proof.
+split => [cdAs|[P Punit /allP/= AsD]]/=; last first.
+  split; last by exists P; rewrite // AsD.
+  move=> A B AAs BAs; move=> /(_ _ _)/diagonalizable_forPex/sigW in AsD.
+  have [[dA /simmxLR->//] [dB /simmxLR->//]] := (AsD _ AAs, AsD _ BAs).
+  by rewrite /comm_mx -!conjmxM 1?diag_mxC// inE stablemx_unit ?unitmx_inv.
+move: cdAs; rewrite (rwP (all_comm_mxP _)) => cdAs.
+have [k] := ubnP (size As); elim: k => [|k IHk]//= in n As cdAs *.
+case: As cdAs => [|A As]//=; first by exists 1%:M; rewrite ?unitmx1.
+rewrite ltnS all_comm_mx_cons => -[/andP[/allP/(_ _ _)/eqP AAsC AsC dAAs]] Ask.
+have /diagonalizablePeigen [rs urs rs1] := dAAs _ (mem_head _ _).
+rewrite (big_nth 0) big_mkord in rs1.
+have eAB (i : 'I_(size rs)) B : B \in A :: As -> stablemx (eigenspace A rs`_i) B.
+   case: n => [|n'] in B A As AAsC AsC {dAAs rs1 Ask} * => B_AAs.
+      by rewrite thinmx0 sub0mx.
+  rewrite comm_mx_stable_eigenspace//.
+  by move: B_AAs; rewrite !inE => /predU1P [->//|/AAsC].
+apply/(@codiagonalizable_on _ _ _ (_ :: _) rs1) => [|i|i /=].
+- apply: mxdirect_sum_eigenspace => i j _ _ rsij; apply/val_inj.
+  by apply: uniqP rsij; rewrite ?inE.
+- by apply/allP => B B_AAs; rewrite eAB.
+rewrite (@conjmx_eigenvalue _ _ _ rs`_i) ?eq_row_base ?row_base_free//.
+set Bs := map _ _; suff [P Punit /= PBs] : codiagonalizable Bs.
+  exists P; rewrite /= ?PBs ?andbT// /(diagonalizable_for _ _).
+  by rewrite conjmx_scalar ?mx_scalar_is_diag// row_free_unit.
+apply: IHk; rewrite ?size_map/= ?ltnS//; split.
+  apply/all_comm_mxP => _ _ /mapP[/= B BAs ->] /mapP[/= h hAs ->].
+  rewrite -!conjmxM ?inE ?stablemx_row_base ?eAB ?inE ?BAs ?hAs ?orbT//.
+  by rewrite (all_comm_mxP _ AsC).
+move=> _ /mapP[/= B BAs ->].
+have: stablemx (row_base (eigenspace A rs`_i)) B.
+  by rewrite stablemx_row_base eAB// inE BAs orbT.
+have := dAAs B; rewrite inE BAs orbT => /(_ isT) [P Punit].
+move=> /diagonalizable_forPex[D /(simmxLR Punit)->] sePD.
+have rAeP : row_free (row_base (eigenspace A rs`_i) *m invmx P).
+  by rewrite /row_free mxrankMfree ?row_free_unit ?unitmx_inv// eq_row_base.
+rewrite -conjMumx ?unitmx_inv ?row_base_free//.
+apply/diagonalizable_conj_diag => //.
+by rewrite stablemx_comp// stablemx_unit ?unitmx_inv.
+Qed.
+
+End Diag.


### PR DESCRIPTION
##### Motivation for this change

The main results in this PR are the three following diagonalization theorems:
- `diagonalizablePeigen`: a matrix is diagonalizable iff there is a sequence of scalars r, such that the sum of the associated eigenspaces is full.
- `diagonalizableP`: a matrix is diagonalizable iff its minimal polynomial divides a split polynomial with simple roots.
- `codiagonalizableP`: a sequence of matrices are diagonalizable in the same basis iff they are all diagonalizable and commute pairwize.


This is a part of #207 that was also useful in [`abel.v`](https://github.com/math-comp/Abel/blob/52a56a29d509783804c39715c6d24a4b0bcf0373/theories/abel.v#L333).

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.