### PR TITLE
Deploy `mathcomp/mathcomp-dev:coq-8.16` & Add ci-analysis-dev job anew

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,10 @@ coq-8.14:
   extends: .opam-build-once
 
 coq-8.15:
-  # to be replaced with .opam-build-once when 8.15.0 available
+  extends: .opam-build-once
+
+coq-8.16:
+  # to be replaced with .opam-build-once when 8.16.0 available
   extends: .opam-build
 
 coq-dev:
@@ -140,26 +143,31 @@ coq-dev:
     variables:
       - $CRON_MODE == "nightly"
 
-test-coq-dev:
-  extends: .test
+test-coq-8.13:
+  extends: .test-once
   variables:
-    COQ_VERSION: "dev"
-
-test-coq-8.15:
-  # to be replaced with .test-once when 8.15.0 available
-  extends: .test
-  variables:
-    COQ_VERSION: "8.15"
+    COQ_VERSION: "8.13"
 
 test-coq-8.14:
   extends: .test-once
   variables:
     COQ_VERSION: "8.14"
 
-test-coq-8.13:
+test-coq-8.15:
   extends: .test-once
   variables:
-    COQ_VERSION: "8.13"
+    COQ_VERSION: "8.15"
+
+test-coq-8.16:
+  # to be replaced with .test-once when 8.16.0 available
+  extends: .test
+  variables:
+    COQ_VERSION: "8.16"
+
+test-coq-dev:
+  extends: .test
+  variables:
+    COQ_VERSION: "dev"
 
 # set CONTRIB_URL, script, COQ_VERSION, CONTRIB_VERSION when using
 .ci:
@@ -349,15 +357,15 @@ ci-multinomials-dev:
     - opam install -y -v -j "${NJOBS}" --deps-only coq-mathcomp-analysis
     - opam install -y -v -j "${NJOBS}" coq-mathcomp-analysis
 
-ci-analysis-8.13:
-  extends: .ci-analysis
-  variables:
-    COQ_VERSION: "8.13"
-
 ci-analysis-8.14:
   extends: .ci-analysis
   variables:
     COQ_VERSION: "8.14"
+
+ci-analysis-dev:
+  extends: .ci-analysis
+  variables:
+    COQ_VERSION: "dev"
 
 # The FCSL-PCM library
 .ci-fcsl-pcm:
@@ -423,7 +431,10 @@ mathcomp-dev_coq-8.14:
   extends: .docker-deploy-once
 
 mathcomp-dev_coq-8.15:
-  # to be replaced with .docker-deploy-once when 8.15.0 available
+  extends: .docker-deploy-once
+
+mathcomp-dev_coq-8.16:
+  # to be replaced with .docker-deploy-once when 8.16.0 available
   extends: .docker-deploy
 
 mathcomp-dev_coq-dev:

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -9,7 +9,7 @@ license: "CECILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { ((>= "8.13" & < "8.16~") | (= "dev"))} ]
+depends: [ "coq" { ((>= "8.13" & < "8.17~") | (= "dev"))} ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
##### Motivation for this change

Add jobs for testing/deploying `mathcomp/mathcomp-dev:coq-8.16` now that `coqorg/coq:8.16` is available.

& Add a missing job for mathcomp-analysis (that should compile according to https://github.com/math-comp/analysis/blob/master/.github/workflows/docker-action.yml )

Cc @proux01 @CohenCyril @palmskog FYI

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
