### PR TITLE
Don't rename argument of section variable

### DIFF
--- a/mathcomp/fingroup/fingroup.v
+++ b/mathcomp/fingroup/fingroup.v
@@ -2994,7 +2994,7 @@ Definition maxgroup A gP := maxset (fun A => group_set A && gP <<A>>%G) A.
 Definition mingroup A gP := minset (fun A => group_set A && gP <<A>>%G) A.
 
 Variable gP : pred {group gT}.
-Arguments gP G%G.
+Arguments gP _%G.
 
 Lemma ex_maxgroup : (exists G, gP G) -> {G : {group gT} | maxgroup G gP}.
 Proof.


### PR DESCRIPTION
The rename is unreliable in current Coq (see coq/coq#14498) and may be
forbidden soon (see coq/coq#14573).

Practically mathcomp only renames arguments for 1 variable and the
rename is not actually used (see diff).