### PR TITLE
Adding partial congruence with `predn`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemmas `perm_on_id`, `perm_onC`, `tperm_on`
 
 - in `seq.v`
-  + lemmas `find_pred0`, `find_predT`
+  + lemmas `find_pred0`, `find_predT`, `unzip1_seq`, `unzip2_seq`, `perm_zip_sym`, `perm_zip1`, 
+	`perm_zip2`
 
 - in `bigop.v`
   + lemma `big_if`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -42,10 +42,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemmas `addnCBA`, `addnBr_leq`, `addnBl_leq`, `subnDAC`,
     `subnCBA`, `subnBr_leq`, `subnBl_leq`, `subnBAC`, `subDnAC`,
     `subDnCA`, `subDnCAC`, `addnBC`, `addnCB`, `addBnAC`, `addBnCAC`,
-    `addBnA`, `subBnAC`, `eqn_sub2lE`, `eqn_sub2rE`
+    `addBnA`, `subBnAC`, `eqn_sub2lE`, `eqn_sub2rE`, `congr_pred`
 
 - in `ssrfun.v`
   + lemmas `inj_omap`, `omap_id`, `eq_omap`, `omapK`
+
 - in `order.v`
   + notations `0%O`, `1%O`, `0^d%O` and `1^d%O` as backward compatible
     replacements of removed  notation `0`, `1`, `0^d` and `1^d`

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -3205,7 +3205,50 @@ Lemma zip_map I f g (s : seq I) :
   zip (map f s) (map g s) = [seq (f i, g i) | i <- s].
 Proof. by elim: s => //= i s ->. Qed.
 
+Lemma unzip1_seq x y s t l :
+  size s = size t -> unzip1 [seq nth (x, y) (zip s t) i | i <- l] = [seq nth x s i | i <- l].
+Proof. by move=> st; elim: l => [//=|n l IH /=]; rewrite nth_zip /= ?IH ?st. Qed.
+
+Lemma unzip2_seq x y s t l :
+  size s = size t -> unzip2 [seq nth (x, y) (zip s t) i | i <- l] = [seq nth y t i | i <- l].
+Proof. by move=> st; elim: l => [//=|n l IH /=]; rewrite nth_zip /= ?IH ?st. Qed.
+
 End Zip.
+
+Lemma perm_zip_sym (S T : eqType) (x : S) (y : T) (s1 s2 : seq S) (t1 t2 : seq T) : 
+  size s1 = size t1 -> size s2 = size t2 -> 
+  perm_eq (zip s1 t1) (zip s2 t2) -> perm_eq (zip t1 s1) (zip t2 s2).
+Proof.
+move=> eq1 eq2 /(perm_iotaP (x, y)) [l p] eqz.  
+rewrite size_zip -eq2 minnn in p.
+apply/(perm_iotaP (y, x)); exists l => //; first by rewrite size_zip -eq2  minnn.   
+have -> : s1 = [seq nth x s2 i | i <- l].    
+  by rewrite -(@unzip1_seq _ _ _ y _ t2) -?eqz ?unzip1_zip // eq1.
+have -> : t1 = [seq nth y t2 i | i <- l].
+  by rewrite -(@unzip2_seq _ _ x _ s2) -?eqz ?unzip2_zip // eq1.  
+rewrite zip_map.
+apply: (@eq_from_nth _ (y, x)) => [|j ltjs]; first by rewrite !size_map. 
+rewrite size_map in ltjs.
+by rewrite ?(nth_map 0) ?nth_zip.
+Qed.
+
+Lemma perm_zip1 (S T : eqType) (x : S) (y : T) (s1 s2 : seq S) (t1 t2 : seq T) : 
+  size s1 = size t1 -> size s2 = size t2 ->
+  perm_eq (zip s1 t1) (zip s2 t2) -> perm_eq s1 s2.
+Proof. 
+move=> eq1 eq2 /(perm_iotaP (x, y)) [l p] eqz.
+rewrite size_zip -eq2 minnn in p.
+apply/(perm_iotaP x); exists l => //.
+rewrite -(@unzip1_zip _ _ s1 t1) ?eq12 //= ?eqz ?eq1 //= /unzip1 -?map_comp.
+apply: (@eq_from_nth _ x) => [|j ltjs]; first by rewrite !size_map.
+rewrite size_map in ltjs.
+by rewrite !(nth_map 0) /= ?nth_zip.
+Qed. 
+
+Lemma perm_zip2 (S T : eqType) (x : S) (y : T) (s1 s2 : seq S) (t1 t2 : seq T) : 
+  size s1 = size t1 -> size s2 = size t2 ->
+  perm_eq (zip s1 t1) (zip s2 t2) -> perm_eq t1 t2.
+Proof. by move=> ? ? ?; rewrite (@perm_zip1 _ _ _ _ _ _ s1 s2) 1?perm_zip_sym. Qed.
 
 Prenex Implicits zip unzip1 unzip2 all2.
 

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -354,6 +354,10 @@ Proof. by case: n. Qed.
 Lemma prednK n : 0 < n -> n.-1.+1 = n.
 Proof. exact: ltn_predK. Qed.
 
+Lemma congr_pred m n : 
+  0 < m -> 0 < n -> (m.-1 == n.-1) = (m == n).
+Proof. by case: m => [//=|m _ /= lt0n]; rewrite -(@prednK n) ?eqSS. Qed.
+
 Lemma leqNgt m n : (m <= n) = ~~ (n < m).
 Proof. by elim: m n => [|m IHm] []. Qed.
 


### PR DESCRIPTION
##### Motivation for this change

A partial congruence lemma regarding `predn` that I found useful.

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
