### PR TITLE
`set_nth` lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -38,6 +38,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `choice.v`, added coercion `Choice.mixin`
 - In `seq.v`, added lemmas `mkseqS`, `mkseq_uniqP`
 
+- in `seq.v`, added lemmas `nth_seq1`, `set_nthE`, `count_set_nth`,
+  `count_set_nth_ltn`, `count_set_nthF`
+
 ### Changed
 
 - in `rat.v`


### PR DESCRIPTION
##### Motivation for this change

Added lemmas:
- `set_nthE` --- expresses `set_nth` through `take` and `drop`; 
- `count_set_nth` --- allows to rewrite `count a (set_nth x0 s n x)`

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
