### PR TITLE
Add [in A] notation.

### DIFF
--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -52,6 +52,7 @@ with builtins; with (import <nixpkgs> {}).lib;
       paramcoq.override.version = "master";
       coq-elpi.override.version = "coq-master";
       hierarchy-builder.override.version = "coq-master";
+      multinomials.override.version = "#68";
     };
     "coq-8.17".coqPackages = common-bundles // {
       coq.override.version = "8.17";
@@ -59,21 +60,26 @@ with builtins; with (import <nixpkgs> {}).lib;
       mathcomp-classical.job = false;
       mathcomp-analysis.job = false;
       graph-theory.job = false;
+      multinomials.override.version = "#68";
     };
     "coq-8.16".coqPackages = common-bundles // {
       coq.override.version = "8.16";
+      multinomials.override.version = "#68";
     };
     "coq-8.15".coqPackages = common-bundles // {
       coq.override.version = "8.15";
+      multinomials.override.version = "#68";
     };
     "coq-8.14".coqPackages = common-bundles // {
       coq.override.version = "8.14";
+      multinomials.override.version = "#68";
     };
     "coq-8.13".coqPackages = common-bundles // {
       coq.override.version = "8.13";
       mathcomp-classical.job = false;
       mathcomp-analysis.job = false;
       graph-theory.job = false;
+      multinomials.override.version = "#68";
     };
   };
 }

--- a/.nix/coq-overlays/graph-theory/default.nix
+++ b/.nix/coq-overlays/graph-theory/default.nix
@@ -7,11 +7,13 @@ mkCoqDerivation {
   pname = "graph-theory";
 
   release."0.9".sha256 = "sha256-Hl3JS9YERD8QQziXqZ9DqLHKp63RKI9HxoFYWSkJQZI=";
+  release."0.9.1".sha256 = "sha256-lRRY+501x+DqNeItBnbwYIqWLDksinWIY4x/iojRNYU=";
 
   releaseRev = v: "v${v}";
 
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
+    { case = range "8.14" "8.16"; out = "0.9.1"; }
     { case = range "8.13" "8.16"; out = "0.9"; }
   ] null;
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `path.v` 
   + lemmas `prefix_path`, `prefix_sorted`, `infix_sorted`, `suffix_sorted` 
 
+- in `ssrbool.v`
+  + notation `[in A]`
+
+- in `seq.v`
+  + lemmas `allT`, `all_mapT`, `inj_in_map`, and `mapK_in`.
+
 - in `ssralg.v`
   + lemmas `natr1`, `nat1r`, `telescope_sumr_eq`, `telescope_prodr_eq`, `telescope_prodf_eq`
 
@@ -108,7 +114,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 	 `map2_mx_left_in`, `map2_mx_left`, `map2_mx_right_in`, `map2_mx_right`,
 	 `map2_mxA`, `map2_1mx`, `map2_mx1`, `map2_mxC`, `map2_0mx`, `map2_mx0`,
 	 `map2_mxDl`, `map2_mxDr`, `diag_mx_is_additive`, `mxtrace_is_additive`
-
+- in `finset.v`
+  + lemmas `set_nil`, `set_seq1`
 
 - in `ssralg.v`
   + lemmas `divrN`, `divrNN`
@@ -117,6 +124,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `poly.v`:
   + generalize `eq_poly`
+- in `ssrbool.v`, `eqtype.v`, `seq.v`, `path.v`, `fintype.v`, `fingraph.v`,
+  `prime.v`, `binomial.v`, `fingraph.v`, `bigop.v`, `ssralg.v`, `ssrnum.v`,
+  `poly.v`, `mxpoly.v`, `action.v`, `perm.v`, `presentation.v`, `abelian.v`,
+  `cyclic.v`, `frobenius.v`, `maximal.v`, `primitive_action.v`, `alt.v`,
+  `burnside_app.v`, `mxrepresentation.v`, `mxabelian.v`, `character.v`,
+  `inertia.v`, `integral_char.v`, `separable.v`, `galois.v`,
+  `algebraics_fundamental.v`, changed `mem XXX` and `[mem XXX]` to `[in XX]`.
+- Regressions: now redundanrt instances of `inE` rewriting `mem A x` to
+  `x \in A` must be deleted or made optional, as `[in A] x` directly
+  beta-reduces to `x \in A`.
 
 - in `poly.v`:
   + made hornerE preserve powers
@@ -133,7 +150,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `mxtraceD`, `mxtrace_diag`, `mxtrace_scalar`, `trace_mx11`, 
     `mxtrace_block`
 
+- in `seq.v`:
+  + changed names of implicit arguments of `map_id`, `eq_map`,
+    `map_comp`, `mapK`, `eq_in_map`
+
 ### Renamed
+
+- in `eqtype.v` and `gseries.v`, renamed `rel_of_simpl_rel` to `rel_of_simpl`,
+  the actual name used in the coq `ssr.ssrbool.v` file.
 
 ### Removed
 
@@ -170,6 +194,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `ssrnat.v`:
   + notatin `fact_smonotone` (deprecated in 1.13.0)
+
+- in `ssrbool.v`, removed outdated `Coq 8.10` compatibility code.
 
 ### Infrastructure
 

