### PR TITLE
Adding vm_compute rewrite rule

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -96,6 +96,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemmas `opp_fun_is_additive` and `opp_fun_is_scalable`
   + canonical instances `opp_fun_additive` and `opp_fun_linear`
   + notation `f \* g` for definition `mul_fun`
+- in `ssreflect.v`, typeclass `vm_compute_eq` and lemma `vm_compute`
+  in order to trigger a call to the tactic `vm_compute` when rewriting
+  using `rewrite [pattern]vm_compute`.
+
 
 - in `order.v`
   + notation `f \min g` and `f \max g` for definitions `min_fun` and `max_fun`
@@ -120,6 +124,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `ssrnum.v`
   + lemmas `mulr_ge0_gt0`, `splitr`, `ler_addgt0Pr`, `ler_addgt0Pl`,
     `lt_le`, `gt_ge`
+- In `rat.v`
+  + lemma `rat_vm_compute` which is a specialization to the rewriting
+    rule `vm_compute` to trigger `vm_compute` by a rewrite.
 
 ### Changed
 

--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -1025,3 +1025,7 @@ Notation "[ 'rat' x // y ]" := (@Rat (x, y) _) (only printing) : ring_scope.
 (* For debugging purposes we provide the parsable version *)
 Notation "[ 'rat' x // y ]" :=
   (@Rat (x : int, y : int) (fracq_subproof (x : int, y : int))) : ring_scope.
+
+(* A specialization of vm_compute rewrite rule for pattern _%:Q *)
+Lemma rat_vm_compute n (x : rat) : vm_compute_eq n%:Q x -> n%:Q = x.
+Proof. exact. Qed.

--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -61,3 +61,14 @@ Notation "'[' '!' rules ']'"         := (ltac:(rewrite !rules))
   (at level 0, rules at level 200, only parsing) : ssripat_scope.
 
 End ipat.
+
+(* A class to trigger reduction by rewriting.                           *)
+(* Usage: rewrite [pattern]vm_compute.                                  *)
+(* Alternatively one may redefine a lemma as in algebra/rat.v :         *)
+(* Lemma rat_vm_compute n (x : rat) : vm_compute_eq n%:Q x -> n%:Q = x. *)
+(* Proof. exact. Qed.                                                   *)
+
+Class vm_compute_eq {T : Type} (x y : T) := vm_compute : x = y.
+
+Hint Extern 0 (@vm_compute_eq _ _ _) =>
+       vm_compute; reflexivity : typeclass_instances.


### PR DESCRIPTION
##### Motivation for this change

Introduces a `vm_compute` rewrite rule to trigger `vm_compute`
delimited with a pattern using the ractic `rewrite
[pattern]vm_compute`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~added corresponding documentation in the headers~
- [ ] backport to Coq
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.