### PR TITLE
Mx

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -97,8 +97,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `exchange_big_dep_nat_idem`, `exchange_big_nat_idem`,
     `big_undup_AC`
 - in `matrix.v`
-  + definition `Vandrmonde`
-  + lemma `det_Vandermonde`
+  + definitions `Vandrmonde`, `map2_mx`
+  + lemma `det_Vandermonde`, `map2_trmx`, `map2_const_mx`, `map2_row`,
+	 `map2_col`, `map2_row'`, `map2_col'`, `map2_mxsub`, `map2_row_perm`,
+	 `map2_col_perm`, `map2_xrow`, `map2_xcol`, `map2_castmx`,
+	 `map2_conform_mx`, `map2_mxvec`, `map2_vec_mx`, `map2_row_mx`,
+	 `map2_col_mx`, `map2_block_mx`, `map2_lsubmx`, `map2_rsubmx`,
+	 `map2_usubmx`, `map2_dsubmx`, `map2_ulsubmx`, `map2_ursubmx`,
+	 `map2_dlsubmx`, `map2_drsubmx`, `eq_in_map2_mx`, `eq_map2_mx`,
+	 `map2_mx_left_in`, `map2_mx_left`, `map2_mx_right_in`, `map2_mx_right`,
+	 `map2_mxA`, `map2_1mx`, `map2_mx1`, `map2_mxC`, `map2_0mx`, `map2_mx0`,
+	 `map2_mxDl`, `map2_mxDr`, `diag_mx_is_additive`, `mxtrace_is_additive`
+
 
 - in `ssralg.v`
   + lemmas `divrN`, `divrNN`
@@ -110,6 +120,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `poly.v`:
   + made hornerE preserve powers
