### PR TITLE
simpler type for zcontents

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + fix `\meet^p_` and `\join^p_` notations
   + fix the scope of `n.-tuplelexi` notations
 
+- in `intdiv.v`
+  + `zcontents` is now of type `{poly int} -> int`
 ### Renamed
 
 ### Removed

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -710,7 +710,7 @@ End Chinese.
 
 Section ZpolyScale.
 
-Definition zcontents p :=
+Definition zcontents (p : {poly int}) : int :=
   sgz (lead_coef p) * \big[gcdn/0%N]_(i < size p) `|(p`_i)%R|%N.
 
 Lemma sgz_contents p : sgz (zcontents p) = sgz (lead_coef p).


### PR DESCRIPTION
##### Motivation for this change

Before 
```coq 
Check zcontents
	 : {poly int_numDomainType} -> int_Ring
```
After
```coq 
Check zcontents
	 : {poly int} -> int
```


##### Things done/to do

<!-- please fill in the following checklist -->
- [X] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