--- a/mathcomp/algebra/mxalgebra.v
+++ b/mathcomp/algebra/mxalgebra.v
@@ -2421,7 +2421,7 @@ Lemma mxdirect_delta n f : {in P &, injective f} ->
 Proof.
 pose fP := image f P => Uf; have UfP: uniq fP by apply/dinjectiveP.
 suffices /mxdirectP : mxdirect (\sum_i <<delta_mx 0 i : 'rV[F]_n>>).
-  rewrite /= !(bigID [mem fP] predT) -!big_uniq //= !big_map !big_enum.
+  rewrite /= !(bigID [in fP] predT) -!big_uniq //= !big_map !big_enum.
   by move/mxdirectP; rewrite mxdirect_addsE => /andP[].
 apply/mxdirectP=> /=; transitivity (mxrank (1%:M : 'M[F]_n)).
   apply/eqmx_rank; rewrite submx1 mx1_sum_delta summx_sub_sums // => i _.

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -1152,7 +1152,7 @@ have{mon_p pw0 intRp intRq}: genI S.
   split; set S1 := _ ++ _; first exists p.
     split=> // i; rewrite -[p]coefK coef_poly; case: ifP => // lt_i_p.
     by apply: genS; rewrite mem_cat orbC mem_nth.
-  set S2 := S1; have: all (mem S1) S2 by apply/allP.
+  set S2 := S1; have: all [in S1] S2 by apply/allP.
   elim: S2 => //= y S2 IH /andP[S1y S12]; split; last exact: IH.
   have{q S S1 IH S1y S12 intRp intRq} [q mon_q qx0]: integralOver RtoK y.
     by move: S1y; rewrite mem_cat => /orP[]; [apply: intRq | apply: intRp].

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -1342,7 +1342,7 @@ Qed.
 
 Implicit Type S : {pred R}.
 
-Definition polyOver S := [qualify a p : {poly R} | all (mem S) p].
+Definition polyOver S := [qualify a p : {poly R} | all [in S] p].
 
 Fact polyOver_key S : pred_key (polyOver S). Proof. by []. Qed.
 Canonical polyOver_keyed S := KeyedQualifier (polyOver_key S).

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -5465,7 +5465,7 @@ Section Zmodule.
 
 Variables (V : zmodType) (S : {pred V}).
 Variables (subS : zmodPred S) (kS : keyed_pred subS).
-Variable U : subType (mem kS).
+Variable U : subType [in kS].
 
 Let inU v Sv : U := Sub v Sv.
 Let zeroU := inU (rpred0 kS).
@@ -5495,7 +5495,7 @@ Definition cast_zmodType (V : zmodType) T (VeqT : V = T :> Type) :=
   let cast mV := let: erefl in _ = T := VeqT return Zmodule.class_of T in mV in
   Zmodule.Pack (cast (Zmodule.class V)).
 
-Variable (T : subType (mem kS)) (V : zmodType) (VeqT: V = T :> Type).
+Variable (T : subType [in kS]) (V : zmodType) (VeqT: V = T :> Type).
 
 Let inT x Sx : T := Sub x Sx.
 Let oneT := inT (rpred1 kS).
@@ -5534,7 +5534,7 @@ Section Lmodule.
 
 Variables (R : ringType) (V : lmodType R) (S : {pred V}).
 Variables (linS : submodPred S) (kS : keyed_pred linS).
-Variables (W : subType (mem kS)) (Z : zmodType) (ZeqW : Z = W :> Type).
+Variables (W : subType [in kS]) (Z : zmodType) (ZeqW : Z = W :> Type).
 
 Let scaleW a (w : W) := (Sub _ : _ -> W) (rpredZ a (valP w)).
 Let W' := cast_zmodType ZeqW.
@@ -5581,7 +5581,7 @@ Definition cast_ringType (Q : ringType) T (QeqT : Q = T :> Type) :=
 Variables (R : unitRingType) (S : {pred R}).
 Variables (ringS : divringPred S) (kS : keyed_pred ringS).
 
-Variables (T : subType (mem kS)) (Q : ringType) (QeqT : Q = T :> Type).
+Variables (T : subType [in kS]) (Q : ringType) (QeqT : Q = T :> Type).
 
 Let inT x Sx : T := Sub x Sx.
 Let invT (u : T) := inT (rpredVr (valP u)).

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -3475,7 +3475,7 @@ Lemma leif_AGM_scaled (I : finType) (A : {pred I}) (E : I -> R) (n := #|A|) :
 Proof.
 have [m leAm] := ubnP #|A|; elim: m => // m IHm in A leAm E n * => Ege0.
 apply/leifP; case: ifPn => [/forall_inP-Econstant | Enonconstant].
-  have [i /= Ai | A0] := pickP (mem A); last by rewrite [n]eq_card0 ?big_pred0.
+  have [i /= Ai | A0] := pickP [in A]; last by rewrite [n]eq_card0 ?big_pred0.
   have /eqfun_inP-E_i := Econstant i Ai; rewrite -(eq_bigr _ E_i) sumr_const.
   by rewrite exprMn_n prodrMn_const -(eq_bigr _ E_i) prodr_const.
 set mu := \sum_(i in A) E i; pose En i := E i *+ n.

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -2066,7 +2066,7 @@ Proof.
 set D := codom _; have Df: dprod_Iirr _ \in D := codom_f dprod_Iirr _.
 have: 'chi_k 1%g ^+ 2 != 0 by rewrite mulf_neq0 ?irr1_neq0.
 apply: contraR => notDk; move/eqP: (irr_sum_square G).
-rewrite (bigID (mem D)) (reindex _ (bij_on_codom dprod_Iirr_inj (0, 0))) /=.
+rewrite (bigID [in D]) (reindex _ (bij_on_codom dprod_Iirr_inj (0, 0))) /=.
 have ->: #|G|%:R = \sum_i \sum_j 'chi_(dprod_Iirr (i, j)) 1%g ^+ 2.
   rewrite -(dprod_card KxH) natrM.
   do 2![rewrite -irr_sum_square (mulr_suml, mulr_sumr); apply: eq_bigr => ? _].

--- a/mathcomp/character/inertia.v
+++ b/mathcomp/character/inertia.v
@@ -1171,7 +1171,7 @@ have [inj_Mphi | /injectivePn[i [j i'j eq_mm_ij]]] := boolP (injectiveb mmLth).
   have ->: e%:R * 'chi_p0 1%g = 'Res[L] theta 1%g by rewrite DthL cfunE.
   rewrite cfRes1 -(ler_pmul2l (gt0CiG K L)) -cfInd1 // -/phi.
   rewrite -card_quotient // -card_Iirr_abelian // mulr_natl.
-  rewrite ['Ind phi]cfun_sum_cfdot sum_cfunE (bigID (mem (codom mmLth))) /=.
+  rewrite ['Ind phi]cfun_sum_cfdot sum_cfunE (bigID [in codom mmLth]) /=.
   rewrite ler_paddr ?sumr_ge0 // => [i _|].
     by rewrite char1_ge0 ?rpredZ_Cnat ?Cnat_cfdot_char ?cfInd_char ?irr_char.
   rewrite -big_uniq //= big_image -sumr_const ler_sum // => i _.

--- a/mathcomp/character/integral_char.v
+++ b/mathcomp/character/integral_char.v
@@ -40,7 +40,7 @@ Local Open Scope ring_scope.
 Lemma group_num_field_exists (gT : finGroupType) (G : {group gT}) :
   {Qn : splittingFieldType rat & galois 1 {:Qn} &
     {QnC : {rmorphism Qn -> algC}
-         & forall nuQn : argumentType (mem ('Gal({:Qn}%VS / 1%VS))),
+         & forall nuQn : argumentType [in 'Gal({:Qn} / 1)],
               {nu : {rmorphism algC -> algC} |
                  {morph QnC: a / nuQn a >-> nu a}}
          & {w : Qn & #|G|.-primitive_root w /\ <<1; w>>%VS = fullv
@@ -133,7 +133,7 @@ transitivity (\sum_(x in zi ^: G) \sum_(y in zj ^: G) aG (x * y)%g).
 pose h2 xy : gT := (xy.1 * xy.2)%g.
 pose h1 xy := enum_rank_in (classes1 G) (h2 xy ^: G).
 rewrite pair_big (partition_big h1 xpredT) //=; apply: eq_bigr => k _.
-rewrite (partition_big h2 (mem (enum_val k))) /= => [|[x y]]; last first.
+rewrite (partition_big h2 [in enum_val k]) /= => [|[x y]]; last first.
   case/andP=> /andP[/= /sKG Gx /sKG Gy] /eqP <-.
   by rewrite enum_rankK_in ?class_refl ?mem_classes ?groupM ?Gx ?Gy.
 rewrite scaler_sumr; apply: eq_bigr => g Kk_g; rewrite scaler_nat.
@@ -539,7 +539,7 @@ have [j ->]: exists j, 'chi_i = 'Res 'chi[G]_j.
   rewrite card_Iirr_abelian ?(abelianS sHG) //.
   rewrite -(eqn_pmul2r (indexg_gt0 G H)) Lagrange //; apply/eqP.
   rewrite -sum_nat_const -card_Iirr_abelian // -sum1_card.
-  rewrite (partition_big rH (mem (codom rH))) /=; last exact: image_f.
+  rewrite (partition_big rH [in codom rH]) /=; last exact: image_f.
   have nsHG: H <| G by rewrite -sub_abelian_normal.
   apply: eq_bigr => _ /codomP[i ->]; rewrite -card_quotient ?normal_norm //.
   rewrite -card_Iirr_abelian ?quotient_abelian //.

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -874,7 +874,7 @@ have nb_irr: #|sS| = (p ^ n.*2 + p.-1)%N.
     apply/imsetP; exists z; rewrite //.
     apply/eqP; rewrite eqEcard sub1set class_refl cards1.
     by rewrite -index_cent1 (setIidPl _) ?indexgg // sub_cent1.
-  move/eqP: (class_formula S); rewrite (bigID (mem Zcl)) /=.
+  move/eqP: (class_formula S); rewrite (bigID [in Zcl]) /=.
   rewrite (eq_bigr (fun _ => 1%N)) => [|zS]; last first.
     case/andP=> _ /setIdP[/imsetP[z Sz ->{zS}] /subsetIP[_ cSzS]].
     rewrite (setIidPl _) ?indexgg // sub_cent1 (subsetP cSzS) //.
@@ -980,12 +980,12 @@ split=> // [i | ze | i].
   by rewrite phi_ze exprM.
 rewrite deg_phi {i}; set d := irr_degree i0.
 apply/eqP; move/eqP: (sum_irr_degree sS F'S splitF).
-rewrite (bigID (mem linS)) /= -/irr_degree.
-rewrite (eq_bigr (fun _ => 1%N)) => [|i]; last by rewrite !inE; move/eqP->.
+rewrite (bigID [in linS]) /= -/irr_degree.
+rewrite (eq_bigr (fun=> 1%N)) => [|i]; last by rewrite !inE; move/eqP->.
 rewrite sum1_card nb_lin.
-rewrite (eq_bigl (mem (codom iphi))) // => [|i]; last first.
+rewrite (eq_bigl [in codom iphi]) // => [|i]; last first.
   by rewrite -in_setC -im_iphi.
-rewrite (eq_bigr (fun _ => d ^ 2))%N => [|_ /codomP[i ->]]; last first.
+rewrite (eq_bigr (fun=> d ^ 2))%N => [|_ /codomP[i ->]]; last first.
   by rewrite deg_phi.
 rewrite sum_nat_const card_image // card_ord oSpn (expnS p) -{3}[p]prednK //.
 rewrite mulSn eqn_add2l eqn_pmul2l; last by rewrite -ltnS prednK.

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -3430,7 +3430,7 @@ have defW W: (\sum_(x in Xv W) M *m rG x :=: W)%MS.
   have sMxWx: (M *m rG x <= Wx)%MS by rewrite PackSocleK component_mx_id.
   by rewrite (sumsmx_sup Wx) //; apply: contra notW_Mx => /eqP <-.
 have dxXv W: mxdirect (\sum_(x in Xv W) M *m rG x).
-  move: dxX1; rewrite !mxdirectE /= !(bigID (sMv W) (mem X)) /=.
+  move: dxX1; rewrite !mxdirectE /= !(bigID (sMv W) [in X]) /=.
   by rewrite -mxdirectE mxdirect_addsE /= => /andP[].
 have def_t W: #|Xv W| = t.
   rewrite /t -{1}(Clifford_rank_components W) mulKn 1?(cardD1 W) //.
@@ -4584,12 +4584,12 @@ pose h' u := irr_comp sGq (quo_repr (sG'k u) nG'G).
 have irrGq u: mx_irreducible (quo_repr (sG'k u) nG'G).
   by apply/quo_mx_irr; apply: socle_irr.
 exists (fun i => oapp h' [1 sGq]%irr (insub i)) => [j | i] lin_i.
-  rewrite (insubT (mem _) lin_i) /=; apply/esym/eqP/socle_rsimP.
+  rewrite (insubT [in _] lin_i) /=; apply/esym/eqP/socle_rsimP.
   apply: mx_rsim_trans (rsim_irr_comp sGq F'Gq (irrGq _)).
   have [g lin_g inj_g hom_g] := rsim_irr_comp sG F'G (irrG j).
   exists g => [||G'x]; last 1 [case/morphimP=> x _ Gx ->] || by [].
   by rewrite quo_repr_coset ?hom_g.
-rewrite (insubT (mem _) lin_i) /=; apply/esym/eqP/socle_rsimP.
+rewrite (insubT [in _] lin_i) /=; apply/esym/eqP/socle_rsimP.
 set u := exist _ _ _; apply: mx_rsim_trans (rsim_irr_comp sG F'G (irrG _)).
 have [g lin_g inj_g hom_g] := rsim_irr_comp sGq F'Gq (irrGq u).
 exists g => [||x Gx]; last 1 [have:= hom_g (coset _ x)] || by [].

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -331,7 +331,7 @@ have QtoQ z x: x \in sQ z -> {Qxz : 'AHom(Q x, Q z) | morph_ofQ x z Qxz}.
     by exists (linfun_ahom (LRMorphism QxzM)) => u; rewrite lfunE QxzE.
   split=> [u v|]; first by apply: (canLR (ofQ_K z)); rewrite !rmorphB !QxzE.
   by split=> [u v|]; apply: (canLR (ofQ_K z)); rewrite ?rmorph1 ?rmorphM ?QxzE.
-pose sQs z s := all (mem (sQ z)) s.
+pose sQs z s := all [in sQ z] s.
 have inQsK z s: sQs z s -> map (ofQ z) (map (inQ z) s) = s.
   by rewrite -map_comp => /allP/(_ _ _)/inQ_K; apply: map_id_in.
 have inQpK z p: p \is a polyOver (sQ z) -> (p ^ inQ z) ^ ofQ z = p.

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -298,7 +298,7 @@ Lemma kHom_extends K E f p U :
   {g | kHom K U g & {in E, f =1 g}}.
 Proof.
 move=> sKE homEf Kp /sig2_eqW[rs Dp <-{U}].
-set r := rs; have rs_r: all (mem rs) r by apply/allP.
+set r := rs; have rs_r: all [in rs] r by apply/allP.
 elim: r rs_r => [_|z r IHr /=/andP[rs_z rs_r]] /= in E f sKE homEf *.
   by exists f; rewrite ?Fadjoin_nil.
 set Ez := <<E; z>>%AS; pose fpEz := map_poly f (minPoly E z).
@@ -509,7 +509,7 @@ suffices [kAutL in_kAutL] : {kAutL : seq 'AEnd(L) | forall f, isAutL kAutL f}.
   by exists kAutL => f; rewrite -in_kAutL k1AHom.
 have [p Kp /sig2_eqW[rs Dp defL]] := splittingPoly.
 do [rewrite {}/isAutL -(erefl (asval 1)); set r := rs; set E := 1%AS] in defL *.
-have [sKE rs_r]: (1 <= E)%VS /\ all (mem rs) r by split; last apply/allP.
+have [sKE rs_r]: (1 <= E)%VS /\ all [in rs] r by split; last apply/allP.
 elim: r rs_r => [_|z r IHr /=/andP[rs_z rs_r]] /= in (E) sKE defL *.
   rewrite Fadjoin_nil in defL; exists [tuple \1%AF] => f; rewrite defL inE.
   apply/idP/eqP=> [/kAHomP f1 | ->]; last exact: kHom1.
@@ -648,7 +648,7 @@ have Df1 u: inLz (f1 u) = f (inLz u).
   rewrite !comp_lfunE limg_lfunVK //= -[limg _]/(asval imL).
   have [r def_pz defLz] := splitLpz; set r1 := r.
   have: inLz u \in <<1 & r1>>%VS by rewrite defLz.
-  have: all (mem r) r1 by apply/allP.
+  have: all [in r] r1 by apply/allP.
   elim/last_ind: r1 {u}(inLz u) => [|r1 y IHr1] u.
     by rewrite Fadjoin_nil => _ Fu; rewrite fFid // (subvP (sub1v _)).
   rewrite all_rcons adjoin_rcons => /andP[rr1 ry] /Fadjoin_polyP[pu r1pu ->].
@@ -1118,7 +1118,7 @@ Qed.
 
 Lemma normalFieldP K E :
   reflect {in E, forall a, exists2 r,
-            all (mem E) r & minPoly K a = \prod_(b <- r) ('X - b%:P)}
+            all [in E] r & minPoly K a = \prod_(b <- r) ('X - b%:P)}
           (normalField K E).
 Proof.
 apply: (iffP eqfun_inP) => [nKE a Ea | nKE x]; last first.
@@ -1166,7 +1166,7 @@ move=> sKE; apply: (iffP idP) => [nKE| [p Kp [rs Dp defE]]]; last first.
   rewrite -!root_prod_XsubC -!(eqp_root Dp) in rs_a *.
   by apply: kHom_root_id homKg Kp _ rs_a; rewrite ?subvf ?memvf.
 pose splitK a r := minPoly K a = \prod_(b <- r) ('X - b%:P).
-have{nKE} rK_ a: {r | a \in E -> all (mem E) r /\ splitK a r}.
+have{nKE} rK_ a: {r | a \in E -> all [in E] r /\ splitK a r}.
   case Ea: (a \in E); last by exists [::].
   by have /sig2_eqW[r] := normalFieldP _ _ nKE a Ea; exists r.
 have sXE := basis_mem (vbasisP E); set X : seq L := vbasis E in sXE.
@@ -1393,7 +1393,7 @@ have [x1 | ntx] := eqVneq x 1%g.
   by rewrite -{1}normEa1 /galNorm DgalE x1 cycle1 big_set1 !gal_id divr1.
 pose c_ y := \prod_(i < invm (injm_Zpm x) y) (x ^+ i)%g a.
 have nz_c1: c_ 1%g != 0 by rewrite /c_ morph1 big_ord0 oner_neq0.
-have [d] := @gal_independent_contra _ (mem 'Gal(E / K)) _ _ (group1 _) nz_c1.
+have [d] := @gal_independent_contra _ [in 'Gal(E / K)] _ _ (group1 _) nz_c1.
 set b := \sum_(y in _) _ => Ed nz_b; exists b.
   split=> //; apply: rpred_sum => y galEy.
   by apply: rpredM; first apply: rpred_prod => i _; apply: memv_gal.

--- a/mathcomp/field/separable.v
+++ b/mathcomp/field/separable.v
@@ -892,7 +892,7 @@ pose K' := <<K & s>>%VS.
 have sepKs: all (separable_element K) s.
   by rewrite all_map /f; apply/allP=> i _ /=; case: ex_minnP => m /andP[].
 have [x sepKx defKx]: {x | x \in E /\ separable_element K x & K' = <<K; x>>%VS}.
-  have: all (mem E) s.
+  have: all [in E] s.
     rewrite all_map; apply/allP=> i; rewrite mem_iota => ltis /=.
     by rewrite rpredX // vbasis_mem // memt_nth.
   rewrite {}/K'; elim/last_ind: s sepKs => [|s t IHs].

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -810,7 +810,7 @@ Proof.
 move=> GactS; have sGD := acts_dom GactS.
 transitivity (\sum_(a in G) \sum_(x in 'Fix_(S | to)[a]) 1%N).
   by apply: eq_bigr => a _; rewrite -sum1_card.
-rewrite (exchange_big_dep (mem S)) /= => [|a x _]; last by case/setIP.
+rewrite (exchange_big_dep [in S]) /= => [|a x _]; last by case/setIP.
 rewrite (set_partition_big _ (orbit_partition GactS)) -sum_nat_const /=.
 apply: eq_bigr => _ /imsetP[x Sx ->].
 rewrite -(card_orbit_in_stab x sGD) -sum_nat_const.

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -275,7 +275,7 @@ Proof. by rewrite -{1}tpermV mulVg. Qed.
 Lemma card_perm A : #|perm_on A| = (#|A|)`!.
 Proof.
 pose ffA := {ffun {x | x \in A} -> T}.
-rewrite -ffactnn -{2}(card_sig (mem A)) /= -card_inj_ffuns_on.
+rewrite -ffactnn -{2}(card_sig [in A]) /= -card_inj_ffuns_on.
 pose fT (f : ffA) := [ffun x => oapp f x (insub x)].
 pose pfT f := insubd (1 : {perm T}) (fT f).
 pose fA s : ffA := [ffun u => s (val u)].

--- a/mathcomp/fingroup/presentation.v
+++ b/mathcomp/fingroup/presentation.v
@@ -204,7 +204,7 @@ Lemma homGrp_trans rT gT (H : {set rT}) (G : {group gT}) p :
   H \homg G -> G \homg Grp p -> H \homg Grp p.
 Proof.
 case/homgP=> h <-{H}; rewrite /hom; move: {p}(p _) => p.
-have evalG e t: all (mem G) e -> eval (map h e) t = h (eval e t).
+have evalG e t: all [in G] e -> eval (map h e) t = h (eval e t).
   move=> Ge; apply: (@proj2 (eval e t \in G)); elim: t => /=.
   - move=> i; case: (leqP (size e) i) => [le_e_i | lt_i_e].
       by rewrite !nth_default ?size_map ?morph1.
@@ -217,14 +217,14 @@ have evalG e t: all (mem G) e -> eval (map h e) t = h (eval e t).
   by move=> t1 [Gt1 ->] t2 [Gt2 ->]; rewrite groupR ?morphR.
 have and_relE xT x1 x2 r: @and_rel xT x1 x2 r = (x1 == x2) && r :> bool.
   by case: r => //=; rewrite andbT.
-have rsatG e f: all (mem G) e -> rel e f NoRel -> rel (map h e) f NoRel.
+have rsatG e f: all [in G] e -> rel e f NoRel -> rel (map h e) f NoRel.
   move=> Ge; have: NoRel -> NoRel by []; move: NoRel {2 4}NoRel.
   elim: f => [x1 x2 | f1 IH1 f2 IH2] r hr IHr; last by apply: IH1; apply: IH2.
   by rewrite !and_relE !evalG //; case/andP; move/eqP->; rewrite eqxx.
 set s := env1; set vT := gT : finType in s *.
 set s' := env1; set vT' := rT : finType in s' *.
 have (v): let: Env A e := s v in
-  A \subset G -> all (mem G) e /\ exists v', s' v' = Env (h @* A) (map h e).
+  A \subset G -> all [in G] e /\ exists v', s' v' = Env (h @* A) (map h e).
 - rewrite /= cycle_subG andbT => Gv; rewrite morphim_cycle //.
   by split; last exists (h v).
 elim: p 1%N vT vT' s s' => /= [p IHp | f] n vT vT' s s' Gs.

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -264,7 +264,7 @@ Qed.
 
 Lemma exponent_witness G : nilpotent G -> {x | x \in G & exponent G = #[x]}.
 Proof.
-move=> nilG; have [//=| /= x Gx max_x] := @arg_maxnP _ 1 (mem G) order.
+move=> nilG; have [//=| /= x Gx max_x] := @arg_maxnP _ 1 [in G] order.
 exists x => //; apply/eqP; rewrite eqn_dvd dvdn_exponent // andbT.
 apply/dvdn_biglcmP=> y Gy; apply/dvdn_partP=> //= p.
 rewrite mem_primes => /andP[p_pr _]; have p_gt1: p > 1 := prime_gt1 p_pr.
@@ -1956,7 +1956,7 @@ Lemma max_card_abelian G :
   abelian G -> #|G| <= exponent G ^ 'r(G) ?= iff homocyclic G.
 Proof.
 move=> cGG; have [b defG def_tG] := abelian_structure cGG.
-have Gb: all (mem G) b.
+have Gb: all [in G] b.
   apply/allP=> x b_x; rewrite -(bigdprodWY defG); have [b1 b2] := splitPr b_x.
   by rewrite big_cat big_cons /= mem_gen // setUCA inE cycle_id.
 have ->: homocyclic G = all (pred1 (exponent G)) (abelian_type G).

--- a/mathcomp/solvable/alt.v
+++ b/mathcomp/solvable/alt.v
@@ -165,9 +165,9 @@ pose A3 := [set x : {perm T} | #[x] == 3]; suffices oA3: #|A :&: A3| = 8.
   rewrite -(([set P] =P 'Syl_2(A)) _) ?cards1 // eqEsubset sub1set inE sylP.
   by apply/subsetP=> Q sylQ; rewrite inE -val_eqE /= !sQ2 // inE.
 rewrite -[8]/(4 * 2)%N -{}oQ3 -sum1_card -sum_nat_const.
-rewrite (partition_big (fun x => <[x]>%G) (mem 'Syl_3(A))) => [|x]; last first.
+rewrite (partition_big (fun x => <[x]>%G) [in 'Syl_3(A)]) => [|x]; last first.
   by case/setIP=> Ax; rewrite /= !inE pHallE p_part cycle_subG Ax oA.
-apply: eq_bigr => Q; rewrite inE /= inE pHallE oA p_part -?natTrecE //=.
+apply: eq_bigr => Q; rewrite inE pHallE oA p_part -?natTrecE //=.
 case/andP=> sQA /eqP oQ; have:= oQ.
 rewrite (cardsD1 1) group1 -sum1_card => [[/= <-]]; apply: eq_bigl => x.
 rewrite setIC -val_eqE /= 2!inE in_setD1 -andbA -{4}[x]expg1 -order_dvdn dvdn1.
@@ -191,7 +191,7 @@ have FF (H : {group {perm T}}): H <| 'Alt_T -> H :<>: 1 -> 20 %| #|H|.
   have F6: 5 %| #|H| by rewrite -oT -cardsT (atrans_dvd F5).
   have F7: 4 %| #|H|.
     have F7: #|[set~ x]| = 4 by rewrite cardsC1 oT.
-    case: (pickP (mem [set~ x])) => [y Hy | ?]; last by rewrite eq_card0 in F7.
+    case: (pickP [in [set~ x]]) => [y Hy | ?]; last by rewrite eq_card0 in F7.
     pose K := 'C_H[x | 'P]%G.
     have F8 : K \subset H by apply: subsetIl.
     pose Gx := 'C_('Alt_T)[x | 'P]%G.

--- a/mathcomp/solvable/burnside_app.v
+++ b/mathcomp/solvable/burnside_app.v
@@ -1133,19 +1133,19 @@ Qed.
 Lemma uniq4_uniq6 : forall x y z t : cube,
   uniq [:: x; y; z; t] -> exists u, exists v, uniq [:: x; y; z; t; u; v].
 Proof.
-move=> x y z t Uxt; move: (cardC (mem [:: x; y; z; t])).
+move=> x y z t Uxt; move: (cardC [in [:: x; y; z; t]]).
 rewrite card_ord  (card_uniq_tuple Uxt) => hcard.
-have hcard2: #|predC (mem [:: x; y; z; t])| = 2.
+have hcard2: #|[predC [:: x; y; z; t]]| = 2.
   by apply: (@addnI 4); rewrite /injective  hcard.
-have:  #|predC (mem [:: x; y; z; t])| != 0 by rewrite hcard2.
+have:  #|[predC [:: x; y; z; t]]| != 0 by rewrite hcard2.
 case/existsP=> u Hu; exists u.
-move: (cardC (mem [:: x; y; z; t; u])); rewrite card_ord => hcard5.
+move: (cardC [in [:: x; y; z; t; u]]); rewrite card_ord => hcard5.
 have: #|[predC [:: x; y; z; t; u]]| !=0.
   rewrite -lt0n  -(ltn_add2l #|[:: x; y; z; t; u]|) hcard5 addn0.
   by apply: (leq_ltn_trans (card_size [:: x; y; z; t; u])).
-case/existsP => v; rewrite inE (mem_cat _ [:: _; _; _; _]) => /norP[Hv Huv].
-exists v; rewrite (cat_uniq [:: x; y; z; t]) Uxt andTb.
-by rewrite -rev_uniq /= negb_or Hu orbF Hv Huv.
+case/existsP => v; rewrite (mem_cat _ [:: _; _; _; _]) => /norP[Hv Huv].
+exists v; rewrite (cat_uniq [:: x; y; z; t]) Uxt andTb -rev_uniq /= orbF.
+by rewrite negb_or Hu Hv Huv.
 Qed.
 
 Lemma card_n4 : forall x y z t : cube, uniq [:: x; y; z; t] ->

--- a/mathcomp/solvable/cyclic.v
+++ b/mathcomp/solvable/cyclic.v
@@ -768,7 +768,7 @@ rewrite -ltnS -szP -(size_map f) max_ring_poly_roots -?size_poly_eq0 ?{}szP //.
   move/eqP=> yn1 ->{fy}; apply/eqP.
   by rewrite !(hornerE, hornerXn) -fX // yn1 f1 subrr.
 have: uniq rs by apply: enum_uniq.
-have: all (mem G) rs by apply/allP=> y; rewrite mem_enum; case/setIP.
+have: all [in G] rs by apply/allP=> y; rewrite mem_enum; case/setIP.
 elim: rs => //= y rs IHrs /andP[Gy Grs] /andP[y_rs]; rewrite andbC.
 move/IHrs=> -> {IHrs}//; apply/allP=> _ /mapP[z rs_z ->].
 have{Grs} Gz := allP Grs z rs_z; rewrite /diff_roots -!fM // (centsP abelG) //.

--- a/mathcomp/solvable/frobenius.v
+++ b/mathcomp/solvable/frobenius.v
@@ -724,7 +724,7 @@ rewrite -(partnC p n_gt0) Gauss_dvd ?coprime_partC //; apply/andP; split.
 rewrite -sum1_card (partition_big_imset (fun x => x.`_p ^: G)) /=.
 apply: dvdn_sum => _ /imsetP[x /setIP[Gx Ax] ->].
 set y := x.`_p; have oy: #[y] = (n`_p * p)%N by rewrite order_constt pA.
-rewrite (partition_big (fun x => x.`_p) (mem (y ^: G))) /= => [|z]; last first.
+rewrite (partition_big (fun x => x.`_p) [in y ^: G]) /= => [|z]; last first.
   by case/andP=> _ /eqP <-; rewrite /= class_refl.
 pose G' := ('C_G[y] / <[y]>)%G; pose n' := gcdn #|G'| n`_p^'.
 have n'_gt0: 0 < n' by rewrite gcdn_gt0 cardG_gt0.

--- a/mathcomp/solvable/maximal.v
+++ b/mathcomp/solvable/maximal.v
@@ -624,7 +624,7 @@ have cfHM: M \subset 'C(autm Af @* H).
   rewrite centsC (sameP commG1P trivgP) -tifHM subsetI commg_subl commg_subr.
   by rewrite (subset_trans sMG) // (subset_trans sfHG).
 exists (autm Af @* H <*> M)%G; rewrite /normal /= join_subG sMG sfHG normsY //=.
-rewrite (bigD1 f) ?inE ?eqxx // (eq_bigl (mem I)) /= => [|g]; last first.
+rewrite (bigD1 f) ?inE ?eqxx // (eq_bigl [in I]) /= => [|g]; last first.
   by rewrite /= !inE andbC; case: eqP => // ->.
 by rewrite defM -(autmE Af) -morphimEsub // dprodE // cent_joinEr ?eqxx.
 Qed.

--- a/mathcomp/solvable/primitive_action.v
+++ b/mathcomp/solvable/primitive_action.v
@@ -207,7 +207,7 @@ Lemma dtuple_on_add_D1 n x (t : n.-tuple sT) :
      = (x \in S) && (t \in n.-dtuple(S :\ x)).
 Proof.
 rewrite dtuple_on_add !inE (andbCA (~~ _)); do 2!congr (_ && _).
-rewrite -!(eq_subset (in_set (mem t))) setDE setIC subsetI; congr (_ && _).
+rewrite -!(eq_subset (in_set [in t])) setDE setIC subsetI; congr (_ && _).
 by rewrite -setCS setCK sub1set !inE.
 Qed.
 

--- a/mathcomp/ssreflect/binomial.v
+++ b/mathcomp/ssreflect/binomial.v
@@ -457,7 +457,7 @@ have inc_A (A : {set 'I_n}) : sorted ltn (map val (enum A)).
   rewrite -(eq_filter (mem_map val_inj _)) -filter_map.
   by rewrite (sorted_filter ltn_trans) // unlock val_ord_enum iota_ltn_sorted.
 rewrite -!sum1dep_card (reindex_onto f_t f_A) /= => [|A]; last first.
-  by move/eqP=> cardAm; apply/setP=> x; rewrite inE -(mem_enum (mem A)) -val_fA.
+  by move/eqP=> cardAm; apply/setP=> x; rewrite inE -(mem_enum A) -val_fA.
 apply: eq_bigl => t.
 apply/idP/idP => [inc_t|/andP [/eqP t_m /eqP <-]]; last by rewrite val_fA.
 have ft_m: #|f_t t| = m.

--- a/mathcomp/ssreflect/eqtype.v
+++ b/mathcomp/ssreflect/eqtype.v
@@ -412,9 +412,9 @@ Arguments pred2P {T T2 x y z u}.
 Arguments predD1P {T x y b}.
 Prenex Implicits pred1 pred2 pred3 pred4 predU1 predC1 predD1.
 
-Notation "[ 'predU1' x & A ]" := (predU1 x [mem A])
+Notation "[ 'predU1' x & A ]" := (predU1 x [in A])
   (at level 0, format "[ 'predU1'  x  &  A ]") : fun_scope.
-Notation "[ 'predD1' A & x ]" := (predD1 [mem A] x)
+Notation "[ 'predD1' A & x ]" := (predD1 [in A] x)
   (at level 0, format "[ 'predD1'  A  &  x ]") : fun_scope.
 
 (* Lemmas for reflected equality and functions.   *)
@@ -843,7 +843,7 @@ Arguments pair_eqP {T1 T2}.
 Definition predX T1 T2 (p1 : pred T1) (p2 : pred T2) :=
   [pred z | p1 z.1 & p2 z.2].
 
-Notation "[ 'predX' A1 & A2 ]" := (predX [mem A1] [mem A2])
+Notation "[ 'predX' A1 & A2 ]" := (predX [in A1] [in A2])
   (at level 0, format "[ 'predX'  A1  &  A2 ]") : fun_scope.
 
 Section OptionEqType.

--- a/mathcomp/ssreflect/fingraph.v
+++ b/mathcomp/ssreflect/fingraph.v
@@ -160,7 +160,7 @@ Proof. by move->; apply: connect0. Qed.
 Lemma connect1 x y : e x y -> connect x y.
 Proof. by move=> e_xy; apply/connectP; exists [:: y]; rewrite /= ?e_xy. Qed.
 
-Lemma path_connect x p : path e x p -> subpred (mem (x :: p)) (connect x).
+Lemma path_connect x p : path e x p -> subpred [in x :: p] (connect x).
 Proof.
 move=> e_p y p_y; case/splitPl: p / p_y e_p => p q <-.
 by rewrite cat_path => /andP[e_p _]; apply/connectP; exists p.

--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -210,6 +210,10 @@ Notation "[ 'set' x 'in' A | P & Q ]" := [set x in A | P && Q]
 Notation "[ 'set' x : T 'in' A | P & Q ]" := [set x : T in A | P && Q]
   (at level 0, x at level 99, only parsing) : set_scope.
 
+(* Set spanned by a sequence. *)
+Notation "[ 'set' :: s ]" := (finset [in pred_of_seq s])
+  (at level 0, format "[ 'set' ::  s ]") : set_scope.
+
 (* This lets us use set and subtypes of set, like group or coset_of, both as  *)
 (* collective predicates and as arguments of the \pi(_) notation.             *)
 Coercion pred_of_set: set_type >-> fin_pred_sort.
@@ -351,12 +355,12 @@ Proof. by rewrite -!proper0 => sAB /proper_sub_trans->. Qed.
 
 Lemma set_0Vmem A : (A = set0) + {x : T | x \in A}.
 Proof.
-case: (pickP (mem A)) => [x Ax | A0]; [by right; exists x | left].
+case: (pickP [in A]) => [x Ax | A0]; [by right; exists x | left].
 by apply/setP=> x; rewrite inE; apply: A0.
 Qed.
 
-Lemma set_enum A : [set x | x \in enum A] = A.
-Proof. by apply/setP => x; rewrite inE mem_enum. Qed.
+Lemma set_enum A : [set:: enum A] = A.
+Proof. by apply/setP=> x; rewrite inE mem_enum. Qed.
 
 Lemma enum_set0 : enum set0 = [::] :> seq T.
 Proof. by rewrite (eq_enum (in_set _)) enum0. Qed.
@@ -398,7 +402,12 @@ Proof. by rewrite !inE; apply: predU1P. Qed.
 Lemma in_setU1 x a B : (x \in a |: B) = (x == a) || (x \in B).
 Proof. by rewrite !inE. Qed.
 
-Lemma set_cons a s : [set x in a :: s] = a |: [set x in s].
+Lemma set_nil : [set:: nil] = @set0 T. Proof. by rewrite -enum_set0 set_enum. Qed.
+
+Lemma set_seq1 a : [set:: [:: a]] = [set a].
+Proof. by rewrite -enum_set1 set_enum. Qed.
+
+Lemma set_cons a s : [set:: a :: s] = a |: [set:: s].
 Proof. by apply/setP=> x; rewrite !inE. Qed.
 
 Lemma setU11 x B : x \in x |: B.
@@ -548,7 +557,6 @@ Lemma set0I A : set0 :&: A = set0.
 Proof. by apply/setP => x; rewrite !inE andFb. Qed.
 
 Lemma setI0 A : A :&: set0 = set0.
-
 Proof. by rewrite setIC set0I. Qed.
 
 Lemma setIA A B C : A :&: (B :&: C) = A :&: B :&: C.
@@ -1066,8 +1074,7 @@ Local Notation imset_def :=
   (fun (aT rT : finType) f mD => [set y in @image_mem aT rT f mD]).
 Local Notation imset2_def :=
   (fun (aT1 aT2 rT : finType) f (D1 : mem_pred aT1) (D2 : _ -> mem_pred aT2) =>
-     [set y in @image_mem _ rT (uncurry f)
-                           (mem [pred u | D1 u.1 & D2 u.1 u.2])]).
+     [set y : rT in [seq uncurry f u | u in [pred u | D1 u.1 & D2 u.1 u.2]]]).
 
 Module Type ImsetSig.
 Parameter imset : forall aT rT : finType,
@@ -1234,26 +1241,26 @@ Qed.
 Lemma imset_inj : injective f -> injective (fun A : {set aT} => f @: A).
 Proof.
 move=> inj_f A B => /setP E; apply/setP => x.
-by rewrite -(mem_imset (mem A) x inj_f) E mem_imset.
+by rewrite -(mem_imset A x inj_f) E mem_imset.
 Qed.
 
 Lemma imset_disjoint (A B : {pred aT}) :
   injective f -> [disjoint f @: A & f @: B] = [disjoint A & B].
 Proof.
 move=> inj_f; apply/pred0Pn/pred0Pn => /= [[_ /andP[/imsetP[x xA ->]] xB]|].
-  by exists x; rewrite xA -(mem_imset (mem B) x inj_f).
+  by exists x; rewrite xA -(mem_imset B x inj_f).
 by move=> [x /andP[xA xB]]; exists (f x); rewrite !mem_imset ?xA.
 Qed.
 
 Lemma imset2_f (D : {pred aT}) (D2 : aT -> {pred aT2}) x x2 :
     x \in D -> x2 \in D2 x ->
-  f2 x x2 \in imset2 f2 (mem D) (fun x1 => mem (D2 x1)).
+  f2 x x2 \in [set f2 y y2 | y in D, y2 in D2 y].
 Proof. by move=> Dx Dx2; apply/imset2P; exists x x2. Qed.
 
 Lemma mem_imset2 (D : {pred aT}) (D2 : aT -> {pred aT2}) x x2 :
     injective2 f2 ->
-  f2 x x2 \in imset2 f2 (mem D) (fun x1 => mem (D2 x1)) = 
-    ((x \in D) && (x2 \in D2 x)).
+  (f2 x x2 \in [set f2 y y2 | y in D, y2 in D2 y])
+    = (x \in D) && (x2 \in D2 x).
 Proof.
 move=> inj2_f; apply/imset2P/andP => [|[xD xD2]]; last by exists x x2.
 by move => [x' x2' xD xD2 eq_f2]; case: (inj2_f _ _ _ _ eq_f2) => -> ->.
@@ -1422,7 +1429,7 @@ Lemma big_setID A B F :
      aop (\big[aop/idx]_(i in A :&: B) F i)
          (\big[aop/idx]_(i in A :\: B) F i).
 Proof.
-rewrite (bigID (mem B)) setDE.
+rewrite (bigID [in B]) setDE.
 by congr (aop _ _); apply: eq_bigl => i; rewrite !inE.
 Qed.
 
@@ -1841,8 +1848,7 @@ Proof. by rewrite /trivIset cover1 big_set1. Qed.
 Lemma trivIsetP P :
   reflect {in P &, forall A B, A != B -> [disjoint A & B]} (trivIset P).
 Proof.
-have->: P = [set x in enum (mem P)] by apply/setP=> x; rewrite inE mem_enum.
-elim: {P}(enum _) (enum_uniq (mem P)) => [_ | A e IHe] /=.
+rewrite -[P]set_enum; elim: {P}(enum _) (enum_uniq P) => [_ | A e IHe] /=.
   by rewrite /trivIset /cover !big_set0 cards0; left=> A; rewrite inE.
 case/andP; rewrite set_cons -(in_set (fun B => B \in e)) => PA {}/IHe.
 move: {e}[set x in e] PA => P PA IHP.
@@ -2031,7 +2037,7 @@ Let rhs P E := \big[op/idx]_(A in P) \big[op/idx]_(x in A) E x.
 Lemma big_trivIset_cond P (K : pred T) (E : T -> R) :
   trivIset P -> \big[op/idx]_(x in cover P | K x) E x = rhs_cond P K E.
 Proof.
-move=> tiP; rewrite (partition_big (pblock P) (mem P)) -/op => /= [|x].
+move=> tiP; rewrite (partition_big (pblock P) [in P]) -/op => /= [|x].
   apply: eq_bigr => A PA; apply: eq_bigl => x; rewrite andbAC; congr (_ && _).
   rewrite -mem_pblock; apply/andP/idP=> [[Px /eqP <- //] | Ax].
   by rewrite (def_pblock tiP PA Ax).

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -612,7 +612,7 @@ Proof. by rewrite lt0n; apply: pred0Pn. Qed.
 Lemma card_le1P {A} : reflect {in A, forall x, A =i pred1 x} (#|A| <= 1).
 Proof.
 apply: (iffP idP) => [A1 x xA y|]; last first.
-  by have [/= x xA /(_ _ xA)/eq_card1->|/eq_card0->//] := pickP (mem A).
+  by have [/= x xA /(_ _ xA)/eq_card1->|/eq_card0->//] := pickP [in A].
 move: A1; rewrite (cardD1 x) xA ltnS leqn0 => /eqP/card0_eq/(_ y).
 by rewrite !inE; have [->|]:= eqP.
 Qed.
@@ -737,7 +737,7 @@ Proof.
 by move/subsetP=> sAB /subsetP=> sBC; apply/subsetP=> x /sAB; apply: sBC.
 Qed.
 
-Lemma subset_all s A : (s \subset A) = all (mem A) s.
+Lemma subset_all s A : (s \subset A) = all [in A] s.
 Proof. exact: (sameP (subsetP _ _) allP). Qed.
 
 Lemma properE A B : A \proper B = (A \subset B) && ~~(B \subset A).
@@ -904,7 +904,7 @@ Lemma disjoint_cons x s B :
   [disjoint x :: s & B] = (x \notin B) && [disjoint s & B].
 Proof. exact: disjointU1. Qed.
 
-Lemma disjoint_has s A : [disjoint s & A] = ~~ has (mem A) s.
+Lemma disjoint_has s A : [disjoint s & A] = ~~ has [in A] s.
 Proof.
 apply/negbRL; apply/pred0Pn/hasP => [[x /andP[]]|[x]]; exists x => //.
 exact/andP.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -638,7 +638,7 @@ Lemma sorted_eq_in s1 s2 :
 Proof.
 move=> /in3_sig leT_tr /in2_sig/(_ _ _ _)/val_inj leT_anti + + /[dup] s1s2.
 have /all_sigP[s1' ->] := allss s1.
-have /all_sigP[{s1s2}s2 ->] : all (mem s1) s2 by rewrite -(perm_all _ s1s2).
+have /all_sigP[{s1s2}s2 ->] : all [in s1] s2 by rewrite -(perm_all _ s1s2).
 by rewrite !sorted_map => ss1' ss2 /(perm_map_inj val_inj)/(sorted_eq leT_tr)->.
 Qed.
 
@@ -648,7 +648,7 @@ Lemma irr_sorted_eq_in s1 s2 :
 Proof.
 move=> /in3_sig leT_tr /in1_sig leT_irr + + /[dup] s1s2.
 have /all_sigP[s1' ->] := allss s1.
-have /all_sigP[s2' ->] : all (mem s1) s2 by rewrite -(eq_all_r s1s2).
+have /all_sigP[s2' ->] : all [in s1] s2 by rewrite -(eq_all_r s1s2).
 rewrite !sorted_map => ss1' ss2' {}s1s2; congr map.
 by apply: (irr_sorted_eq leT_tr) => // x; rewrite -!(mem_map val_inj).
 Qed.
@@ -856,7 +856,7 @@ Fixpoint shorten x p :=
   else [::].
 
 Variant shorten_spec x p : T -> seq T -> Type :=
-   ShortenSpec p' of path e x p' & uniq (x :: p') & subpred (mem p') (mem p) :
+   ShortenSpec p' of path e x p' & uniq (x :: p') & {subset p' <= p} :
      shorten_spec x p (last x p') p'.
 
 Lemma shortenP x p : path e x p -> shorten_spec x p (last x p) (shorten x p).
@@ -1413,7 +1413,7 @@ Proof.
 move=> /in2_sig leT_total /in3_sig leT_tr /in2_sig/(_ _ _ _)/val_inj leT_asym.
 apply: (iffP idP) => s1s2; last by rewrite -(perm_sort leT) s1s2 perm_sort.
 move: (s1s2); have /all_sigP[s1' ->] := allss s1.
-have /all_sigP[{s1s2}s2 ->] : all (mem s1) s2 by rewrite -(perm_all _ s1s2).
+have /all_sigP[{s1s2}s2 ->] : all [in s1] s2 by rewrite -(perm_all _ s1s2).
 by rewrite !sort_map => /(perm_map_inj val_inj) /(perm_sortP leT_total)->.
 Qed.
 

--- a/mathcomp/ssreflect/prime.v
+++ b/mathcomp/ssreflect/prime.v
@@ -575,7 +575,7 @@ by apply/andP/idP=> [[pr_q q_p] | /eqP-> //]; rewrite -dvdn_prime2.
 Qed.
 
 Lemma coprime_has_primes m n :
-  0 < m -> 0 < n -> coprime m n = ~~ has (mem (primes m)) (primes n).
+  0 < m -> 0 < n -> coprime m n = ~~ has [in primes m] (primes n).
 Proof.
 move=> m_gt0 n_gt0; apply/eqP/hasPn=> [mn1 p | no_p_mn].
   rewrite /= !mem_primes m_gt0 n_gt0 /= => /andP[pr_p p_n].
@@ -1030,7 +1030,7 @@ Variables (n : nat) (pi : nat_pred).
 
 Definition negn : nat_pred := [predC pi].
 
-Definition pnat : pred nat := fun m => (m > 0) && all (mem pi) (primes m).
+Definition pnat : pred nat := fun m => (m > 0) && all [in pi] (primes m).
 
 Definition partn := \prod_(0 <= p < n.+1 | p \in pi) p ^ logn p n.
 
@@ -1050,7 +1050,7 @@ Lemma negnK pi : pi^'^' =i pi.
 Proof. by move=> p; apply: negbK. Qed.
 
 Lemma eq_negn pi1 pi2 : pi1 =i pi2 -> pi1^' =i pi2^'.
-Proof. by move=> eq_pi n; rewrite 3!inE /= eq_pi. Qed.
+Proof. by move=> eq_pi n; rewrite inE eq_pi. Qed.
 
 Lemma eq_piP m n : \pi(m) =i \pi(n) <-> \pi(m) = \pi(n).
 Proof.
@@ -1143,7 +1143,7 @@ Qed.
 Lemma p_part_gt1 p n : (n`_p > 1) = (p \in \pi(n)).
 Proof. by rewrite ltn_neqAle part_gt0 andbT eq_sym p_part_eq1 negbK. Qed.
 
-Lemma primes_part pi n : primes n`_pi = filter (mem pi) (primes n).
+Lemma primes_part pi n : primes n`_pi = filter [in pi] (primes n).
 Proof.
 have ltnT := ltn_trans; have [->|n_gt0] := posnP n; first by rewrite partn0.
 apply: (irr_sorted_eq ltnT ltnn); rewrite ?(sorted_primes, sorted_filter) //.
@@ -1600,7 +1600,7 @@ have ->: totient np = #|[pred d : 'I_np | coprime np d]|.
   apply: (@addnI (1 * q)); rewrite -mulnDl [1 + _]prednK // mul1n.
   have def_np: np = p * q by rewrite -expnS prednK // -p_part.
   pose mulp := [fun d : 'I_q => in_mod _ np0 (p * d)].
-  rewrite -def_np -{1}[np]card_ord -(cardC (mem (codom mulp))).
+  rewrite -def_np -{1}[np]card_ord -(cardC [in codom mulp]).
   rewrite card_in_image => [|[d1 ltd1] [d2 ltd2] /= _ _ []]; last first.
     move/eqP; rewrite def_np -!muln_modr ?modn_small //.
     by rewrite eqn_pmul2l // => eq_op12; apply/eqP.

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -5,6 +5,59 @@ From Coq Require Export ssrbool.
 #[deprecated(since="mathcomp 1.15", note="Use rel_of_simpl instead.")]
 Notation rel_of_simpl_rel := rel_of_simpl.
 
+(******************************************************************************)
+(* Local additions:                                                           *)
+(*        [in A] == the applicative counterpart of a collective predicate A:  *)
+(*                  [in A] x beta-expands to x \in A. This is similar to      *)
+(*                  mem A, except that mem A x only simplfies to x \in A.     *)
+(* --> These will become part of the core SSReflect library in later Coq      *)
+(* versions.                                                                  *)
+(*   For the sake of backwards compatibility, this file also replicates       *)
+(* v8.13-15 additions, including a generalization of the statments of         *)
+(* `homoRL_in`, `homoLR_in`, `homo_mono_in`, `monoLR_in`, `monoRL_in`, and    *)
+(* `can_mono_in`.                                                             *)
+(******************************************************************************)
+
+(*******************)
+(* v8.13 additions *)
+(*******************)
+
+Section HomoMonoMorphismFlip.
+Variables (aT rT : Type) (aR : rel aT) (rR : rel rT) (f : aT -> rT).
+Variable (aD aD' : {pred aT}).
+
+Lemma homo_sym : {homo f : x y / aR x y >-> rR x y} ->
+  {homo f : y x / aR x y >-> rR x y}.
+Proof. by move=> fR y x; apply: fR. Qed.
+
+Lemma mono_sym : {mono f : x y / aR x y >-> rR x y} ->
+  {mono f : y x / aR x y >-> rR x y}.
+Proof. by move=> fR y x; apply: fR. Qed.
+
+Lemma homo_sym_in : {in aD &, {homo f : x y / aR x y >-> rR x y}} ->
+  {in aD &, {homo f : y x / aR x y >-> rR x y}}.
+Proof. by move=> fR y x yD xD; apply: fR. Qed.
+
+Lemma mono_sym_in : {in aD &, {mono f : x y / aR x y >-> rR x y}} ->
+  {in aD &, {mono f : y x / aR x y >-> rR x y}}.
+Proof. by move=> fR y x yD xD; apply: fR. Qed.
+
+Lemma homo_sym_in11 : {in aD & aD', {homo f : x y / aR x y >-> rR x y}} ->
+  {in aD' & aD, {homo f : y x / aR x y >-> rR x y}}.
+Proof. by move=> fR y x yD xD; apply: fR. Qed.
+
+Lemma mono_sym_in11 : {in aD & aD', {mono f : x y / aR x y >-> rR x y}} ->
+  {in aD' & aD, {mono f : y x / aR x y >-> rR x y}}.
+Proof. by move=> fR y x yD xD; apply: fR. Qed.
+
+End HomoMonoMorphismFlip.
+Arguments homo_sym {aT rT} [aR rR f].
+Arguments mono_sym {aT rT} [aR rR f].
+Arguments homo_sym_in {aT rT} [aR rR f aD].
+Arguments mono_sym_in {aT rT} [aR rR f aD].
+Arguments homo_sym_in11 {aT rT} [aR rR f aD aD'].
+Arguments mono_sym_in11 {aT rT} [aR rR f aD aD'].
+
 (******************)
 (* v8.14 addtions *)
 (******************)
@@ -282,3 +335,16 @@ Proof. by case: b1 b2 => [] []. Qed.
 Lemma if_add b1 b2 T (x y : T) :
   (if b1 (+) b2 then x else y) = (if b1 then if b2 then y else x else if b2 then x else y).
 Proof. by case: b1 b2 => [] []. Qed.
+
+(********************)
+(* Future additions *)
+(********************)
+
+Notation "[ 'in' A ]" := (in_mem^~ (mem A))
+  (at level 0, format "[ 'in'  A ]") : fun_scope.
+
+Notation "[ 'predI' A & B ]" := (predI [in A] [in B]) : fun_scope.
+Notation "[ 'predU' A & B ]" := (predU [in A] [in B]) : fun_scope.
+Notation "[ 'predD' A & B ]" := (predD [in A] [in B]) : fun_scope.
+Notation "[ 'predC' A ]" := (predC [in A]) : fun_scope.
+Notation "[ 'preim' f 'of' A ]" := (preim f [in A]) : fun_scope.


### PR DESCRIPTION
Add `[in A]` notation for `fun x => x \in A`, the natural applicative equivalent of a collective predicate `A`.
Replace `(mem A)` and `[mem A]`, which had a similar purpose but require an explicit `/=` or `inE` to turn `mem A x` to `x \in A`, which is sometimes awkward.
Remove the Coq 8.10 compatibility code from `ssrbool.v`, which is actually incompatible with Coq < 8.13.
Add lemmas for `all` and `map`: `allT`, `all_mapT`, `inj_in_map`, `mapK_in`.

##### Motivation for this change

<!-- please explain your reason for doing this change -->
The existing notation for passing a collective predicate `A` (e.g., a `seq` or `finest`) where an applicative one is expected
(e.g, as arguments of `all`, `filter` or `eq_bigl`), namely `[mem A]` or `(mem A)`, require an explicit simplification step to
convert an application `mem A x` to the expected statement `x \in A`.
   This  simplification step may be awkward when a simple `/=` would cause other unwanted simplification in the goal; indeed this is the reason for including a rule for expanding `simpl_pred` in the `inE` multi-rule. The new definition avoids this as `[in A] x` simply beta-reduces to `x \in A`. In addition, using the `in` keyword is more natural and meshes well with `mathcomp` functionals, e.g. `all [in A] s` or `pick [in A]`.
  Use of the new notation has been propagated to the whole library, including in `ssrbool.v` and `eqtype.v` notation such as `[predD A & B]` or `[predU1 x & A]`. 
  Possible regression: non-`?` rewriting with `inE` intended to expand `mem A x` instances are now errors. There were only a few instances of this in all of `mathcomp`. An easy backward compatible fix in client libraries would be be to make such rewrites optional (i.e.,, `rewrite ?inE`).
  This PR also adds a few useful lemmas to `seq.v`, whose use had motivated the introduction of the `[in A]` notation:
-  `allT` and `all_mapT` help prove instances of `all` with a predicate that always holds, on a possibly empty non-`eqType`.
- `inj_in_map` and `mapK_in` are localized versions of `inj_map` and `mapK`.
  Finally, this PR removes the Coq 8.10 compatibility code in `ssrbool.v`, which is outdated: it uses the `name` attribute in notations, which only works for Coq >= 8.13. The only use of that code in the `mathcomp` library was to provide the `simp_rel >-> rel` coercion under the alternative name `rel_of_simpl_rel`. This was fixed by replacing this with the `rel_of_simpl` name actually provided by `ssr.ssrbool` in the two instances (in `eqtype.v` and `gseries.v`) where it was used.

The`[in A]` notation should eventually be pushed to the Coq `ssr` library, but it seems prudent to see how often `inE` regressions occur in clients before doing so.

##### Things done/to do

- [X] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [X] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
