### PR TITLE
Fix typo in documentation of rational numbers

### DIFF
--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -16,7 +16,7 @@ From mathcomp Require Import ssrint.
 (* x \is a Qint == x is an element of rat whose denominator is equal to 1     *)
 (* x \is a Qnat == x is a non-negative element of rat whose denominator       *)
 (*                 is equal to 1                                              *)
-(*       ratr r == generic embedding of (r : rat) into an arbitrary unitring. *)
+(*       ratr r == generic embedding of (r : rat) into an arbitrary unit ring.*)
 (* [rat x // y] == smart constructor for rationals, definitionally equal      *)
 (*                 to x / y for concrete values, intended for printing only   *)
 (*                 of normal forms. The parsable notation is for debugging.   *)


### PR DESCRIPTION
##### Motivation for this change

I got confused and googled what an "unitring" is ;)

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] ~added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevent -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
