### PR TITLE
generalize leq_bigmax_cond

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -31,6 +31,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     read as `(-12)%:~R`
 
 - in `bigop.v`, added lemmas `telescope_big`, `telescope_sumn` and `telescope_sumn_in`
+- in `seq.v`, added statement `size_take_min`.
+- in `bigop.v`:
+  + `leq_bigmax_seq`, `bigmax_leqP_seq`, `bigmax_sup_seq`
 
 ### Changed
 

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -773,7 +773,7 @@ Qed.
 
 Lemma p_rank_abelem p G : p.-abelem G -> 'r_p(G) = logn p #|G|.
 Proof.
-move=> abelG; apply/eqP; rewrite eqn_leq andbC (bigmax_sup G) //.
+move=> abelG; apply/eqP; rewrite eqn_leq andbC (bigmax_sup G)//.
   by apply/bigmax_leqP=> E /[1!inE] /andP[/lognSg->].
 by rewrite inE subxx.
 Qed.
@@ -881,7 +881,7 @@ Lemma rankS A B : A \subset B -> 'r(A) <= 'r(B).
 Proof.
 move=> sAB; rewrite /rank !big_mkord; apply/bigmax_leqP=> p _.
 have leAB: #|A| < #|B|.+1 by rewrite ltnS subset_leq_card.
-by rewrite (bigmax_sup (widen_ord leAB p)) // p_rankS.
+by rewrite (bigmax_sup (widen_ord leAB p)) ?p_rankS.
 Qed.
 
 Lemma rank_geP n G : reflect (exists E, E \in 'E^n(G)) (n <= 'r(G)).
@@ -2066,7 +2066,7 @@ suffices lti_lnO e: (i < lnO p e _ G) = (e < logn p #[x]).
   have [-> //|logx_gt0] := posnP (logn p #[x]).
   have lexpG: (logn p #[x]).-1 < logn p #|G|.
     by rewrite prednK // dvdn_leq_log ?order_dvdG.
-  by rewrite (@bigmax_sup _ (Ordinal lexpG)) ?(prednK, lti_lnO).
+  by rewrite (bigmax_sup (Ordinal lexpG)) ?(prednK, lti_lnO).
 rewrite /lnO -(count_logn_dprod_cycle _ _ defG).
 case: (ltnP e) (b_sorted p) => [lt_e_x | le_x_e].
   rewrite -(cat_take_drop i.+1 b) -map_rev rev_cat !map_cat cat_path.

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -2018,9 +2018,18 @@ Lemma prodn_gt0 I r (P : pred I) F :
   (forall i, 0 < F i) -> 0 < \prod_(i <- r | P i) F i.
 Proof. by move=> Fpos; apply: prodn_cond_gt0. Qed.
 
+Lemma leq_bigmax_seq (I : eqType) r (P : pred I) F i0 :
+  i0 \in r -> P i0 -> F i0 <= \max_(i <- r | P i) F i.
+Proof.
+move=> + Pi0; elim: r => // h t ih; rewrite inE big_cons.
+move=> /predU1P[<-|i0t]; first by rewrite Pi0 leq_maxl.
+by case: ifPn => Ph; [rewrite leq_max ih// orbT|rewrite ih].
+Qed.
+Arguments leq_bigmax_seq [I r P F].
+
 Lemma leq_bigmax_cond (I : finType) (P : pred I) F i0 :
   P i0 -> F i0 <= \max_(i | P i) F i.
-Proof. by move=> Pi0; rewrite (bigD1 i0) ?leq_maxl. Qed.
+Proof. exact: leq_bigmax_seq. Qed.
 Arguments leq_bigmax_cond [I P F].
 
 Lemma leq_bigmax (I : finType) F (i0 : I) : F i0 <= \max_i F i.
@@ -2035,10 +2044,25 @@ apply: (iffP idP) => leFm => [i Pi|].
 by elim/big_ind: _ => // m1 m2; rewrite geq_max => ->.
 Qed.
 
+Lemma bigmax_leqP_seq (I : eqType) r (P : pred I) m F :
+  reflect (forall i, i \in r -> P i -> F i <= m) (\max_(i <- r | P i) F i <= m).
+Proof.
+apply: (iffP idP) => leFm => [i ri Pi|].
+  exact/(leq_trans _ leFm)/leq_bigmax_seq.
+rewrite big_seq_cond; elim/big_ind: _ => // [m1 m2|i /andP[ri]].
+  by rewrite geq_max => ->.
+exact: leFm.
+Qed.
+
 Lemma bigmax_sup (I : finType) i0 (P : pred I) m F :
   P i0 -> m <= F i0 -> m <= \max_(i | P i) F i.
 Proof. by move=> Pi0 le_m_Fi0; apply: leq_trans (leq_bigmax_cond i0 Pi0). Qed.
 Arguments bigmax_sup [I] i0 [P m F].
+
+Lemma bigmax_sup_seq (I : eqType) r i0 (P : pred I) m F :
+  i0 \in r -> P i0 -> m <= F i0 -> m <= \max_(i <- r | P i) F i.
+Proof. by move=> i0r Pi0 ?; apply: leq_trans (leq_bigmax_seq i0 _ _). Qed.
+Arguments bigmax_sup_seq [I r] i0 [P m F].
 
 Lemma bigmax_eq_arg (I : finType) i0 (P : pred I) F :
   P i0 -> \max_(i | P i) F i = F [arg max_(i > i0 | P i) F i].


### PR DESCRIPTION
##### Motivation for this change

We happened to have a use for a version of `leq_bigmax` over an `eqType`
(here
https://github.com/affeldt-aist/infotheo/blob/56a667c1421a9eb7a62593512a609711c0938f4f/ecc_modern/ldpc_algo_proof.v#L72-L73)
Would this "generalization" make sense?

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
~~- [ ] added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
