### PR TITLE
Remove 1.14.0 deprecation

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -393,6 +393,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `order.v`
   + notations `0`, `1`, `0^d` and `1^d` in `order_scope`
 
+- in `ssrbool.v`
+  + notation `mono2W_in` that was deprecated in 1.14.0
+
 ### Deprecated
 
 - in `order.v`

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -63,9 +63,6 @@ Lemma mono1W_in (aT rT : predArgType) (f : aT -> rT) (aD : {pred aT})
 Proof. by move=> fP x xD xP; rewrite fP. Qed.
 Arguments mono1W_in [aT rT f aD aP rP].
 
-#[deprecated(since="mathcomp 1.14.0", note="Use mono1W_in instead.")]
-Notation mono2W_in := mono1W_in.
-
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

Fixes: https://github.com/math-comp/math-comp/issues/957

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
