### PR TITLE
Adding tuple_uniqP

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -49,6 +49,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `seq.v`, added lemmas `nth_seq1`, `set_nthE`, `count_set_nth`,
   `count_set_nth_ltn`, `count_set_nthF`
 
+- in `tuple.v`:
+  + lemma `tuple_uniqP`
+
 ### Changed
 
 - in `rat.v`

--- a/mathcomp/ssreflect/tuple.v
+++ b/mathcomp/ssreflect/tuple.v
@@ -334,19 +334,13 @@ move=> s_x; pose i := index x s; have lt_i: i < size s by rewrite index_mem.
 by exists (Ordinal lt_i); rewrite (tnth_nth x) nth_index.
 Qed.
 
-Lemma tuple_uniqP (x0 : T) (t : n.-tuple T) : 
-  reflect (injective (tnth t)) (uniq t).
+Lemma tuple_uniqP (t : n.-tuple T) : reflect (injective (tnth t)) (uniq t).
 Proof.
-apply: introP => [/uniqP u i1 i2 eq12|].  
-- apply: val_inj => /=.
-  move: (u x0 i1 i2) eq12.
-  by rewrite !(tnth_nth x0) !inE !size_tuple !ltn_ord => /(_ erefl erefl).
-- apply: contraNnot => tinj.
-  apply/(@uniqP _ x0) => i1 i2. 
-  rewrite !inE !size_tuple => lti1k1 lti2k1 eq12.
-  have/eqP: Ordinal lti1k1 = Ordinal lti2k1 
-    by apply: tinj; rewrite !(tnth_nth x0).
-  by rewrite -(inj_eq val_inj) /= => /eqP.
+case: {+}n => [|m] in t *; first by rewrite tuple0; constructor => -[].
+pose x0 := tnth t ord0; apply/(equivP (uniqP x0)); split=> tinj i j.
+  by rewrite !(tnth_nth x0) => /tinj/val_inj; apply; rewrite size_tuple inE.
+rewrite !size_tuple !inE => im jm; have := tinj (Ordinal im) (Ordinal jm).
+by rewrite !(tnth_nth x0) => /[apply]-[].
 Qed.
 
 End EqTuple.

--- a/mathcomp/ssreflect/tuple.v
+++ b/mathcomp/ssreflect/tuple.v
@@ -334,6 +334,21 @@ move=> s_x; pose i := index x s; have lt_i: i < size s by rewrite index_mem.
 by exists (Ordinal lt_i); rewrite (tnth_nth x) nth_index.
 Qed.
 
+Lemma tuple_uniqP (x0 : T) (t : n.-tuple T) : 
+  reflect (injective (tnth t)) (uniq t).
+Proof.
+apply: introP => [/uniqP u i1 i2 eq12|].  
+- apply: val_inj => /=.
+  move: (u x0 i1 i2) eq12.
+  by rewrite !(tnth_nth x0) !inE !size_tuple !ltn_ord => /(_ erefl erefl).
+- apply: contraNnot => tinj.
+  apply/(@uniqP _ x0) => i1 i2. 
+  rewrite !inE !size_tuple => lti1k1 lti2k1 eq12.
+  have/eqP: Ordinal lti1k1 = Ordinal lti2k1 
+    by apply: tinj; rewrite !(tnth_nth x0).
+  by rewrite -(inj_eq val_inj) /= => /eqP.
+Qed.
+
 End EqTuple.
 
 Definition tuple_choiceMixin n (T : choiceType) :=


### PR DESCRIPTION
##### Motivation for this change

I suggest to add this tuple version of the `uniqP` lemma for sequences.

I have no idea why the file `bigop.v` is also part of this PR (it was mentioned in a previous PR, regarding telescopes). I must have done something improper with git. Sorry for that. The only modified file should be `tuple.v`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
