### PR TITLE
Fix the \max notation

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -38,6 +38,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `intdiv.v`
   + `zcontents` is now of type `{poly int} -> int`
   + `divz` is now of type `int -> int -> int`
+
+- in `order.v`
+  + fix the definition of `max_fun` (notation `\max`)
+    which was equal to `min_fun`
+
 ### Renamed
 
 ### Removed

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -1168,7 +1168,7 @@ Section LiftedPOrder.
 Variable T' : Type.
 Implicit Type f : T' -> T.
 Definition min_fun f g x := min (f x) (g x).
-Definition max_fun f g x := min (f x) (g x).
+Definition max_fun f g x := max (f x) (g x).
 End LiftedPOrder.
 
 End POrderDef.


### PR DESCRIPTION
##### Motivation for this change

Apparently, I'm the one who got it wrong in https://github.com/math-comp/math-comp/pull/887

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
