### PR TITLE
`mkseq` lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -36,7 +36,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `ssrbool.v`, added lemma `all_sig2_cond`
 - in `choice.v`, added coercion `Choice.mixin`
-- In `seq.v`, added lemmas `mkseqS`, `mkseq_in_uniq`
 - In `seq.v`, added lemmas `mkseqS`, `mkseq_uniqP`
 
 ### Changed

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `ssrbool.v`, added lemma `all_sig2_cond`
 - in `choice.v`, added coercion `Choice.mixin`
+- In `seq.v`, added lemmas `mkseqS`, `mkseq_in_uniq`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `ssrbool.v`, added lemma `all_sig2_cond`
 - in `choice.v`, added coercion `Choice.mixin`
 - In `seq.v`, added lemmas `mkseqS`, `mkseq_in_uniq`
+- In `seq.v`, added lemmas `mkseqS`, `mkseq_uniqP`
 
 ### Changed
 

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2819,6 +2819,10 @@ Definition mkseq f n : seq T := map f (iota 0 n).
 Lemma size_mkseq f n : size (mkseq f n) = n.
 Proof. by rewrite size_map size_iota. Qed.
 
+Lemma mkseqS f n : 
+  mkseq f n.+1 = rcons (mkseq f n) (f n).
+Proof. by rewrite /mkseq -addn1 iotaD add0n map_cat cats1. Qed.
+
 Lemma eq_mkseq f g : f =1 g -> mkseq f =1 mkseq g.
 Proof. by move=> Efg n; apply: eq_map Efg _. Qed.
 
@@ -2855,6 +2859,10 @@ End MakeSeq.
 Section MakeEqSeq.
 
 Variable T : eqType.
+
+Lemma mkseq_in_uniq (f : nat -> T) n : 
+  { in iota 0 n &, injective f } -> uniq (mkseq f n).
+Proof. by move/map_inj_in_uniq ->; apply: iota_uniq. Qed.
 
 Lemma mkseq_uniq (f : nat -> T) n : injective f -> uniq (mkseq f n).
 Proof. by move/map_inj_uniq->; apply: iota_uniq. Qed.

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2860,9 +2860,13 @@ Section MakeEqSeq.
 
 Variable T : eqType.
 
-Lemma mkseq_in_uniq (f : nat -> T) n : 
-  { in iota 0 n &, injective f } -> uniq (mkseq f n).
-Proof. by move/map_inj_in_uniq ->; apply: iota_uniq. Qed.
+Lemma mkseq_uniqP (f : nat -> T) n :
+  reflect {in iota 0 n &, injective f} (uniq (mkseq f n)).
+Proof.
+apply: (iffP idP); last by move/map_inj_in_uniq ->; apply: iota_uniq.
+move=> /(uniqP (f 0)) Huniq i j; rewrite !mem_iota add0n !leq0n /= => Hi Hj fij.
+by apply: Huniq; rewrite ?size_mkseq // !nth_mkseq.
+Qed.
 
 Lemma mkseq_uniq (f : nat -> T) n : injective f -> uniq (mkseq f n).
 Proof. by move/map_inj_uniq->; apply: iota_uniq. Qed.

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -2861,11 +2861,10 @@ Section MakeEqSeq.
 Variable T : eqType.
 
 Lemma mkseq_uniqP (f : nat -> T) n :
-  reflect {in iota 0 n &, injective f} (uniq (mkseq f n)).
+  reflect {in gtn n &, injective f} (uniq (mkseq f n)).
 Proof.
-apply: (iffP idP); last by move/map_inj_in_uniq ->; apply: iota_uniq.
-move=> /(uniqP (f 0)) Huniq i j; rewrite !mem_iota add0n !leq0n /= => Hi Hj fij.
-by apply: Huniq; rewrite ?size_mkseq // !nth_mkseq.
+apply: (equivP (uniqP (f 0))); rewrite size_mkseq.
+by split=> injf i j lti ltj; have:= injf i j lti ltj; rewrite !nth_mkseq.
 Qed.
 
 Lemma mkseq_uniq (f : nat -> T) n : injective f -> uniq (mkseq f n).


### PR DESCRIPTION
##### Motivation for this change

This small PR adds two lemmas related to `mkseq`: `mkseqS` and `mkseq_in_uniq`. 
The latter is a stronger version of `mkseq_uniq` (analogous to `map_inj_uniq`/`map_inj_in_uniq`).

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