+
+- in `matrix.v`:
+  + updated `oppmx`, `addmx`, `addmxA`, `addmxC`, `add0mx`
+  + moved to an earlier section of the file `diag_mx`, 
+    `tr_diag_mx`, `diag_mx_row`, `diag_mxP`, `diag_mx_is_diag`, 
+    `diag_mx_is_trig`, `scalar_mx`, `diag_const_mx`, `tr_scalar_mx`, 
+    `scalar_mx_is_additive`, `is_scalar_mx`, `is_scalar_mxP`, 
+    `scalar_mx_is_scalar`, `mx0_is_scalar`, `scalar_mx_is_diag`, 
+    `is_scalar_mx_is_diag`, `scalar_mx_is_trig`, `is_scalar_mx_is_trig`, 
+    `mx11_scalar`, `scalar_mx_block`, `mxtrace`, `mxtrace_tr`, `mxtrace0`, 
+    `mxtraceD`, `mxtrace_diag`, `mxtrace_scalar`, `trace_mx11`, 
+    `mxtrace_block`
 
 ### Renamed
 

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -1550,7 +1550,7 @@ Lemma map2_mx_left_in (f : R -> R -> R) (M : 'M_(m, n)) (M' : 'M_(m, n)) :
   (forall i j, f (M i j) (M' i j) = M i j) -> map2_mx f M M' = M.
 Proof. by move=> fM; apply/matrixP => i j; rewrite !mxE. Qed.
 
-Lemma map2_mx_left (f : R -> R -> R) : f =1 (fun x _ => x) ->
+Lemma map2_mx_left (f : R -> R -> R) : f =2 (fun x _ => x) ->
   forall (M : 'M_(m, n)) (M' : 'M_(m, n)), map2_mx f M M' = M.
 Proof. by move=> fl M M'; rewrite map2_mx_left_in// =>i j; rewrite fl. Qed.
 
@@ -1558,7 +1558,7 @@ Lemma map2_mx_right_in (f : R -> R -> R) (M : 'M_(m, n)) (M' : 'M_(m, n)) :
   (forall i j, f (M i j) (M' i j) = M' i j) -> map2_mx f M M' = M'.
 Proof. by move=> fM; apply/matrixP => i j; rewrite !mxE. Qed.
 
-Lemma map2_mx_right (f : R -> R -> R) : f =1 (fun _ x => x) ->
+Lemma map2_mx_right (f : R -> R -> R) : f =2 (fun _ x => x) ->
   forall (M : 'M_(m, n)) (M' : 'M_(m, n)), map2_mx f M M' = M'.
 Proof. by move=> fr M M'; rewrite map2_mx_right_in// =>i j; rewrite fr. Qed.
 

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -1540,6 +1540,44 @@ Proof. by move=> fr M M'; rewrite map2_mx_right_in// =>i j; rewrite fr. Qed.
 
 End Map2Eq.
 
+Section MatrixLaws.
+
+Context {T : Type} {m n : nat} {idm : T}.
+
+Lemma map2_mxA {opm : Monoid.law idm} : associative (@map2_mx _ _ _ opm m n).
+Proof. by move=> A B C; apply/matrixP=> i j; rewrite !mxE Monoid.mulmA. Qed.
+
+Lemma map2_1mx {opm : Monoid.law idm} : left_id (const_mx idm) (@map2_mx _ _ _ opm m n).
+Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE Monoid.mul1m. Qed.
+
+Lemma map2_mx1 {opm : Monoid.law idm} : right_id (const_mx idm) (@map2_mx _ _ _ opm m n).
+Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE Monoid.mulm1. Qed.
+
+Canonical map2_mx_monoid {opm : Monoid.law idm} := Monoid.Law (map2_mxA (opm:=opm)) map2_1mx map2_mx1.
+
+Lemma map2_mxC {opm : Monoid.com_law idm} : commutative (@map2_mx _ _ _ opm m n).
+Proof. by move=> A B; apply/matrixP=> i j; rewrite !mxE Monoid.mulmC. Qed.
+
+Canonical map2_mx_comoid {opm : Monoid.com_law idm} := Monoid.ComLaw (map2_mxC (opm:=opm)).
+
+Lemma map2_0mx {opm : Monoid.mul_law idm} : left_zero (const_mx idm) (@map2_mx _ _ _ opm m n).
+Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE Monoid.mul0m. Qed.
+
+Lemma map2_mx0 {opm : Monoid.mul_law idm} : right_zero (const_mx idm) (@map2_mx _ _ _ opm m n).
+Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE Monoid.mulm0. Qed.
+
+Canonical map2_mx_muloid {opm : Monoid.mul_law idm} := Monoid.MulLaw (map2_0mx (opm:=opm)) map2_mx0.
+
+Lemma map2_mxDl {mul : T -> T -> T} {add : Monoid.add_law idm mul} : left_distributive (@map2_mx _ _ _ mul m n) (@map2_mx _ _ _ add m n).
+Proof. by move=> A B C; apply/matrixP=> i j; rewrite !mxE Monoid.mulmDl. Qed.
+
+Lemma map2_mxDr {mul : T -> T -> T} {add : Monoid.add_law idm mul} : right_distributive (@map2_mx _ _ _ mul m n) (@map2_mx _ _ _ add m n).
+Proof. by move=> A B C; apply/matrixP=> i j; rewrite !mxE Monoid.mulmDr. Qed.
+
+Canonical map2_mx_addoid {mul : T -> T -> T} {add : Monoid.add_law idm mul} := Monoid.AddLaw (map2_mxDl (add:=add)) map2_mxDr.
+
+End MatrixLaws.
+
 (*****************************************************************************)
 (********************* Matrix Zmodule (additive) structure *******************)
 (*****************************************************************************)

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -36,7 +36,7 @@ From mathcomp Require Import div prime binomial ssralg finalg zmodp countalg.
 (*     map_mx f A == the pointwise image of A by f, i.e., the matrix Af       *)
 (*                   congruent to A with Af i j = f (A i j) for all i and j.  *)
 (*     map2_mx f A B == the pointwise image of A and B by f, i.e., the matrix *)
-(*                     ABf congruent to A with Af i j = f (A i j) for all i   *)
+(*                     ABf congruent to A with ABf i j = f (A i j) for all i  *)
 (*                     and j.                                                 *)
 (*            A^T == the matrix transpose of A.                               *)
 (*        row i A == the i'th row of A (this is a row vector).                *)

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -1397,6 +1397,150 @@ Arguments map_mx_id_in {R m n} [f M].
 Arguments map_mx_id {R m n} [f].
 
 (*****************************************************************************)
+(********************* Matrix lifted laws *******************)
+(*****************************************************************************)
+
+Section Map2Matrix.
+Context {R S T : Type} (f : R -> S -> T).
+
+Fact map2_mx_key : unit. Proof. by []. Qed.
+Definition map2_mx m n (A : 'M_(m, n)) (B : 'M_(m, n)) := \matrix[map2_mx_key]_(i, j) f (A i j) (B i j).
+
+Section OneMatrix.
+
+Variables (m n : nat) (A : 'M[R]_(m, n)) (B : 'M[S]_(m, n)).
+
+Lemma map2_trmx : (map2_mx A B)^T = map2_mx A^T B^T.
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_const_mx a b : map2_mx (const_mx a) (const_mx b) = const_mx (f a b) :> 'M_(m, n).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_row i : map2_mx (row i A) (row i B) = row i (map2_mx A B).
+Proof. by apply/rowP=> j; rewrite !mxE. Qed.
+
+Lemma map2_col j : map2_mx (col j A) (col j B) = col j (map2_mx A B).
+Proof. by apply/colP=> i; rewrite !mxE. Qed.
+
+Lemma map2_row' i0 : map2_mx (row' i0 A) (row' i0 B) = row' i0 (map2_mx A B).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_col' j0 : map2_mx (col' j0 A) (col' j0 B) = col' j0 (map2_mx A B).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_mxsub m' n' g h : map2_mx (@mxsub _ _ _  m' n' g h A) (@mxsub _ _ _  m' n' g h B) = mxsub g h (map2_mx A B).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_row_perm s : map2_mx (row_perm s A) (row_perm s B) = row_perm s (map2_mx A B).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_col_perm s : map2_mx (col_perm s A) (col_perm s B) = col_perm s (map2_mx A B).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_xrow i1 i2 : map2_mx (xrow i1 i2 A) (xrow i1 i2 B) = xrow i1 i2 (map2_mx A B).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_xcol j1 j2 : map2_mx (xcol j1 j2 A) (xcol j1 j2 B) = xcol j1 j2 (map2_mx A B).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_castmx m' n' c : map2_mx (castmx c A) (castmx c B) = castmx c (map2_mx A B) :> 'M_(m', n').
+Proof. by apply/matrixP=> i j; rewrite !(castmxE, mxE). Qed.
+
+Lemma map2_conform_mx m' n' (A' : 'M_(m', n')) (B' : 'M_(m', n')) :
+  map2_mx (conform_mx A' A) (conform_mx B' B) = conform_mx (map2_mx A' B') (map2_mx A B).
+Proof.
+move: A' B'; have [[<- <-] A' B'|] := eqVneq (m, n) (m', n').
+  by rewrite !conform_mx_id.
+by rewrite negb_and => neq_mn A' B'; rewrite !nonconform_mx.
+Qed.
+
+Lemma map2_mxvec : map2_mx (mxvec A) (mxvec B) = mxvec (map2_mx A B).
+Proof. by apply/rowP=> i; rewrite !(castmxE, mxE). Qed.
+
+Lemma map2_vec_mx (v : 'rV_(m * n)) (w : 'rV_(m * n)) : map2_mx (vec_mx v) (vec_mx w) = vec_mx (map2_mx v w).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+End OneMatrix.
+
+Section Block.
+
+Variables m1 m2 n1 n2 : nat.
+Variables (Aul : 'M[R]_(m1, n1)) (Aur : 'M[R]_(m1, n2)).
+Variables (Adl : 'M[R]_(m2, n1)) (Adr : 'M[R]_(m2, n2)).
+Variables (Bh : 'M[R]_(m1, n1 + n2)) (Bv : 'M[R]_(m1 + m2, n1)).
+Variable B : 'M[R]_(m1 + m2, n1 + n2).
+Variables (A'ul : 'M[S]_(m1, n1)) (A'ur : 'M[S]_(m1, n2)).
+Variables (A'dl : 'M[S]_(m2, n1)) (A'dr : 'M[S]_(m2, n2)).
+Variables (B'h : 'M[S]_(m1, n1 + n2)) (B'v : 'M[S]_(m1 + m2, n1)).
+Variable B' : 'M[S]_(m1 + m2, n1 + n2).
+
+Lemma map2_row_mx : map2_mx (row_mx Aul Aur) (row_mx A'ul A'ur) = row_mx (map2_mx Aul A'ul) (map2_mx Aur A'ur).
+Proof. by apply/matrixP=> i j; do 2![rewrite !mxE //; case: split => ?]. Qed.
+
+Lemma map2_col_mx : map2_mx (col_mx Aul Adl) (col_mx A'ul A'dl) = col_mx (map2_mx Aul A'ul) (map2_mx Adl A'dl).
+Proof. by apply/matrixP=> i j; do 2![rewrite !mxE //; case: split => ?]. Qed.
+
+Lemma map2_block_mx :
+  map2_mx (block_mx Aul Aur Adl Adr) (block_mx A'ul A'ur A'dl A'dr) = block_mx (map2_mx Aul A'ul) (map2_mx Aur A'ur) (map2_mx Adl A'dl) (map2_mx Adr A'dr).
+Proof. by apply/matrixP=> i j; do 3![rewrite !mxE //; case: split => ?]. Qed.
+
+Lemma map2_lsubmx : map2_mx (lsubmx Bh) (lsubmx B'h) = lsubmx (map2_mx Bh B'h).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_rsubmx : map2_mx (rsubmx Bh) (rsubmx B'h) = rsubmx (map2_mx Bh B'h).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_usubmx : map2_mx (usubmx Bv) (usubmx B'v) = usubmx (map2_mx Bv B'v).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_dsubmx : map2_mx (dsubmx Bv) (dsubmx B'v) = dsubmx (map2_mx Bv B'v).
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_ulsubmx : map2_mx (ulsubmx B) (ulsubmx B') = ulsubmx (map2_mx B B').
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_ursubmx : map2_mx (ursubmx B) (ursubmx B') = ursubmx (map2_mx B B').
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_dlsubmx : map2_mx (dlsubmx B) (dlsubmx B') = dlsubmx (map2_mx B B').
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+Lemma map2_drsubmx : map2_mx (drsubmx B) (drsubmx B') = drsubmx (map2_mx B B').
+Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
+
+End Block.
+
+End Map2Matrix.
+
+Section Map2Eq.
+
+Context {R S T : Type} {m n : nat}.
+
+Lemma eq_in_map2_mx (f g : R -> S -> T) (M : 'M[R]_(m, n)) (M' : 'M[S]_(m, n)) :
+  (forall i j, f (M i j) (M' i j) = g (M i j) (M' i j)) -> map2_mx f M M' = map2_mx g M M'.
+Proof. by move=> fg; apply/matrixP => i j; rewrite !mxE. Qed.
+
+Lemma eq_map2_mx (f g : R -> S -> T) : f =2 g ->
+  @map2_mx _ _ _ f m n =2 @map2_mx _ _ _ g m n.
+Proof. by move=> eq_fg M M'; apply/eq_in_map2_mx. Qed.
+
+Lemma map2_mx_left_in (f : R -> R -> R) (M : 'M_(m, n)) (M' : 'M_(m, n)) :
+  (forall i j, f (M i j) (M' i j) = M i j) -> map2_mx f M M' = M.
+Proof. by move=> fM; apply/matrixP => i j; rewrite !mxE. Qed.
+
+Lemma map2_mx_left (f : R -> R -> R) : f =1 (fun x _ => x) -> forall (M : 'M_(m, n)) (M' : 'M_(m, n)), map2_mx f M M' = M.
+Proof. by move=> fl M M'; rewrite map2_mx_left_in// =>i j; rewrite fl. Qed.
+
+Lemma map2_mx_right_in (f : R -> R -> R) (M : 'M_(m, n)) (M' : 'M_(m, n)) :
+  (forall i j, f (M i j) (M' i j) = M' i j) -> map2_mx f M M' = M'.
+Proof. by move=> fM; apply/matrixP => i j; rewrite !mxE. Qed.
+
+Lemma map2_mx_right (f : R -> R -> R) : f =1 (fun _ x => x) -> forall (M : 'M_(m, n)) (M' : 'M_(m, n)), map2_mx f M M' = M'.
+Proof. by move=> fr M M'; rewrite map2_mx_right_in// =>i j; rewrite fr. Qed.
+
+End Map2Eq.
+
+(*****************************************************************************)
 (********************* Matrix Zmodule (additive) structure *******************)
 (*****************************************************************************)
 
@@ -1998,6 +2142,7 @@ Section ScalarMx.
 
 Variable n : nat.
 
+(*TODO: undergeneralize to monoid *)
 Fact scalar_mx_key : unit. Proof. by []. Qed.
 Definition scalar_mx x : 'M[R]_n :=
   \matrix[scalar_mx_key]_(i , j) (x *+ (i == j)).
@@ -2563,7 +2708,7 @@ Arguments mulmxr {_ _ _} B A /.
 Section Trace.
 
 Variable n : nat.
-
+(*TODO: undergeneralize to monoid *)
 Definition mxtrace (A : 'M[R]_n) := \sum_i A i i.
 Local Notation "'\tr' A" := (mxtrace A) : ring_scope.
 

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -1593,20 +1593,15 @@ Implicit Types A B : 'M[V]_(m, n).
 
 Fact oppmx_key : unit. Proof. by []. Qed.
 Fact addmx_key : unit. Proof. by []. Qed.
-Definition oppmx A := \matrix[oppmx_key]_(i, j) (- A i j).
-Definition addmx A B := \matrix[addmx_key]_(i, j) (A i j + B i j).
+Definition oppmx := @map_mx V V -%R m n.
+Definition addmx := @map2_mx V V V +%R m n.
 (* In principle, diag_mx and scalar_mx could be defined here, but since they *)
 (* only make sense with the graded ring operations, we defer them to the     *)
 (* next section.                                                             *)
 
-Lemma addmxA : associative addmx.
-Proof. by move=> A B C; apply/matrixP=> i j; rewrite !mxE addrA. Qed.
-
-Lemma addmxC : commutative addmx.
-Proof. by move=> A B; apply/matrixP=> i j; rewrite !mxE addrC. Qed.
-
-Lemma add0mx : left_id (const_mx 0) addmx.
-Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE add0r. Qed.
+Definition addmxA : associative addmx := map2_mxA.
+Definition addmxC : commutative addmx := map2_mxC.
+Definition add0mx : left_id (const_mx 0) addmx := map2_1mx.
 
 Lemma addNmx : left_inverse (const_mx 0) oppmx addmx.
 Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE addNr. Qed.

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -1,4 +1,3 @@
-
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq choice.

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -35,6 +35,9 @@ From mathcomp Require Import div prime binomial ssralg finalg zmodp countalg.
 (*                   should be determined by context).                        *)
 (*     map_mx f A == the pointwise image of A by f, i.e., the matrix Af       *)
 (*                   congruent to A with Af i j = f (A i j) for all i and j.  *)
+(*     map2_mx f A B == the pointwise image of A and B by f, i.e., the matrix *)
+(*                     ABf congruent to A with Af i j = f (A i j) for all i   *)
+(*                     and j.                                                 *)
 (*            A^T == the matrix transpose of A.                               *)
 (*        row i A == the i'th row of A (this is a row vector).                *)
 (*        col j A == the j'th column of A (a column vector).                  *)
@@ -1405,7 +1408,8 @@ Section Map2Matrix.
 Context {R S T : Type} (f : R -> S -> T).
 
 Fact map2_mx_key : unit. Proof. by []. Qed.
-Definition map2_mx m n (A : 'M_(m, n)) (B : 'M_(m, n)) := \matrix[map2_mx_key]_(i, j) f (A i j) (B i j).
+Definition map2_mx m n (A : 'M_(m, n)) (B : 'M_(m, n)) :=
+  \matrix[map2_mx_key]_(i, j) f (A i j) (B i j).
 
 Section OneMatrix.
 
@@ -1414,7 +1418,8 @@ Variables (m n : nat) (A : 'M[R]_(m, n)) (B : 'M[S]_(m, n)).
 Lemma map2_trmx : (map2_mx A B)^T = map2_mx A^T B^T.
 Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 
-Lemma map2_const_mx a b : map2_mx (const_mx a) (const_mx b) = const_mx (f a b) :> 'M_(m, n).
+Lemma map2_const_mx a b :
+  map2_mx (const_mx a) (const_mx b) = const_mx (f a b) :> 'M_(m, n).
 Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 
 Lemma map2_row i : map2_mx (row i A) (row i B) = row i (map2_mx A B).
@@ -1429,26 +1434,34 @@ Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 Lemma map2_col' j0 : map2_mx (col' j0 A) (col' j0 B) = col' j0 (map2_mx A B).
 Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 
-Lemma map2_mxsub m' n' g h : map2_mx (@mxsub _ _ _  m' n' g h A) (@mxsub _ _ _  m' n' g h B) = mxsub g h (map2_mx A B).
+Lemma map2_mxsub m' n' g h :
+  map2_mx (@mxsub _ _ _  m' n' g h A) (@mxsub _ _ _  m' n' g h B) =
+  mxsub g h (map2_mx A B).
 Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 
-Lemma map2_row_perm s : map2_mx (row_perm s A) (row_perm s B) = row_perm s (map2_mx A B).
+Lemma map2_row_perm s :
+  map2_mx (row_perm s A) (row_perm s B) = row_perm s (map2_mx A B).
 Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 
-Lemma map2_col_perm s : map2_mx (col_perm s A) (col_perm s B) = col_perm s (map2_mx A B).
+Lemma map2_col_perm s :
+  map2_mx (col_perm s A) (col_perm s B) = col_perm s (map2_mx A B).
 Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 
-Lemma map2_xrow i1 i2 : map2_mx (xrow i1 i2 A) (xrow i1 i2 B) = xrow i1 i2 (map2_mx A B).
+Lemma map2_xrow i1 i2 :
+  map2_mx (xrow i1 i2 A) (xrow i1 i2 B) = xrow i1 i2 (map2_mx A B).
 Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 
-Lemma map2_xcol j1 j2 : map2_mx (xcol j1 j2 A) (xcol j1 j2 B) = xcol j1 j2 (map2_mx A B).
+Lemma map2_xcol j1 j2 :
+  map2_mx (xcol j1 j2 A) (xcol j1 j2 B) = xcol j1 j2 (map2_mx A B).
 Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 
-Lemma map2_castmx m' n' c : map2_mx (castmx c A) (castmx c B) = castmx c (map2_mx A B) :> 'M_(m', n').
+Lemma map2_castmx m' n' c :
+  map2_mx (castmx c A) (castmx c B) = castmx c (map2_mx A B) :> 'M_(m', n').
 Proof. by apply/matrixP=> i j; rewrite !(castmxE, mxE). Qed.
 
 Lemma map2_conform_mx m' n' (A' : 'M_(m', n')) (B' : 'M_(m', n')) :
-  map2_mx (conform_mx A' A) (conform_mx B' B) = conform_mx (map2_mx A' B') (map2_mx A B).
+  map2_mx (conform_mx A' A) (conform_mx B' B) =
+  conform_mx (map2_mx A' B') (map2_mx A B).
 Proof.
 move: A' B'; have [[<- <-] A' B'|] := eqVneq (m, n) (m', n').
   by rewrite !conform_mx_id.
@@ -1458,7 +1471,8 @@ Qed.
 Lemma map2_mxvec : map2_mx (mxvec A) (mxvec B) = mxvec (map2_mx A B).
 Proof. by apply/rowP=> i; rewrite !(castmxE, mxE). Qed.
 
-Lemma map2_vec_mx (v : 'rV_(m * n)) (w : 'rV_(m * n)) : map2_mx (vec_mx v) (vec_mx w) = vec_mx (map2_mx v w).
+Lemma map2_vec_mx (v : 'rV_(m * n)) (w : 'rV_(m * n)) :
+  map2_mx (vec_mx v) (vec_mx w) = vec_mx (map2_mx v w).
 Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 
 End OneMatrix.
@@ -1475,14 +1489,20 @@ Variables (A'dl : 'M[S]_(m2, n1)) (A'dr : 'M[S]_(m2, n2)).
 Variables (B'h : 'M[S]_(m1, n1 + n2)) (B'v : 'M[S]_(m1 + m2, n1)).
 Variable B' : 'M[S]_(m1 + m2, n1 + n2).
 
-Lemma map2_row_mx : map2_mx (row_mx Aul Aur) (row_mx A'ul A'ur) = row_mx (map2_mx Aul A'ul) (map2_mx Aur A'ur).
+Lemma map2_row_mx :
+  map2_mx (row_mx Aul Aur) (row_mx A'ul A'ur) =
+  row_mx (map2_mx Aul A'ul) (map2_mx Aur A'ur).
 Proof. by apply/matrixP=> i j; do 2![rewrite !mxE //; case: split => ?]. Qed.
 
-Lemma map2_col_mx : map2_mx (col_mx Aul Adl) (col_mx A'ul A'dl) = col_mx (map2_mx Aul A'ul) (map2_mx Adl A'dl).
+Lemma map2_col_mx :
+  map2_mx (col_mx Aul Adl) (col_mx A'ul A'dl) =
+  col_mx (map2_mx Aul A'ul) (map2_mx Adl A'dl).
 Proof. by apply/matrixP=> i j; do 2![rewrite !mxE //; case: split => ?]. Qed.
 
 Lemma map2_block_mx :
-  map2_mx (block_mx Aul Aur Adl Adr) (block_mx A'ul A'ur A'dl A'dr) = block_mx (map2_mx Aul A'ul) (map2_mx Aur A'ur) (map2_mx Adl A'dl) (map2_mx Adr A'dr).
+  map2_mx (block_mx Aul Aur Adl Adr) (block_mx A'ul A'ur A'dl A'dr) =
+  block_mx
+   (map2_mx Aul A'ul) (map2_mx Aur A'ur) (map2_mx Adl A'dl) (map2_mx Adr A'dr).
 Proof. by apply/matrixP=> i j; do 3![rewrite !mxE //; case: split => ?]. Qed.
 
 Lemma map2_lsubmx : map2_mx (lsubmx Bh) (lsubmx B'h) = lsubmx (map2_mx Bh B'h).
@@ -1518,7 +1538,8 @@ Section Map2Eq.
 Context {R S T : Type} {m n : nat}.
 
 Lemma eq_in_map2_mx (f g : R -> S -> T) (M : 'M[R]_(m, n)) (M' : 'M[S]_(m, n)) :
-  (forall i j, f (M i j) (M' i j) = g (M i j) (M' i j)) -> map2_mx f M M' = map2_mx g M M'.
+  (forall i j, f (M i j) (M' i j) = g (M i j) (M' i j)) ->
+  map2_mx f M M' = map2_mx g M M'.
 Proof. by move=> fg; apply/matrixP => i j; rewrite !mxE. Qed.
 
 Lemma eq_map2_mx (f g : R -> S -> T) : f =2 g ->
@@ -1529,14 +1550,16 @@ Lemma map2_mx_left_in (f : R -> R -> R) (M : 'M_(m, n)) (M' : 'M_(m, n)) :
   (forall i j, f (M i j) (M' i j) = M i j) -> map2_mx f M M' = M.
 Proof. by move=> fM; apply/matrixP => i j; rewrite !mxE. Qed.
 
-Lemma map2_mx_left (f : R -> R -> R) : f =1 (fun x _ => x) -> forall (M : 'M_(m, n)) (M' : 'M_(m, n)), map2_mx f M M' = M.
+Lemma map2_mx_left (f : R -> R -> R) : f =1 (fun x _ => x) ->
+  forall (M : 'M_(m, n)) (M' : 'M_(m, n)), map2_mx f M M' = M.
 Proof. by move=> fl M M'; rewrite map2_mx_left_in// =>i j; rewrite fl. Qed.
 
 Lemma map2_mx_right_in (f : R -> R -> R) (M : 'M_(m, n)) (M' : 'M_(m, n)) :
   (forall i j, f (M i j) (M' i j) = M' i j) -> map2_mx f M M' = M'.
 Proof. by move=> fM; apply/matrixP => i j; rewrite !mxE. Qed.
 
-Lemma map2_mx_right (f : R -> R -> R) : f =1 (fun _ x => x) -> forall (M : 'M_(m, n)) (M' : 'M_(m, n)), map2_mx f M M' = M'.
+Lemma map2_mx_right (f : R -> R -> R) : f =1 (fun _ x => x) ->
+  forall (M : 'M_(m, n)) (M' : 'M_(m, n)), map2_mx f M M' = M'.
 Proof. by move=> fr M M'; rewrite map2_mx_right_in// =>i j; rewrite fr. Qed.
 
 End Map2Eq.
@@ -1548,34 +1571,45 @@ Context {T : Type} {m n : nat} {idm : T}.
 Lemma map2_mxA {opm : Monoid.law idm} : associative (@map2_mx _ _ _ opm m n).
 Proof. by move=> A B C; apply/matrixP=> i j; rewrite !mxE Monoid.mulmA. Qed.
 
-Lemma map2_1mx {opm : Monoid.law idm} : left_id (const_mx idm) (@map2_mx _ _ _ opm m n).
+Lemma map2_1mx {opm : Monoid.law idm} :
+  left_id (const_mx idm) (@map2_mx _ _ _ opm m n).
 Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE Monoid.mul1m. Qed.
 
-Lemma map2_mx1 {opm : Monoid.law idm} : right_id (const_mx idm) (@map2_mx _ _ _ opm m n).
+Lemma map2_mx1 {opm : Monoid.law idm} :
+  right_id (const_mx idm) (@map2_mx _ _ _ opm m n).
 Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE Monoid.mulm1. Qed.
 
-Canonical map2_mx_monoid {opm : Monoid.law idm} := Monoid.Law (map2_mxA (opm:=opm)) map2_1mx map2_mx1.
+Canonical map2_mx_monoid {opm : Monoid.law idm} :=
+  Monoid.Law (map2_mxA (opm:=opm)) map2_1mx map2_mx1.
 
-Lemma map2_mxC {opm : Monoid.com_law idm} : commutative (@map2_mx _ _ _ opm m n).
+Lemma map2_mxC {opm : Monoid.com_law idm} :
+  commutative (@map2_mx _ _ _ opm m n).
 Proof. by move=> A B; apply/matrixP=> i j; rewrite !mxE Monoid.mulmC. Qed.
 
-Canonical map2_mx_comoid {opm : Monoid.com_law idm} := Monoid.ComLaw (map2_mxC (opm:=opm)).
+Canonical map2_mx_comoid {opm : Monoid.com_law idm} :=
+  Monoid.ComLaw (map2_mxC (opm:=opm)).
 
-Lemma map2_0mx {opm : Monoid.mul_law idm} : left_zero (const_mx idm) (@map2_mx _ _ _ opm m n).
+Lemma map2_0mx {opm : Monoid.mul_law idm} :
+  left_zero (const_mx idm) (@map2_mx _ _ _ opm m n).
 Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE Monoid.mul0m. Qed.
 
-Lemma map2_mx0 {opm : Monoid.mul_law idm} : right_zero (const_mx idm) (@map2_mx _ _ _ opm m n).
+Lemma map2_mx0 {opm : Monoid.mul_law idm} :
+  right_zero (const_mx idm) (@map2_mx _ _ _ opm m n).
 Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE Monoid.mulm0. Qed.
 
-Canonical map2_mx_muloid {opm : Monoid.mul_law idm} := Monoid.MulLaw (map2_0mx (opm:=opm)) map2_mx0.
+Canonical map2_mx_muloid {opm : Monoid.mul_law idm} :=
+  Monoid.MulLaw (map2_0mx (opm:=opm)) map2_mx0.
 
-Lemma map2_mxDl {mul : T -> T -> T} {add : Monoid.add_law idm mul} : left_distributive (@map2_mx _ _ _ mul m n) (@map2_mx _ _ _ add m n).
+Lemma map2_mxDl {mul : T -> T -> T} {add : Monoid.add_law idm mul} :
+  left_distributive (@map2_mx _ _ _ mul m n) (@map2_mx _ _ _ add m n).
 Proof. by move=> A B C; apply/matrixP=> i j; rewrite !mxE Monoid.mulmDl. Qed.
 
-Lemma map2_mxDr {mul : T -> T -> T} {add : Monoid.add_law idm mul} : right_distributive (@map2_mx _ _ _ mul m n) (@map2_mx _ _ _ add m n).
+Lemma map2_mxDr {mul : T -> T -> T} {add : Monoid.add_law idm mul} :
+  right_distributive (@map2_mx _ _ _ mul m n) (@map2_mx _ _ _ add m n).
 Proof. by move=> A B C; apply/matrixP=> i j; rewrite !mxE Monoid.mulmDr. Qed.
 
-Canonical map2_mx_addoid {mul : T -> T -> T} {add : Monoid.add_law idm mul} := Monoid.AddLaw (map2_mxDl (add:=add)) map2_mxDr.
+Canonical map2_mx_addoid {mul : T -> T -> T} {add : Monoid.add_law idm mul} :=
+  Monoid.AddLaw (map2_mxDl (add:=add)) map2_mxDr.
 
 End MatrixLaws.
 
@@ -1787,7 +1821,8 @@ Proof. by apply: (iffP 'forall_'forall_implyP) => /(_ _ _ _)/eqP. Qed.
 
 Lemma is_diag_mx_is_trig m n (A : 'M[V]_(m, n)) : is_diag_mx A -> is_trig_mx A.
 Proof.
-by move=> /is_diag_mxP A_eq0; apply/is_trig_mxP=> i j lt_ij; rewrite A_eq0// ltn_eqF.
+by move=> /is_diag_mxP A_eq0; apply/is_trig_mxP=> i j lt_ij;
+   rewrite A_eq0// ltn_eqF.
 Qed.
 
 Lemma mx0_is_trig m n : is_trig_mx (0 : 'M[V]_(m, n)).
@@ -2805,7 +2840,8 @@ Qed.
 
 Canonical mxtrace_linear := Linear mxtrace_is_scalar.
 
-Lemma mxtraceZ a (A : 'M_n) : \tr (a *: A) = a * \tr A. Proof. exact: scalarZ. Qed.
+Lemma mxtraceZ a (A : 'M_n) : \tr (a *: A) = a * \tr A.
+Proof. exact: scalarZ. Qed.
 
 Lemma mxtrace1 : \tr (1%:M : 'M[R]_n) = n%:R. Proof. exact: mxtrace_scalar. Qed.
 
@@ -4410,7 +4446,8 @@ Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 Lemma mxcol_const m a : \mxcol_j (const_mx a : 'M[V]_(p_ j, m)) = const_mx a.
 Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 
-Lemma mxcol_sum (I : finType) m (C_ : forall j i, 'M[V]_(p_ i, m)) (P : {pred I}):
+Lemma mxcol_sum
+  (I : finType) m (C_ : forall j i, 'M[V]_(p_ i, m)) (P : {pred I}):
   \mxcol_i (\sum_(j | P j) C_ j i) = \sum_(j | P j) \mxcol_i (C_ j i).
 Proof.
 apply/matrixP => i j; rewrite !(mxE, summxE).

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -1761,7 +1761,7 @@ Lemma diagonalizable_for_mxminpoly {n} {P A : 'M[F]_n.+1}
 Proof.
 rewrite /rs => pu /(diagonalizable_forLR pu)[d {A rs}->].
 rewrite mxminpoly_uconj ?unitmx_inv// mxminpoly_diag.
-by rewrite (@eq_map _ _ _ (d 0))// => i; rewrite conjmxVK// mxE eqxx.
+by rewrite [in X in _ = X](@eq_map _ _ _ (d 0))// => i; rewrite conjmxVK// mxE eqxx.
 Qed.
 
 End Simmxity.


### PR DESCRIPTION
##### Motivation for this change

Generalizes a few operations on matrices (pointwise lifting of operations, moving diagonal matrices, scalar matrices and trace to the zmodType section).
Note that the last commit breaks (and fixes again) diagonalizable_for_mxinpoly (mxpoly.v), some rewrite does not rewrite the same term depending on where diag_mx is defined.
Note that I did not edit CHANGELOG_UNRELEASED.md as I do not quite know how to extend it.

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
