### PR TITLE
Added theorem pairwise_trans

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- in `seq.v`, added theorem `pairwise_trans`,
+
 - in `prime.v` 
   + theorems `trunc_log0`, `trunc_log1`, `trunc_log_eq0`,
     `trunc_log_gt0`, `trunc_log0n`, `trunc_log1n`, `leq_trunc_log`,

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -3846,6 +3846,22 @@ case: eqVneq eq_xs_ys => /= [->|ne_xy] eq_xs_ys ys_x xs_y.
 by case/eqP: ne_xy; apply: r_asym; rewrite (allP r_x_xs) ?(allP r_y_ys).
 Qed.
 
+Lemma pairwise_trans s : antisymmetric r ->
+   pairwise r s -> {in s & &, transitive r}.
+Proof.
+move=> /(_ _ _ _)/eqP r_anti + y x z => /pairwiseP-/(_ y) ltP ys xs zs.
+have [-> //|neqxy] := eqVneq x y; have [-> //|neqzy] := eqVneq z y.
+move=> lxy lyz; move: ys xs zs lxy neqxy lyz neqzy.
+move=> /(nthP y)[j jlt <-] /(nthP y)[i ilt <-] /(nthP y)[k klt <-].
+have [ltij|ltji|->] := ltngtP i j; last 2 first.
+- by move=> leij; rewrite r_anti// leij ltP.
+- by move=> lejj; rewrite r_anti// lejj.
+move=> _ _; have [ltjk|ltkj|->] := ltngtP j k; last 2 first.
+- by move=> lejk; rewrite r_anti// lejk ltP.
+- by move=> lekk; rewrite r_anti// lekk.
+by move=> _ _; apply: (ltP) => //; apply: ltn_trans ltjk.
+Qed.
+
 End EqPairwise.
 
 Arguments subseq_pairwise {T r xs ys}.


### PR DESCRIPTION
##### Motivation for this change

If a list `s` is pairwise for an antisymmetric relation, then this
relation is transitive in `s`.

(If the relation is not antisymmetric, the relation is not necessarily
transitive, e.g. pose `<=` such that `pairwise <= [:: x; y; z]`,
`z <= y <= x`, and not `z <= x`).

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~~added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.