### PR TITLE
Adding `congr_pred`to ssrnat.v

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `FieldMonic.deg2_poly_canonical`, `FieldMonic.deg2_poly_factor`,
     `FieldMonic.deg2_poly_root1`, `FieldMonic.deg2_poly_root2`
 
+- in `ssrnat.v`
+  + lemma `congr_pred`
+
 - in `ssrnum.v`
   + lemmas `NumClosed.deg2_poly_factor`, `NumClosed.deg2_poly_root1`,
     `NumClosed.deg2_poly_root2`, `NumClosedMonic.deg2_poly_factor`,

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -354,6 +354,9 @@ Proof. by case: n. Qed.
 Lemma prednK n : 0 < n -> n.-1.+1 = n.
 Proof. exact: ltn_predK. Qed.
 
+Lemma congr_pred m n : 0 < m -> 0 < n -> (m.-1 == n.-1) = (m == n).
+Proof. by case: m => [//=|m _ /= lt0n]; rewrite -(@prednK n) ?eqSS. Qed.
+
 Lemma leqNgt m n : (m <= n) = ~~ (n < m).
 Proof. by elim: m n => [|m IHm] []. Qed.
 


### PR DESCRIPTION
##### Motivation for this change

A partial congruence lemma regarding `predn` that I found useful.

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
