### PR TITLE
Add subset lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -14,6 +14,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemma `foldl_foldr`
   + lemmas `unzip1_map_nth_zip`, `unzip2_map_nth_zip`, `perm_zip_sym`,
 	`perm_zip1`, `perm_zip2`
+  + lemmas `find_pred0`, `find_predT`
+
+- in `bigop.v`
+  + lemma `big_if`
+
+- in `seq.v`
+  + lemmas `sumn_ncons`, `sumn_set_nth`, `sumn_set_nth_ltn`,
+    `sumn_set_nth0`
+
+- in `finset.v`
+  + lemmas `bigA_distr`, `subset_cons`, `subset_cons2`, `subset_catl`,
+    `subset_catr`, `subset_cat2`, `filter_subset`, `subset_filter`,
+    `map_subset`.
 
 - in `poly.v`
   + multirule `coefE`

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -726,7 +726,6 @@ Qed.
 Lemma filter_subset p s : [seq a <- s | p a] \subset s.
 Proof. by apply/subsetP=> x; rewrite mem_filter => /andP[]. Qed.
 
-
 Lemma subset_filter p s1 s2 :
   s1 \subset s2 -> [seq a <- s1 | p a] \subset [seq a <- s2 | p a].
 Proof.

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -428,7 +428,7 @@ Section OpsTheory.
 
 Variable T : finType.
 
-Implicit Types (A B C D: {pred T}) (P Q : pred T) (x y : T) (s : seq T).
+Implicit Types (A B C D : {pred T}) (P Q : pred T) (x y : T) (s : seq T).
 
 Lemma enumP : Finite.axiom (Finite.enum T).
 Proof. by rewrite unlock; apply: enumP_subdef. Qed.
@@ -707,7 +707,7 @@ Lemma subset_cons s x : s \subset x :: s.
 Proof. by apply/subsetP => y /[!inE] ->; rewrite orbT. Qed.
 
 Lemma subset_cons2 s1 s2 x : s1 \subset s2 -> x :: s1 \subset x :: s2.
-Proof. 
+Proof.
 by move=> ?; apply/subsetP => y /[!inE]; case: eqP => // _; apply: subsetP.
 Qed.
 
@@ -732,14 +732,7 @@ Proof.
 by move/subsetP=> s12; apply/subsetP=> x; rewrite !mem_filter=> /andP[-> /s12].
 Qed.
 
-Lemma map_subset {T' : eqType} s1 s2 (f : T -> T') :
-  s1 \subset s2 -> {subset [seq f x | x <- s1 ] <= [seq f x | x <- s2]}.
-Proof.
-move=> /subsetP ss1s2 x /mapP[y yins1] eqxfy.
-by apply/mapP; exists y => //; apply: ss1s2.
-Qed.
-
-Lemma properE A B : A \proper B = (A \subset B) && ~~(B \subset A).
+Lemma properE A B : A \proper B = (A \subset B) && ~~ (B \subset A).
 Proof. by []. Qed.
 
 Lemma properP A B :
@@ -914,6 +907,13 @@ Lemma disjoint_cat s1 s2 A :
 Proof. by rewrite !disjoint_has has_cat negb_or. Qed.
 
 End OpsTheory.
+
+Lemma map_subset {T T' : finType} (s1 s2 : seq T) (f : T -> T') :
+  s1 \subset s2 -> [seq f x | x <- s1 ] \subset [seq f x | x <- s2].
+Proof.
+move=> s1s2; apply/subsetP => _ /mapP[y] /[swap] -> ys1.
+by apply/mapP; exists y => //; move/subsetP : s1s2; exact.
+Qed.
 
 #[global] Hint Resolve subxx_hint : core.
 

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -703,56 +703,41 @@ Qed.
 Lemma subset_all s A : (s \subset A) = all [in A] s.
 Proof. exact: (sameP (subsetP _ _) allP). Qed.
 
-Lemma subset_cons s x:
-  s \subset x :: s.
-Proof. by apply/subsetP=> y; rewrite inE=> yins; rewrite yins orbT.
+Lemma subset_cons s x : s \subset x :: s.
+Proof. by apply/subsetP => y /[!inE] ->; rewrite orbT. Qed.
+
+Lemma subset_cons2 s1 s2 x : s1 \subset s2 -> x :: s1 \subset x :: s2.
+Proof. 
+by move=> ?; apply/subsetP => y /[!inE]; case: eqP => // _; apply: subsetP.
 Qed.
 
-Lemma subset_cons2 s1 s2 x:
-  s1 \subset s2 -> x :: s1 \subset x :: s2.
+Lemma subset_catl s s' : s \subset s ++ s'.
+Proof. by apply/subsetP=> x xins; rewrite mem_cat xins. Qed.
+
+Lemma subset_catr s s' : s \subset s' ++ s.
+Proof. by apply/subsetP => x xins; rewrite mem_cat xins orbT. Qed.
+
+Lemma subset_cat2 s1 s2 s3 : s1 \subset s2 -> s3 ++ s1 \subset s3 ++ s2.
 Proof.
-move/subsetP=> ss1s2; apply/subsetP => y.
-by rewrite !inE; case: eqP=> //= _; apply: ss1s2.
+move=> /subsetP s12; apply/subsetP => x.
+by rewrite !mem_cat => /orP[->|/s12->]; rewrite ?orbT.
 Qed.
 
