### PR TITLE
Lemmas relating preffix/infix/suffix and path/sorted

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- in `path.v` 
+  + lemmas `prefix_path`, `prefix_sorted`, `infix_sorted`, `suffix_sorted` 
+
 ### Changed
 
 ### Renamed

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -508,6 +508,28 @@ Qed.
 
 End CycleAll2Rel.
 
+Section PreInSuffix.
+
+Variables (T : eqType) (e : rel T).
+Implicit Type s : seq T.
+
+Local Notation path := (path e).
+Local Notation sorted := (sorted e).
+
+Lemma prefix_path x s1 s2 : prefix s1 s2 -> path x s2 -> path x s1.
+Proof. by rewrite prefixE => /eqP <-; exact: take_path. Qed.
+
+Lemma prefix_sorted s1 s2 : prefix s1 s2 -> sorted s2 -> sorted s1.
+Proof. by rewrite prefixE => /eqP <-; exact: take_sorted. Qed.
+
+Lemma infix_sorted s1 s2 : infix s1 s2 -> sorted s2 -> sorted s1.
+Proof. by rewrite infixE => /eqP <- ?; apply/take_sorted/drop_sorted. Qed.
+
+Lemma suffix_sorted s1 s2 : suffix s1 s2 -> sorted s2 -> sorted s1.
+Proof. by rewrite suffixE => /eqP <-; exact: drop_sorted. Qed.
+
+End PreInSuffix.
+
 Section EqSorted.
 
 Variables (T : eqType) (leT : rel T).


### PR DESCRIPTION
##### Motivation for this change

The predicates `prefix/infix/suffix` were just added to `seq.v` and I found myself in need of theory regarding `path/sorted`. If there are more lemmas that should be added, let me know.

##### Things done/to do

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] ~added corresponding documentation in the headers~

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
