### PR TITLE
Add number notation for int

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     are now read as `12%:R` or `42%:R`
 
 - in `ssrint.v`
+  + number notation in scope int_scope, `12` or `-42`
+    are now read as `Posz 12` or `Negz 41`
+
+- in `ssrint.v`
   + number notation in scope ring_scope, numbers such as `-12` are now
     read as `(-12)%:~R`
 

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -986,10 +986,10 @@ move=> {A leA}IHa; wlog Di: i M Da / i = 0; last rewrite {i}Di in Da.
   exists (xrow i 0 L); first by rewrite xrowE unitmx_mul unitmx_perm.
   exists R => //; exists d; rewrite //= xrowE -!mulmxA (mulmxA L) -dM xrowE.
   by rewrite mulmxA -perm_mxM tperm2 perm_mx1 mul1mx.
-without loss /forallP a_dvM0: / [forall j, a %| M 0 j]%Z.
+without loss /forallP a_dvM0: / [forall j, a %| M 0%R j]%Z.
   case: (altP forallP) => [_ IH|/forallPn/sigW/IHa IH _]; exact: IH.
 without loss{Da a_dvM0} Da: M / forall j, M 0 j = a.
-  pose Uur := col' 0 (\row_j (1 - (M 0 j %/ a)%Z)).
+  pose Uur := col' 0 (\row_j (1 - (M 0%R j %/ a)%Z)).
   pose U : 'M_(1 + n) := block_mx 1 Uur 0 1%:M; pose M1 := M *m U.
   have uU: U \in unitmx by rewrite unitmxE det_ublock !det1 mulr1.
   case/(_ (M *m U)) => [j | L uL [R uR [d dvD dM]]].

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -13,12 +13,16 @@ From mathcomp Require Import poly.
 (*                However (Posz m = Posz n) is displayed as (m = n :> int)    *)
 (*                (and so are ==, != and <>)                                  *)
 (*                Lemma NegzE : turns (Negz n) into - n.+1%:Z.                *)
+(*    <number> == <number> as an int with <number> an optional minus sign     *)
+(*                followed by a sequence of digits. This notation is in       *)
+(*                int_scope (delimited with %Z).                              *)
 (*      x *~ m == m times x, with m : int;                                    *)
 (*                convertible to x *+ n if m is Posz n                        *)
 (*                convertible to x *- n.+1 if m is Negz n.                    *)
 (*       m%:~R == the image of m : int in a generic ring (:= 1 *~ m).         *)
 (*    <number> == <number>%:~R with <number> an optional minus sign followed  *)
-(*                by a sequence of digits                                     *)
+(*                by a sequence of digits. This notation is in ring_scope     *)
+(*                (delimited with %R).                                        *)
 (*       x ^ m == x to the m, with m : int;                                   *)
 (*                convertible to x ^+ n if m is Posz n                        *)
 (*                convertible to x ^- n.+1 if m is Negz n.                    *)
@@ -74,6 +78,22 @@ Notation "n == m :> 'int'" := (Posz n == Posz m) (only printing) : ring_scope.
 Notation "n != m :> 'int'" := (Posz n != Posz m) (only printing) : ring_scope.
 Notation "n <> m :> 'int'" := (Posz n <> Posz m) (only printing) : ring_scope.
 
+Definition parse_int (x : Number.int) : int :=
+  match x with
+  | Number.IntDecimal (Decimal.Pos u) => Posz (Nat.of_uint u)
+  | Number.IntDecimal (Decimal.Neg u) => Negz (Nat.of_uint u).-1
+  | Number.IntHexadecimal (Hexadecimal.Pos u) => Posz (Nat.of_hex_uint u)
+  | Number.IntHexadecimal (Hexadecimal.Neg u) => Negz (Nat.of_hex_uint u).-1
+  end.
+
+Definition print_int (x : int) : Number.int :=
+  match x with
+  | Posz n => Number.IntDecimal (Decimal.Pos (Nat.to_uint n))
+  | Negz n => Number.IntDecimal (Decimal.Neg (Nat.to_uint n.+1))
+  end.
+
+Number Notation int parse_int print_int : int_scope.
+
 Definition natsum_of_int (m : int) : nat + nat :=
   match m with Posz p => inl _ p | Negz n => inr _ n end.
 
@@ -109,7 +129,6 @@ Definition oppz m := nosimpl
     | Negz n => Posz (n.+1)%N
   end.
 
-Local Notation "0" := (Posz 0) : int_scope.
 Local Notation "-%Z" := (@oppz) : int_scope.
 Local Notation "- x" := (oppz x) : int_scope.
 Local Notation "+%Z" := (@addz) : int_scope.
@@ -258,7 +277,6 @@ Definition mulz (m n : int) :=
     | Negz n', Posz m' => - (m' * (n'.+1%N))%N%:Z
   end.
 
-Local Notation "1" := (1%N:int) : int_scope.
 Local Notation "*%Z" := (@mulz) : int_scope.
 Local Notation "x * y" := (mulz x y) : int_scope.
 


### PR DESCRIPTION
Now, 12 or -42 are read as Posz 12 or Negz 41 in scope int_scope.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
- [x] merge #841
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
