### PR TITLE
Generalize lemmas from monoid to semigroups

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -15,6 +15,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `poly.v`, added lemmas `comm_polyD`, `comm_polyM` and `comm_poly_exp`.
 
+- in `bigop.v`
+  + lemmas `big_seq1_id`, `big_nat1_id`, `big_pred1_eq_id`,
+    `big_pred1_id`, `big_const_idem`, `big1_idem`, `big_id_idem`,
+    `big_rem_AC`, `perm_big_AC`, `big_enum_cond_AC`, `bigD1_AC`,
+    `bigD1_seq_AC`, `big_image_cond_AC`, `big_image_AC`,
+    `big_image_cond_id_AC`, `Lemma`, `cardD1x`, `reindex_omap_AC`,
+    `reindex_onto_AC`, `reindex_AC`, `reindex_inj_AC`, `bigD1_ord_AC`,
+    `big_enum_val_cond_AC`, `big_enum_rank_cond_AC`, `big_nat_rev_AC`,
+    `big_rev_mkord_AC`, `big_mkcond_idem`, `big_mkcondr_idem`,
+    `big_mkcondl_idem`, `big_rmcond_idem`, `big_rmcond_in_idem`,
+    `big_cat_idem`, `big_allpairs_dep_idem`, `big_allpairs_idem`,
+    `big_cat_nat_idem`, `big_split_idem`, `big_id_idem_AC`,
+    `bigID_idem`, `bigU_idem`, `partition_big_idem`,
+    `sig_big_dep_idem`, `pair_big_dep_idem`, `pair_big_idem`,
+    `pair_bigA_idem`, `exchange_big_dep_idem`, `exchange_big_idem`,
+    `exchange_big_dep_nat_idem`, `exchange_big_nat_idem`
+
 ### Changed
 
 - in `poly.v`:

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -30,7 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `bigID_idem`, `bigU_idem`, `partition_big_idem`,
     `sig_big_dep_idem`, `pair_big_dep_idem`, `pair_big_idem`,
     `pair_bigA_idem`, `exchange_big_dep_idem`, `exchange_big_idem`,
-    `exchange_big_dep_nat_idem`, `exchange_big_nat_idem`
+    `exchange_big_dep_nat_idem`, `exchange_big_nat_idem`,
+    `big_undup_AC`
 
 ### Changed
 

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1226,6 +1226,16 @@ elim: r =>// i r ih; rewrite big_cons rem_cons inE =>/predU1P[-> /[!eqxx]//|zr].
 by case: eqP => [-> //|]; rewrite ih// big_cons; case: ifPn; case: ifPn.
 Qed.
 
+Lemma big_undup_AC (I : eqType) (r : seq I) (P : pred I) F :
+    idempotent op ->
+  \big[op/x]_(i <- undup r | P i) F i = \big[op/x]_(i <- r | P i) F i.
+Proof.
+move=> opxx; rewrite -!(big_filter _ _ _ P) filter_undup.
+elim: {P r}(filter P r) => //= i r IHr.
+case: ifP => [r_i | _]; rewrite !big_cons {}IHr //.
+by rewrite (big_rem_AC _ _ r_i) opA opxx.
+Qed.
+
 Lemma perm_big_AC (I : eqType) r1 r2 (P : pred I) F :
     perm_eq r1 r2 ->
   \big[op/x]_(i <- r1 | P i) F i = \big[op/x]_(i <- r2 | P i) F i.
@@ -1841,12 +1851,7 @@ Qed.
 Lemma big_undup (I : eqType) (r : seq I) (P : pred I) F :
     idempotent *%M ->
   \big[*%M/1]_(i <- undup r | P i) F i = \big[*%M/1]_(i <- r | P i) F i.
-Proof.
-move=> idM; rewrite -!(big_filter _ _ _ P) filter_undup.
-elim: {P r}(filter P r) => //= i r IHr.
-case: ifP => [r_i | _]; rewrite !big_cons {}IHr //.
-by rewrite (big_rem _ _ r_i) mulmA idM.
-Qed.
+Proof. apply: big_undup_AC; [exact: mulmA|exact: mulmC]. Qed.
 
 Lemma eq_big_idem (I : eqType) (r1 r2 : seq I) (P : pred I) F :
     idempotent *%M -> r1 =i r2 ->


### PR DESCRIPTION
##### Motivation for this change

Many lemmas for bigops on monoids (particularly abelian ones) were already valid on (abelian) semigroups. This generalization could be improved by adding semigroups to the monoid hierarchy, when porting to HB.

Some lemmas don't require a monoid with a neutral element but only an idempotent element. This is particularly useful for min/max that are idempotent but generally don't have a neutral element.

This is used for min/max in Analysis: https://github.com/math-comp/analysis/pull/712

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
