### PR TITLE
Force term elaboration

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -110,7 +110,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `ssrbool.v`, added `homo_mono1`.
 
 - In `ssreflect.v`:
-  + notation `[elaborate t]` forcing the elaboration of `t` using Coq's `refine` tactic. This notation can be used in tandem with `have` to force type class resolution when an explicit proof term `t` is provided (otherwise type class instances are quantified implicitly by `have`).
+  + notation `[elaborate t]` forcing the elaboration of `t` using Coq's `refine` tactic.
+    This notation can be used in tandem with `have` to force type class resolution when an
+    explicit proof term `t` is provided (otherwise type class instances are quantified implicitly by `have`).
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -111,8 +111,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - In `ssreflect.v`:
   + notation `[elaborate t]` forcing the elaboration of `t` using Coq's `refine` tactic.
-    This notation can be used in tandem with `have` to force type class resolution when an
-    explicit proof term `t` is provided (otherwise type class instances are quantified implicitly by `have`).
+    This notation can be used in tandem with `have` to force type class resolution
+    when an explicit proof term `t` is provided (otherwise type class instances are
+    quantified implicitly by `have`).
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -110,7 +110,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `ssrbool.v`, added `homo_mono1`.
 
 - In `ssreflect.v`:
-  + notation `!!`
+  + notation `[elaborate t]` forcing the elaboration of `t` using Coq's `refine` tactic. This notation can be used in tandem with `have` to force type class resolution when an explicit proof term `t` is provided (otherwise type class instances are quantified implicitly by `have`).
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -109,6 +109,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `ssrbool.v`, added `homo_mono1`.
 
+- In `ssreflect.v`:
+  + notation `!!`
+
 ### Changed
 
 - in `rat.v`

--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -11,7 +11,6 @@ Global Set Bullet Behavior "None".
 (*          !! x == triggers pretyping to fill the holes of the term x. The   *)
 (*                  main use case is to trigger typeclass inference in the    *)
 (*                  body of a ssreflect have := !! body.                      *)
-(*                  Credits: Enrico Tassi.                                    *)
 (*                                                                            *)
 (*   Intro pattern ltac views:                                                *)
 (*   - calling rewrite from an intro pattern, use with parsimony              *)
@@ -20,34 +19,6 @@ Global Set Bullet Behavior "None".
 (******************************************************************************)
 
 Reserved Notation "!! x" (at level 100, only parsing).
-
-Module NonPropType.
-
-Structure call_of (condition : unit) (result : bool) := Call {callee : Type}.
-Definition maybeProp (T : Type) := tt.
-Definition call T := Call (maybeProp T) false T.
-
-Structure test_of (result : bool) := Test {condition :> unit}.
-Definition test_Prop (P : Prop) := Test true (maybeProp P).
-Definition test_negative := Test false tt.
-
-Structure type :=
-  Check {result : bool; test : test_of result; frame : call_of test result}.
-Definition check result test frame := @Check result test frame.
-
-Module Exports.
-Canonical call.
-Canonical test_Prop.
-Canonical test_negative.
-Canonical check.
-Notation nonPropType := type.
-Coercion callee : call_of >-> Sortclass.
-Coercion frame : type >-> call_of.
-Notation notProp T := (@check false test_negative (call T)).
-End Exports.
-
-End NonPropType.
-Export NonPropType.Exports.
 
 Module Deprecation.
 

--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -8,9 +8,9 @@ Global Set Bullet Behavior "None".
 (******************************************************************************)
 (* Local additions:                                                           *)
 (*                                                                            *)
-(*          !! x == triggers pretyping to fill the holes of the term x. The   *)
-(*                  main use case is to trigger typeclass inference in the    *)
-(*                  body of a ssreflect have := !! body.                      *)
+(* [elaborate x] == triggers coq elaboration to fill the holes of the term x  *)
+(*                  The main use case is to trigger typeclass inference in    *)
+(*                  the body of a ssreflect have := [elaborate body].         *)
 (*                                                                            *)
 (*   Intro pattern ltac views:                                                *)
 (*   - calling rewrite from an intro pattern, use with parsimony              *)
@@ -18,7 +18,7 @@ Global Set Bullet Behavior "None".
 (*     => /[! rules]   := rewrite !rules                                      *)
 (******************************************************************************)
 
-Reserved Notation "!! x" (at level 100, only parsing).
+Reserved Notation "[ 'elaborate' x ]" (at level 0).
 
 Module Deprecation.
 
@@ -59,7 +59,7 @@ End Exports.
 End Deprecation.
 Export Deprecation.Exports.
 
-Notation "!! x" := (ltac:(refine x)) (only parsing).
+Notation "[ 'elaborate' x ]" := (ltac:(refine x)) (only parsing).
 
 Module Export ipat.
 

--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -8,11 +8,46 @@ Global Set Bullet Behavior "None".
 (******************************************************************************)
 (* Local additions:                                                           *)
 (*                                                                            *)
+(*          !! x == triggers pretyping to fill the holes of the term x. The   *)
+(*                  main use case is to trigger typeclass inference in the    *)
+(*                  body of a ssreflect have := !! body.                      *)
+(*                  Credits: Enrico Tassi.                                    *)
+(*                                                                            *)
 (*   Intro pattern ltac views:                                                *)
 (*   - calling rewrite from an intro pattern, use with parsimony              *)
 (*     => /[1! rules]  := rewrite rules                                       *)
 (*     => /[! rules]   := rewrite !rules                                      *)
 (******************************************************************************)
+
+Reserved Notation "!! x" (at level 100, only parsing).
+
+Module NonPropType.
+
+Structure call_of (condition : unit) (result : bool) := Call {callee : Type}.
+Definition maybeProp (T : Type) := tt.
+Definition call T := Call (maybeProp T) false T.
+
+Structure test_of (result : bool) := Test {condition :> unit}.
+Definition test_Prop (P : Prop) := Test true (maybeProp P).
+Definition test_negative := Test false tt.
+
+Structure type :=
+  Check {result : bool; test : test_of result; frame : call_of test result}.
+Definition check result test frame := @Check result test frame.
+
+Module Exports.
+Canonical call.
+Canonical test_Prop.
+Canonical test_negative.
+Canonical check.
+Notation nonPropType := type.
+Coercion callee : call_of >-> Sortclass.
+Coercion frame : type >-> call_of.
+Notation notProp T := (@check false test_negative (call T)).
+End Exports.
+
+End NonPropType.
+Export NonPropType.Exports.
 
 Module Deprecation.
 
@@ -52,6 +87,8 @@ End Exports.
 
 End Deprecation.
 Export Deprecation.Exports.
+
+Notation "!! x" := (ltac:(refine x)) (only parsing).
 
 Module Export ipat.
 


### PR DESCRIPTION
##### Motivation for this change

Cyril introduced this notation in MathComp-Analysis based on an idea by Enrico
and it has since be scheduled for backport (see https://github.com/math-comp/analysis/issues/5).
We have been using it for a while in `posnum.v`, `nngnum.v`, and now `signed.v`.
This is just a copy-paste, together with the documentation written by Pierre.

@CohenCyril @gares @proux01 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
