### PR TITLE
forall/exists_cons + some easy lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- in `ssrbool.v`, added lemmas `andPP` and `orPP`.
+
 - in `bigop.v`, added lemma `sumnB`.
 
 - in `seq.v`,
@@ -26,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `filter_iota_leq`, `map_nth_iota0` and `map_nth_iota`
   + new lemmas `cat_nilp`, `rev_nilp`, `allrelT`, `allrel_relI`, and
     `pairwise_relI`.
+  + new lemmas: `forall_cons`, `exists_cons`, `sub_map`, `eq_mem_map`,
+    `eq_in_pmap`.
 
 - in `path.v`, new lemmas: `sorted_pairwise(_in)`, `path_pairwise(_in)`,
   `cycle_all2rel(_in)`, `pairwise_sort`, and `sort_pairwise_stable`.

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -388,3 +388,10 @@ End in_sig.
 Arguments in1_sig {T1 D1 P1}.
 Arguments in2_sig {T1 T2 D1 D2 P2}.
 Arguments in3_sig {T1 T2 T3 D1 D2 D3 P3}.
+
+Lemma andPP {P Q p q} : reflect P p -> reflect Q q -> reflect (P /\ Q) (p && q).
+Proof. by move=> rP rQ; apply: (iffP andP) => -[/rP ? /rQ ?]. Qed.
+
+Lemma orPP {P Q p q} : reflect P p -> reflect Q q -> reflect (P \/ Q) (p || q).
+Proof. by move=> rP rQ; apply: (iffP orP) => -[/rP ?|/rQ ?]; tauto. Qed.
+


### PR DESCRIPTION
##### Motivation for this change

* Introduce lemmas `forall_cons` and `exists_cons` to simplify inductive proofs involving `{in s, _}` 
  (and `{subset s1 <= s2}`)
* Some new lemmas suggested in #620 (except `filter_mem_eq`, which is trivial to inline)

closes: #620 

Remark, I'm not sure `forall_cons` and `exists_cons` are the best names, so I'm open to suggestions.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
