### PR TITLE
chore: Temporarily skip coqbot-docker-gitlab builds to save CI mins

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,8 @@ stages:
     - docker build -f Dockerfile.make --pull --build-arg=coq_image="coqorg/coq:${COQ_VERSION}" -t "${IMAGE}" .
   except:
     refs:
+      # TODO: comment-out when we'll have more CI minutes
+      - /^pr-.*$/
       - tags
       - merge_requests
       - schedules
@@ -76,6 +78,8 @@ make-coq-latest:
     - docker logout "${CI_REGISTRY}"
   except:
     refs:
+      # TODO: comment-out when we'll have more CI minutes
+      - /^pr-.*$/
       - tags
       - merge_requests
 
@@ -83,6 +87,8 @@ make-coq-latest:
   extends: .opam-build
   except:
     refs:
+      # TODO: comment-out when we'll have more CI minutes
+      - /^pr-.*$/
       - tags
       - merge_requests
       - schedules
@@ -132,6 +138,8 @@ coq-dev:
     - make test-suite TEST_SKIP_BUILD=1
   except:
     refs:
+      # TODO: comment-out when we'll have more CI minutes
+      - /^pr-.*$/
       - tags
       - merge_requests
 
@@ -140,6 +148,8 @@ coq-dev:
   extends: .test
   except:
     refs:
+      # TODO: comment-out when we'll have more CI minutes
+      - /^pr-.*$/
       - tags
       - merge_requests
       - schedules
@@ -199,6 +209,8 @@ test-coq-dev:
     - git describe --all --long --abbrev=40 --always --dirty
   except:
     refs:
+      # TODO: comment-out when we'll have more CI minutes
+      - /^pr-.*$/
       - tags
       - merge_requests
       - schedules


### PR DESCRIPTION
##### Motivation for this change

@proux01 and I just saw that more ~95% of September CI minutes is already spent:

<details><summary>Screenshots</summary>

![2022-09-13_14-55-20_Screenshot_math-comp_CI_5%](https://user-images.githubusercontent.com/10367254/189913692-52e47db3-fa62-4008-b712-e49fd3dedee6.png)

![2022-09-13_14-56-20_Screenshot_math-comp_CI_evolution](https://user-images.githubusercontent.com/10367254/189913748-b20f819f-2999-4324-8bb9-cc92d4add0cb.png)

![2022-09-13_14-57-28_Screenshot_math-comp_CI_minutes](https://user-images.githubusercontent.com/10367254/189913764-911dc2bc-b776-41fe-be9b-2c9d36962028.png)

</details>

As a result, we'll submit ASAP a request to benefit for more CI minutes as an open-source project.

Meanwhile, just to summarize, there are 3 kinds of docker-gitlab builds:

1. those after each force-push of a branch that is work-in-progress in math-comp (relatively-costly builds)
2. those after merging a math-comp PR (relatively-costly builds, only 3 of them since September 1st)
3. those for coq-dev, after the merge of a coq PR (much less costly, but a larger number of them)

This temporary PR, once merged, will just skip builds of kind 1. (that should represent > 1/2 CI time), while we'll be waiting for a reply of GitLab. This testing gap for on-going PRs should somehow be filled with Nix builds.
But 2. and 3. should really be kept for now, given they ensure math-comp.dev is kept up-to-date on Docker Hub.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] ~added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~
- [x] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
