### PR TITLE
Various renamings about big meet and join + 2 missing lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `rank_bij_on`, `sig_bij_on`, `le_sig`, `le_sig1`, `le_rank`,
     `le_Rank`, `lt_sig`, `lt_rank`, `lt_Rank`, `eq_Rank`, `rankEsum`,
     `RankEsum`, `rect`, and `eqRank`.
+  + lemmas `joins_le` and `meets_ge`.
 
 - in `matrix.v`, seven new definitions:
   + `mxblock`, `mxcol`, `mxrow` and `mxdiag` with notations
@@ -127,6 +128,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `path.v`,
   + `sub_(path|cycle|sorted)_in` -> `sub_in_(path|cycle|sorted)`
   + `eq_(path|cycle)_in` -> `eq_in_(path|cycle)`
+
+- in `order.v`
+  + `join_(|sup_|min_)seq` -> `joins_(|sup_|min_)seq`
+  + `meet_(|sup_|min_)seq` -> `meets_(|sup_|min_)seq`
+  + `join_(sup|min)` -> `joins_(sup|min)`
 
 ### Removed
 


### PR DESCRIPTION
##### Motivation for this change

- Some lemmas were misnamed, cf https://github.com/math-comp/math-comp/pull/741#discussion_r630303069
- Two lemmas added for the sake of completeness

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.