### PR TITLE
Adding find_pred0 and find_predT to seq.v.

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `perm.v`
   + lemmas `perm_on_id`, `perm_onC`, `tperm_on`
 
+- in `seq.v`
+  + lemmas `find_pred0`, `find_predT`
+
 - in `bigop.v`
   + lemma `big_if`
 

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -580,6 +580,11 @@ Proof. by rewrite -cats1 all_cat all_seq1 andbC. Qed.
 
 End SeqFind.
 
+Lemma find_pred0 s : find pred0 s = size s. Proof. by []. Qed.
+
+Lemma find_predT s : find predT s = 0.
+Proof. by case: s. Qed.
+
 Lemma eq_find a1 a2 : a1 =1 a2 -> find a1 =1 find a2.
 Proof. by move=> Ea; elim=> //= x s IHs; rewrite Ea IHs. Qed.
 


### PR DESCRIPTION
##### Motivation for this change

Adding limit cases for `find`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and make sure there is a milestone.
