### PR TITLE
Generalize `rootCV` so that the degree is not necessarily positive

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `prime.v` 
   + definition `trunc_log` now it is 0 when p <= 1 
 
+- in `ssrnum.v`
+  + generalized lemma `rootCV` so that the degree is not necessarily positive.
+
 ### Renamed
 
 ### Removed

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -4824,9 +4824,10 @@ Proof.
 by case: n => [|n] k_gt0; [rewrite !root0C expr0n gtn_eqF | apply: rootCX].
 Qed.
 
-Lemma rootCV n x : (n > 0)%N -> 0 <= x -> n.-root x^-1 = (n.-root x)^-1.
+Lemma rootCV n x : 0 <= x -> n.-root x^-1 = (n.-root x)^-1.
 Proof.
-move=> n_gt0 x_ge0; apply/eqP.
+move=> x_ge0; have [->|n_gt0] := posnP n; first by rewrite !root0C invr0.
+apply/eqP.
 by rewrite -(eqr_expn2 n_gt0) ?(invr_ge0, rootC_ge0) // !exprVn !rootCK.
 Qed.
 


### PR DESCRIPTION
##### Motivation for this change

I found that this generalization could be useful to reason about the rational power (`exp_quo`) defined in apery.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
