### PR TITLE
natrS

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `path.v` 
   + lemmas `prefix_path`, `prefix_sorted`, `infix_sorted`, `suffix_sorted` 
+- in `ssralg.v`
+  + lemmas `natr1`, `nat1r`
 
 ### Changed
 

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -1075,6 +1075,10 @@ Proof. by rewrite mulrnAr mulr1. Qed.
 Lemma natrD m n : (m + n)%:R = m%:R + n%:R :> R.
 Proof. exact: mulrnDr. Qed.
 
+Lemma natr1 n : n%:R + 1 = n.+1%:R :> R. Proof. by rewrite mulrSr. Qed.
+
+Lemma nat1r n : 1 + n%:R = n.+1%:R :> R. Proof. by rewrite mulrS. Qed.
+
 Lemma natrB m n : n <= m -> (m - n)%:R = m%:R - n%:R :> R.
 Proof. exact: mulrnBr. Qed.
 
@@ -1102,7 +1106,7 @@ Proof. by elim: m => [|m IHm]; rewrite ?mul1r // !exprS -mulrA -IHm. Qed.
 Lemma exprSr x n : x ^+ n.+1 = x ^+ n * x.
 Proof. by rewrite -addn1 exprD expr1. Qed.
 
-Lemma expr_sum x (I : Type) (s : seq I) (P : pred I) F : 
+Lemma expr_sum x (I : Type) (s : seq I) (P : pred I) F :
   x ^+ (\sum_(i <- s | P i) F i) = \prod_(i <- s | P i) x ^+ F i :> R.
 Proof. exact: (big_morph _ (exprD _)). Qed.
 
@@ -5704,6 +5708,8 @@ Definition mulrnAr := mulrnAr.
 Definition mulr_natl := mulr_natl.
 Definition mulr_natr := mulr_natr.
 Definition natrD := natrD.
+Definition nat1r := nat1r.
+Definition natr1 := natr1.
 Definition natrB := natrB.
 Definition natr_sum := natr_sum.
 Definition natrM := natrM.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -142,7 +142,7 @@ rewrite normrN normrM ler_pmul //.
   rewrite normf_div -!intr_norm -!abszE ler_pimulr ?ler0n //.
   by rewrite invf_le1 ?ler1n ?ltr0n ?absz_gt0 ?denq_eq0.
 rewrite normrX ger0_norm ?(ltrW x_gt0) // ler_weexpn2l ?leq_ord //.
-by rewrite (le_trans _ lb_x) // -natrD addn1 ler1n.
+by rewrite (le_trans _ lb_x) // natr1 ler1n.
 Qed.
 
 Definition decidable_embedding sT T (f : sT -> T) :=


### PR DESCRIPTION
##### Motivation for this change

Similarly to `natrD` which is essentially `mulrnDr`. In MathComp-Analysis, there were several places where
`natrD` was used together with `addn1/add1n` (I only found one occurrence in MathComp), in such
situation I believe that `natrS/natSr` are desirable from a user point of view.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
