### PR TITLE
Fix `\meet^p` and `\join^p` notations and the scope of `n.-tuplelexi` notation

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- in `order.v`
+  + fix `\meet^p_` and `\join^p_` notations
+  + fix the scope of `n.-tuplelexi` notations
+
 ### Renamed
 
 ### Removed

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -6513,8 +6513,15 @@ Notation "><^p y" := [pred x | ~~ (>=<^p%O x y)] : order_scope.
 Notation "><^p y :> T" := (><^p (y : T)) (only parsing) : order_scope.
 Notation "x ><^p y" := (~~ (><^p%O x y)) : order_scope.
 
-Notation "x `&^p` y" :=  (@meet prod_display _ x y) : order_scope.
-Notation "x `|^p` y" := (@join prod_display _ x y) : order_scope.
+(* The following Local Notations are here to define the \join^p_ and \meet^p_ *)
+(* notations later. Do not remove them.                                       *)
+Local Notation "0" := (@bottom prod_display _).
+Local Notation "1" := (@top prod_display _).
+Local Notation meet := (@meet prod_display _).
+Local Notation join := (@join prod_display _).
+
+Notation "x `&^p` y" :=  (meet x y) : order_scope.
+Notation "x `|^p` y" := (join x y) : order_scope.
 
 Notation "\join^p_ ( i <- r | P ) F" :=
   (\big[join/0]_(i <- r | P%B) F%O) : order_scope.
@@ -8076,9 +8083,9 @@ Module Exports.
 
 Notation "n .-tuplelexi[ disp ]" := (type disp n)
   (at level 2, disp at next level, format "n .-tuplelexi[ disp ]") :
-  order_scope.
+  type_scope.
 Notation "n .-tuplelexi" := (n.-tuplelexi[lexi_display])
-  (at level 2, format "n .-tuplelexi") : order_scope.
+  (at level 2, format "n .-tuplelexi") : type_scope.
 
 Canonical eqType.
 Canonical choiceType.


### PR DESCRIPTION
##### Motivation for this change

Bug fixes.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
