### PR TITLE
fix: minor symlink issue

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+INITIAL_AUTHORS.md


### PR DESCRIPTION
##### Motivation for this change

`AUTHORS` was renamed (and extended) into file `INITIAL_AUTHORS.md`,
but there are several symlinks that still pointed to the `AUTHORS` filename.

href: https://gitlab.com/math-comp/math-comp/-/jobs/1614401855#L293

Hence this small PR (but maybe you'd prefer a different fix?)

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.