### PR TITLE
Fix some inheritance issues

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -186,6 +186,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - across the library, the deprecation mechanism to use has been changed from the
   `deprecate` notation to the `deprecated` attribute (cf. Removed section).
 
+- in `finalg.v`, `finFieldType` now inherits from `countDecFieldType`.
+
 ### Renamed
 
 - in `path.v`,
@@ -229,5 +231,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `order.v`, remove the deprecation aliases `eq_sorted_(le|lt)`.
 
 ### Infrastructure
+
+- The way `hierachy.ml` recognizes inheritance has been changed: `S1` inherits
+  from `S2` when there is a coercion path from `S1.sort` to `S2.sort` and there
+  is a canonical structure instance that unifies `S1.sort` and `S2.sort`,
+  regardless of where (which module) these constants are declared.
+  As a result, it recognizes non-forgetful inheritance and checks the uniqueness
+  of join and exhaustiveness of canonical declarations involving it.
 
 ### Misc

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -1068,31 +1068,60 @@ Section Joins.
 Variable cT : Field.type.
 Let class : Field.class_of cT := Field.class cT.
 
-Definition type := Eval hnf in DecFieldType cT (DecidableFieldMixin cT).
-Definition finType := @Finite.Pack type (fin_ class).
-Definition finZmodType := @Zmodule.Pack type class.
-Definition finRingType := @Ring.Pack type class.
-Definition finUnitRingType := @UnitRing.Pack type class.
-Definition finComRingType := @ComRing.Pack type class.
-Definition finComUnitRingType := @ComUnitRing.Pack type class.
-Definition finIdomainType := @IntegralDomain.Pack type class.
-Definition baseFinGroupType := base_group type finZmodType finZmodType.
-Definition finGroupType := fin_group baseFinGroupType cT.
+Canonical decFieldType := Eval hnf in DecFieldType cT (DecidableFieldMixin cT).
+Definition countDecFieldType := [countDecFieldType of cT].
+Definition decField_finType := @Finite.Pack decFieldType (fin_ class).
+Definition decField_finZmodType := @Zmodule.Pack decFieldType class.
+Definition decField_finRingType := @Ring.Pack decFieldType class.
+Definition decField_finUnitRingType := @UnitRing.Pack decFieldType class.
+Definition decField_finComRingType := @ComRing.Pack decFieldType class.
+Definition decField_finComUnitRingType := @ComUnitRing.Pack decFieldType class.
+Definition decField_finIdomainType := @IntegralDomain.Pack decFieldType class.
+Definition decField_baseFinGroupType :=
+  base_group decFieldType decField_finZmodType decField_finZmodType.
+Definition decField_finGroupType := fin_group decField_baseFinGroupType cT.
+Definition countDecField_finType := @Finite.Pack countDecFieldType (fin_ class).
+Definition countDecField_finZmodType := @Zmodule.Pack countDecFieldType class.
+Definition countDecField_finRingType := @Ring.Pack countDecFieldType class.
+Definition countDecField_finUnitRingType :=
+  @UnitRing.Pack countDecFieldType class.
+Definition countDecField_finComRingType :=
+  @ComRing.Pack countDecFieldType class.
+Definition countDecField_finComUnitRingType :=
+  @ComUnitRing.Pack countDecFieldType class.
+Definition countDecField_finIdomainType :=
+  @IntegralDomain.Pack countDecFieldType class.
+Definition countDecField_baseFinGroupType :=
+  base_group countDecFieldType countDecField_finZmodType
+             countDecField_finZmodType.
+Definition countDecField_finGroupType :=
+  fin_group countDecField_baseFinGroupType cT.
 
 End Joins.
 
 Module Exports.
-Coercion type : Field.type >-> GRing.DecidableField.type.
-Canonical type.
-Canonical finType.
-Canonical finZmodType.
-Canonical finRingType.
-Canonical finUnitRingType.
-Canonical finComRingType.
-Canonical finComUnitRingType.
-Canonical finIdomainType.
-Canonical baseFinGroupType.
-Canonical finGroupType.
+Coercion decFieldType : Field.type >-> GRing.DecidableField.type.
+Coercion countDecFieldType : Field.type >-> CountRing.DecidableField.type.
+Canonical decFieldType.
+Canonical countDecFieldType.
+Canonical decField_finType.
+Canonical decField_finZmodType.
+Canonical decField_finRingType.
+Canonical decField_finUnitRingType.
+Canonical decField_finComRingType.
+Canonical decField_finComUnitRingType.
+Canonical decField_finIdomainType.
+Canonical decField_baseFinGroupType.
+Canonical decField_finGroupType.
+Canonical countDecField_finType.
+Canonical countDecField_finZmodType.
+Canonical countDecField_finRingType.
+Canonical countDecField_finUnitRingType.
+Canonical countDecField_finComRingType.
+Canonical countDecField_finComUnitRingType.
+Canonical countDecField_finIdomainType.
+Canonical countDecField_baseFinGroupType.
+Canonical countDecField_finGroupType.
 
 End Exports.
 

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -283,12 +283,6 @@ Definition zmodType := @GRing.Zmodule.Pack cT class.
 
 End ClassDef.
 
