### PR TITLE
feat: Add CI/CD with `coqorg/coq:8.14-rc1`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,6 +98,10 @@ coq-8.12:
 coq-8.13:
   extends: .opam-build-once
 
+coq-8.14:
+  # to be replaced with .opam-build-once when 8.14.0 available
+  extends: .opam-build
+
 coq-dev:
   extends: .opam-build
 
@@ -143,6 +147,12 @@ test-coq-dev:
   extends: .test
   variables:
     COQ_VERSION: "dev"
+
+test-coq-8.14:
+  # to be replaced with .test-once when 8.14.0 available
+  extends: .test
+  variables:
+    COQ_VERSION: "8.14"
 
 test-coq-8.13:
   extends: .test-once
@@ -512,6 +522,10 @@ mathcomp-dev_coq-8.12:
 
 mathcomp-dev_coq-8.13:
   extends: .docker-deploy-once
+
+mathcomp-dev_coq-8.14:
+  # to be replaced with .docker-deploy-once when 8.14.0 available
+  extends: .docker-deploy
 
 mathcomp-dev_coq-dev:
   extends: .docker-deploy

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -9,7 +9,7 @@ license: "CECILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { ((>= "8.11" & < "8.14~") | (= "dev"))} ]
+depends: [ "coq" { ((>= "8.11" & < "8.15~") | (= "dev"))} ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
##### Motivation for this change

Coq 8.14+rc1 has been recently released (in the opam repo coq-`core-dev`),
and as a follow-up of https://github.com/coq-community/docker-coq/pull/34 it is now possible (for GitLab's CI)
to build and deploy mathcomp-dev with `coqorg/coq:8.14-rc1` - hence this PR…

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
