### PR TITLE
Fixing rat_interlock + Add gaia in CI

### DIFF
--- a/.github/workflows/nix-action-coq-8.11.yml
+++ b/.github/workflows/nix-action-coq-8.11.yml
@@ -5,10 +5,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -24,10 +32,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target QuickChick
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"QuickChick\" \\\n --dry-run 2>&1 > /dev/null)\n\
-        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
-        \ \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 >\
+        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
@@ -54,10 +62,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -73,8 +89,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target Verdi
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"Verdi\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -97,14 +113,182 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
         --argstr job "Verdi"
-  coq:
-    needs: []
+  addition-chains:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target addition-chains
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-algebra'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "mathcomp-algebra"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: paramcoq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "paramcoq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "addition-chains"
+  autosubst:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target autosubst
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "autosubst"
+  category-theory:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target category-theory
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: equations'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "equations"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "category-theory"
+  coq:
+    needs: []
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -120,8 +304,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coq
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"coq\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -134,10 +318,18 @@ jobs:
     - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -153,8 +345,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coq-bits
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"coq-bits\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"coq-bits\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -176,10 +368,18 @@ jobs:
     - multinomials
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -195,8 +395,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coqeal
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"coqeal\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -229,10 +429,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -248,10 +456,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coquelicot
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"coquelicot\" \\\n --dry-run 2>&1 > /dev/null)\n\
-        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
-        \ \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 >\
+        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
@@ -270,10 +478,18 @@ jobs:
     - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -289,8 +505,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target fourcolor
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"fourcolor\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -305,16 +521,78 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
         --argstr job "fourcolor"
+  gaia:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    - mathcomp-algebra
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target gaia
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"gaia\" \\\n   --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-algebra'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "mathcomp-algebra"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "gaia"
   interval:
     needs:
     - coq
     - coquelicot
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -330,8 +608,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target interval
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"interval\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -365,10 +643,18 @@ jobs:
     - mathcomp-character
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -384,8 +670,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -427,10 +713,18 @@ jobs:
     - mathcomp-real-closed
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -446,9 +740,9 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-abel
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-abel\" \\\n --dry-run 2>&1 >\
-        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-abel\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
@@ -473,10 +767,18 @@ jobs:
     - mathcomp-fingroup
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -492,8 +794,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-algebra
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-algebra\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -522,10 +824,18 @@ jobs:
     - mathcomp-real-closed
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -541,10 +851,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-analysis
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-analysis\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-analysis\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
@@ -583,10 +893,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -602,10 +920,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-bigenough
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-bigenough\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
@@ -628,10 +946,18 @@ jobs:
     - mathcomp-field
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -647,10 +973,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-character
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-character\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-character\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
@@ -688,10 +1014,18 @@ jobs:
     - mathcomp-solvable
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -707,8 +1041,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-field
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-field\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -741,10 +1075,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -760,10 +1102,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-fingroup
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-fingroup\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
@@ -782,10 +1124,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -801,8 +1151,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-finmap
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-finmap\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -825,10 +1175,18 @@ jobs:
     - mathcomp-bigenough
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -844,8 +1202,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-real-closed
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-real-closed\" \\\n --dry-run\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run\
         \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
         \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -873,10 +1231,18 @@ jobs:
     - coq
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -892,8 +1258,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-single
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-single\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-single\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -912,10 +1278,18 @@ jobs:
     - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -931,10 +1305,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-solvable
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-solvable\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
@@ -960,10 +1334,18 @@ jobs:
     - coq
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -979,10 +1361,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-ssreflect
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"mathcomp-ssreflect\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
@@ -1000,10 +1382,18 @@ jobs:
     - mathcomp-bigenough
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -1019,9 +1409,9 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target multinomials
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"multinomials\" \\\n --dry-run 2>&1 >\
-        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
@@ -1053,10 +1443,18 @@ jobs:
     - mathcomp-character
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -1072,8 +1470,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target odd-order
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.11\" --argstr job \"odd-order\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"odd-order\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -1088,11 +1486,118 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
         --argstr job "odd-order"
