### PR TITLE
[CI] Remove 8.11 and 8.12 jobs for Analysis from gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -435,20 +435,15 @@ ci-multinomials-dev:
     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-analysis
     - opam install -y -v -j "${NJOBS}" coq-mathcomp-analysis
 
-ci-analysis-8.11:
-  extends: .ci-analysis
-  variables:
-    COQ_VERSION: "8.11"
-
-ci-analysis-8.12:
-  extends: .ci-analysis
-  variables:
-    COQ_VERSION: "8.12"
-
 ci-analysis-8.13:
   extends: .ci-analysis
   variables:
     COQ_VERSION: "8.13"
+
+ci-analysis-8.14:
+  extends: .ci-analysis
+  variables:
+    COQ_VERSION: "8.14"
 
 # The FCSL-PCM library
 .ci-fcsl-pcm:


### PR DESCRIPTION
Mathcomp analysis recently dropped support for those Coq versions:
https://github.com/math-comp/analysis/pull/343
