### PR TITLE
Add parsing notations for _ = _ :> int and the like

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -31,6 +31,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemmas `ltn_half_double`, `leq_half_double`, `gtn_half_double`
   + lemmas `uphalfE`, `ltn_uphalf_double`, `geq_uphalf_double`, `gtn_uphalf_double`
 
+- in `ssrint.v`
+  + printing only notation for `x = y :> int`, opening `int_scope` on
+    `x` and `y` to better match the already existing parsing only
+    notation with the introduction of number notations in `ring_scope`
+
 ### Changed
 
 - in `poly.v`:

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -52,13 +52,13 @@ Declare Scope rat_scope.
 
 Reserved Notation "n %:Z" (at level 2, left associativity, format "n %:Z").
 Reserved Notation "n = m :> 'int'"
-  (at level 70, m at next level, format "n  =  m  :>  'int'", only printing).
+  (at level 70, m at next level, format "n  =  m  :>  'int'").
 Reserved Notation "n == m :> 'int'"
-  (at level 70, m at next level, format "n  ==  m  :>  'int'", only printing).
+  (at level 70, m at next level, format "n  ==  m  :>  'int'").
 Reserved Notation "n != m :> 'int'"
-  (at level 70, m at next level, format "n  !=  m  :>  'int'", only printing).
+  (at level 70, m at next level, format "n  !=  m  :>  'int'").
 Reserved Notation "n <> m :> 'int'"
-  (at level 70, m at next level, format "n  <>  m  :>  'int'", only printing).
+  (at level 70, m at next level, format "n  <>  m  :>  'int'").
 
 Import Order.TTheory GRing.Theory Num.Theory.
 Delimit Scope int_scope with Z.
@@ -73,9 +73,16 @@ Variant int : Set := Posz of nat | Negz of nat.
 Notation "n %:Z" := (Posz n) (only parsing) : int_scope.
 Notation "n %:Z" := (Posz n) (only parsing) : ring_scope.
 
+Notation "n = m :> 'int'"  := (@eq int n%Z m%Z) (only parsing)  : ring_scope.
 Notation "n = m :> 'int'"  := (Posz n = Posz m) (only printing)  : ring_scope.
+Notation "n == m :> 'int'" := ((n%Z : int) == (m%Z : int)) (only parsing)
+  : ring_scope.
 Notation "n == m :> 'int'" := (Posz n == Posz m) (only printing) : ring_scope.
+Notation "n != m :> 'int'" := ((n%Z : int) != (m%Z : int)) (only parsing)
+  : ring_scope.
 Notation "n != m :> 'int'" := (Posz n != Posz m) (only printing) : ring_scope.
+Notation "n <> m :> 'int'" := (not (@eq int n%Z m%Z)) (only parsing)
+  : ring_scope.
 Notation "n <> m :> 'int'" := (Posz n <> Posz m) (only printing) : ring_scope.
 
 Definition parse_int (x : Number.int) : int :=


### PR DESCRIPTION
##### Motivation for this change

This way `2 = 1 :> int` is parsed as `2%Z = 1%Z` and not `2%R = 1%R`
(that is `Posz 2 = Posz 1` (matching the already existing printing only
rule for `_ = _ :> int`) and not `intmul GRIng.one 2 = GRing.one`).
This should enable to retrieve the parsing behavior of `_ = _ :> int`
before the introduction of the number notation in ring_scope.

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
