### PR TITLE
Generalizing ssralg.v telescopes.

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + number notation in scope ring_scope, numbers such as `-12` are now
     read as `(-12)%:~R`
 
+- in `bigop.v`, added lemmas `telescope_big`, `telescope_sumn` and `telescope_sumn_in`
+
 ### Changed
 
 - in `rat.v`

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -872,9 +872,9 @@ Proof. by rewrite big_const_nat iter_addr_0. Qed.
 Lemma telescope_sumr n m (f : nat -> V) : n <= m ->
   \sum_(n <= k < m) (f k.+1 - f k) = f m - f n.
 Proof.
-rewrite leq_eqVlt => /predU1P[-> | ]; first by rewrite subrr big_geq.
-case: m => // m lenm; rewrite sumrB big_nat_recr // big_nat_recl //=.
-by rewrite addrC opprD addrA subrK addrC.
+move=> nm; rewrite (telescope_big (fun i j => f j - f i)).
+  by case: ltngtP nm => // ->; rewrite subrr.
+by move=> k /andP[nk km]/=; rewrite addrC subrKA.
 Qed.
 
 Section ClosedPredicates.
@@ -2998,12 +2998,8 @@ Lemma telescope_prodr n m (f : nat -> R) :
     (forall k, n < k < m -> f k \is a unit) -> n < m ->
   \prod_(n <= k < m) (f k / f k.+1) = f n / f m.
 Proof.
-move=> Uf /subnK-Dm; do [rewrite -{}Dm; move: {m}(m - _)%N => m] in Uf *.
-rewrite unlock /index_iota -addSnnS addnK /= -mulrA; congr (_ * _).
-have{Uf}: all [preim f of unit] (iota n.+1 m).
-  by apply/allP=> k; rewrite mem_iota addnC => /Uf.
-elim: m n => [|m IHm] n /=; first by rewrite mulr1.
-by rewrite -mulrA addSnnS => /andP[/mulKr-> /IHm].
+move=> Uf ltnm; rewrite (telescope_big (fun i j => f i / f j)) ?ltnm//.
+by move=> k ltnkm /=; rewrite mulrA divrK// Uf.
 Qed.
 
 Lemma commrV x y : comm x y -> comm x y^-1.


### PR DESCRIPTION
##### Motivation for this change

I needed to add successive differences of natural numbers, `bigop`-style, and wrote a lemma that I thought could be made more general. I then discovered that something similar already exists in ssralg.v under the name of "telescope" (not the dependent-type version), although the current lemmas (and proofs) are specific to only two cases (`add` and `prod`). 

I suggest in this PR to generalize this notion of telescope so that these lemmas are all instances of a more general lemma, `telescope_op`. This one also handles my initial need for `nat` (see modified file), and other applications can also be envisioned, e.g. the following (somewhat artificial) ones:
```
Lemma telescope_union n m (T : finType) (f : nat -> {set T}): 
  n <= m -> {homo f : x y / x <= y >-> y \subset x} ->
  \bigcup_(n <= k < m) (f k :\: f k.+1) = f n :\: f m.

Lemma telescope_maxn_cste n m f a :
  n < m -> (forall n, f n = a) -> \max_(n <= k < m) f k = a.

Lemma telescope_maxn_dec n m f : 
  n < m -> {homo f : x y / x <= y} -> \max_(n <= k < m) maxn (f k) (f k.+1) = f m.
```

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
