### PR TITLE
clean type for divz

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `intdiv.v`
   + `zcontents` is now of type `{poly int} -> int`
+  + `divz` is now of type `int -> int -> int`
 ### Renamed
 
 ### Removed

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -52,7 +52,7 @@ Unset Printing Implicit Defensive.
 Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
-Definition divz (m d : int) :=
+Definition divz (m d : int) : int :=
   let: (K, n) := match m with Posz n => (Posz, n) | Negz n => (Negz, n) end in
   sgz d * K (n %/ `|d|)%N.
 
@@ -367,7 +367,7 @@ Lemma lez_divLR d m n : 0 < d -> (d %| m)%Z -> ((m %/ d)%Z <= n) = (m <= n * d).
 Proof. by move=> /ler_pmul2r <- /divzK->. Qed.
 
 Lemma ltz_divRL d m n : 0 < d -> (d %| m)%Z -> (n < m %/ d)%Z = (n * d < m).
-Proof. by move=> /ltr_pmul2r <- /divzK->. Qed.
+Proof. by move=> /ltr_pmul2r/(_ n)<- /divzK->. Qed.
 
 Lemma eqz_div d m n : d != 0 -> (d %| m)%Z -> (n == m %/ d)%Z = (n * d == m).
 Proof. by move=> /mulIf/inj_eq <- /divzK->. Qed.


### PR DESCRIPTION
##### Motivation for this change

Before 
```coq
Check divz 
  : int -> int -> int_Ring
```
After 
```coq
Check divz 
  : int -> int -> int
```
<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [X] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