+  reglang:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target reglang
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "reglang"
+  relation-algebra:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target relation-algebra
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.11\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: aac-tactics'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "aac-tactics"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.11"
+        --argstr job "relation-algebra"
 name: Nix CI for bundle coq-8.11
 'on':
   pull_request:
-    branches:
-    - '**'
+    paths:
+    - .github/workflows/**
+  pull_request_target:
+    types:
+    - opened
+    - synchronize
+    - reopened
   push:
     branches:
     - master

--- a/.github/workflows/nix-action-coq-8.12.yml
+++ b/.github/workflows/nix-action-coq-8.12.yml
@@ -5,10 +5,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -24,10 +32,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target QuickChick
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"QuickChick\" \\\n --dry-run 2>&1 > /dev/null)\n\
-        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
-        \ \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 >\
+        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
@@ -54,10 +62,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -73,8 +89,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target Verdi
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"Verdi\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -97,14 +113,182 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
         --argstr job "Verdi"
-  coq:
-    needs: []
+  addition-chains:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target addition-chains
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-algebra'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "mathcomp-algebra"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: paramcoq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "paramcoq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "addition-chains"
+  autosubst:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target autosubst
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "autosubst"
+  category-theory:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target category-theory
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: equations'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "equations"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "category-theory"
+  coq:
+    needs: []
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -120,8 +304,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coq
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"coq\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -134,10 +318,18 @@ jobs:
     - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -153,8 +345,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coq-bits
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"coq-bits\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"coq-bits\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -176,10 +368,18 @@ jobs:
     - multinomials
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -195,8 +395,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coqeal
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"coqeal\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -229,10 +429,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -248,10 +456,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coquelicot
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"coquelicot\" \\\n --dry-run 2>&1 > /dev/null)\n\
-        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
-        \ \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 >\
+        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
@@ -270,10 +478,18 @@ jobs:
     - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -289,8 +505,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target fourcolor
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"fourcolor\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -305,16 +521,78 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
         --argstr job "fourcolor"
+  gaia:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    - mathcomp-algebra
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target gaia
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"gaia\" \\\n   --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-algebra'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "mathcomp-algebra"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "gaia"
   interval:
     needs:
     - coq
     - coquelicot
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -330,8 +608,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target interval
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"interval\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -365,10 +643,18 @@ jobs:
     - mathcomp-character
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -384,8 +670,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -427,10 +713,18 @@ jobs:
     - mathcomp-real-closed
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -446,9 +740,9 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-abel
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-abel\" \\\n --dry-run 2>&1 >\
-        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-abel\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
@@ -473,10 +767,18 @@ jobs:
     - mathcomp-fingroup
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -492,8 +794,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-algebra
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-algebra\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -522,10 +824,18 @@ jobs:
     - mathcomp-real-closed
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -541,10 +851,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-analysis
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-analysis\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-analysis\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
@@ -583,10 +893,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -602,10 +920,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-bigenough
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-bigenough\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
@@ -628,10 +946,18 @@ jobs:
     - mathcomp-field
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -647,10 +973,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-character
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-character\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-character\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
@@ -688,10 +1014,18 @@ jobs:
     - mathcomp-solvable
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -707,8 +1041,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-field
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-field\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -741,10 +1075,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -760,10 +1102,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-fingroup
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-fingroup\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
@@ -782,10 +1124,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -801,8 +1151,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-finmap
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-finmap\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -825,10 +1175,18 @@ jobs:
     - mathcomp-bigenough
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -844,8 +1202,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-real-closed
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-real-closed\" \\\n --dry-run\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run\
         \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
         \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -873,10 +1231,18 @@ jobs:
     - coq
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -892,8 +1258,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-single
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-single\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-single\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -912,10 +1278,18 @@ jobs:
     - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -931,10 +1305,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-solvable
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-solvable\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
@@ -960,10 +1334,18 @@ jobs:
     - coq
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -979,10 +1361,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-ssreflect
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"mathcomp-ssreflect\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
@@ -1000,10 +1382,18 @@ jobs:
     - mathcomp-bigenough
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -1019,9 +1409,9 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target multinomials
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"multinomials\" \\\n --dry-run 2>&1 >\
-        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
@@ -1053,10 +1443,18 @@ jobs:
     - mathcomp-character
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -1072,8 +1470,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target odd-order
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.12\" --argstr job \"odd-order\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"odd-order\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -1088,11 +1486,118 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
         --argstr job "odd-order"
+  reglang:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target reglang
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "reglang"
+  relation-algebra:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target relation-algebra
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.12\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: aac-tactics'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "aac-tactics"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.12"
+        --argstr job "relation-algebra"
 name: Nix CI for bundle coq-8.12
 'on':
   pull_request:
-    branches:
-    - '**'
+    paths:
+    - .github/workflows/**
+  pull_request_target:
+    types:
+    - opened
+    - synchronize
+    - reopened
   push:
     branches:
     - master

--- a/.github/workflows/nix-action-coq-8.13.yml
+++ b/.github/workflows/nix-action-coq-8.13.yml
@@ -1,14 +1,79 @@
 jobs:
+  QuickChick:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target QuickChick
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 >\
+        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq-ext-lib'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "coq-ext-lib"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: simple-io'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "simple-io"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "QuickChick"
   Verdi:
     needs:
     - coq
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -24,8 +89,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target Verdi
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"Verdi\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -48,14 +113,183 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
         --argstr job "Verdi"
-  coq:
-    needs: []
+  addition-chains:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    - mathcomp-algebra
+    - paramcoq
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target addition-chains
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-algebra'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-algebra"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: paramcoq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "paramcoq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "addition-chains"
+  autosubst:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target autosubst
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "autosubst"
+  category-theory:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target category-theory
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: equations'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "equations"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "category-theory"
+  coq:
+    needs: []
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -71,8 +305,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coq
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"coq\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -85,10 +319,18 @@ jobs:
     - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -104,8 +346,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coq-bits
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"coq-bits\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"coq-bits\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -128,10 +370,18 @@ jobs:
     - multinomials
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -147,8 +397,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coqeal
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"coqeal\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -181,10 +431,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -200,10 +458,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target coquelicot
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"coquelicot\" \\\n --dry-run 2>&1 > /dev/null)\n\
-        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
-        \ \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 >\
+        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
@@ -222,10 +480,18 @@ jobs:
     - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -241,8 +507,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target fourcolor
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"fourcolor\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -257,16 +523,136 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
         --argstr job "fourcolor"
+  gaia:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    - mathcomp-algebra
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target gaia
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"gaia\" \\\n   --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-algebra'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-algebra"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "gaia"
+  graph-theory:
+    needs:
+    - coq
+    - mathcomp-algebra
+    - mathcomp-finmap
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target graph-theory
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"graph-theory\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-algebra'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-algebra"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-finmap'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-finmap"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: hierarchy-builder'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "hierarchy-builder"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "graph-theory"
   interval:
     needs:
     - coq
     - coquelicot
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -282,8 +668,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target interval
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"interval\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -317,10 +703,18 @@ jobs:
     - mathcomp-character
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -336,8 +730,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -379,10 +773,18 @@ jobs:
     - mathcomp-real-closed
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -398,9 +800,9 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-abel
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-abel\" \\\n --dry-run 2>&1 >\
-        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-abel\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
@@ -425,10 +827,18 @@ jobs:
     - mathcomp-fingroup
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -444,8 +854,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-algebra
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-algebra\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -474,10 +884,18 @@ jobs:
     - mathcomp-real-closed
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -493,10 +911,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-analysis
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-analysis\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-analysis\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
@@ -535,10 +953,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -554,10 +980,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-bigenough
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-bigenough\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
@@ -580,10 +1006,18 @@ jobs:
     - mathcomp-field
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -599,10 +1033,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-character
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-character\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-character\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
@@ -640,10 +1074,18 @@ jobs:
     - mathcomp-solvable
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -659,8 +1101,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-field
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-field\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -693,10 +1135,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -712,10 +1162,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-fingroup
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-fingroup\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
@@ -734,10 +1184,18 @@ jobs:
     - mathcomp-ssreflect
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -753,8 +1211,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-finmap
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-finmap\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -777,10 +1235,18 @@ jobs:
     - mathcomp-bigenough
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -796,8 +1262,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-real-closed
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-real-closed\" \\\n --dry-run\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run\
         \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
         \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -825,10 +1291,18 @@ jobs:
     - coq
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -844,8 +1318,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-single
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-single\" \\\n --dry-run 2>&1\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-single\" \\\n   --dry-run 2>&1\
         \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -864,10 +1338,18 @@ jobs:
     - mathcomp-algebra
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -883,10 +1365,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-solvable
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-solvable\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
@@ -912,10 +1394,18 @@ jobs:
     - coq
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -931,10 +1421,10 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target mathcomp-ssreflect
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"mathcomp-ssreflect\" \\\n --dry-run 2>&1\
-        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
-        built:\" | sed \"s/.*/built/\")\n"
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run\
+        \ 2>&1 > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
@@ -952,10 +1442,18 @@ jobs:
     - mathcomp-bigenough
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -971,9 +1469,9 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target multinomials
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"multinomials\" \\\n --dry-run 2>&1 >\
-        \ /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
         built:\" | sed \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
