### PR TITLE
Adapt again w.r.t. coq/coq#16004 after recent changes in master.

### DIFF
--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -5148,9 +5148,9 @@ Arguments conjCK {C} x.
 Arguments sqrCK {C} [x] le0x.
 Arguments sqrCK_P {C x}.
 
-Hint Extern 0 (is_true (in_mem ('Re _) _)) =>
+#[global] Hint Extern 0 (is_true (in_mem ('Re _) _)) =>
   solve [apply: Creal_Re] : core.
-Hint Extern 0 (is_true (in_mem ('Im _) _)) =>
+#[global] Hint Extern 0 (is_true (in_mem ('Im _) _)) =>
   solve [apply: Creal_Im] : core.
 
 End Theory.


### PR DESCRIPTION
For some reason I missed those two lines, but now it seems to compile fine locally on coq/coq#16004.
