### PR TITLE
Add Construction of Finite Fields via Polynomials

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -41,6 +41,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `seq.v`, added lemmas `nth_seq1`, `set_nthE`, `count_set_nth`,
   `count_set_nth_ltn`, `count_set_nthF`
 
+- in `finfield.v`, added type of polynomial quotients `qpoly` and algebraic structures:
+  + canonical instances making `qpoly p` (for `p` irreducible) a `subType` `eqType`,
+    `choiceType`, `countType`, `subCountType`, `finType`, `ZmodType`, `ringType`,
+    `comRingType`, `unitRingType`, `comUnitRingType`, `idomainType`, `fieldType`, and
+    `finFieldType`
+  + added definition of `primitive_poly` and `dlog` (discrete log)
+  + added lemmas `exp_dlog`, `dlog0`, `dlog_exp`, `qx_field_sz1`, and `qpoly_exp_modn1`
+
+- in `ssrnat.v`, added lemma `leq_predR`
+
 ### Changed
 
 - in `rat.v`

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -57,7 +57,7 @@ From mathcomp Require ssrnum ssrint algC cyclotomic.
 (* quotienting by an irreducible polynomial.                                  *)
 (*                   qpoly p ==  the type of polynomials of size < deg p      *)
 (*          primitive_poly p <-> p (of degree m) has a root alpha which       *)
-(*                               generates the field F_(p^m)                  *)
+(*                               generates the field                          *)
 (*                   dlog q  == the discrete log of element q (n such that    *)
 (*                              x ^+ n = q)                                   *)
 (******************************************************************************)
@@ -788,8 +788,8 @@ Lemma qpoly_inj: injective qp. Proof. exact: val_inj. Qed.
 
 (* Size of the Finite Field *)
 
-(* We prove the cardinality of this set by giving a mapping from qpolys to    *)
-(* tuples of length (size).-1                                                 *)
+(* We prove the cardinality of this set by giving a map from qpolys to tuples *)
+(* of length (size p).-1.                                                     *)
 
 Definition qpoly_seq (q: qpoly) : seq F :=
   q ++ nseq ((size p).-1 - size q) 0.
@@ -973,7 +973,7 @@ Canonical qpoly_ringType := RingType qpoly qpoly_comRingMixin.
 Canonical qpoly_comRingType := ComRingType qpoly qpoly_mulC.
 
 (* Now we want to show that inverses exist and are computable. *)
-(* We do this in several steps                                 *)
+(* We do this in several steps.                                *)
 Definition prime_poly (p: {poly F}) : Prop :=
   forall (q r : {poly F}), p %| (q * r) -> (p %| q) || (p %| r).
 
@@ -1020,8 +1020,8 @@ by apply GRing.subr0_eq.
 Qed.
 
 (* To show that inverses exist, we define the map f_q(x) = q * x and we show *)
-(* that this is injective (and thus bijective since the set is finite)       *)
-(* if q != 0 *)
+(* that this is injective (and thus bijective) if q != 0.                    *)
+
 Definition qmul_map (q: qpoly) := qmul q.
 
 Lemma qmul_map_inj (q: qpoly) : 
@@ -1051,7 +1051,7 @@ move: can2 => /( _ 1).
 by rewrite GRing.mulrC.
 Qed.
 
-(* A (slow) computable inverse function from the above *)
+(* A (slow) inverse function from the above *)
 Definition qinv (q: qpoly) :=
   nth q0 (enum qpoly) (find (fun x => x * q == 1) (enum qpoly)).
 
@@ -1234,7 +1234,6 @@ Qed.
 Definition qpow_map (i: dlog_ord) : qpolyNZ :=
   Qnz (qpow_unit i).
 
-(* We need to know that p does not divide x^n for any n *)
 Lemma irred_dvdn_Xn (r: {poly F}) (n: nat):
   irreducible_poly r ->
   2 < size r ->

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -342,6 +342,11 @@ Proof. by case: n => [//|n]; rewrite ltnSn. Qed.
 Lemma ltn_predRL m n : (m < n.-1) = (m.+1 < n).
 Proof. by case: n => [//|n]; rewrite succnK. Qed.
 
+Lemma leq_predR m n :
+  0 < n ->
+  (m <= n.-1) = (m < n).
+Proof. by case : n => [//|n/= _]; rewrite ltnS. Qed.
+
 Lemma ltn_predK m n : m < n -> n.-1.+1 = n.
 Proof. by case: n. Qed.
 


### PR DESCRIPTION
##### Motivation for this change

This change adds the explicit construction of finite fields via polynomials quotiented by an irreducible polynomial. It defines the type `qpoly p`, a polynomial quotiented by `p`, and gives all the definitions, lemmas, and structures needed to define a `finFieldType`. Furthermore, for the case when the polynomial `p` is primitive, this PR includes a discrete log definition and proves that all nonzero elements in the field have a discrete log.

These changes were useful for recent work formalizing a Reed-Solomon implementation in Coq, and can be generally useful when verifying algorithms or code that involve construction or use of specific finite fields.

Several months ago, I mentioned these additions to @amahboubi during a meeting, and she encouraged me to submit this pull request.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