@@ -1005,10 +1503,18 @@ jobs:
     - mathcomp-character
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -1024,8 +1530,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target odd-order
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"odd-order\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"odd-order\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -1045,10 +1551,18 @@ jobs:
     - coq
     runs-on: ubuntu-latest
     steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.tested_ref }}
     - name: Cachix install
       uses: cachix/install-nix-action@v12
       with:
@@ -1064,8 +1578,8 @@ jobs:
         name: math-comp
     - id: stepCheck
       name: Checking presence of CI target paramcoq
-      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
-        \ bundle \"coq-8.13\" --argstr job \"paramcoq\" \\\n --dry-run 2>&1 > /dev/null)\n\
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"paramcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
         echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
         \ \"s/.*/built/\")\n"
     - if: steps.stepCheck.outputs.status == 'built'
@@ -1076,11 +1590,118 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
         --argstr job "paramcoq"
+  reglang:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target reglang
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "reglang"
+  relation-algebra:
+    needs:
+    - coq
+    - mathcomp-ssreflect
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which ref to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_ref=${{\
+        \ github.ref }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{\
+        \ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge\
+        \ | cut -f1)\n  if [ -z \"$merge_commit\" ]; then\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/head\" >> $GITHUB_ENV\n  else\n    echo \"tested_ref=refs/pull/${{\
+        \ github.event.number }}/merge\" >> $GITHUB_ENV\n  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_ref }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target relation-algebra
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
+        \ bundle \"coq-8.13\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: aac-tactics'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "aac-tactics"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: mathcomp-ssreflect'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "mathcomp-ssreflect"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "coq-8.13"
+        --argstr job "relation-algebra"
 name: Nix CI for bundle coq-8.13
 'on':
   pull_request:
-    branches:
-    - '**'
+    paths:
+    - .github/workflows/**
+  pull_request_target:
+    types:
+    - opened
+    - synchronize
+    - reopened
   push:
     branches:
     - master

--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -35,7 +35,7 @@ with builtins; with (import <nixpkgs> {}).lib;
     master = [
       "mathcomp-finmap" "mathcomp-bigenough" "mathcomp-analysis"
       "mathcomp-abel" "multinomials" "mathcomp-real-closed" "coqeal"
-      "fourcolor" "odd-order"
+      "fourcolor" "odd-order" "gaia"
     ];
     common-bundles = listToAttrs (forEach master (p:
        { name = p; value.override.version = "master"; }))

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -190,9 +190,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - In `rat.v`
   + new lemmas `minr_rat`, `maxr_rat`
-  + constants `fracq`, `oppq`, `addq`, `mulq` and `invq` are
-    "locked" when applied to variables, computation occurs only when
-    applied to constructors.
+  + constants `fracq`, `oppq`, `addq`, `mulq`, `invq`, `normq`,
+    `le_rat`, and `lt_rat` are "locked" when applied to variables,
+    computation occurs only when applied to constructors. Moreover the
+    new definition of `fracq` ensures that if `x` and `y` of type
+    `int * int` represent the same rational then `fracq x` is
+    definitionally equal to `fracq y` (i.e. the underlying proofs are
+    the same).
 
 - In `intdiv.v`
   + new definition `lcmz`

--- a/mathcomp/Make.test-suite
+++ b/mathcomp/Make.test-suite
@@ -2,6 +2,7 @@ test_suite/test_hierarchy_all.v
 test_suite/test_ssrAC.v
 test_suite/test_guard.v
 test_suite/test_regular_conv.v
+test_suite/test_rat.v
 
 -I .
 

--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -72,20 +72,28 @@ Proof. by rewrite /numq /denq; case: x=> [[a b] /= /andP []]. Qed.
 Fact RatK x P : @Rat (numq x, denq x) P = x.
 Proof. by move: x P => [[a b] P'] P; apply: val_inj. Qed.
 
-Definition fracq1_subdef n d : int :=
-  (-1) ^ ((d < 0) (+) (n < 0)) * (`|n| %/ gcdn `|n| `|d|)%:Z.
-Arguments fracq1_subdef /.
-Definition fracq2_subdef n d : int := (`|d| %/ gcdn `|n| `|d|)%:Z.
-Arguments fracq2_subdef /.
-
 Definition fracq_subdef x :=
-  (fracq1_subdef x.1 x.2, fracq2_subdef x.1 x.2).
+  if x.2 != 0 then  let g := gcdn `|x.1| `|x.2| in
+    ((-1) ^ ((x.2 < 0) (+) (x.1 < 0)) * (`|x.1| %/ g)%:Z, (`|x.2| %/ g)%:Z)
+ else (0, 1).
 Arguments fracq_subdef /.
 
-Fact fracq_subproof x (y := fracq_subdef x) : (`|x.2| > 0)%N ->
+Definition fracq_opt_subdef (x : int * int) :=
+  if (0 < x.2) && coprime `|x.1| `|x.2| then x else fracq_subdef x.
+
+Lemma fracq_opt_subdefE x : fracq_opt_subdef x = fracq_subdef x.
+Proof.
+rewrite /fracq_opt_subdef; case: ifP => //; case: x => n d /= /andP[d_gt0 cnd].
+rewrite /fracq_subdef gt_eqF//= lt_gtF//= (eqP cnd) !divn1 abszEsg gtz0_abs//.
+rewrite mulrA sgz_def mulrnAr -signr_addb addbb expr0.
+by have [->|] := eqVneq n 0; rewrite (mulr0, mul1r).
+Qed.
+
+Fact fracq_subproof x (y := fracq_opt_subdef x) :
   (0 < y.2) && (coprime `|y.1| `|y.2|).
 Proof.
-rewrite {}/y/=; case: x => [/= n d] dN0.
+rewrite {}/y fracq_opt_subdefE /=; have [] //= := eqVneq x.2 0.
+case: x => [/= n d]; rewrite -absz_gt0 => dN0.
 have ggt0 : (0 < gcdn `|n| `|d|)%N by rewrite gcdn_gt0 dN0 orbT.
 rewrite ltz_nat divn_gt0// dvdn_leq ?dvdn_gcdr//=.
 rewrite abszM abszX abszN1 exp1n mul1n absz_nat.
@@ -93,27 +101,40 @@ rewrite /coprime -(@eqn_pmul2r (gcdn `|n| `|d|))// mul1n.
 by rewrite muln_gcdl !divnK ?(dvdn_gcdl, dvdn_gcdr).
 Qed.
 
-(* We use a match expression in order to "lock" the definition of fracq.  *)
-(* Indeed, the kernel will try to reduce a fracq only when applied to     *)
-(* a term which has "enough" constructors: i.e. it reduces to a pair of   *)
-(* a Posz or Negz on the first component, and a Posz of 0 or S, or a Negz *)
-(* on the second component. See issue #698.                               *)
+Lemma fracq_opt_subdef_id x :
+  fracq_opt_subdef (fracq_opt_subdef x) = fracq_subdef x.
+Proof.
+rewrite [fracq_opt_subdef (_ x)]/fracq_opt_subdef.
+by rewrite fracq_subproof fracq_opt_subdefE.
+Qed.
+
+(* We use a match expression in order to "lock" the definition of fracq.   *)
+(* Indeed, the kernel will try to reduce a fracq only when applied to      *)
+(* a term which has "enough" constructors: i.e. it reduces to a pair of    *)
+(* a Posz or Negz on the first component, and a Posz of 0 or S, or a Negz  *)
+(* on the second component. See issue #698.                                *)
+(* Additionally, we use fracq_opt_subdef to precompute the normal form     *)
+(* before we use fracq_subproof in order to make sure the proof will be    *)
+(* independent from the input of fracq. This ensure reflexivity of any     *)
+(* computation involving rationals as long as all operators use fracq.     *)
+(* As a consequence val (fracq x) = fracq_opt_subdef (fracq_opt_subdef x)) *)
 Definition fracq '((n', d')) : rat :=
   match d', n' with
-  | Posz 0 as d, _ as n => @Rat (0, 1) isT
-  | _ as d, Posz _ as n | _ as d, _ as n => Rat (@fracq_subproof (n, d) isT)
+  | Posz 0 as d, _ as n => Rat (fracq_subproof (1, 0))
+  | _ as d, Posz _ as n | _ as d, _ as n =>
+     Rat (fracq_subproof (fracq_opt_subdef (n, d)))
   end.
 Arguments fracq : simpl never.
 
-Lemma val_fracq x : val (fracq x) = if x.2 != 0 then fracq_subdef x else (0, 1).
-Proof. case: x => [[n|n] [[|[|d]]|d]]//=. Qed.
+Lemma val_fracq x : val (fracq x) = fracq_subdef x.
+Proof. by case: x => [[n|n] [[|[|d]]|d]]//=; rewrite !fracq_opt_subdef_id. Qed.
 
-Lemma num_fracq x : numq (fracq x) =
-  if x.2 != 0 then fracq1_subdef x.1 x.2 else 0.
+Lemma num_fracq x : numq (fracq x) = if x.2 != 0 then
+  (-1) ^ ((x.2 < 0) (+) (x.1 < 0)) * (`|x.1| %/ gcdn `|x.1| `|x.2|)%:Z else 0.
 Proof. by rewrite /numq val_fracq/=; case: ifP. Qed.
 
 Lemma den_fracq x : denq (fracq x) =
-  if x.2 != 0 then fracq2_subdef x.1 x.2 else 1.
+  if x.2 != 0 then (`|x.2| %/ gcdn `|x.1| `|x.2|)%:Z else 1.
 Proof. by rewrite /denq val_fracq/=; case: ifP. Qed.
 
 Fact ratz_frac n : ratz n = fracq (n, 1).
@@ -522,21 +543,30 @@ Proof. by rewrite -{2}[x]divq_num_den divfK // intq_eq0 denq_eq0. Qed.
 Lemma denqP x : {d | denq x = d.+1}.
 Proof. by rewrite /denq; case: x => [[_ [[|d]|]] //= _]; exists d. Qed.
 
-Definition normq (x : rat) : rat :=  `|numq x|%:~R / (denq x)%:~R.
-Definition le_rat (x y : rat) := numq x * denq y <= numq y * denq x.
-Definition lt_rat (x y : rat) := numq x * denq y < numq y * denq x.
+Definition normq '(Rat x _) : rat := `|x.1|%:~R / (x.2)%:~R.
+Definition le_rat '(Rat x _) '(Rat y _) := x.1 * y.2 <= y.1 * x.2.
+Definition lt_rat '(Rat x _) '(Rat y _) := x.1 * y.2 < y.1 * x.2.
+
+Lemma normqE x : normq x = `|numq x|%:~R / (denq x)%:~R.
+Proof. by case: x. Qed.
+
+Lemma le_ratE x y : le_rat x y = (numq x * denq y <= numq y * denq x).
+Proof. by case: x; case: y. Qed.
+
+Lemma lt_ratE x y : lt_rat x y = (numq x * denq y < numq y * denq x).
+Proof. by case: x; case: y. Qed.
 
 Lemma gt_rat0 x : lt_rat 0 x = (0 < numq x).
-Proof. by rewrite /lt_rat mul0r mulr1. Qed.
+Proof. by rewrite lt_ratE mul0r mulr1. Qed.
 
 Lemma lt_rat0 x : lt_rat x 0 = (numq x < 0).
-Proof. by rewrite /lt_rat mul0r mulr1. Qed.
+Proof. by rewrite lt_ratE mul0r mulr1. Qed.
 
 Lemma ge_rat0 x : le_rat 0 x = (0 <= numq x).
-Proof. by rewrite /le_rat mul0r mulr1. Qed.
+Proof. by rewrite le_ratE mul0r mulr1. Qed.
 
 Lemma le_rat0 x : le_rat x 0 = (numq x <= 0).
-Proof. by rewrite /le_rat mul0r mulr1. Qed.
+Proof. by rewrite le_ratE mul0r mulr1. Qed.
 
 Fact le_rat0D x y : le_rat 0 x -> le_rat 0 y -> le_rat 0 (x + y).
 Proof.
@@ -572,7 +602,7 @@ Qed.
 
 Fact subq_ge0 x y : le_rat 0 (y - x) = le_rat x y.
 Proof.
-symmetry; rewrite ge_rat0 /le_rat -subr_ge0.
+symmetry; rewrite ge_rat0 !le_ratE -subr_ge0.
 case: ratP => nx dx cndx; case: ratP => ny dy cndy.
 rewrite -!mulNr addf_div ?intq_eq0 // !mulNr -!rmorphM -rmorphB /=.
 symmetry; rewrite !leNgt -sgr_cp0 sgr_numq_div mulrC gtr0_sg //.
@@ -580,7 +610,7 @@ by rewrite mul1r sgr_cp0.
 Qed.
 
 Fact le_rat_total : total le_rat.
-Proof. by move=> x y; apply: le_total. Qed.
+Proof. by move=> x y; rewrite !le_ratE; apply: le_total. Qed.
 
 Fact numq_sign_mul (b : bool) x : numq ((-1) ^+ b * x) = (-1) ^+ b * numq x.
 Proof. by case: b; rewrite ?(mul1r, mulN1r) // numqN. Qed.
@@ -602,16 +632,16 @@ by apply: (canRL (signrMK _)); rewrite mulz_sign_abs.
 Qed.
 
 Fact norm_ratN x : normq (- x) = normq x.
-Proof. by rewrite /normq numqN denqN normrN. Qed.
+Proof. by rewrite !normqE numqN denqN normrN. Qed.
 
 Fact ge_rat0_norm x : le_rat 0 x -> normq x = x.
 Proof.
 rewrite ge_rat0; case: ratP=> [] // n d cnd n_ge0.
-by rewrite /normq /= normr_num_div ?ger0_norm // divq_num_den.
+by rewrite normqE /= normr_num_div ?ger0_norm // divq_num_den.
 Qed.
 
 Fact lt_rat_def x y : (lt_rat x y) = (y != x) && (le_rat x y).
-Proof. by rewrite /lt_rat lt_def rat_eq. Qed.
+Proof. by rewrite lt_ratE le_ratE lt_def rat_eq. Qed.
 
 Definition ratLeMixin : realLeMixin rat_idomainType :=
   RealLeMixin le_rat0D le_rat0M le_rat0_anti subq_ge0

--- a/mathcomp/test_suite/test_rat.v
+++ b/mathcomp/test_suite/test_rat.v
@@ -1,0 +1,15 @@
+From mathcomp Require Import all_ssreflect all_algebra.
+
+Local Open Scope ring_scope.
+
+Goal 2%:Q + 2%:Q = 4%:Q.
+Proof. reflexivity. Qed.
+
+Goal - 2%:Q = -1 * 2%:Q.
+Proof. reflexivity. Qed.
+
+Goal 2%:Q ^+ 2 = 4%:Q.
+Proof. reflexivity. Qed.
+
+Goal (-1)^-1 = -1 :> rat.
+Proof. reflexivity. Qed.


### PR DESCRIPTION
##### Motivation for this change

Fixes https://github.com/coq-community/gaia/issues/4 by making sure operations on rationals produce a canonical representative of the rational (not only the ratio, but also the proof). This makes `(-1)^-1 = -1` hold by reflexivity and hence fixes the breakage in `gaia`.

CC @thery 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~~added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.