### PR TITLE
Made hornerE respect powers

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `poly.v`:
   + generalize `eq_poly`
 
+- in `poly.v`:
+  + made hornerE preserve powers
+
 ### Renamed
 
 ### Removed

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -2100,8 +2100,8 @@ Lemma horner_prod I r (P : pred I) (F : I -> {poly R}) x :
 Proof. by elim/big_rec2: _ => [|i _ p _ <-]; rewrite (hornerM, hornerC). Qed.
 
 Definition hornerE :=
-  (hornerD, hornerN, hornerX, hornerC, horner_cons,
-   simp, hornerCM, hornerZ, hornerM).
+  (hornerD, hornerN, hornerX, hornerC, horner_exp,
+   simp, hornerCM, hornerZ, hornerM, horner_cons).
 
 Definition horner_eval (x : R) := horner^~ x.
 Lemma horner_evalE x p : horner_eval x p = p.[x]. Proof. by []. Qed.
@@ -2619,7 +2619,7 @@ transitivity (\prod_(w <- zn) ('X - w%:P)); first by rewrite big_map.
 have n_gt0: n > 0 := prim_order_gt0 prim_z.
 rewrite (@all_roots_prod_XsubC _ ('X^n - 1) zn); first 1 last.
 - by rewrite size_Xn_sub_1 // size_map size_iota subn0.
-- apply/allP=> _ /mapP[i _ ->] /=; rewrite rootE !hornerE hornerXn.
+- apply/allP=> _ /mapP[i _ ->] /=; rewrite rootE !hornerE.
   by rewrite exprAC (prim_expr_order prim_z) expr1n subrr.
 - rewrite uniq_rootsE map_inj_in_uniq ?iota_uniq // => i j.
   rewrite !mem_index_iota => ltin ltjn /eqP.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -1318,7 +1318,7 @@ Proof.
 case x_ge0: (0 <= x); last by exists 0.
 have le0x1: 0 <= x + 1 by rewrite -nnegrE rpredD ?rpred1.
 have [|y /andP[y_ge0 _]] := @poly_ivt ('X^2 - x%:P) _ _ le0x1.
-  rewrite !hornerE -subr_ge0 add0r opprK x_ge0 -expr2 sqrrD mulr1.
+  rewrite !hornerE -subr_ge0 add0r expr0n sub0r opprK x_ge0 sqrrD mulr1.
   by rewrite addrAC !addrA addrK -nnegrE !rpredD ?rpredX ?rpred1.
 by rewrite rootE !hornerE subr_eq0; exists y.
 Qed.
@@ -4461,7 +4461,7 @@ have{} Dp: p = \prod_(z <- r) ('X - z%:P).
   rewrite Dp lead_coefE sz_p coefB coefXn coefC -mulrb -mulrnA mulnb lt0n andNb.
   by rewrite subr0 eqxx scale1r; apply/esym/perm_big; rewrite perm_sort.
 have mem_rP z: (n > 0)%N -> reflect (z ^+ n = x) (z \in r).
-  move=> n_gt0; rewrite -root_prod_XsubC -Dp rootE !hornerE hornerXn n_gt0.
+  move=> n_gt0; rewrite -root_prod_XsubC -Dp rootE !hornerE n_gt0.
   by rewrite subr_eq0; apply: eqP.
 exists r`_0 => [|z n_gt0 /(mem_rP z n_gt0) r_z].
   have sz_r: size r = n by apply: succn_inj; rewrite -sz_p Dp size_prod_XsubC.

--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -178,7 +178,7 @@ have /dvdzP[b Da]: (denq y %| a)%Z.
   apply/dvdzP; exists (\sum_(i < d) p1`_i * numq y ^+ i * denq y ^+ (d - i.+1)).
   apply: ZtoQinj; rewrite /ZtoQ rmorphM mulr_suml rmorph_sum /=.
   transitivity ((p1 ^ intr).[y] * (denq y ^+ d)%:~R).
-    rewrite Dp1 !hornerE hornerXn (rootP qy0) subr0.
+    rewrite Dp1 !hornerE (rootP qy0) subr0.
     by rewrite !rmorphX /= numqE exprMn mulrA.
   have sz_p1: (size (p1 ^ ZtoQ)%R <= d)%N.
     rewrite Dp1 size_scale ?intr_eq0 //; apply/leq_sizeP=> i.

--- a/mathcomp/field/closed_field.v
+++ b/mathcomp/field/closed_field.v
@@ -869,7 +869,7 @@ have Kclosed: GRing.ClosedField.axiom Kfield.
   exists (EtoKM j.+1 w); apply/eqP; rewrite -subr_eq0; apply/eqP.
   transitivity (EtoKM j.+1 (map_poly (toE m j.+1 (leqW lemj)) p).[w]).
     rewrite -horner_map -map_poly_comp toEtoKp EtoK_E; move/EtoKM: w => w.
-    rewrite rmorphB [_ 'X^n]map_polyXn !hornerE hornerXn; congr (_ - _ : Kring).
+    rewrite rmorphB [_ 'X^n]map_polyXn !hornerE; congr (_ - _ : Kring).
     rewrite (@horner_coef_wide _ n) ?size_map_poly ?size_poly //.
     by apply: eq_bigr => i _; rewrite coef_map coef_rVpoly valK mxE /= DpE.
   suffices Dpj: map_poly (toE m j lemj) p = pj.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -639,7 +639,7 @@ Proof. by rewrite /minPoly rpredB ?rpredX ?polyOverX ?Fadjoin_polyOver. Qed.
 
 Lemma minPolyxx : (minPoly K x).[x] = 0.
 Proof.
-by rewrite !hornerE hornerXn Fadjoin_poly_eq ?subrr ?rpredX ?memv_adjoin.
+by rewrite !hornerE Fadjoin_poly_eq ?subrr ?rpredX ?memv_adjoin.
 Qed.
 
 Lemma root_minPoly : root (minPoly K x) x. Proof. exact/rootP/minPolyxx. Qed.

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -100,7 +100,7 @@ have le_oppX_n: size oppX <= n by rewrite size_opp size_polyX finRing_gt1.
 have: size pF = (size (enum F)).+1 by rewrite -cardE size_addl size_polyXn.
 move/all_roots_prod_XsubC->; last by rewrite uniq_rootsE enum_uniq.
   by rewrite big_enum lead_coefDl ?size_polyXn // lead_coefXn scale1r.
-by apply/allP=> x _; rewrite rootE !hornerE hornerXn expf_card subrr.
+by apply/allP=> x _; rewrite rootE !hornerE expf_card subrr.
 Qed.
 
 Lemma finCharP : {p | prime p & p \in [char F]}.
@@ -548,7 +548,7 @@ pose Em := fixedSpace (a ^+ k)%g; rewrite card_Fp //= dimv1 expn1 in Da.
 have{splitLq} [zs DqL defL] := splitLq.
 have Uzs: uniq zs.
   rewrite -separable_prod_XsubC -(eqp_separable DqL) Dq separable_root andbC.
-  rewrite /root !hornerE subr_eq0 eq_sym hornerXn expr0n gtn_eqF ?oner_eq0 //=.
+  rewrite /root !hornerE subr_eq0 eq_sym expr0n gtn_eqF ?oner_eq0 //=.
   rewrite cyclotomic.separable_Xn_sub_1 // -subn1 natrB // subr_eq0.
   by rewrite natrX charf0 // expr0n gtn_eqF // eq_sym oner_eq0.
 suffices /eq_card->: Fm =i zs.
@@ -556,7 +556,7 @@ suffices /eq_card->: Fm =i zs.
   by rewrite -(eqp_size DqL) size_addl size_polyXn // size_opp size_polyX.
 have in_zs: zs =i Em.
   move=> z; rewrite -root_prod_XsubC -(eqp_root DqL) (sameP fixedSpaceP eqP).
-  rewrite /root !hornerE subr_eq0 /= hornerXn /m; congr (_ == z).
+  rewrite /root !hornerE subr_eq0 /= /m; congr (_ == z).
   elim: (k) => [|i IHi]; first by rewrite gal_id.
   by rewrite expgSr expnSr exprM IHi galM ?Da ?memvf.
 suffices defEm: Em = {:L}%VS by move=> z; rewrite in_zs defEm memvf.
@@ -649,7 +649,7 @@ suffices: (aq n %| (q - 1)%:R)%C.
   by rewrite leC_nat dvdC_nat; apply: dvdn_leq; rewrite subn_gt0.
 have prod_aq m: m %| n -> \prod_(d < n.+1 | d %| m) aq d = (q ^ m - 1)%:R.
   move=> m_dv_n; transitivity ('X^m - 1).[q%:R : algC]; last first.
-    by rewrite !hornerE hornerXn -natrX natrB ?expn_gt0 ?prime_gt0.
+    by rewrite !hornerE -natrX natrB ?expn_gt0 ?prime_gt0.
   rewrite (prod_cyclotomic (dvdn_prim_root z_prim m_dv_n)).
   have def_divm: perm_eq (divisors m) [seq d <- index_iota 0 n.+1 | d %| m].
     rewrite uniq_perm ?divisors_uniq ?filter_uniq ?iota_uniq // => d.

--- a/mathcomp/field/separable.v
+++ b/mathcomp/field/separable.v
@@ -629,7 +629,7 @@ have co_c_g: coprimep c g.
   by rewrite Dq separable_mul => /and3P[].
 have{g K'g co_c_g} /size_poly1P[a nz_a Dc]: size c == 1%N.
   suffices c_dv_g: c %| g by rewrite -(eqp_size (dvdp_gcd_idl c_dv_g)).
-  have: q %| g by rewrite minPoly_dvdp // rootE !hornerE hornerXn subrr.
+  have: q %| g by rewrite minPoly_dvdp // rootE !hornerE subrr.
   by apply: dvdp_trans; rewrite Dq dvdp_mulIl.
 rewrite {q}Dq {c}Dc mulrBr -rmorphM -rmorphN -cons_poly_def qualifE.
 by rewrite polyseq_cons !polyseqC nz_a /= rpredN andbCA => /and3P[/fpredMl->].


### PR DESCRIPTION
##### Motivation for this change

As discussed in issue #920, I would like `rewrite !hornerE` to respect powers ; that is to keep nice-looking expressions without any strange compositions of `GRing.mul_monoid` strangeness.

This doesn't make the proofs using the tactic very different per se, but when you run them you do see the difference in expression readability.

##### Things done/to do

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers <- not sure it's relevant


<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
