### PR TITLE
Add left associativity for doubling and halving operators

### DIFF
--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -164,8 +164,8 @@ Lemma succn_inj : injective succn. Proof. by move=> n m []. Qed.
 
 (* Predeclare postfix doubling/halving operators. *)
 
-Reserved Notation "n .*2" (at level 2, format "n .*2").
-Reserved Notation "n ./2" (at level 2, format "n ./2").
+Reserved Notation "n .*2" (at level 2, left associativity, format "n .*2").
+Reserved Notation "n ./2" (at level 2, left associativity, format "n ./2").
 
 (* Canonical comparison and eqType for nat.                                *)
 


### PR DESCRIPTION
##### Currently the doubling operator causes a notation clash with the stdpp library since it is not left associative. 

This MR adds left associativity for the doubling and halving operator to resolve this notation conflict. It is also logically better to have these operators be left associative instead of being right associative
