### PR TITLE
Fix [rat x // y] notation

### DIFF
--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -942,10 +942,9 @@ Qed.
 
 Add Field rat_field : rat_field_theory.
 
-(* For debugging purposes we provide the parsable version *)
-Notation "[rat x // y ]" :=
-  (@Rat (x : int, y : int) (fracq_subproof (x : int, y : int)))
-  (only parsing) : ring_scope.
-
 (* Pretty printing or normal element of rat. *)
-Notation "[rat x // y ]" := (@Rat (x, y) _) (only printing) : ring_scope.
+Notation "[ 'rat' x // y ]" := (@Rat (x, y) _) (only printing) : ring_scope.
+
+(* For debugging purposes we provide the parsable version *)
+Notation "[ 'rat' x // y ]" :=
+  (@Rat (x : int, y : int) (fracq_subproof (x : int, y : int))) : ring_scope.


### PR DESCRIPTION
##### Motivation for this change

It seems that it made `[rat` a keyword. IIUC, `rat` should be treated as an identifier here.

##### Things done/to do

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
