### PR TITLE
in `ssrbool.v`, renamed `mono2W_in` to `mono1W_in` (was misnamed).

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Renamed
 
+- in `ssrbool.v`, renamed `mono2W_in` to `mono1W_in` (was misnamed).
+
 ### Removed
 
 ### Infrastructure

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -418,3 +418,17 @@ Arguments andPP {P Q p q}.
 Arguments orPP {P Q p q}.
 Arguments implyPP {P Q p q}.
 Prenex Implicits negPP andPP orPP implyPP.
+
+(******************)
+(* v8.16 addtions *)
+(******************)
+
+Lemma mono1W_in (aT rT : predArgType) (f : aT -> rT) (aD : {pred aT})
+    (aP : pred aT) (rP : pred rT) :
+  {in aD, {mono f : x / aP x >-> rP x}} ->
+  {in aD, {homo f : x / aP x >-> rP x}}.
+Proof. by move=> fP x xD xP; rewrite fP. Qed.
+Arguments mono1W_in [aT rT f aD aP rP].
+
+#[deprecated(since="mathcomp 1.14.0", note="Use mono1W_in instead.")]
+Notation mono2W_in := mono1W_in.


### PR DESCRIPTION
##### Motivation for this change

bug fix

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~~added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.