### PR TITLE
Fine grained addition in rat

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -205,7 +205,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     new definition of `fracq` ensures that if `x` and `y` of type
     `int * int` represent the same rational then `fracq x` is
     definitionally equal to `fracq y` (i.e. the underlying proofs are
-    the same).
+    the same). Additionally, `addq` and `mulq` are tuned to minimize
+    the number of integer arithmetic operations when the denominators
+    are equal to one.
+  + notation `[rat x // y]` for displaying the normal form of a
+    rational. We also provide the parsable notation for debugging
+    purposes.
 
 - In `intdiv.v`
   + new definition `lcmz`


### PR DESCRIPTION
##### Motivation for this change

Fixes #807

We finetune `addq` to optimize the `hnf` of `N%:Q` for concrete `N` that are not "too" large. (thanks @thery for the brainstorming) e.g.

```coq
Goal (locked 30%:Q = 30%:Q)%R -> false.
Proof.
Time Fail discriminate.
(* Finished transaction in 0.65 secs (0.649u,0.s) (successful) *)
(* about 1s for 40%:Q, about 2s for 50%:Q, about 4s for 60%:Q etc *)
```

This is not optimal, so we also provide the lemma `rat_vm_compute` to first reduce rationals of the form `_%:Q` using `vm_compute`, which then makes the hnf trivial.

@pi8027 could you test if this is enough to solve the inefficiencies encountered in apery?

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.