### PR TITLE
Fix the scope of `{ 'symbol' ... }` notations

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -79,6 +79,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `fintype.v`
   + `enum_ordS` now a notation
+- The following notations are now declared in `type_scope`:
+  + `{tuple n of T}` and `{bseq n of T}` in `tuple.v`,
+  + `{subset T}` and `{subset [d] T}` in `order.v`,
+  + `{morphism D >-> T}` in `morphism.v`,
+  + `{acts A, on S | to}` and `{acts A, on group G | to}` in `action.v`,
+  + `{additive U -> V}`, `{rmorphism R -> S}`, `{linear U -> V}`,
+    `{linear U -> V | s}`, `{scalar U}`, `{lrmorphism A -> B}`,
+    `{lrmorphism A -> B | s}` in `ssralg.v`,
+  + `{poly R}` in `poly.v`,
+  + `{quot I}` and `{ideal_quot I}` in `ring_quotient.v`, and
+  + `{ratio T}` and `{fraction T}` in `fraction.v`.
 
 ### Renamed
 

--- a/mathcomp/algebra/fraction.v
+++ b/mathcomp/algebra/fraction.v
@@ -69,7 +69,7 @@ Proof. by rewrite /Ratio /insubd; case: insubP; rewrite //= eqxx. Qed.
 
 End FracDomain.
 
-Notation "{ 'ratio' T }" := (ratio_of (Phant T)).
+Notation "{ 'ratio' T }" := (ratio_of (Phant T)) : type_scope.
 Identity Coercion type_fracdomain_of : ratio_of >-> ratio.
 
 Notation "'\n_' x"  := (frac x).1
@@ -112,7 +112,7 @@ Canonical equivf_equiv := EquivRel equivf equivf_refl equivf_sym equivf_trans.
 
 Definition type := {eq_quot equivf}.
 Definition type_of of phant R := type.
-Notation "{ 'fraction' T }" := (type_of (Phant T)).
+Notation "{ 'fraction' T }" := (type_of (Phant T)) : type_scope.
 
 (* we recover some structure for the quotient *)
 Canonical frac_quotType := [quotType of type].

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -151,7 +151,7 @@ Bind Scope ring_scope with polynomial.
 Arguments polyseq {R} p%R.
 Arguments poly_inj {R} [p1%R p2%R] : rename.
 Arguments coefp {R} i%N / p%R.
-Notation "{ 'poly' T }" := (poly_of (Phant T)).
+Notation "{ 'poly' T }" := (poly_of (Phant T)) : type_scope.
 
 Definition poly_countMixin (R : countRingType) :=
   [countMixin of polynomial R by <:].

--- a/mathcomp/algebra/ring_quotient.v
+++ b/mathcomp/algebra/ring_quotient.v
@@ -559,7 +559,7 @@ Canonical rquot_zmodQuotType := ZmodQuotType 0 -%R +%R type rquot_zmodQuotMixin.
 
 End ZmodQuotient.
 
-Notation "{quot I }" := (@type_of _ _ _ I (Phant _)).
+Notation "{quot I }" := (@type_of _ _ _ I (Phant _)) : type_scope.
 
 Section RingQuotient.
 
@@ -626,7 +626,8 @@ End IDomainQuotient.
 
 End Quotient.
 
-Notation "{ideal_quot I }" := (@Quotient.type_of _ _ _ I (Phant _)).
+Notation "{ideal_quot I }" :=
+  (@Quotient.type_of _ _ _ I (Phant _)) : type_scope.
 Notation "x == y %[mod_ideal I ]" :=
   (x == y %[mod {ideal_quot I}]) : quotient_scope.
 Notation "x = y %[mod_ideal I ]" :=

--- a/mathcomp/algebra/ring_quotient.v
+++ b/mathcomp/algebra/ring_quotient.v
@@ -85,15 +85,16 @@ Unset Printing Implicit Defensive.
 Local Open Scope ring_scope.
 Local Open Scope quotient_scope.
 
-Reserved Notation "{ideal_quot I }" (at level 0, format "{ideal_quot  I }").
-Reserved Notation "m = n %[mod_ideal I ]" (at level 70, n at next level,
-  format "'[hv ' m '/'  =  n '/'  %[mod_ideal  I ] ']'").
-Reserved Notation "m == n %[mod_ideal I ]" (at level 70, n at next level,
-  format "'[hv ' m '/'  ==  n '/'  %[mod_ideal  I ] ']'").
-Reserved Notation "m <> n %[mod_ideal I ]" (at level 70, n at next level,
-  format "'[hv ' m '/'  <>  n '/'  %[mod_ideal  I ] ']'").
-Reserved Notation "m != n %[mod_ideal I ]" (at level 70, n at next level,
-  format "'[hv ' m '/'  !=  n '/'  %[mod_ideal  I ] ']'").
+Reserved Notation "{ 'ideal_quot' I }"
+  (at level 0, format "{ 'ideal_quot'  I }").
+Reserved Notation "m = n %[ 'mod_ideal' I ]" (at level 70, n at next level,
+  format "'[hv ' m '/'  =  n '/'  %[ 'mod_ideal'  I ] ']'").
+Reserved Notation "m == n %[ 'mod_ideal' I ]" (at level 70, n at next level,
+  format "'[hv ' m '/'  ==  n '/'  %[ 'mod_ideal'  I ] ']'").
+Reserved Notation "m <> n %[ 'mod_ideal' I ]" (at level 70, n at next level,
+  format "'[hv ' m '/'  <>  n '/'  %[ 'mod_ideal'  I ] ']'").
+Reserved Notation "m != n %[ 'mod_ideal' I ]" (at level 70, n at next level,
+  format "'[hv ' m '/'  !=  n '/'  %[ 'mod_ideal'  I ] ']'").
 
 
 Section ZmodQuot.
