### PR TITLE
add ptr to contributing guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 <!-- please fill in the following checklist -->
 - [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
 - [ ] added corresponding documentation in the headers
+- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
 <!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
 <!-- You may also add more items to explain what you did and what remains to do -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,4 @@
 <!-- leave this note as a reminder to reviewers -->
 ##### Automatic note to reviewers
 
-Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
+Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and make sure there is a milestone.


### PR DESCRIPTION
##### Motivation for this change

the addition of a link to the contributing guide was discussed during the last meeting
https://github.com/math-comp/math-comp/wiki/Minutes-March-08-2023
as a way to help contributors (and to simplify review)

##### Things done/to do

<!-- please fill in the following checklist -->
~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)~~
~~- [ ] added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
