### PR TITLE
Adding sorting on tuples.

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `path.v`, new lemmas: `sorted_pairwise(_in)`, `path_pairwise(_in)`,
   `cycle_all2rel(_in)`, `pairwise_sort`, and `sort_pairwise_stable`.
 
-- in `tuple.v', added Canonical tuple for sort.
+- in `tuple.v`, added Canonical tuple for sort.
 
 - in `interval.v`, new lemmas: `ge_pinfty`, `le_ninfty`, `gt_pinfty`, `lt_ninfty`.
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- in `tuple.v', addedd Canonical definition for sort
+
 ### Added
 
 - in `bigop.v`, added lemma `sumnB`.

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,8 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-- in `tuple.v', addedd Canonical definition for sort
-
 ### Added
 
 - in `bigop.v`, added lemma `sumnB`.
@@ -26,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `path.v`, new lemmas: `sorted_pairwise(_in)`, `path_pairwise(_in)`,
   `cycle_all2rel(_in)`, `pairwise_sort`, and `sort_pairwise_stable`.
+
+- in `tuple.v', added Canonical tuple for sort.
 
 - in `interval.v`, new lemmas: `ge_pinfty`, `le_ninfty`, `gt_pinfty`, `lt_ninfty`.
 

--- a/mathcomp/ssreflect/tuple.v
+++ b/mathcomp/ssreflect/tuple.v
@@ -208,9 +208,9 @@ Lemma allpairs_tupleP f t (u : m.-tuple U) : @size rT (allpairs f t u) == n * m.
 Proof. by rewrite size_allpairs !size_tuple. Qed.
 Canonical allpairs_tuple f t u := Tuple (allpairs_tupleP f t u).
 
-Lemma sort_tupleP T n r t : size (sort r t) == n.
+Lemma sort_tupleP r t : size (sort r t) == n.
 Proof. by rewrite size_sort size_tuple. Qed.
-Canonical sort_tuple T n r t := Tuple (@sort_tupleP T n r t).
+Canonical sort_tuple r t := Tuple (@sort_tupleP T n r t).
 
 Definition thead (u : n.+1.-tuple T) := tnth u ord0.
 

--- a/mathcomp/ssreflect/tuple.v
+++ b/mathcomp/ssreflect/tuple.v
@@ -1,7 +1,7 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat.
-From mathcomp Require Import seq choice fintype.
+From mathcomp Require Import seq choice fintype path.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/mathcomp/ssreflect/tuple.v
+++ b/mathcomp/ssreflect/tuple.v
@@ -210,7 +210,7 @@ Canonical allpairs_tuple f t u := Tuple (allpairs_tupleP f t u).
 
 Lemma sort_tupleP r t : size (sort r t) == n.
 Proof. by rewrite size_sort size_tuple. Qed.
-Canonical sort_tuple r t := Tuple (@sort_tupleP T n r t).
+Canonical sort_tuple r t := Tuple (sort_tupleP r t).
 
 Definition thead (u : n.+1.-tuple T) := tnth u ord0.
 

--- a/mathcomp/ssreflect/tuple.v
+++ b/mathcomp/ssreflect/tuple.v
@@ -208,7 +208,7 @@ Lemma allpairs_tupleP f t (u : m.-tuple U) : @size rT (allpairs f t u) == n * m.
 Proof. by rewrite size_allpairs !size_tuple. Qed.
 Canonical allpairs_tuple f t u := Tuple (allpairs_tupleP f t u).
 
-Lemma sort_tupleP T n r (t : n.-tuple T): size (sort r t) == n.
+Lemma sort_tupleP T n r t : size (sort r t) == n.
 Proof. by rewrite size_sort size_tuple. Qed.
 Canonical sort_tuple T n r t := Tuple (@sort_tupleP T n r t).
 

--- a/mathcomp/ssreflect/tuple.v
+++ b/mathcomp/ssreflect/tuple.v
@@ -208,6 +208,10 @@ Lemma allpairs_tupleP f t (u : m.-tuple U) : @size rT (allpairs f t u) == n * m.
 Proof. by rewrite size_allpairs !size_tuple. Qed.
 Canonical allpairs_tuple f t u := Tuple (allpairs_tupleP f t u).
 
+Lemma sort_tupleP T n r (t : n.-tuple T): size (sort r t) == n.
+Proof. by rewrite size_sort size_tuple. Qed.
+Canonical sort_tuple T n r t := Tuple (@sort_tupleP T n r t).
+
 Definition thead (u : n.+1.-tuple T) := tnth u ord0.
 
 Lemma tnth0 x t : tnth [tuple of x :: t] ord0 = x.


### PR DESCRIPTION
##### Motivation for this change

This update allows easy sorting on tuples using:
```coq
Variable (n : nat) (T : finType) (r : rel T) (s : n.-tuple T).
Let s' := [tuple of sort r s].
```
##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
