### PR TITLE
Adapt to coq/coq#15789

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -41,6 +41,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- in `ssrAC.v`
+  + `Leaf_of_nat` is no longer a coercion
+
 ### Infrastructure
 
 ### Misc

--- a/mathcomp/algebra/fraction.v
+++ b/mathcomp/algebra/fraction.v
@@ -159,8 +159,8 @@ Lemma pi_add : {morph \pi : x y / addf x y >-> add x y}.
 Proof.
 move=> x y; unlock add; apply/eqmodP; rewrite /= equivfE /addf /=.
 rewrite !numden_Ratio ?mulf_neq0 ?domP // mulrDr mulrDl; apply/eqP.
-symmetry; rewrite (AC (2*2)%AC (3*1*2*4)%AC) (AC (2*2)%AC (3*2*1*4)%AC)/=.
-by rewrite !equivf_l (ACl ((2*3)*(1*4))%AC) (ACl ((2*3)*(4*1))%AC)/=.
+symmetry; rewrite (AC (2*2) (3*1*2*4)) (AC (2*2) (3*2*1*4))/=.
+by rewrite !equivf_l (ACl ((2*3)*(1*4))) (ACl ((2*3)*(4*1)))/=.
 Qed.
 Canonical pi_add_morph := PiMorph2 pi_add.
 
@@ -248,8 +248,8 @@ Lemma mul_addl : left_distributive mul add.
 Proof.
 elim/quotW=> x; elim/quotW=> y; elim/quotW=> z; apply/eqP.
 rewrite !piE /equivf /mulf /addf !numden_Ratio ?mulf_neq0 ?domP //; apply/eqP.
-rewrite !(mulrDr, mulrDl) (AC (3*(2*2))%AC (4*2*7*((1*3)*(6*5)))%AC)/=.
-by rewrite [X in _ + X](AC (3*(2*2))%AC (4*6*7*((1*3)*(2*5)))%AC)/=.
+rewrite !(mulrDr, mulrDl) (AC (3*(2*2)) (4*2*7*((1*3)*(6*5))))/=.
+by rewrite [X in _ + X](AC (3*(2*2)) (4*6*7*((1*3)*(2*5))))/=.
 Qed.
 
 Lemma nonzero1 : 1%:F != 0%:F :> type.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -4389,7 +4389,7 @@ have JE x : x^* = `|x|^+2 / x.
   by apply: (canRL (mulfK _)) => //; rewrite mulrC -normCK.
 move=> x; have [->|x_neq0] := eqVneq x 0; first by rewrite !rmorph0.
 rewrite !JE normrM normfV exprMn normrX normr_id.
-rewrite invfM exprVn (AC (2*2)%AC (1*(2*3)*4)%AC)/= -invfM -exprMn.
+rewrite invfM exprVn (AC (2*2) (1*(2*3)*4))/= -invfM -exprMn.
 by rewrite divff ?mul1r ?invrK // !expf_eq0 normr_eq0 //.
 Qed.
 
@@ -4641,7 +4641,7 @@ Proof. by rewrite oppC_rect addC_rect. Qed.
 Lemma mulC_rect x1 y1 x2 y2 : (x1 + 'i * y1) * (x2 + 'i * y2) =
                               x1 * x2 - y1 * y2 + 'i * (x1 * y2 + x2 * y1).
 Proof.
-rewrite mulrDl !mulrDr (AC (2*2)%AC (1*4*(2*3))%AC)/= mulrACA.
+rewrite mulrDl !mulrDr (AC (2*2) (1*4*(2*3)))/= mulrACA.
 by rewrite -expr2 sqrCi mulN1r -!mulrA [_ * ('i * _)]mulrCA [_ * y1]mulrC.
 Qed.
 
@@ -4960,7 +4960,7 @@ have{lin_xy} def2xy: `|x| * `|y| *+ 2 = x * y ^* + y * x ^*.
 have def_xy: x * y^* = y * x^*.
   apply/eqP; rewrite -subr_eq0 -[_ == 0](@expf_eq0 _ _ 2).
   rewrite (canRL (subrK _) (subr_sqrDB _ _)) opprK -def2xy exprMn_n exprMn.
-  by rewrite mulrN (@GRing.mul C).[AC (2*2)%AC (1*4*(3*2))%AC] -!normCK mulNrn addNr.
+  by rewrite mulrN (@GRing.mul C).[AC (2*2) (1*4*(3*2))] -!normCK mulNrn addNr.
 have{def_xy def2xy} def_yx: `|y * x| = y * x^*.
   by apply: (mulIf nz2); rewrite !mulr_natr mulrC normrM def2xy def_xy.
 rewrite -{1}(divfK nz_x y) invC_norm mulrCA -{}def_yx !normrM invfM.

--- a/mathcomp/ssreflect/ssrAC.v
+++ b/mathcomp/ssreflect/ssrAC.v
@@ -89,7 +89,6 @@ Definition Leaf_of_nat n := Leaf ((pos_of_nat n n) - 1)%positive.
 Module Import Syntax.
 Bind Scope AC_scope with syntax.
 Coercion Leaf : positive >-> syntax.
-Coercion Leaf_of_nat : nat >-> syntax.
 Number Notation positive Pos.of_num_int Pos.to_num_uint : AC_scope.
 Notation "x * y" := (Op x%AC y%AC) : AC_scope.
 End Syntax.

--- a/mathcomp/ssreflect/ssrAC.v
+++ b/mathcomp/ssreflect/ssrAC.v
@@ -227,11 +227,11 @@ Notation opAC op  p s := (opACof op (AC.pattern p%AC) s%AC) (only parsing).
 Notation opACl op s := (opAC op (AC.Leaf_of_nat (size (AC.serial s%AC))) s%AC)
   (only parsing).
 
-Notation "op .[ 'ACof' p s ]" := (opACof op p s)
+Notation "op .[ 'ACof' p s ]" := (opACof op p%AC s%AC)
   (at level 2, p at level 1, left associativity, only parsing).
-Notation "op .[ 'AC' p s ]" := (opAC op p s)
+Notation "op .[ 'AC' p s ]" := (opAC op p%AC s%AC)
   (at level 2, p at level 1, left associativity, only parsing).
-Notation "op .[ 'ACl' s ]" := (opACl op s)
+Notation "op .[ 'ACl' s ]" := (opACl op s%AC)
   (at level 2, left associativity, only parsing).
 
 Notation AC_strategy :=


### PR DESCRIPTION
Adapt to coq/coq#15789

##### Motivation for this change

This just removes a coercion that that was unused and, with the generalization of coercions in coq/coq#15789, made for nonsense coercion paths.

This also takes the opportunity to remove a few useless `%AC` scope indications.

##### Things done/to do

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
