### PR TITLE
Canonical additive, linear and rmorphism for fst and snd

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -143,6 +143,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - In `ssralg.v`
   + new lemma `fmorph_eq`
+  + Canonical additive, linear and rmorphism for `fst` and `snd`
 
 - In `rat.v`
   + new lemmas `minr_rat`, `maxr_rat`

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -6383,6 +6383,13 @@ Proof. by move=> x; congr (_, _); apply: addNr. Qed.
 Definition pair_zmodMixin := ZmodMixin pair_addA pair_addC pair_add0 pair_addN.
 Canonical pair_zmodType := Eval hnf in ZmodType (M1 * M2) pair_zmodMixin.
 
+Fact fst_is_additive : additive fst.
+Proof. by []. Qed.
+Canonical fst_additive := Additive fst_is_additive.
+Fact snd_is_additive : additive snd.
+Proof. by []. Qed.
+Canonical snd_additive := Additive snd_is_additive.
+
 End PairZmod.
 
 Section PairRing.
@@ -6412,6 +6419,13 @@ Proof. by rewrite xpair_eqE oner_eq0. Qed.
 Definition pair_ringMixin :=
   RingMixin pair_mulA pair_mul1l pair_mul1r pair_mulDl pair_mulDr pair_one_neq0.
 Canonical pair_ringType := Eval hnf in RingType (R1 * R2) pair_ringMixin.
+
+Fact fst_is_multiplicative : multiplicative fst.
+Proof. by []. Qed.
+Canonical fst_rmorphism := AddRMorphism fst_is_multiplicative.
+Fact snd_is_multiplicative : multiplicative snd.
+Proof. by []. Qed.
+Canonical snd_rmorphism := AddRMorphism snd_is_multiplicative.
 
 End PairRing.
 
@@ -6448,6 +6462,13 @@ Definition pair_lmodMixin :=
   LmodMixin pair_scaleA pair_scale1 pair_scaleDr pair_scaleDl.
 Canonical pair_lmodType := Eval hnf in LmodType R (V1 * V2) pair_lmodMixin.
 
+Fact fst_is_scalable : scalable fst.
+Proof. by []. Qed.
+Canonical fst_linear := AddLinear fst_is_scalable.
+Fact snd_is_scalable : scalable snd.
+Proof. by []. Qed.
+Canonical snd_linear := AddLinear snd_is_scalable.
+
 End PairLmod.
 
 Section PairLalg.
@@ -6457,6 +6478,9 @@ Variables (R : ringType) (A1 A2 : lalgType R).
 Fact pair_scaleAl a (u v : A1 * A2) : a *: (u * v) = (a *: u) * v.
 Proof. by congr (_, _); apply: scalerAl. Qed.
 Canonical pair_lalgType :=  Eval hnf in LalgType R (A1 * A2) pair_scaleAl.
+
+Definition fst_lrmorphism := [lrmorphism of fst].
+Definition snd_lrmorphism := [lrmorphism of snd].
 
 End PairLalg.
 

--- a/mathcomp/field/separable.v
+++ b/mathcomp/field/separable.v
@@ -228,7 +228,7 @@ have co_p0_q0: coprimep p0 q0.
     by rewrite mulrC mulrBr mul_polyC addrAC -addrA -opprB -rmorphM -rmorphB.
   have ->: q0 = q2 ^ at_t \Po ('X - y%:P) by rewrite polyCK ?comp_polyXaddC_K.
   apply/coprimep_comp_poly/Bezout_coprimepP; exists (u ^ at_t, v ^ at_t).
-  by rewrite -!rmorphM -rmorphD Dr /= map_polyC polyC_eqp1.
+  by rewrite /= -!rmorphM -rmorphD Dr /= map_polyC polyC_eqp1.
 have{co_p0_q0}: gcdp p0 (q ^ iota) %= 'X - y%:P.
   rewrite /eqp Dq (eqp_dvdl _ (Gauss_gcdpr _ _)) // dvdp_gcdr dvdp_gcd.
   rewrite dvdp_mull // -root_factor_theorem rootE horner_comp !hornerE.


### PR DESCRIPTION
There is zmod, ring, l-module and various Canonical structure on pairs but the projection fst and snd are missing algebraic structures. I'm adding those.

- [x ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
