### PR TITLE
Renaming mem_imset_eq -> mem_imset and mem_imset2_eq -> mem_imset2

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -178,6 +178,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `matrix.v`, `card_matrix` -> `card_mx`
 
 - in `ssralg.v`, `prodr_natmul` ->  `prodrMn`
+- in `finset`
+  + `mem_imset_eq`  -> `mem_imset`
+  + `mem_imset2_eq` -> `mem_imset2`
+  
+
 ### Removed
 
 - in `ssreflect.v`, the `deprecate` notation has been deprecated. Use the

--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -1211,7 +1211,7 @@ Qed.
 Lemma imset_f (D : {pred aT}) x : x \in D -> f x \in f @: D.
 Proof. by move=> Dx; apply/imsetP; exists x. Qed.
 
-Lemma mem_imset_eq (D : {pred aT}) x : injective f -> f x \in f @: D = (x \in D).
+Lemma mem_imset (D : {pred aT}) x : injective f -> f x \in f @: D = (x \in D).
 Proof.
 by move=> f_inj; apply/imsetP/idP;[case=> [y] ? /f_inj -> | move=> ?; exists x].
 Qed.
@@ -1236,9 +1236,10 @@ Lemma imset2_f (D : {pred aT}) (D2 : aT -> {pred aT2}) x x2 :
   f2 x x2 \in imset2 f2 (mem D) (fun x1 => mem (D2 x1)).
 Proof. by move=> Dx Dx2; apply/imset2P; exists x x2. Qed.
 
-Lemma mem_imset2_eq (D : {pred aT}) (D2 : aT -> {pred aT2}) x x2 :
+Lemma mem_imset2 (D : {pred aT}) (D2 : aT -> {pred aT2}) x x2 :
     injective2 f2 ->
-  f2 x x2 \in imset2 f2 (mem D) (fun x1 => mem (D2 x1)) = ((x \in D) && (x2 \in D2 x)).
+  f2 x x2 \in imset2 f2 (mem D) (fun x1 => mem (D2 x1)) = 
+    ((x \in D) && (x2 \in D2 x)).
 Proof.
 move=> inj2_f; apply/imset2P/andP => [|[xD xD2]]; last by exists x x2.
 by move => [x' x2' xD xD2 eq_f2]; case: (inj2_f _ _ _ _ eq_f2) => -> ->.
@@ -2357,7 +2358,7 @@ End Greatest.
 
 End SetFixpoint.
 
-#[deprecated(since="mathcomp 1.12.0", note="Use imset_f instead.")]
-Notation mem_imset := imset_f (only parsing).
-#[deprecated(since="mathcomp 1.12.0", note="Use imset2_f instead.")]
-Notation mem_imset2 := imset2_f (only parsing).
+#[deprecated(since="mathcomp 1.13.0", note="Use mem_imset instead.")]
+Notation mem_imset_eq := mem_imset (only parsing).
+#[deprecated(since="mathcomp 1.13.0", note="Use mem_imset2 instead.")]
+Notation mem_imset2_eq := mem_imset2 (only parsing).


### PR DESCRIPTION
##### Motivation for this change

<!-- please explain your reason for doing this change -->

rename mem_imset_eq and mem_imset2_eq and remove deprecation aliases #602

in `finset`
  + `mem_imset_eq`  -> `mem_imset`
  + `mem_imset2_eq` -> `mem_imset2`
 

##### Things done/to do

<!-- please fill in the following checklist -->
- [X] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