@@ -559,7 +560,7 @@ Canonical rquot_zmodQuotType := ZmodQuotType 0 -%R +%R type rquot_zmodQuotMixin.
 
 End ZmodQuotient.
 
-Notation "{quot I }" := (@type_of _ _ _ I (Phant _)) : type_scope.
+Notation "{ 'quot' I }" := (@type_of _ _ _ I (Phant _)) : type_scope.
 
 Section RingQuotient.
 
@@ -626,15 +627,15 @@ End IDomainQuotient.
 
 End Quotient.
 
-Notation "{ideal_quot I }" :=
+Notation "{ 'ideal_quot' I }" :=
   (@Quotient.type_of _ _ _ I (Phant _)) : type_scope.
-Notation "x == y %[mod_ideal I ]" :=
+Notation "x == y %[ 'mod_ideal' I ]" :=
   (x == y %[mod {ideal_quot I}]) : quotient_scope.
-Notation "x = y %[mod_ideal I ]" :=
+Notation "x = y %[ 'mod_ideal' I ]" :=
   (x = y %[mod {ideal_quot I}]) : quotient_scope.
-Notation "x != y %[mod_ideal I ]" :=
+Notation "x != y %[ 'mod_ideal' I ]" :=
   (x != y %[mod {ideal_quot I}]) : quotient_scope.
-Notation "x <> y %[mod_ideal I ]" :=
+Notation "x <> y %[ 'mod_ideal' I ]" :=
   (x <> y %[mod {ideal_quot I}]) : quotient_scope.
 
 Canonical Quotient.rquot_eqType.

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -1848,7 +1848,7 @@ Notation additive f := (axiom f).
 Coercion apply : map >-> Funclass.
 Notation Additive fA := (Pack (Phant _) fA).
 Notation "{ 'additive' fUV }" := (map (Phant fUV))
-  (at level 0, format "{ 'additive'  fUV }") : ring_scope.
+  (at level 0, format "{ 'additive'  fUV }") : type_scope.
 Notation "[ 'additive' 'of' f 'as' g ]" := (@clone _ _ _ f g _ _ idfun id)
   (at level 0, format "[ 'additive'  'of'  f  'as'  g ]") : form_scope.
 Notation "[ 'additive' 'of' f ]" := (@clone _ _ _ f f _ _ id id)
@@ -2064,7 +2064,7 @@ Coercion apply : map >-> Funclass.
 Notation RMorphism fM := (Pack (Phant _) fM).
 Notation AddRMorphism fM := (pack fM id).
 Notation "{ 'rmorphism' fRS }" := (map (Phant fRS))
-  (at level 0, format "{ 'rmorphism'  fRS }") : ring_scope.
+  (at level 0, format "{ 'rmorphism'  fRS }") : type_scope.
 Notation "[ 'rmorphism' 'of' f 'as' g ]" := (@clone _ _ _ f g _ _ idfun id)
   (at level 0, format "[ 'rmorphism'  'of'  f  'as'  g ]") : form_scope.
 Notation "[ 'rmorphism' 'of' f ]" := (@clone _ _ _ f f _ _ id id)
@@ -2275,11 +2275,11 @@ Coercion apply : map >-> Funclass.
 Notation Linear fL := (Pack (Phant _) fL).
 Notation AddLinear fZ := (pack fZ id).
 Notation "{ 'linear' fUV | s }" := (map s (Phant fUV))
-  (at level 0, format "{ 'linear'  fUV  |  s }") : ring_scope.
+  (at level 0, format "{ 'linear'  fUV  |  s }") : type_scope.
 Notation "{ 'linear' fUV }" := {linear fUV | *:%R}
-  (at level 0, format "{ 'linear'  fUV }") : ring_scope.
+  (at level 0, format "{ 'linear'  fUV }") : type_scope.
 Notation "{ 'scalar' U }" := {linear U -> _ | *%R}
-  (at level 0, format "{ 'scalar'  U }") : ring_scope.
+  (at level 0, format "{ 'scalar'  U }") : type_scope.
 Notation "[ 'linear' 'of' f 'as' g ]" := (@clone _ _ _ _ _ f g _ _ idfun id)
   (at level 0, format "[ 'linear'  'of'  f  'as'  g ]") : form_scope.
 Notation "[ 'linear' 'of' f ]" := (@clone _ _ _ _ _ f f _ _ id id)
