### PR TITLE
WIP galmx : gal_of -> matrix

### DIFF
--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -1648,3 +1648,105 @@ Arguments fixedFieldP {F L E A a}.
 Arguments normalFieldP {F L K E}.
 Arguments splitting_galoisField {F L K E}.
 Arguments galois_fixedField {F L K E}.
+
+Section galmx.
+Variable (K : fieldType) (L : splittingFieldType K) (E F : {subfield L}).
+Hypothesis sub_EF : (E <= F)%VS.
+
+Local Notation n := (\dim_E F).-1.+1.
+
+Variables (e : n.-tuple (fieldOver E)).
+
+Definition galrow (v : fieldOver E) := \row_i coord e i v.
+Lemma galrow_is_linear : linear galrow.
+Proof. by move=> x v1 v2; apply/rowP=> i; rewrite !mxE linearP. Qed.
+Canonical galrow_linear := Linear galrow_is_linear.
+
+Lemma coord_rowof i v : coord e i v = galrow v 0 i.
+Proof. by rewrite !mxE. Qed.
+
+Definition galvec (v : 'rV[subvs_of E]_n) : fieldOver E := \sum_i v 0 i *: e`_i.
+
+Lemma galvec_delta i : galvec (delta_mx 0 i) = e`_i.
+Proof.
+rewrite /galvec (bigD1 i)//= mxE !eqxx scale1r big1 ?addr0// => j neq_ji.
+by rewrite mxE (negPf neq_ji) andbF scale0r.
+Qed.
+
+Lemma galvec_is_linear : linear galvec.
+Proof.
+move=> x v1 v2; rewrite linear_sum -big_split/=.
+by apply: eq_bigr => i _/=; rewrite !mxE scalerDl scalerA.
+Qed.
+Canonical galvec_linear := Linear galvec_is_linear.
+
+Variable e_basis : basis_of (aspaceOver E F) e.
+
+Lemma galrowK : {in F, cancel galrow galvec}.
+Proof.
+move=> v vF; rewrite [v in RHS](coord_basis e_basis) ?memvf//.
+  by apply: eq_bigr => i; rewrite !mxE// => _.
+by rewrite mem_aspaceOver.
+Qed.
+
+Lemma galvecK : cancel galvec galrow.
+Proof.
+move=> v; apply/rowP=> i; rewrite !(lfunE, mxE).
+by rewrite coord_sum_free ?(basis_free e_basis).
+Qed.
+
+Lemma galrowE (i : 'I_n) : galrow e`_i = delta_mx 0 i.
+Proof.
+apply/rowP=> k; rewrite !mxE.
+by rewrite eqxx coord_free ?(basis_free e_basis)// eq_sym.
+Qed.
+
+Lemma coord_galvec i v : coord e i (galvec v) = v 0 i.
+Proof. by rewrite coord_rowof galvecK. Qed.
+
+Lemma galrow_eq0 v : v \in F -> (galrow v == 0) = (v == 0).
+Proof. by move=> vF; rewrite -(inj_eq (can_inj galvecK)) galrowK ?linear0. Qed.
+
+Lemma galvec_in v : galvec v \in F.
+Proof.
+rewrite /galvec -(mem_aspaceOver sub_EF) memv_suml // => i _.
+by rewrite memvZ// (basis_mem e_basis)// mem_nth// size_tuple.
+Qed.
+
+Lemma galvec_eq0 v : (galvec v == 0) = (v == 0).
+Proof.
+rewrite -(inj_in_eq (can_in_inj galrowK)) ?galvec_in// ?mem0v//.
+by rewrite galvecK linear0.
+Qed.
+
+Definition galmx (h : gal_of F) := lin1_mx (galrow \o h \o galvec).
+
+Lemma mul_galmx (h : gal_of F) M : h \in 'Gal(F / E)%g ->
+ M *m galmx h = galrow (h (galvec M)).
+Proof.
+move=> Gh; rewrite /galmx; set g := (X in lin1_mx X).
+suff g_is_linear : linear g by rewrite (mul_rV_lin1 (Linear g_is_linear)).
+move=> k y z; rewrite /g/= -[RHS]linearP [in LHS]linearP rmorphD rmorphM/=.
+by rewrite [h (vsval k)](fixed_gal _ Gh)// subvsP.
+Qed.
+
+Lemma galmx1 : galmx 1%g = 1%:M.
+Proof. by apply/row_matrixP => i; rewrite !rowE mulmx1 mul_galmx// gal_id galvecK. Qed.
+
+Lemma galmxM : {in 'Gal(F / E)%g &, forall g g',
+  galmx (g * g')%g = (galmx g * galmx g')}.
+Proof.
+move=> g g' gG g'G; apply/row_matrixP => i; rewrite !rowE mulmxA.
+by rewrite !mul_galmx ?groupM// galM ?galvec_in// galrowK// memv_gal ?galvec_in.
+Qed.
+
+Lemma galmxX g i : g \in 'Gal(F / E)%g -> galmx (g ^+ i)%g = galmx g ^+ i.
+Proof.
+move=> gG; elim: i => [|i IHi]; first by rewrite galmx1.
+by rewrite expgS exprS galmxM ?groupX// IHi.
+Qed.
+
+Lemma galvecM v g : g \in 'Gal(F / E)%g -> galvec (v *m galmx g) = g (galvec v).
+Proof. by move=> gG; rewrite mul_galmx// galrowK ?memv_gal ?galvec_in. Qed.
+
+End galmx.


### PR DESCRIPTION
##### Motivation for this change

Adding the operator galmx which gives a matrix representation of an
element of a galois group. It was used in a -- now deleted -- proof
in the proof of Abel-Ruffini's theorem:
```coq
Variables (F0 : fieldType) (L : splittingFieldType F0).
Implicit Types (E F K : {subfield L}) (w : L) (n : nat).

(* - each element of G is diagonalizable *)
(* - the elements of G are simultaneously diagonalizable *)
(* - their eigenvalues are n-th root of the unity because their minimal *)
(*   polynomial divides X^n - 1 *)
(* - let (r1, ..., rn) be their common basis *)
(* - we use the fact :  ri^n is unchanged by any m of G => ri^n is in E *)
(*   - let lambda be the eigenvalue which corresponds to m and ri *)
(*   - then m(ri^n) = (m(ri))^n (m automorphism) *)
(*   - m(ri) = lambda ri (lambda eigenvalue) *)
(*   - lambda^n ri^n = ri^n (lambda is an n-th root of the unity) *)
(*   - ri^n is unchanged by m *)
(*   - then ri^n is in E *)
(* - ri is a radical element on E *)

Lemma abelian_radical_ext w E F (n := \dim_E F) :
    n.-primitive_root w -> w \in E -> galois E F ->
  abelian 'Gal(F / E) -> radical.-ext E F.
Proof.
set G := (X in abelian X) => w_root wE galois_EF abelian_G.
have subv_EF := galois_subW galois_EF.
have n_gt0 : (n > 0)%N by rewrite /n -dim_aspaceOver ?adim_gt0.
have asimp := (mem_aspaceOver, subv_adjoin_seq).
suff [/= w_ /andP[w_basis /allP w_F] m_w {abelian_G}] :
     { w_ : n.-tuple L |
       basis_of (aspaceOver E F) (w_ : seq (fieldOver E)) && all (mem F) w_ &
         forall i m, m \in G -> exists2 l, (l \in E) && (l ^+ n == 1)
                                           & m (tnth w_ i) = l * tnth w_ i }.
  pose f i := <<E & take i w_>>%AS.
  have f0E : f 0%N = E by apply/val_inj; rewrite /f/= take0 Fadjoin_nil.
  have Ew_eq_F : <<E & w_>>%AS = F :> {vspace _}.
    apply/eqP; rewrite eqEsubv/=; apply/andP; split.
      by apply/Fadjoin_seqP; split.
    apply/subvP => x; rewrite -(mem_aspaceOver subv_EF).
    move=> /(coord_basis w_basis)->; rewrite memv_suml// => i _.
    rewrite fieldOver_scaleE/= rpredM//.
      by rewrite (subvP (subv_adjoin_seq _ _))//; apply: valP.
    have lt_iw : (i < size w_)%N by rewrite size_tuple.
    by rewrite (subvP (seqv_sub_adjoin _ (mem_nth 0 lt_iw)))// memv_line.
  exists (ExtData w_ [tuple of nseq n n]) => //; apply/forallP=> /= i.
  rewrite {2}/tnth nth_nseq ltn_ord; apply/radicalP; split=> //.
  suff: (tnth w_ i) ^+ n \in fixedField G.
    by rewrite (galois_fixedField _)//; apply/(subvP (subv_adjoin_seq _ _)).
  apply/fixedFieldP; first by rewrite rpredX ?[_ \in _]w_F ?mem_nth ?size_tuple.
  move=> g /(m_w i)[l /andP[lE /eqP lX1]].
  by rewrite (tnth_nth 0) rmorphX/= => ->; rewrite exprMn lX1 mul1r.
pose LE := [fieldExtType subvs_of E of fieldOver E].
have [e e_basis] : { e : n.-1.+1.-tuple _ | basis_of (aspaceOver E F) e}.
  rewrite prednK//; have := vbasisP (aspaceOver E F); move: (vbasis _).
  by rewrite dim_aspaceOver// => e; exists e.
have e_free := basis_free e_basis.
have Gminpoly g : g \in G -> mxminpoly (galmx e g) %| 'X ^+ n - 1.
  move=> gG; rewrite mxminpoly_min// rmorphB rmorph1 rmorphX/= horner_mx_X.
  apply: (canLR (addrK _)); rewrite add0r -galmxX//.
  by rewrite [n]galois_dim// expg_cardG// galmx1.
have /sig2W [p p_unit dG] : codiagonalisable [seq galmx e g | g in G].
  apply/codiagonalisableP; split.
    apply/all_commP => _ _ /mapP[g gG ->] /mapP[g' g'G ->].
    rewrite ?mem_enum in gG g'G.
    by rewrite -![_ *m _]galmxM// (centsP abelian_G).
  move=> _/mapP[g gG ->]; rewrite mem_enum in gG *.
  pose l := [seq Subvs wE ^+ i | i <- index_iota 0 n].
  apply/diagonalisableP; exists l.
    rewrite map_inj_in_uniq ?iota_uniq//.
    move=> x y; rewrite !mem_index_iota !leq0n/= => x_n y_n.
    move=> /(congr1 val)/=/eqP; rewrite !rmorphX/=.
    by rewrite (eq_prim_root_expr w_root) !modn_small// => /eqP.
  rewrite big_map (@factor_Xn_sub_1 _ _ (Subvs wE)) ?Gminpoly//.
  by rewrite /= -(fmorph_primitive_root [rmorphism of vsval]).
pose w_ := [tuple galvec e (row i p) | i < n.-1.+1].
rewrite -[n]prednK//; exists w_.
  apply/andP; split; last by apply/allP => _ /mapP[/=i _ ->]; rewrite galvec_in.
  rewrite basisEdim; apply/andP; split; last first.
    by rewrite size_tuple dim_aspaceOver// prednK.
  apply/subvP => x /=; rewrite mem_aspaceOver// => xEF.
  have [l ->] : exists l, x = galvec e (l *m p).
    by exists (galrow e x *m invmx p); rewrite mulmxKV ?galrowK.
  rewrite span_def big_map big_enum_cond/= mulmx_sum_row linear_sum/=.
  by  apply: memv_sumr => i _; rewrite linearZ/= [_ \in _]memvZ// memv_line.
move=> i g gG; have /allP /(_ (galmx e g) (map_f _ _))/sim_diagPex := dG.
case=> // [|M pg]; first by rewrite mem_enum.
exists (val (M 0 i)); [apply/andP; split|]; first by rewrite /= subvsP.
  rewrite [X in _ ^+ X]prednK// -subr_eq0.
  have := Gminpoly _ gG; rewrite (simLR _ pg)//.
  move => /dvdpP [q] /(congr1 (val \o horner^~ (M 0 i)))/=.
  rewrite hornerM hornerD hornerN hornerXn hornerC/= rmorphX algid1 => ->.
  rewrite mxminpoly_uconj ?unitmx_inv// mxminpoly_diag/= horner_prod.
  set u := undup _; under eq_bigr do rewrite hornerXsubC.
  suff /eqP-> : \prod_(i0 <- u) (M 0 i - i0) == 0 by rewrite mulr0.
  rewrite prodf_seq_eq0; apply/hasP; exists (M 0 i); rewrite ?subrr ?eqxx//.
  by rewrite mem_undup map_f ?mem_enum.
have /(simP p_unit)/(congr1 (mulmx (@delta_mx _ 1 _ 0 i))) := pg.
rewrite !mulmxA -!rowE row_diag_mx -scalemxAl -rowE => /(congr1 (galvec e)).
by rewrite galvecM// linearZ/= tnth_map tnth_ord_tuple.
Qed.
```

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.