### PR TITLE
meetJoinLeMixin to construct latticeType

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -90,6 +90,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `subseq_(le|lt)_(path|sorted)`, `lt_sorted_uniq`, `sort_lt_id`,
     `perm_sort_leP`, `filter_sort_le`, `(sorted_)(mask|subseq)_sort_le`,
     `mem2_sort_le`.
+  + a new mixin `meetJoinLeMixin` constructing a `latticeType` from `meet`,
+    `join` and proofs that those are respectvely the greatest lower bound and
+    the least upper bound.
 
 - in `matrix.v`, seven new definitions:
   + `mxblock`, `mxcol`, `mxrow` and `mxdiag` with notations


### PR DESCRIPTION
##### Motivation for this change

Currently the mixin for lattice contains a lot of obligations (see discussion at https://github.com/math-comp/math-comp/issues/762). If we already know that <= is a partial order, then the following simpler mixin is sufficient:
```
Record of_ := Build {
  meet : T -> T -> T;
  join : T -> T -> T;
  meetP : forall x y z, (x <= meet y z) = (x <= y) && (x <= z);
  joinP : forall x y z, (join x y <= z) = (x <= z) && (y <= z);
}.
```
I'm adding de necessary code to be able to construct a lattice from such a mixin. In a latter PR we might want to change the internal mixin of a lattice while keeping the external theory as discussed in the issue.

##### Things done/to do

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
