### PR TITLE
Properly deprecate divq_eq

### DIFF
--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -538,10 +538,11 @@ set x := (n, d); rewrite -[n]/x.1 -[d]/x.2 -fracqE.
 by case: fracqP => [_|k fx k_neq0] /=; constructor.
 Qed.
 
-#[deprecated(since="mathcomp 1.13.0", note="Use eqr_div instead.")]
-Lemma divq_eq (nx dx ny dy : rat) :
+Lemma divq_eq_deprecated (nx dx ny dy : rat) :
   dx != 0 -> dy != 0 -> (nx / dx == ny / dy) = (nx * dy == ny * dx).
 Proof. exact: GRing.eqr_div. Qed.
+#[deprecated(since="mathcomp 1.13.0", note="Use eqr_div instead.")]
+Notation divq_eq := divq_eq_deprecated (only parsing).
 
 Variant rat_spec (* (x : rat) *) : rat -> int -> int -> Type :=
   Rat_spec (n : int) (d : nat)  & coprime `|n| d.+1


### PR DESCRIPTION
This was discovered while preparing https://github.com/coq/coq/pull/15760