### PR TITLE
introduce divrN and divrNN

### DIFF
--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -3969,6 +3969,12 @@ have [Ux | U'x] := boolP (x \is a unit); last by rewrite !invr_out ?unitrN.
 by rewrite -mulN1r invrM ?unitrN1 // invrN1 mulrN1.
 Qed.
 
+Lemma divrNN x y: (- x) / (- y) = x / y.
+Proof. by rewrite invrN mulrNN. Qed.
+
+Lemma divrN x y: x / (- y) = - (x / y).
+Proof. by rewrite invrN mulrN. Qed.
+
 Lemma invr_signM n x : ((-1) ^+ n * x)^-1 = (-1) ^+ n * x^-1.
 Proof. by rewrite -signr_odd !mulr_sign; case: ifP => // _; rewrite invrN. Qed.
 


### PR DESCRIPTION
Co-authored-by: Reynald Affeldt <reynald.affeldt@aist.go.jp>

##### Motivation for this change

I wanted the 2 lemmas:

divrNN : $$\frac{- x}{-y} = \frac{x}{y}$$

divrN : $$\frac{x}{-y} = -\frac{x}{y}$$

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
