### PR TITLE
Add omap lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -43,6 +43,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `subDnCA`, `subDnCAC`, `addnBC`, `addnCB`, `addBnAC`, `addBnCAC`,
     `addBnA`, `subBnAC`, `eqn_sub2lE`, `eqn_sub2rE`
 
+- in `ssrfun.v`
+  + lemmas `inj_omap`, `omap_id`, `eq_omap`, `omapK`
+
 ### Changed
 
 - in `order.v`

--- a/mathcomp/ssreflect/ssrfun.v
+++ b/mathcomp/ssreflect/ssrfun.v
@@ -69,3 +69,21 @@ Qed.
 (* this change of order has also been PRed to Coq PR 17249 *)
 Notation "@ 'sval'" := (@proj1_sig) (at level 10, format "@ 'sval'").
 Notation sval := (@proj1_sig _ _).
+
+(**********************)
+(* not yet backported *)
+(**********************)
+
+Lemma inj_omap {aT rT : Type} (f : aT -> rT) :
+  injective f -> injective (omap f).
+Proof. by move=> injf [?|] [?|] //= [/injf->]. Qed.
+
+Lemma omap_id {T : Type} (x : option T) : omap id x = x.
+Proof. by case: x. Qed.
+
+Lemma eq_omap {aT rT : Type} (f g : aT -> rT) : f =1 g -> omap f =1 omap g.
+Proof. by move=> Ef [?|] //=; rewrite Ef. Qed.
+
+Lemma omapK {aT rT : Type} (f : aT -> rT) (g : rT -> aT) :
+  cancel f g -> cancel (omap f) (omap g).
+Proof. by move=> fK [?|] //=; rewrite fK. Qed.


### PR DESCRIPTION
##### Motivation for this change

I found some `omap` lemmas missing while their counterparts for `map` were present.   Among them, `eq_omap` and `omapK` were actually useful for our own development.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [ ] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
