### PR TITLE
Rename big_uncond into big_rmcond

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -178,6 +178,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `matrix.v`, `card_matrix` -> `card_mx`
 
 - in `ssralg.v`, `prodr_natmul` ->  `prodrMn`
+- in `bigop.v`, `big_uncond` -> ` big_rmcond`
+
 ### Removed
 
 - in `ssreflect.v`, the `deprecate` notation has been deprecated. Use the

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1230,7 +1230,7 @@ Lemma big_mkcondl I r (P Q : pred I) F :
      \big[*%M/1]_(i <- r | Q i) (if P i then F i else 1).
 Proof. by rewrite big_andbC big_mkcondr. Qed.
 
-Lemma big_uncond I (r : seq I) (P : pred I) F :
+Lemma big_rmcond I (r : seq I) (P : pred I) F :
   (forall i, ~~ P i -> F i = 1) ->
   \big[*%M/1]_(i <- r | P i) F i = \big[*%M/1]_(i <- r) F i.
 Proof.
@@ -1242,7 +1242,7 @@ Lemma big_rmcond_in (I : eqType) (r : seq I) (P : pred I) F :
   (forall i, i \in r -> ~~ P i -> F i = 1) ->
   \big[*%M/1]_(i <- r | P i) F i = \big[*%M/1]_(i <- r) F i.
 Proof.
-move=> F_eq1; rewrite big_seq_cond [RHS]big_seq_cond !big_mkcondl big_uncond//.
+move=> F_eq1; rewrite big_seq_cond [RHS]big_seq_cond !big_mkcondl big_rmcond//.
 by move=> i /F_eq1; case: ifP => // _ ->.
 Qed.
 
@@ -2018,7 +2018,5 @@ Arguments biggcdn_inf [I] i0 [P F m].
 
 #[deprecated(since="mathcomp 1.12.0", note="Use big_enumP instead.")]
 Notation filter_index_enum := deprecated_filter_index_enum (only parsing).
-#[deprecated(since="mathcomp 1.12.0", note="Use big_rmcond_in instead.")]
-Notation big_rmcond := big_rmcond_in (only parsing).
-#[deprecated(since="mathcomp 1.12.0", note="Use big_rmcond_in instead.")]
-Notation big_uncond_in := big_rmcond_in (only parsing).
+#[deprecated(since="mathcomp 1.13.0", note="Use big_rmcond instead.")]
+Notation big_uncond := big_rmcond (only parsing).


### PR DESCRIPTION
##### Motivation for this change

rename: big_uncond -> big_rmcond & remove big_uncond_in #589
<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [X] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