-(* TODO: Ideally,`numDomain_normedZmodType` should be located in              *)
-(* `NumDomain_joins`. Currently, it's located here to make `hierarchy.ml` can *)
-(* recognize that `numDomainType` inherits `normedZmodType`.                  *)
-Definition numDomain_normedZmodType (R : numDomainType) : type (Phant R) :=
-  @Pack R (Phant R) R (Class (NumDomain.normed_mixin (NumDomain.class R))).
-
 Module Exports.
 Coercion base : class_of >-> GRing.Zmodule.class_of.
 Coercion mixin : class_of >-> normed_mixin_of.
@@ -299,8 +293,6 @@ Coercion choiceType : type >-> Choice.type.
 Canonical choiceType.
 Coercion zmodType : type >-> GRing.Zmodule.type.
 Canonical zmodType.
-Coercion numDomain_normedZmodType : NumDomain.type >-> type.
-Canonical numDomain_normedZmodType.
 Notation normedZmodType R := (type (Phant R)).
 Notation NormedZmodType R T m := (@pack _ (Phant R) T _ m).
 Notation NormedZmodMixin := Mixin.
@@ -322,17 +314,12 @@ Section NumDomain_joins.
 Variables (T : Type) (cT : type).
 
 Notation class := (class cT).
-(* Definition normedZmodType : normedZmodType cT := *)
-(*   @NormedZmodule.Pack *)
-(*      cT (Phant cT) cT *)
-(*      (NormedZmodule.Class (NumDomain.normed_mixin class)). *)
-Notation normedZmodType := (NormedZmodule.numDomain_normedZmodType cT).
-Definition normedZmod_ringType :=
-  @GRing.Ring.Pack normedZmodType class.
-Definition normedZmod_comRingType :=
-  @GRing.ComRing.Pack normedZmodType class.
-Definition normedZmod_unitRingType :=
-  @GRing.UnitRing.Pack normedZmodType class.
+Definition normedZmodType : normedZmodType cT :=
+  @NormedZmodule.Pack
+     cT (Phant cT) cT (NormedZmodule.Class (NumDomain.normed_mixin class)).
+Definition normedZmod_ringType := @GRing.Ring.Pack normedZmodType class.
+Definition normedZmod_comRingType := @GRing.ComRing.Pack normedZmodType class.
+Definition normedZmod_unitRingType := @GRing.UnitRing.Pack normedZmodType class.
 Definition normedZmod_comUnitRingType :=
   @GRing.ComUnitRing.Pack normedZmodType class.
 Definition normedZmod_idomainType :=
@@ -343,8 +330,8 @@ Definition normedZmod_porderType :=
 End NumDomain_joins.
 
 Module Exports.
-(* Coercion normedZmodType : type >-> NormedZmodule.type. *)
-(* Canonical normedZmodType. *)
+Coercion normedZmodType : type >-> NormedZmodule.type.
+Canonical normedZmodType.
 Canonical normedZmod_ringType.
 Canonical normedZmod_comRingType.
 Canonical normedZmod_unitRingType.


### PR DESCRIPTION
##### Motivation for this change

- The way `hierachy.ml` recognizes inheritance has been changed: `S1` inherits  from `S2` when there is a coercion path from `S1.sort` to `S2.sort` and there  is a canonical structure instance that unifies `S1.sort` and `S2.sort`,  regardless of where (which module) these constants are declared.  As a result, it recognizes non-forgetful inheritance and checks the uniqueness  of join and exhaustiveness of canonical declarations involving it.
- `finFieldType` now inherits from `countDecFieldType`. This should probably be done with forgetful inheritance and a factory, but it remains non-forgetful inheritance for now.
- Get rid of a workaround in `ssrnum` thanks to the improvement of `hierarchy.ml`.

Closes #689.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