-Lemma subset_catl (s s': seq T):
-  s \subset s ++ s'.
-Proof.
-by apply/subsetP=> x xins; rewrite mem_cat xins.
-Qed.
+Lemma filter_subset p s : [seq a <- s | p a] \subset s.
+Proof. by apply/subsetP=> x; rewrite mem_filter => /andP[]. Qed.
 
-Lemma subset_catr (s s': seq T):
-  s \subset s' ++ s.
-Proof.
-by apply/subsetP=> x xins; rewrite mem_cat xins; apply/orP; right.
-Qed.
 
-Lemma subset_cat2 (s1 s2 s3: seq T):
-  s1 \subset s2 -> s3 ++ s1 \subset s3 ++ s2.
-Proof.
-move/subsetP=> ss1s2; apply /subsetP=> x; rewrite !mem_cat=> /orP-[xins3|xins1].
-  by apply/orP; left.
-by apply/orP; right; apply ss1s2.
-Qed.
-
-Lemma filter_subset p s :
-  [seq a <- s | p a] \subset s.
-Proof.
-by apply/subsetP=> x; rewrite mem_filter => /andP-[px xins].
-Qed.
-
-Lemma subset_filter p (s1 s2 : seq T) :
+Lemma subset_filter p s1 s2 :
   s1 \subset s2 -> [seq a <- s1 | p a] \subset [seq a <- s2 | p a].
 Proof.
-move/subsetP=> ss1s2; apply/subsetP=> x; rewrite !mem_filter=> /andP-[px xins1].
-by apply/andP; split => //; apply ss1s2.
+by move/subsetP=> s12; apply/subsetP=> x; rewrite !mem_filter=> /andP[-> /s12].
 Qed.
 
 Lemma map_subset {T' : eqType} s1 s2 (f : T -> T') :
   s1 \subset s2 -> {subset [seq f x | x <- s1 ] <= [seq f x | x <- s2]}.
 Proof.
-move/subsetP=> ss1s2 x; move/mapP=> [y yins1] eqxfy; apply/mapP.
-by exists y=> //=; apply ss1s2.
+move=> /subsetP ss1s2 x /mapP[y yins1] eqxfy.
+by apply/mapP; exists y => //; apply: ss1s2.
 Qed.
 
 Lemma properE A B : A \proper B = (A \subset B) && ~~(B \subset A).

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -703,6 +703,58 @@ Qed.
 Lemma subset_all s A : (s \subset A) = all [in A] s.
 Proof. exact: (sameP (subsetP _ _) allP). Qed.
 
+Lemma subset_cons s x:
+  s \subset x :: s.
+Proof. by apply/subsetP=> y; rewrite inE=> yins; rewrite yins orbT.
+Qed.
+
+Lemma subset_cons2 s1 s2 x:
+  s1 \subset s2 -> x :: s1 \subset x :: s2.
+Proof.
+move/subsetP=> ss1s2; apply/subsetP => y.
+by rewrite !inE; case: eqP=> //= _; apply: ss1s2.
+Qed.
+
+Lemma subset_catl (s s': seq T):
+  s \subset s ++ s'.
+Proof.
+by apply/subsetP=> x xins; rewrite mem_cat xins.
+Qed.
+
+Lemma subset_catr (s s': seq T):
+  s \subset s' ++ s.
+Proof.
+by apply/subsetP=> x xins; rewrite mem_cat xins; apply/orP; right.
+Qed.
+
+Lemma subset_cat2 (s1 s2 s3: seq T):
+  s1 \subset s2 -> s3 ++ s1 \subset s3 ++ s2.
+Proof.
+move/subsetP=> ss1s2; apply /subsetP=> x; rewrite !mem_cat=> /orP-[xins3|xins1].
+- by apply/orP; left.
+- by apply/orP; right; apply ss1s2.
+Qed.
+
+Lemma filter_subset p s :
+  [seq a <- s | p a] \subset s.
+Proof.
+by apply/subsetP=> x; rewrite mem_filter => /andP-[px xins].
+Qed.
+
+Lemma subset_filter p (s1 s2 : seq T) :
+  s1 \subset s2 -> [seq a <- s1 | p a] \subset [seq a <- s2 | p a].
+Proof.
+move/subsetP=> ss1s2; apply/subsetP=> x; rewrite !mem_filter=> /andP-[px xins1].
+by apply/andP; split => //; apply ss1s2.
+Qed.
+
+Lemma map_subset {T' : eqType} s1 s2 (f : T -> T') :
+  s1 \subset s2 -> {subset [seq f x | x <- s1 ] <= [seq f x | x <- s2]}.
+Proof.
+move/subsetP=> ss1s2 x; move/mapP=> [y yins1] eqxfy; apply/mapP.
+by exists y=> //=; apply ss1s2.
+Qed.
+
 Lemma properE A B : A \proper B = (A \subset B) && ~~(B \subset A).
 Proof. by []. Qed.
 

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -731,8 +731,8 @@ Lemma subset_cat2 (s1 s2 s3: seq T):
   s1 \subset s2 -> s3 ++ s1 \subset s3 ++ s2.
 Proof.
 move/subsetP=> ss1s2; apply /subsetP=> x; rewrite !mem_cat=> /orP-[xins3|xins1].
-- by apply/orP; left.
-- by apply/orP; right; apply ss1s2.
+  by apply/orP; left.
+by apply/orP; right; apply ss1s2.
 Qed.
 
 Lemma filter_subset p s :


### PR DESCRIPTION
##### Motivation for this change

Adds the missing lemmas from https://github.com/math-comp/math-comp/issues/619. However, I proved them in their `\subset` form, as that seems the most common interface now.

<!-- please explain your reason for doing this change -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [X] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ ] added corresponding documentation in the headers
- [X] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and make sure there is a milestone.
