### PR TITLE
[bigop] Add lemma for boolean enumeration in bigops

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -178,6 +178,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `diagonalizableP`, `diagonalizable_conj_diag`, and
   `codiagonalizableP`.
 
+- in `bigop.v`, added lemma `big_bool`.
+
 ### Changed
 
 - In `ssralg.v` and `ssrint.v`, the nullary ring notations `-%R`, `+%R`, `*%R`,

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1865,6 +1865,10 @@ Lemma big_all_cond :
   \big[andb/true]_(i <- r | P i) B i = all [pred i | P i ==> B i] r.
 Proof. by rewrite big_mkcond unlock. Qed.
 
+Lemma big_bool R (idx : R) (op : Monoid.com_law idx) (F : bool -> R):
+  \big[op/idx]_(i : bool) F i = op (F true) (F false).
+Proof. by rewrite /index_enum !unlock /= Monoid.mulm1. Qed.
+
 End Seq.
 
 Section FinType.


### PR DESCRIPTION
In some cases, such as in the proof in [1], when we have a bigop
over the boolean enumeration, we need to open the implementation
internals which is not optimal and moreover fragile.

We instead provide a helper lemma that expands a bigop over the
booleans with a concrete enumeration, and which is more
straightforward to use than `big_enumP`.

Note we require commutativity of the operator, this is to safeguard
against changes on the low-level `bool_enumP` enumeration.

Co-authored-by: Amel Kebbouche <akebbouc@outlook.fr>

cc: @Amel-Kebbouche

[1] https://github.com/math-comp/analysis/blob/7b53e30b53b96e5eb3cabe476b0191353191b52c/theories/altreals/distr.v#L336

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] ~added corresponding documentation in the headers~
<!-- leave this note as a reminder to reviewers -->

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
