### PR TITLE
fix sval notation

### DIFF
--- a/mathcomp/ssreflect/eqtype.v
+++ b/mathcomp/ssreflect/eqtype.v
@@ -707,8 +707,8 @@ Lemma innew_val T nT : cancel val (@innew T nT).
 Proof. by move=> u; apply: val_inj; apply: SubK. Qed.
 
 (* Prenex Implicits and renaming. *)
-Notation sval := (@proj1_sig _ _).
 Notation "@ 'sval'" := (@proj1_sig) (at level 10, format "@ 'sval'").
+Notation sval := (@proj1_sig _ _).
 
 Section SigProj.
 


### PR DESCRIPTION
##### Motivation for this change

Otherwise, the notation `sval` is not printed.

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
