### PR TITLE
Adding perm-related lemmas for zipped sequences.

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `seq.v`
   + lemma `foldl_foldr`
+  + lemmas `unzip1_map_nth_zip`, `unzip2_map_nth_zip`, `perm_zip_sym`,
+	`perm_zip1`, `perm_zip2`
 
 - in `poly.v`
   + multirule `coefE`

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -3219,7 +3219,42 @@ Lemma zip_map I f g (s : seq I) :
   zip (map f s) (map g s) = [seq (f i, g i) | i <- s].
 Proof. by elim: s => //= i s ->. Qed.
 
+Lemma unzip1_map_nth_zip x y s t l :
+  size s = size t -> 
+  unzip1 [seq nth (x, y) (zip s t) i | i <- l] = [seq nth x s i | i <- l].
+Proof. by move=> st; elim: l => [//=|n l IH /=]; rewrite nth_zip ?IH ?st. Qed.
+
+Lemma unzip2_map_nth_zip x y s t l :
+  size s = size t -> 
+  unzip2 [seq nth (x, y) (zip s t) i | i <- l] = [seq nth y t i | i <- l].
+Proof. by move=> st; elim: l => [//=|n l IH /=]; rewrite nth_zip ?IH ?st. Qed.
+
 End Zip.
+
+Lemma perm_zip_sym (S T : eqType) (s1 s2 : seq S) (t1 t2 : seq T) : 
+  perm_eq (zip s1 t1) (zip s2 t2) -> perm_eq (zip t1 s1) (zip t2 s2).
+Proof.
+have swap t s : zip t s = map (fun u => (u.2, u.1)) (zip s t).
+  by elim: s t => [|x s +] [|y t]//= => ->.
+by rewrite [zip t1 s1]swap [zip t2 s2]swap; apply: perm_map.
+Qed.
+
+Lemma perm_zip1 {S T : eqType} (t1 t2 : seq T) (s1 s2 : seq S): 
+  size s1 = size t1 -> size s2 = size t2 -> 
+  perm_eq (zip s1 t1) (zip s2 t2) -> perm_eq s1 s2.
+Proof.
+wlog [x y] : s1 s2 t1 t2 / (S * T)%type => [hwlog|].
+  case: s2 t2 => [|x s2] [|y t2] //; last exact: hwlog.
+  by case: s1 t1 => [|u s1] [|v t1]//= _ _ /perm_nilP.
+move=> eq1 eq2 /(perm_iotaP (x, y))[ns nsP /(congr1 (@unzip1 _ _))].
+rewrite unzip1_zip ?unzip1_map_nth_zip -?eq1// => ->.
+by apply/(perm_iotaP x); exists ns; rewrite // size_zip -eq2 minnn in nsP.
+Qed.
+
+Lemma perm_zip2 {S T : eqType} (s1 s2 : seq S) (t1 t2 : seq T) :
+  size s1 = size t1 -> size s2 = size t2 ->
+  perm_eq (zip s1 t1) (zip s2 t2) -> perm_eq t1 t2.
+Proof. by move=> ? ? ?; rewrite (@perm_zip1 _ _ s1 s2) 1?perm_zip_sym. Qed.
 
 Prenex Implicits zip unzip1 unzip2 all2.
 


### PR DESCRIPTION
##### Motivation for this change

I found these lemmas useful and suggest them to be added to `seq.v`, if deemed general enough.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [ ] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
