### PR TITLE
refactor(Dockerfile): no need for multi-stage build anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,5 @@ RUN ["/bin/bash", "--login", "-c", "set -x \
   && opam install -y -v -j ${NJOBS} coq-mathcomp-character \
   && opam clean -a -c -s --logs"]
 
-FROM coqorg/base:bare
-
-ENV COMPILER=""
 ENV MATHCOMP_VERSION="dev"
 ENV MATHCOMP_PACKAGE="coq-mathcomp-character"
-
-COPY --from=builder --chown=coq:coq /home/coq/.opam /home/coq/.opam
-COPY --from=builder --chown=coq:coq /home/coq/.profile /home/coq/.profile


### PR DESCRIPTION
##### Motivation for this change

* Remove `FROM coqorg/base:bare` as all `coqorg/coq:*` are mono-switch
* This should speedup mathcomp's CI and increase Docker layers sharing

Cc @proux01 @CohenCyril 

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.