### PR TITLE
Fix [distrLatticeType of T with disp] notation

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `prime.v` 
   + definition `trunc_log` now it is 0 when p <= 1 
 
+- in `order.v`
+  + fix `[distrLatticeType of T with disp]` notation
+
 ### Renamed
 
 ### Removed

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -1634,7 +1634,7 @@ Notation "[ 'distrLatticeType' 'of' T 'for' cT 'with' disp ]" :=
 Notation "[ 'distrLatticeType' 'of' T ]" := [distrLatticeType of T for _]
   (at level 0, format "[ 'distrLatticeType'  'of'  T ]") : form_scope.
 Notation "[ 'distrLatticeType' 'of' T 'with' disp ]" :=
-  [latticeType of T for _ with disp]
+  [distrLatticeType of T for _ with disp]
   (at level 0, format "[ 'distrLatticeType'  'of'  T  'with' disp ]") :
   form_scope.
 End Exports.


### PR DESCRIPTION
##### Motivation for this change

Its RHS was `[latticeType of T for _ with disp]`. Indeed, this should rather be `[distrLatticeType of ...]`.

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
