### PR TITLE
lemmas about abs in ssrint

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -133,6 +133,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `bigop.v`:
   + Lemmas `big_nat_widenl`, `big_geq_mkord`
+- in `ssrint.v`,
+  + Lemmas: `mulr_absz`, `natr_absz`, `lez_abs`
 
 - In `ssralg.v`
   + new lemma `fmorph_eq`

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -1572,6 +1572,9 @@ Proof. by case: (intP m). Qed.
 Lemma ltz0_abs m : (m < 0)%R -> `|m| = - m :> int.
 Proof. by case: (intP m). Qed.
 
+Lemma lez_abs m : m <= `|m|%N :> int.
+Proof. by case: (intP m). Qed.
+
 Lemma absz_sign s : `|(-1) ^+ s| = 1.
 Proof. by rewrite abszX exp1n. Qed.
 
@@ -1597,6 +1600,18 @@ Lemma abszEsg m : (`|m|%:Z = sgz m * m)%R.
 Proof. by rewrite -sgrz -normrEsg. Qed.
 
 End Absz.
+
+Section MoreAbsz.
+Variable R : numDomainType.
+Implicit Type i : int.
+
+Lemma mulr_absz (x : R) i : x *+ `|i| = x *~ `|i|.
+Proof. by rewrite -abszE. Qed.
+
+Lemma natr_absz i : `|i|%:R = `|i|%:~R :> R.
+Proof. by rewrite -abszE. Qed.
+
+End MoreAbsz.
 
 Module Export IntDist.
 


### PR DESCRIPTION
##### Motivation for this change

I find myself wanting the following lemmas on several occasions:
- lemma `lez_abs` is on the model of `ler_norm`
~~- `{l,g}{e,t}z0_norm` are like `{l,g}{e,t}z0_abs` but easier to rewrite in a context with a `numDomainType`~~
- lemma `normrzE` to be used with lemmas `{l,g}{e,t}r0_norm`

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
~~- [ ] added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
