### PR TITLE
prodr_natmul -> prodrMn

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -177,6 +177,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `matrix.v`, `card_matrix` -> `card_mx`
 
+- in `ssralg.v`, `prodr_natmul` ->  `prodrMn`
 ### Removed
 
 - in `ssreflect.v`, the `deprecate` notation has been deprecated. Use the

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -1281,8 +1281,7 @@ rewrite -sum1_card; elim/big_rec3: _ => [|i x n _ _ ->]; first by rewrite mulr1.
 by rewrite exprS !mulrA mulN1r !mulNr commrX //; apply: commrN1.
 Qed.
 
-Lemma prodr_natmul (I : Type) (s : seq I) (P : pred I) 
-              (F : I -> R) (g : I -> nat) : 
+Lemma prodrMn (I : Type) (s : seq I) (P : pred I) (F : I -> R) (g : I -> nat) : 
   \prod_(i <- s | P i) (F i *+ g i) =
   \prod_(i <- s | P i) (F i) *+ \prod_(i <- s | P i) g i.
 Proof.
@@ -1291,7 +1290,7 @@ Qed.
 
 Lemma prodrMn_const n (I : finType) (A : pred I) (F : I -> R) :
   \prod_(i in A) (F i *+ n) = \prod_(i in A) F i *+ n ^ #|A|.
-Proof. by rewrite prodr_natmul prod_nat_const. Qed.
+Proof. by rewrite prodrMn prod_nat_const. Qed.
 
 Lemma natr_prod I r P (F : I -> nat) :
   (\prod_(i <- r | P i) F i)%:R = \prod_(i <- r | P i) (F i)%:R :> R.
@@ -5782,7 +5781,7 @@ Definition prodrXl := prodrXl.
 Definition prodrXr := prodrXr.
 Definition prodrN := prodrN.
 Definition prodrMn_const := prodrMn_const.
-Definition prodr_natmul := prodr_natmul.
+Definition prodrMn := prodrMn.
 Definition natr_prod := natr_prod.
 Definition prodr_undup_exp_count := prodr_undup_exp_count.
 Definition exprDn := exprDn.
@@ -6048,8 +6047,8 @@ Definition imaginary_exists := imaginary_exists.
 Notation null_fun V := (null_fun V) (only parsing).
 Notation in_alg A := (in_alg_loc A).
 
-#[deprecated(since="mathcomp 1.12.0", note="Use prodrMn_const instead.")]
-Notation prodrMn := prodrMn_const (only parsing).
+#[deprecated(since="mathcomp 1.13.0", note="Use prodrMn instead.")]
+Notation prodr_natmul := prodrMn (only parsing).
 
 End Theory.
 


### PR DESCRIPTION
##### Motivation for this change
Cleanup : Adding bigop lemmas for ring : expr_sum and prodr_natmul #623

- remove the deprecation of prodrMn into prodrMn_const
- rename prodr_natmul into prodrMn and create a deprecation alias

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [X] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