@@ -2482,9 +2482,9 @@ Coercion apply : map >-> Funclass.
 Notation LRMorphism f_lrM := (Pack (Phant _) (Class f_lrM f_lrM)).
 Notation AddLRMorphism fZ := (pack fZ id).
 Notation "{ 'lrmorphism' fAB | s }" := (map s (Phant fAB))
-  (at level 0, format "{ 'lrmorphism'  fAB  |  s }") : ring_scope.
+  (at level 0, format "{ 'lrmorphism'  fAB  |  s }") : type_scope.
 Notation "{ 'lrmorphism' fAB }" := {lrmorphism fAB | *:%R}
-  (at level 0, format "{ 'lrmorphism'  fAB }") : ring_scope.
+  (at level 0, format "{ 'lrmorphism'  fAB }") : type_scope.
 Notation "[ 'lrmorphism' 'of' f ]" := (@clone _ _ _ _ _ f _ _ id _ _ id)
   (at level 0, format "[ 'lrmorphism'  'of'  f ]") : form_scope.
 Coercion additive : map >-> Additive.map.

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -267,7 +267,7 @@ Notation "[ 'acts' A , 'on' S | to ]" := (A \subset pred_of_set 'N(S | to))
   (at level 0, format "[ 'acts'  A ,  'on'  S  |  to ]") : form_scope.
 
 Notation "{ 'acts' A , 'on' S | to }" := (acts_on A S to)
-  (at level 0, format "{ 'acts'  A ,  'on'  S  |  to }") : form_scope.
+  (at level 0, format "{ 'acts'  A ,  'on'  S  |  to }") : type_scope.
 
 Notation "[ 'transitive' A , 'on' S | to ]" := (atrans A S to)
   (at level 0, format "[ 'transitive'  A ,  'on'  S  |  to ]") : form_scope.
@@ -1880,7 +1880,7 @@ Notation "''C_' ( G | to ) [ a ]" := 'C_(G | to)([set a])
   (at level 8, format "''C_' ( G  |  to ) [ a ]") : group_scope.
 
 Notation "{ 'acts' A , 'on' 'group' G | to }" := (acts_on_group A G to)
-  (at level 0, format "{ 'acts'  A ,  'on'  'group'  G  |  to }") : form_scope.
+  (at level 0, format "{ 'acts'  A ,  'on'  'group'  G  |  to }") : type_scope.
 
 Section RawGroupAction.
 

--- a/mathcomp/fingroup/morphism.v
+++ b/mathcomp/fingroup/morphism.v
@@ -106,7 +106,7 @@ Proof. by rewrite !inE; apply: andP. Qed.
 End MorphismStructure.
 
 Notation "{ 'morphism' D >-> T }" := (morphism_for D (Phant T))
-  (at level 0, format "{ 'morphism'  D  >->  T }") : group_scope.
+  (at level 0, format "{ 'morphism'  D  >->  T }") : type_scope.
 Notation "[ 'morphism' D 'of' f ]" :=
      (@clone_morphism _ _ D _ (fun fM => @Morphism _ _ D f fM))
    (at level 0, format "[ 'morphism'  D  'of'  f ]") : form_scope.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -7989,9 +7989,9 @@ End SetSubsetOrder.
 
 Module Exports.
 Notation "{ 'subset' [ d ] T }" := (type_of d (Phant T))
-  (at level 2, d at next level, format "{ 'subset' [ d ]  T }") : order_scope.
+  (at level 2, d at next level, format "{ 'subset' [ d ]  T }") : type_scope.
 Notation "{ 'subset' T }" := {subset[subset_display] T}
-  (at level 2, format "{ 'subset' T }") : order_scope.
+  (at level 2, format "{ 'subset' T }") : type_scope.
 
 Canonical eqType.
 Canonical choiceType.

--- a/mathcomp/ssreflect/tuple.v
+++ b/mathcomp/ssreflect/tuple.v
@@ -103,7 +103,7 @@ Notation "n .-tuple" := (tuple_of n)
   (at level 2, format "n .-tuple") : type_scope.
 
 Notation "{ 'tuple' n 'of' T }" := (n.-tuple T : predArgType)
-  (at level 0, only parsing) : form_scope.
+  (at level 0, only parsing) : type_scope.
 
 Notation "[ 'tuple' 'of' s ]" := (tuple (fun sP => @Tuple _ _ s sP))
   (at level 0, format "[ 'tuple'  'of'  s ]") : form_scope.
@@ -495,7 +495,7 @@ Notation "n .-bseq" := (bseq_of n)
   (at level 2, format "n .-bseq") : type_scope.
 
 Notation "{ 'bseq' n 'of' T }" := (n.-bseq T : predArgType)
-  (at level 0, only parsing) : form_scope.
+  (at level 0, only parsing) : type_scope.
 
 Notation "[ 'bseq' 'of' s ]" := (bseq (fun sP => @Bseq _ _ s sP))
   (at level 0, format "[ 'bseq'  'of'  s ]") : form_scope.


### PR DESCRIPTION
##### Motivation for this change

IIUC, any use of those notations has type `Type`, `Prop`, or `predArgType`. So they should be declared in `type_scope`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
