### PR TITLE
fix and strengthen eq_bigmax and eq_bigmin in order.v

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - in `order.v`
+  + fix lemmas `eq_bigmax` and `eq_bigmin` to respect given predicates
+
+- in `order.v`
   + fix `\meet^p_` and `\join^p_` notations
   + fix the scope of `n.-tuplelexi` notations
 

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -4446,12 +4446,16 @@ by apply/bigmax_leP; split => //; exact: PxF.
 Qed.
 
 Lemma eq_bigmin j P F : P j -> (forall i, P i -> F i <= x) ->
-  {i0 | i0 \in I & \big[min/x]_(i | P i) F i = F i0}.
-Proof. by move=> Pi0 Hx; rewrite (bigmin_eq_arg Pi0) //; eexists. Qed.
+  {i0 | i0 \in P & \big[min/x]_(i | P i) F i = F i0}.
+Proof.
+by move=> Pi0 Hx; rewrite (bigmin_eq_arg Pi0) //; eexists => //; case:arg_minP.
+Qed.
 
 Lemma eq_bigmax j P F : P j -> (forall i, P i -> x <= F i) ->
-  {i0 | i0 \in I & \big[max/x]_(i | P i) F i = F i0}.
-Proof. by move=> Pi0 Hx; rewrite (bigmax_eq_arg Pi0) //; eexists. Qed.
+  {i0 | i0 \in P & \big[max/x]_(i | P i) F i = F i0}.
+Proof.
+by move=> Pi0 Hx; rewrite (bigmax_eq_arg Pi0) //; eexists => //; case:arg_maxP.
+Qed.
 
 Lemma le_bigmin2 P F1 F2 : (forall i, P i -> F1 i <= F2 i) ->
   \big[min/x]_(i | P i) F1 i <= \big[min/x]_(i | P i) F2 i.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -4448,13 +4448,13 @@ Qed.
 Lemma eq_bigmin j P F : P j -> (forall i, P i -> F i <= x) ->
   {i0 | i0 \in P & \big[min/x]_(i | P i) F i = F i0}.
 Proof.
-by move=> Pi0 Hx; rewrite (bigmin_eq_arg Pi0) //; eexists => //; case:arg_minP.
+by move=> Pi0 Hx; rewrite (bigmin_eq_arg Pi0) //; eexists=> //; case: arg_minP.
 Qed.
 
 Lemma eq_bigmax j P F : P j -> (forall i, P i -> x <= F i) ->
   {i0 | i0 \in P & \big[max/x]_(i | P i) F i = F i0}.
 Proof.
-by move=> Pi0 Hx; rewrite (bigmax_eq_arg Pi0) //; eexists => //; case:arg_maxP.
+by move=> Pi0 Hx; rewrite (bigmax_eq_arg Pi0) //; eexists=> //; case: arg_maxP.
 Qed.
 
 Lemma le_bigmin2 P F1 F2 : (forall i, P i -> F1 i <= F2 i) ->


### PR DESCRIPTION
##### Motivation for this change

<!-- please explain your reason for doing this change -->
Lemmas eq_bigmax and eq_bigmin in order.v is wrongly stated in weaker forms
that do not respect their argument P in the returned type.

##### Things done/to do

This PR fixes the problem by strengthening the statements and amending the proofs.

<!-- please fill in the following checklist -->
- [YES ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
~- [NO] added corresponding documentation in the headers~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

Also PR-ed to mathcomp-analysis: https://github.com/math-comp/analysis/pull/863

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
