### PR TITLE
Poly over mulr 2closed

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -27,7 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemma `bigA_distr`
 
 - in `poly.v`
-  + lemmas `coef_prod_XsubC`, `coefPn_prod_XsubC`, `coef0_prod_XsubC`
+  + lemmas `coef_prod_XsubC`, `coefPn_prod_XsubC`, `coef0_prod_XsubC`,
+	 `polyOver_mulr_2closed`
 
 - in `ssralg.v`
   + `bool` is now canonically a `fieldType` with additive law `addb` and

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -1410,7 +1410,7 @@ Variables (S : {pred R}) (ringS : semiringPred S) (kS : keyed_pred ringS).
 Fact polyOver_mulr_closed : mulr_closed (polyOver kS).
 Proof.
 split=> [|p q]; first by rewrite polyOverC rpred1.
-apply polyOver_mulr_2closed=>//; apply rpredM.
+by apply polyOver_mulr_2closed=> //; apply rpredM.
 Qed.
 Canonical polyOver_mulrPred := MulrPred polyOver_mulr_closed.
 Canonical polyOver_semiringPred := SemiringPred polyOver_mulr_closed.

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -1386,6 +1386,13 @@ by apply/polyOverP=> i; rewrite coefD rpredD ?(polyOverP _).
 Qed.
 Canonical polyOver_addrPred := AddrPred polyOver_addr_closed.
 
+Lemma polyOver_mulr_2closed :
+  GRing.mulr_2closed kS -> GRing.mulr_2closed (polyOver kS).
+Proof.
+move=>mulS p q /polyOverP Sp /polyOverP Sq; apply/polyOverP=> i.
+by rewrite coefM rpred_sum // => j _; apply mulS.
+Qed.
+
 End PolyOverAdd.
 
 Fact polyOverNr S (addS : zmodPred S) (kS : keyed_pred addS) :
@@ -1402,8 +1409,8 @@ Variables (S : {pred R}) (ringS : semiringPred S) (kS : keyed_pred ringS).
 
 Fact polyOver_mulr_closed : mulr_closed (polyOver kS).
 Proof.
-split=> [|p q /polyOverP Sp /polyOverP Sq]; first by rewrite polyOverC rpred1.
-by apply/polyOverP=> i; rewrite coefM rpred_sum // => j _; apply: rpredM.
+split=> [|p q]; first by rewrite polyOverC rpred1.
+apply polyOver_mulr_2closed=>//; apply rpredM.
 Qed.
 Canonical polyOver_mulrPred := MulrPred polyOver_mulr_closed.
 Canonical polyOver_semiringPred := SemiringPred polyOver_mulr_closed.

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -1389,8 +1389,8 @@ Canonical polyOver_addrPred := AddrPred polyOver_addr_closed.
 Lemma polyOver_mulr_2closed :
   GRing.mulr_2closed kS -> GRing.mulr_2closed (polyOver kS).
 Proof.
-move=>mulS p q /polyOverP Sp /polyOverP Sq; apply/polyOverP=> i.
-by rewrite coefM rpred_sum // => j _; apply mulS.
+move=> mulS p q /polyOverP Sp /polyOverP Sq; apply/polyOverP=> i.
+by rewrite coefM rpred_sum // => j _; apply: mulS.
 Qed.
 
 End PolyOverAdd.
@@ -1410,7 +1410,7 @@ Variables (S : {pred R}) (ringS : semiringPred S) (kS : keyed_pred ringS).
 Fact polyOver_mulr_closed : mulr_closed (polyOver kS).
 Proof.
 split=> [|p q]; first by rewrite polyOverC rpred1.
-by apply polyOver_mulr_2closed=> //; apply rpredM.
+exact/polyOver_mulr_2closed/rpredM.
 Qed.
 Canonical polyOver_mulrPred := MulrPred polyOver_mulr_closed.
 Canonical polyOver_semiringPred := SemiringPred polyOver_mulr_closed.


### PR DESCRIPTION
##### Motivation for this change

Partial resolution of issue #996. rpredM does not work on polynomials over algebras, since these do not have an unit. This PR proposes a quick fix, postponing (and preparing) the hierarchy modification.

##### Things done/to do

Added lemma polyOver_mulr_2closed.

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and make sure there is a milestone.
