### PR TITLE
fix(.dockerignore): Add missing INITIAL_AUTHORS.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 # Begin files referenced by symlinks
 !README.md
 !AUTHORS
+!INITIAL_AUTHORS.md
 !INSTALL.md
 !CeCILL-B
 # End files referenced by symlinks


### PR DESCRIPTION
Cc @proux01 @CohenCyril 

##### Motivation for this change

* This fix is a follow-up of #769 

* Avoid
  ```
  Warning:  Rsync partially failed:
            sending incremental file list
            symlink has no referent: "/home/coq/mathcomp/AUTHORS"
            symlink has no referent: "/home/coq/mathcomp/mathcomp/algebra/AUTHORS"
            symlink has no referent: "/home/coq/mathcomp/mathcomp/character/AUTHORS"
            symlink has no referent: "/home/coq/mathcomp/mathcomp/field/AUTHORS"
            symlink has no referent: "/home/coq/mathcomp/mathcomp/fingroup/AUTHORS"
            symlink has no referent: "/home/coq/mathcomp/mathcomp/solvable/AUTHORS"
            symlink has no referent: "/home/coq/mathcomp/mathcomp/ssreflect/AUTHORS"
            IO error encountered -- skipping file deletion
  ```
  (see e.g. https://github.com/coq-community/docker-coq-action/runs/6955511475?check_suite_focus=true#step:4:419 )

##### Things done/to do

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
