### PR TITLE
Cleanup phantom types

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -35,6 +35,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- in `poly.v`
+  + definition `poly_of` (phantom trick now useless with reverse coercions)
+
 ### Deprecated
 
 ### Infrastructure

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -46,7 +46,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `perm.v`
   + definition `perm_of` (phantom trick now useless with reverse coercions)
 
+- in `ssralg.v`
+  + definitions `char`, `null_fun_head`, `in_alg_head`
+    (phantom trick now useless with reverse coercions)
+
+- in `finalg.v`
+  + definitions `unit_of`
+    (phantom trick now useless with reverse coercions)
+
+- in `matrix.v`
+  + definitions `GLtype`, `GLval`, `GLgroup` and `GLgroup_group`
+    (phantom trick now useless with reverse coercions)
+
+- in `qpoly.v`
+  + definitions `polyn`
+    (phantom trick now useless with reverse coercions)
+
+- in `vector.v`
+  + definitions `vector_axiom_def`, `space`, `vs2mx`, `pred_of_vspace`
+    (phantom trick now useless with reverse coercions)
+
 ### Renamed
+
+- in `ring_quotient.v`
+  + `Quotient.type` -> `Quotient.quot`
+
+- in `qpoly.v`
+  + `npoly_of` -> `npoly` (and removed phantom)
+  + `NPoly_of` -> `NPoly` (and removed phantom)
+  + `npoly` -> `mk_npoly`
 
 ### Removed
 
@@ -59,7 +87,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `order.v`
   + definition `SetSubsetOrder.type_of` (phantom trick now useless with reverse coercions)
 
+- in `fraction.v`
+  + definition `ratio_of` (phantom trick now useless with reverse coercions)
+  + definition `FracField.type_of` (phantom trick now useless with reverse coercions)
+
+- in `ring_quotient.v`
+  + definition `Quotient.type_of` (phantom trick now useless with reverse coercions)
+
 ### Deprecated
+
+- in `vector.v`
+  + notation `vector_axiom`, use `Vector.axiom` instead
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -57,6 +57,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `matrix.v`
   + definitions `GLtype`, `GLval`, `GLgroup` and `GLgroup_group`
     (phantom trick now useless with reverse coercions)
+- in `alt.v`
+  + definitions `Sym`, `Sym_group`, `Alt`, `Alt_group`
+    (phantom trick now useless with reverse coercions)
 
 - in `qpoly.v`
   + definitions `polyn`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -69,6 +69,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + definitions `vector_axiom_def`, `space`, `vs2mx`, `pred_of_vspace`
     (phantom trick now useless with reverse coercions)
 
+- in `fieldext.v`
+  + definition `baseField_type`
+    (phantom trick now useless with reverse coercions)
+
 ### Renamed
 
 - in `ring_quotient.v`
@@ -96,6 +100,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `ring_quotient.v`
   + definition `Quotient.type_of` (phantom trick now useless with reverse coercions)
+
+- in `falgebra.v`
+  + definition `aspace_of` (phantom trick now useless with reverse coercions)
 
 ### Deprecated
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -31,12 +31,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + generalize `ler_sqrt`
   + generalize `ler_psqrt` to use `nneg` instead of `pos`
 
+- in `finset.v`
+  + definitions `set_of` and `setTfor`
+    (phantom trick now useless with reverse coercions)
+
+- in `generic_quotient.v`
+  + `pi_phant` -> `pi_subdef`
+  + `quot_type_subdef` -> `quot_type_of`
+
+- in `fingroup.v`
+  + definitions `group_of`, `group_setT`, `setT_group`
+    (phantom trick now useless with reverse coercions)
+
+- in `perm.v`
+  + definition `perm_of` (phantom trick now useless with reverse coercions)
+
 ### Renamed
 
 ### Removed
 
 - in `poly.v`
   + definition `poly_of` (phantom trick now useless with reverse coercions)
+
+- in `eqtype.v`
+  + definition `sub_type_of` (phantom trick now useless with reverse coercions)
+
+- in `order.v`
+  + definition `SetSubsetOrder.type_of` (phantom trick now useless with reverse coercions)
 
 ### Deprecated
 

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -273,24 +273,22 @@ Section UnitsGroup.
 
 Variable R : finUnitRingType.
 
-Inductive unit_of (phR : phant R) := Unit (x : R) of x \is a GRing.unit.
+Inductive unit_of := Unit (x : R) of x \is a GRing.unit.
 Bind Scope group_scope with unit_of.
 
-Let phR := Phant R.
-Local Notation uT := (unit_of phR).
-Implicit Types u v : uT.
+Implicit Types u v : unit_of.
 Definition uval u := let: Unit x _ := u in x.
 
 #[export] HB.instance Definition _ := [isSub for uval].
-#[export] HB.instance Definition _ := [Finite of uT by <:].
+#[export] HB.instance Definition _ := [Finite of unit_of by <:].
 
-Definition unit1 := Unit phR (@GRing.unitr1 _).
+Definition unit1 := Unit (@GRing.unitr1 _).
 Lemma unit_inv_proof u : (val u)^-1 \is a GRing.unit.
 Proof. by rewrite unitrV ?(valP u). Qed.
-Definition unit_inv u := Unit phR (unit_inv_proof u).
+Definition unit_inv u := Unit (unit_inv_proof u).
 Lemma unit_mul_proof u v : val u * val v \is a GRing.unit.
 Proof. by rewrite (unitrMr _ (valP u)) ?(valP v). Qed.
-Definition unit_mul u v := Unit phR (unit_mul_proof u v).
+Definition unit_mul u v := Unit (unit_mul_proof u v).
 Lemma unit_muluA : associative unit_mul.
 Proof. by move=> u v w; apply/val_inj/mulrA. Qed.
 Lemma unit_mul1u : left_id unit1 unit_mul.
@@ -298,13 +296,13 @@ Proof. by move=> u; apply/val_inj/mul1r. Qed.
 Lemma unit_mulVu : left_inverse unit1 unit_inv unit_mul.
 Proof. by move=> u; apply/val_inj/(mulVr (valP u)). Qed.
 
-#[export] HB.instance Definition _ := isMulGroup.Build uT
+#[export] HB.instance Definition _ := isMulGroup.Build unit_of
   unit_muluA unit_mul1u unit_mulVu.
 
-Lemma val_unit1 : val (1%g : uT) = 1. Proof. by []. Qed.
-Lemma val_unitM x y : val (x * y : uT)%g = val x * val y. Proof. by []. Qed.
-Lemma val_unitV x : val (x^-1 : uT)%g = (val x)^-1. Proof. by []. Qed.
-Lemma val_unitX n x : val (x ^+ n : uT)%g = val x ^+ n.
+Lemma val_unit1 : val (1%g : unit_of) = 1. Proof. by []. Qed.
+Lemma val_unitM x y : val (x * y : unit_of)%g = val x * val y. Proof. by []. Qed.
+Lemma val_unitV x : val (x^-1 : unit_of)%g = (val x)^-1. Proof. by []. Qed.
+Lemma val_unitX n x : val (x ^+ n : unit_of)%g = val x ^+ n.
 Proof. by case: n; last by elim=> //= n ->. Qed.
 
 Definition unit_act x u := x * val u.
@@ -324,12 +322,13 @@ End UnitsGroup.
 
 Module Import UnitsGroupExports.
 Bind Scope group_scope with unit_of.
+Arguments unit_of R%type.
 Canonical unit_action.
 Canonical unit_groupAction.
 End UnitsGroupExports.
 HB.export UnitsGroupExports.
 
-Notation unit R Ux := (Unit (Phant R) Ux).
+Notation unit R Ux := (@Unit R%type _ Ux).
 
 #[export, non_forgetful_inheritance]
 HB.instance Definition _ (R : ComUnitRing.type) := [finGroupMixin of R for +%R].
@@ -454,7 +453,7 @@ Notation finIntegralDomainType := finIdomainType.
 Lemma card_finRing_gt1 (R : finRingType) : 1 < #|R|.
 Proof. by rewrite (cardD1 0) (cardD1 1) !inE GRing.oner_neq0. Qed.
 
-Notation "{ 'unit' R }" := (unit_of (Phant R))
+Notation "{ 'unit' R }" := (unit_of R)
   (at level 0, format "{ 'unit'  R }") : type_scope.
 Prenex Implicits FinRing.uval.
 Notation "''U'" := (unit_action _) (at level 8) : action_scope.

--- a/mathcomp/algebra/fraction.v
+++ b/mathcomp/algebra/fraction.v
@@ -31,18 +31,14 @@ Variable R : ringType.
 
 (* ratios are pairs of R, such that the second member is nonzero *)
 Inductive ratio := mkRatio { frac :> R * R; _ : frac.2 != 0 }.
-Definition ratio_of of phant R := ratio.
-Local Notation "{ 'ratio' T }" := (ratio_of (Phant T)).
 
 HB.instance Definition _ := [isSub for frac].
 HB.instance Definition _ := [Choice of ratio by <:].
-HB.instance Definition _ := SubType.on {ratio R}.
-HB.instance Definition _ := Choice.on {ratio R}.
 
 Lemma denom_ratioP : forall f : ratio, f.2 != 0. Proof. by case. Qed.
 
 Definition ratio0 := (@mkRatio (0, 1) (oner_neq0 _)).
-Definition Ratio x y : {ratio R} := insubd ratio0 (x, y).
+Definition Ratio x y : ratio := insubd ratio0 (x, y).
 
 Lemma numer_Ratio x y : y != 0 -> (Ratio x y).1 = x.
 Proof. by move=> ny0; rewrite /Ratio /insubd insubT. Qed.
@@ -52,7 +48,7 @@ Proof. by move=> ny0; rewrite /Ratio /insubd insubT. Qed.
 
 Definition numden_Ratio := (numer_Ratio, denom_Ratio).
 
-Variant Ratio_spec (n d : R) : {ratio R} -> R -> R -> Type :=
+Variant Ratio_spec (n d : R) : ratio -> R -> R -> Type :=
   | RatioNull of d = 0 : Ratio_spec n d ratio0 n 0
   | RatioNonNull (d_neq0 : d != 0) :
     Ratio_spec n d (@mkRatio (n, d) d_neq0) n d.
@@ -70,8 +66,9 @@ Proof. by rewrite /Ratio /insubd; case: insubP; rewrite //= eqxx. Qed.
 
 End FracDomain.
 
-Notation "{ 'ratio' T }" := (ratio_of (Phant T)) : type_scope.
-Identity Coercion type_fracdomain_of : ratio_of >-> ratio.
+Arguments ratio R%type.
+
+Notation "{ 'ratio' T }" := (ratio T) : type_scope.
 
 Notation "'\n_' x"  := (frac x).1
   (at level 8, x at level 2, format "'\n_' x").
@@ -112,14 +109,10 @@ Qed.
 Canonical equivf_equiv := EquivRel equivf equivf_refl equivf_sym equivf_trans.
 
 Definition type := {eq_quot equivf}.
-Definition type_of of phant R := type.
-Notation "{ 'fraction' T }" := (type_of (Phant T)) : type_scope.
 
 (* we recover some structure for the quotient *)
 HB.instance Definition _ : EqQuotient _ equivf type := EqQuotient.on type.
 HB.instance Definition _ := Choice.on type.
-HB.instance Definition _ := EqQuotient.on {fraction R}.
-HB.instance Definition _ := Choice.on {fraction R}.
 
 (* we explain what was the equivalence on the quotient *)
 Lemma equivf_def (x y : ratio R) : x == y %[mod type]
@@ -141,7 +134,7 @@ case=> [[n d] /= nd]; rewrite /Ratio /insubd; apply: val_inj=> /=.
 by case: insubP=> //=; rewrite nd.
 Qed.
 
-Definition tofrac := lift_embed {fraction R} (fun x : R => Ratio x 1).
+Definition tofrac := lift_embed type (fun x : R => Ratio x 1).
 Canonical tofrac_pi_morph := PiEmbed tofrac.
 
 Notation "x %:F"  := (@tofrac x).
@@ -149,7 +142,7 @@ Notation "x %:F"  := (@tofrac x).
 Implicit Types a b c : type.
 
 Definition addf x y : dom := Ratio (\n_x * \d_y + \n_y * \d_x) (\d_x * \d_y).
-Definition add := lift_op2 {fraction R} addf.
+Definition add := lift_op2 type addf.
 
 Lemma pi_add : {morph \pi : x y / addf x y >-> add x y}.
 Proof.
@@ -161,7 +154,7 @@ Qed.
 Canonical pi_add_morph := PiMorph2 pi_add.
 
 Definition oppf x : dom := Ratio (- \n_x) \d_x.
-Definition opp := lift_op1 {fraction R} oppf.
+Definition opp := lift_op1 type oppf.
 Lemma pi_opp : {morph \pi : x / oppf x >-> opp x}.
 Proof.
 move=> x; unlock opp; apply/eqmodP; rewrite /= /equivf /oppf /=.
@@ -170,7 +163,7 @@ Qed.
 Canonical pi_opp_morph := PiMorph1 pi_opp.
 
 Definition mulf x y : dom := Ratio (\n_x * \n_y) (\d_x * \d_y).
-Definition mul := lift_op2 {fraction R} mulf.
+Definition mul := lift_op2 type mulf.
 
 Lemma pi_mul : {morph \pi : x y / mulf x y >-> mul x y}.
 Proof.
@@ -181,7 +174,7 @@ Qed.
 Canonical pi_mul_morph := PiMorph2 pi_mul.
 
 Definition invf x : dom := Ratio \d_x \n_x.
-Definition inv := lift_op1 {fraction R} invf.
+Definition inv := lift_op1 type invf.
 
 Lemma pi_inv : {morph \pi : x / invf x >-> inv x}.
 Proof.
@@ -277,7 +270,9 @@ End FracField.
 End FracField.
 HB.export FracField.
 
-Notation "{ 'fraction' T }" := (FracField.type_of (Phant T)).
+Arguments FracField.type R%type.
+
+Notation "{ 'fraction' T }" := (FracField.type T).
 Notation equivf := (@FracField.equivf _).
 #[global] Hint Resolve denom_ratioP : core.
 

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -3906,19 +3906,20 @@ HB.instance Definition _ (n : nat) (R : finComUnitRingType) :=
 (* Finite inversible matrices and the general linear group. *)
 Section FinUnitMatrix.
 
-Variables (n : nat) (R : finComUnitRingType).
+Variable n : nat.
 
-Definition GLtype of phant R := {unit 'M[R]_n.-1.+1}.
+Definition GLtype (R : finComUnitRingType) := {unit 'M[R]_n.-1.+1}.
 
-Coercion GLval ph (u : GLtype ph) : 'M[R]_n.-1.+1 :=
+Coercion GLval R (u : GLtype R) : 'M[R]_n.-1.+1 :=
   let: FinRing.Unit A _ := u in A.
 
 End FinUnitMatrix.
 
 Bind Scope group_scope with GLtype.
-Arguments GLval {n%N R ph} u%g.
+Arguments GLtype n%N R%type.
+Arguments GLval {n%N R} u%g.
 
-Notation "{ ''GL_' n [ R ] }" := (GLtype n (Phant R))
+Notation "{ ''GL_' n [ R ] }" := (GLtype n R)
   (at level 0, n at level 2, format "{ ''GL_' n [ R ] }") : type_scope.
 Notation "{ ''GL_' n ( p ) }" := {'GL_n['F_p]}
   (at level 0, n at level 2, p at level 10,
@@ -3934,8 +3935,8 @@ Variables (n : nat) (R : finComUnitRingType).
 HB.instance Definition _ := [Finite of {'GL_n[R]} by <:].
 HB.instance Definition _ := FinGroup.on {'GL_n[R]}.
 
-Definition GLgroup of phant R := [set: {'GL_n[R]}].
-Canonical GLgroup_group ph := Eval hnf in [group of GLgroup ph].
+Definition GLgroup := [set: {'GL_n[R]}].
+Canonical GLgroup_group := Eval hnf in [group of GLgroup].
 
 Implicit Types u v : {'GL_n[R]}.
 
@@ -3954,13 +3955,16 @@ Qed.
 
 End GL_unit.
 
-Notation "''GL_' n [ R ]" := (GLgroup n (Phant R))
+Arguments GLgroup n%N R%type.
+Arguments GLgroup_group n%N R%type.
+
+Notation "''GL_' n [ R ]" := (GLgroup n R)
   (at level 8, n at level 2, format "''GL_' n [ R ]") : group_scope.
 Notation "''GL_' n ( p )" := 'GL_n['F_p]
   (at level 8, n at level 2, p at level 10,
    format "''GL_' n ( p )") : group_scope.
-Notation "''GL_' n [ R ]" := (GLgroup_group n (Phant R)) : Group_scope.
-Notation "''GL_' n ( p )" := (GLgroup_group n (Phant 'F_p)) : Group_scope.
+Notation "''GL_' n [ R ]" := (GLgroup_group n R) : Group_scope.
+Notation "''GL_' n ( p )" := (GLgroup_group n 'F_p) : Group_scope.
 
 (*****************************************************************************)
 (********************** Matrices over a domain *******************************)

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -144,26 +144,18 @@ HB.instance Definition _ := [Choice of polynomial by <:].
 
 Lemma poly_inj : injective polyseq. Proof. exact: val_inj. Qed.
 
-Definition poly_of of phant R := polynomial.
-Identity Coercion type_poly_of : poly_of >-> polynomial.
-
-Local Notation "{poly}" := (poly_of (Phant R)).
-
-HB.instance Definition _ := SubType.on {poly}.
-HB.instance Definition _ := Choice.on {poly}.
-
-Definition coefp i (p : poly_of (Phant R)) := p`_i.
+Definition coefp i (p : polynomial) := p`_i.
 
 End Polynomial.
 
 (* We need to break off the section here to let the Bind Scope directives     *)
 (* take effect.                                                               *)
-Bind Scope ring_scope with poly_of.
 Bind Scope ring_scope with polynomial.
+Arguments polynomial R%type.
 Arguments polyseq {R} p%R.
 Arguments poly_inj {R} [p1%R p2%R] : rename.
 Arguments coefp {R} i%N / p%R.
-Notation "{ 'poly' T }" := (poly_of (Phant T)) : type_scope.
+Notation "{ 'poly' T }" := (polynomial T) : type_scope.
 
 Section SemiPolynomialTheory.
 
@@ -320,7 +312,6 @@ Qed.
 
 HB.instance Definition _ := GRing.isNmodule.Build (polynomial R)
   add_polyA add_polyC add_poly0.
-HB.instance Definition _ := GRing.Nmodule.on {poly R}.
 
 (* Properties of the zero polynomial *)
 Lemma polyC0 : 0%:P = 0 :> {poly R}. Proof. by []. Qed.
@@ -503,7 +494,6 @@ Proof. by rewrite polyC_eq0 oner_neq0. Qed.
 HB.instance Definition _ := GRing.Nmodule_isSemiRing.Build (polynomial R)
   mul_polyA mul_1poly mul_poly1 mul_polyDl mul_polyDr mul_0poly mul_poly0
   poly1_neq0.
-HB.instance Definition _ := GRing.SemiRing.on {poly R}.
 
 Lemma polyC1 : 1%:P = 1 :> {poly R}. Proof. by []. Qed.
 
@@ -619,7 +609,6 @@ Qed.
 
 HB.instance Definition _ := GRing.Nmodule_isZmodule.Build (polynomial R)
   add_polyN.
-HB.instance Definition _ := GRing.Zmodule.on {poly R}.
 
 (* Size, leading coef, morphism properties of coef *)
 
@@ -724,7 +713,6 @@ HB.instance Definition _ := GRing.Zmodule_isLmodule.Build R (polynomial R)
   scale_polyA scale_1poly scale_polyDr scale_polyDl.
 HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build R (polynomial R)
   scale_polyAl.
-HB.instance Definition _ := GRing.Lalgebra.on {poly R}.
 
 Lemma mul_polyC a p : a%:P * p = a *: p.
 Proof. by rewrite -scale_polyE. Qed.
@@ -2436,7 +2424,6 @@ Qed.
 HB.instance Definition _ := GRing.Ring_hasCommutativeMul.Build (polynomial R)
   poly_mul_comm.
 HB.instance Definition _ := GRing.Lalgebra_isComAlgebra.Build R (polynomial R).
-HB.instance Definition _ := GRing.ComAlgebra.on {poly R}.
 
 Lemma coef_prod_XsubC (ps : seq R) (n : nat) :
   (n <= size ps)%N ->
@@ -2654,11 +2641,9 @@ Proof. by rewrite /poly_inv => p /negbTE/= ->. Qed.
 
 HB.instance Definition _ := GRing.ComRing_hasMulInverse.Build (polynomial R)
   poly_mulVp poly_intro_unit poly_inv_out.
-HB.instance Definition _ := GRing.ComUnitRing.on {poly R}.
 
 HB.instance Definition _ := GRing.ComUnitRing_isIntegral.Build (polynomial R)
   poly_idomainAxiom.
-HB.instance Definition _ := GRing.IntegralDomain.on {poly R}.
 
 Lemma poly_unitE p :
   (p \in GRing.unit) = (size p == 1) && (p`_0 \in GRing.unit).
@@ -2834,26 +2819,16 @@ End PolynomialIdomain.
 
 (* FIXME: these are seamingly artifical ways to close the inheritance graph *)
 (*    We make parameters more and more precise to trigger completion by HB  *)
-
 HB.instance Definition _ (R : countRingType) :=
   [Countable of polynomial R by <:].
-HB.instance Definition _ (R : countRingType) := Countable.on {poly R}.
-
 HB.instance Definition _ (R : countComRingType) :=
   [Countable of polynomial R by <:].
-HB.instance Definition _ (R : countComRingType) := Countable.on {poly R}.
-
 HB.instance Definition _ (R : countUnitRingType) :=
   [Countable of polynomial R by <:].
-HB.instance Definition _ (R : countUnitRingType) := Countable.on {poly R}.
-
 HB.instance Definition _ (R : countComUnitRingType) :=
   [Countable of polynomial R by <:].
-HB.instance Definition _ (R : countComUnitRingType) := Countable.on {poly R}.
-
 HB.instance Definition _ (R : countIdomainType) :=
   [Countable of polynomial R by <:].
-HB.instance Definition _ (R : countIdomainType) := Countable.on {poly R}.
 
 Section MapFieldPoly.
 

--- a/mathcomp/algebra/ring_quotient.v
+++ b/mathcomp/algebra/ring_quotient.v
@@ -310,28 +310,22 @@ Qed.
 Canonical equiv_equiv := EquivRelPack equiv_is_equiv.
 Canonical equiv_encModRel := defaultEncModRel equiv.
 
-Definition type := {eq_quot equiv}.
-Definition type_of of phant R := type.
-Local Notation quot := (type_of (Phant R)).
+Definition quot := {eq_quot equiv}.
 
 #[export]
-HB.instance Definition _ : EqQuotient R equiv type := EqQuotient.on type.
-#[export]
-HB.instance Definition _ := Choice.on type.
-#[export]
-HB.instance Definition _ := EqQuotient.on quot.
+HB.instance Definition _ : EqQuotient R equiv quot := EqQuotient.on quot.
 #[export]
 HB.instance Definition _ := Choice.on quot.
 
-Lemma idealrBE x y : (x - y) \in I = (x == y %[mod type]).
+Lemma idealrBE x y : (x - y) \in I = (x == y %[mod quot]).
 Proof. by rewrite piE equivE. Qed.
 
-Lemma idealrDE x y : (x + y) \in I = (x == - y %[mod type]).
+Lemma idealrDE x y : (x + y) \in I = (x == - y %[mod quot]).
 Proof. by rewrite -idealrBE opprK. Qed.
 
-Definition zero : type := lift_cst type 0.
-Definition add := lift_op2 type +%R.
-Definition opp := lift_op1 type -%R.
+Definition zero : quot := lift_cst quot 0.
+Definition add := lift_op2 quot +%R.
+Definition opp := lift_op1 quot -%R.
 
 Canonical pi_zero_morph := PiConst zero.
 
@@ -363,18 +357,15 @@ Lemma addNq: left_inverse zero opp add.
 Proof. by move=> x; rewrite -[x]reprK !piE addNr. Qed.
 
 #[export]
-HB.instance Definition _ := GRing.isZmodule.Build type addqA addqC add0q addNq.
+HB.instance Definition _ := GRing.isZmodule.Build quot addqA addqC add0q addNq.
 #[export]
-HB.instance Definition _ := GRing.Zmodule.on quot.
-#[export]
-HB.instance Definition _ := @isZmodQuotient.Build R equiv 0 -%R +%R type
+HB.instance Definition _ := @isZmodQuotient.Build R equiv 0 -%R +%R quot
   (lock _) pi_opp pi_add.
-#[export]
-HB.instance Definition _ := @ZmodQuotient.on quot.
 
 End ZmodQuotient.
 
-Notation "{ 'quot' I }" := (@type_of _ I (Phant _)) : type_scope.
+Arguments quot R%type I%type.
+Notation "{ 'quot' I }" := (quot I) : type_scope.
 
 Section RingQuotient.
 
@@ -415,16 +406,12 @@ Lemma nonzero1q: one != 0.
 Proof. by rewrite piE equivE subr0 idealr1. Qed.
 
 #[export]
-HB.instance Definition _ := GRing.Zmodule_isComRing.Build (type idealI)
+HB.instance Definition _ := GRing.Zmodule_isComRing.Build (quot idealI)
   mulqA mulqC mul1q mulq_addl nonzero1q.
-#[export]
-HB.instance Definition _ := GRing.ComRing.on {quot idealI}.
 
 #[export]
 HB.instance Definition _ := @isRingQuotient.Build
-  R (equiv idealI) 0 -%R +%R 1%R *%R (type idealI) (lock _) pi_mul.
-#[export]
-HB.instance Definition _ := @RingQuotient.on {quot idealI}.
+  R (equiv idealI) 0 -%R +%R 1%R *%R (quot idealI) (lock _) pi_mul.
 
 End RingQuotient.
 
@@ -444,8 +431,7 @@ End Quotient.
 
 Export Quotient.Exports.
 
-Notation "{ 'ideal_quot' I }" :=
-  (@Quotient.type_of _ I (Phant _)) : type_scope.
+Notation "{ 'ideal_quot' I }" := (@Quotient.quot _ I) : type_scope.
 Notation "x == y %[ 'mod_ideal' I ]" :=
   (x == y %[mod {ideal_quot I}]) : quotient_scope.
 Notation "x = y %[ 'mod_ideal' I ]" :=

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -949,10 +949,8 @@ Local Notation "\prod_ ( m <= i < n ) F" := (\big[*%R/1%R]_(m <= i < n) F%R).
 (* The ``field'' characteristic; the definition, and many of the theorems,   *)
 (* has to apply to rings as well; indeed, we need the Frobenius automorphism *)
 (* results for a non commutative ring in the proof of Gorenstein 2.6.3.      *)
-Definition char (R : semiRingType) of phant R : nat_pred :=
+Definition char (R : semiRingType) : nat_pred :=
   [pred p | prime p & p%:R == 0 :> R].
-
-Local Notation "[ 'char' R ]" := (char (Phant R)) : ring_scope.
 
 (* Converse ring tag. *)
 Definition converse R : Type := R.
@@ -1184,12 +1182,12 @@ rewrite exprD1n !big_ord_recr big_ord0 /= add0r.
 by rewrite addrC addrA addrAC.
 Qed.
 
-Definition Frobenius_aut p of p \in [char R] := fun x => x ^+ p.
+Definition Frobenius_aut p of p \in char R := fun x => x ^+ p.
 
 Section FrobeniusAutomorphism.
 
 Variable p : nat.
-Hypothesis charFp : p \in [char R].
+Hypothesis charFp : p \in char R.
 
 Lemma charf0 : p%:R = 0 :> R. Proof. by apply/eqP; case/andP: charFp. Qed.
 Lemma charf_prime : prime p. Proof. by case/andP: charFp. Qed.
@@ -1209,7 +1207,7 @@ move/(congr1 (fun m => m%:R : R))/eqP.
 by rewrite natrD !natrM charf0 n0 !mulr0 pn1 addr0 oner_eq0.
 Qed.
 
-Lemma charf_eq : [char R] =i (p : nat_pred).
+Lemma charf_eq : char R =i (p : nat_pred).
 Proof.
 move=> q; apply/andP/eqP=> [[q_pr q0] | ->]; last by rewrite charf0.
 by apply/eqP; rewrite eq_sym -dvdn_prime2 // dvdn_charf.
@@ -1256,7 +1254,7 @@ End FrobeniusAutomorphism.
 
 Section Char2.
 
-Hypothesis charR2 : 2 \in [char R].
+Hypothesis charR2 : 2 \in char R.
 
 Lemma addrr_char2 x : x + x = 0. Proof. by rewrite -mulr2n mulrn_char. Qed.
 
@@ -1469,7 +1467,7 @@ Proof. by rewrite subrX1 !big_ord_recr big_ord0 /= addrAC add0r. Qed.
 Section FrobeniusAutomorphism.
 
 Variable p : nat.
-Hypothesis charFp : p \in [char R].
+Hypothesis charFp : p \in char R.
 
 Hint Resolve charf_prime : core.
 
@@ -1488,10 +1486,10 @@ Qed.
 
 End FrobeniusAutomorphism.
 
-Lemma exprNn_char x n : [char R].-nat n -> (- x) ^+ n = - (x ^+ n).
+Lemma exprNn_char x n : (char R).-nat n -> (- x) ^+ n = - (x ^+ n).
 Proof.
 pose p := pdiv n; have [|n_gt1 charRn] := leqP n 1; first by case: (n) => [|[]].
-have charRp: p \in [char R] by rewrite (pnatPpi charRn) // pi_pdiv.
+have charRp: p \in char R by rewrite (pnatPpi charRn) // pi_pdiv.
 have /p_natP[e ->]: p.-nat n by rewrite -(eq_pnat _ (charf_eq charRp)).
 elim: e => // e IHe; rewrite expnSr !exprM {}IHe.
 by rewrite -Frobenius_autE Frobenius_autN.
@@ -1499,7 +1497,7 @@ Qed.
 
 Section Char2.
 
-Hypothesis charR2 : 2 \in [char R].
+Hypothesis charR2 : 2 \in char R.
 
 Lemma oppr_char2 x : - x = x.
 Proof. by apply/esym/eqP; rewrite -addr_eq0 addrr_char2. Qed.
@@ -1835,7 +1833,7 @@ HB.export AdditiveExports.
 (* Lifted additive operations. *)
 Section LiftedNmod.
 Variables (U : Type) (V : nmodType).
-Definition null_fun_head (phV : phant V) of U : V := let: Phant := phV in 0.
+Definition null_fun of U : V := 0.
 Definition add_fun (f g : U -> V) x := f x + g x.
 End LiftedNmod.
 Section LiftedZmod.
@@ -1857,13 +1855,12 @@ End LiftedSemiRing.
 Section LiftedScale.
 Variables (R : ringType) (U : Type) (V : lmodType R) (A : lalgType R).
 Definition scale_fun a (f : U -> V) x := a *: f x.
-Definition in_alg_head (phA : phant A) k : A := let: Phant := phA in k%:A.
+Definition in_alg_head k : A := k%:A.
 End LiftedScale.
 
-Notation null_fun V := (null_fun_head (Phant V)) (only parsing).
 (* The real in_alg notation is declared after GRing.Theory so that at least *)
 (* in Coq 8.2 it gets precedence when GRing.Theory is not imported.         *)
-Local Notation in_alg_loc A := (in_alg_head (Phant A)) (only parsing).
+Local Notation in_alg_loc A := (in_alg_head A) (only parsing).
 
 Local Notation "\0" := (null_fun _) : ring_scope.
 Local Notation "f \+ g" := (add_fun f g) : ring_scope.
@@ -1874,6 +1871,8 @@ Local Notation "x \*o f" := (mull_fun x f) : ring_scope.
 Local Notation "x \o* f" := (mulr_fun x f) : ring_scope.
 Local Notation "f \* g" := (mul_fun f g) : ring_scope.
 
+Arguments null_fun {_} V _ /.
+Arguments in_alg_head {_} A _ /.
 Arguments add_fun {_ _} f g _ /.
 Arguments sub_fun {_ _} f g _ /.
 Arguments opp_fun {_ _} f _ /.
@@ -2101,7 +2100,7 @@ Proof. by elim: n => [|n IHn] x; rewrite ?rmorph1 // !exprS rmorphM IHn. Qed.
 
 Lemma rmorph_nat n : f n%:R = n%:R. Proof. by rewrite rmorphMn rmorph1. Qed.
 
-Lemma rmorph_char p : p \in [char R] -> p \in [char S].
+Lemma rmorph_char p : p \in char R -> p \in char S.
 Proof. by rewrite !inE -rmorph_nat => /andP[-> /= /eqP->]; rewrite rmorph0. Qed.
 
 Lemma rmorph_eq_nat x n : injective f -> (f x == n%:R) = (x == n%:R).
@@ -2636,7 +2635,7 @@ Qed.
 
 Section FrobeniusAutomorphism.
 
-Variables (p : nat) (charRp : p \in [char R]).
+Variables (p : nat) (charRp : p \in char R).
 
 Lemma Frobenius_aut_is_additive : additive (Frobenius_aut charRp).
 Proof. move=> x y; exact: Frobenius_autB_comm (mulrC _ _). Qed.
@@ -2656,10 +2655,10 @@ HB.instance Definition _ := isMultiplicative.Build R R (Frobenius_aut charRp)
 
 End FrobeniusAutomorphism.
 
-Lemma exprDn_char x y n : [char R].-nat n -> (x + y) ^+ n = x ^+ n + y ^+ n.
+Lemma exprDn_char x y n : (char R).-nat n -> (x + y) ^+ n = x ^+ n + y ^+ n.
 Proof.
 pose p := pdiv n; have [|n_gt1 charRn] := leqP n 1; first by case: (n) => [|[]].
-have charRp: p \in [char R] by rewrite (pnatPpi charRn) ?pi_pdiv.
+have charRp: p \in char R by rewrite (pnatPpi charRn) ?pi_pdiv.
 have{charRn} /p_natP[e ->]: p.-nat n by rewrite -(eq_pnat _ (charf_eq charRp)).
 by elim: e => // e IHe; rewrite !expnSr !exprM IHe -Frobenius_autE rmorphD.
 Qed.
@@ -3978,7 +3977,7 @@ Lemma sqrf_eq0 x : (x ^+ 2 == 0) = (x == 0). Proof. exact: expf_eq0. Qed.
 Lemma expf_neq0 x m : x != 0 -> x ^+ m != 0.
 Proof. by move=> x_nz; rewrite expf_eq0; apply/nandP; right. Qed.
 
-Lemma natf_neq0 n : (n%:R != 0 :> R) = [char R]^'.-nat n.
+Lemma natf_neq0 n : (n%:R != 0 :> R) = (char R)^'.-nat n.
 Proof.
 have [-> | /prod_prime_decomp->] := posnP n; first by rewrite eqxx.
 rewrite !big_seq; elim/big_rec: _ => [|[p e] s /=]; first by rewrite oner_eq0.
@@ -3986,14 +3985,14 @@ case/mem_prime_decomp=> p_pr _ _; rewrite pnatM pnatX eqn0Ngt orbC => <-.
 by rewrite natrM natrX mulf_eq0 expf_eq0 negb_or negb_and pnatE ?inE p_pr.
 Qed.
 
-Lemma natf0_char n : n > 0 -> n%:R == 0 :> R -> exists p, p \in [char R].
+Lemma natf0_char n : n > 0 -> n%:R == 0 :> R -> exists p, p \in char R.
 Proof.
-move=> n_gt0 nR_0; exists (pdiv n`_[char R]).
+move=> n_gt0 nR_0; exists (pdiv n`_(char R)).
 apply: pnatP (pdiv_dvd _); rewrite ?part_pnat // ?pdiv_prime //.
 by rewrite ltn_neqAle eq_sym partn_eq1 // -natf_neq0 nR_0 /=.
 Qed.
 
-Lemma charf'_nat n : [char R]^'.-nat n = (n%:R != 0 :> R).
+Lemma charf'_nat n : (char R)^'.-nat n = (n%:R != 0 :> R).
 Proof.
 have [-> | n_gt0] := posnP n; first by rewrite eqxx.
 apply/idP/idP => [|nz_n]; last first.
@@ -4003,7 +4002,7 @@ have [p_pr _] := andP charRp; rewrite (eq_pnat _ (eq_negn (charf_eq charRp))).
 by rewrite p'natE // (dvdn_charf charRp) n0.
 Qed.
 
-Lemma charf0P : [char R] =i pred0 <-> (forall n, (n%:R == 0 :> R) = (n == 0)%N).
+Lemma charf0P : char R =i pred0 <-> (forall n, (n%:R == 0 :> R) = (n == 0)%N).
 Proof.
 split=> charF0 n; last by rewrite !inE charF0 andbC; case: eqP => // ->.
 have [-> | n_gt0] := posnP; first exact: eqxx.
@@ -4204,7 +4203,7 @@ by move=> ?; rewrite -mulr_suml -(divr1 a) eqr_div ?oner_eq0// mulr1 divr1.
 Qed.
 
 Lemma char0_natf_div :
-  [char F] =i pred0 -> forall m d, d %| m -> (m %/ d)%:R = m%:R / d%:R :> F.
+  char F =i pred0 -> forall m d, d %| m -> (m %/ d)%:R = m%:R / d%:R :> F.
 Proof.
 move/charf0P=> char0F m [|d] d_dv_m; first by rewrite divn0 invr0 mulr0.
 by rewrite natr_div // unitfE char0F.
@@ -4230,7 +4229,7 @@ Proof. exact: inj_eq fmorph_inj. Qed.
 Lemma fmorph_eq1 x : (f x == 1) = (x == 1).
 Proof. by rewrite -(inj_eq fmorph_inj) rmorph1. Qed.
 
-Lemma fmorph_char : [char R] =i [char F].
+Lemma fmorph_char : char R =i char F.
 Proof. by move=> p; rewrite !inE -fmorph_eq0 rmorph_nat. Qed.
 
 End FieldMorphismInj.
@@ -4278,7 +4277,7 @@ Qed.
 
 End ModuleTheory.
 
-Lemma char_lalg (A : lalgType F) : [char A] =i [char F].
+Lemma char_lalg (A : lalgType F) : char A =i char F.
 Proof. by move=> p; rewrite inE -scaler_nat scaler_eq0 oner_eq0 orbF. Qed.
 
 End FieldTheory.
@@ -6137,7 +6136,8 @@ Notation "1" := (@one _) : ring_scope.
 Notation "- 1" := (opp 1) : ring_scope.
 
 Notation "n %:R" := (natmul 1 n) : ring_scope.
-Notation "[ 'char' R ]" := (char (Phant R)) : ring_scope.
+Arguments GRing.char R%type.
+Notation "[ 'char' R ]" := (GRing.char R) : ring_scope.
 Notation Frobenius_aut chRp := (Frobenius_aut chRp).
 Notation "*%R" := (@mul _) : fun_scope.
 Notation "x * y" := (mul x y) : ring_scope.
@@ -6158,6 +6158,8 @@ Notation "x \*o f" := (mull_fun x f) : ring_scope.
 Notation "x \o* f" := (mulr_fun x f) : ring_scope.
 Notation "f \* g" := (mul_fun f g) : ring_scope.
 
+Arguments null_fun {_} V _ /.
+Arguments in_alg_head {_} A _ /.
 Arguments add_fun {_ _} f g _ /.
 Arguments sub_fun {_ _} f g _ /.
 Arguments opp_fun {_ _} f _ /.

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -367,7 +367,7 @@ Definition cfReal phi := cfAut conjC phi == phi.
 Definition cfConjC_subset (S1 S2 : seq classfun) :=
   [/\ uniq S1, {subset S1 <= S2} & cfAut_closed conjC S1].
 
-Fact cfun_vect_iso : vector_axiom #|classes G| classfun.
+Fact cfun_vect_iso : Vector.axiom #|classes G| classfun.
 Proof.
 exists (fun phi => \row_i phi (repr (enum_val i))) => [a phi psi|].
   by apply/rowP=> i; rewrite !(mxE, cfunE).

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -788,7 +788,7 @@ Lemma cfdotElr A B phi psi :
      phi \in 'CF(G, A) -> psi \in 'CF(G, B) ->
   '[phi, psi] = #|G|%:R^-1 * \sum_(x in A :&: B) phi x * (psi x)^*.
 Proof.
-move=> Aphi Bpsi; rewrite (big_setID G) cfdotE (big_setID (A :&: B)) setIC /=.
+move=> Aphi Bpsi; rewrite (big_setID G)/= cfdotE (big_setID (A :&: B))/= setIC.
 congr (_ * (_ + _)); rewrite !big1 // => x /setDP[_].
   by move/cfun0->; rewrite mul0r.
 rewrite inE; case/nandP=> notABx; first by rewrite (cfun_on0 Aphi) ?mul0r.
@@ -1580,7 +1580,7 @@ Definition cfIsom :=
   locked_with cfIsom_key (cfMorph \o 'Res[G1] : 'CF(G) -> 'CF(R)).
 Canonical cfIsom_unlockable := [unlockable of cfIsom].
 
-Lemma cfIsomE phi x : x \in G -> cfIsom phi (f x) = phi x.
+Lemma cfIsomE phi (x : aT : finType) : x \in G -> cfIsom phi (f x) = phi x.
 Proof.
 move=> Gx; rewrite unlock cfMorphE //= /restrm ?defG ?cfRes_id ?invmE //.
 by rewrite -defR mem_morphim.

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -200,7 +200,7 @@ apply/subsetP=> v; rewrite inE genmxE => /submxP[u ->{v}].
 rewrite mulmx_sum_row group_prod // => i _.
 rewrite rowK; move: (enum_val i) (enum_valP i) => v Lv.
 have [->|] := eqVneq (u 0 i) 0; first by rewrite scale0r group1.
-by rewrite -unitfE => aP; rewrite ((actsP linL) (FinRing.Unit _ aP)) ?inE.
+by rewrite -unitfE => aP; rewrite ((actsP linL) (FinRing.Unit aP)) ?inE.
 Qed.
 
 Lemma rowg_mx1 : rowg_mx 1%g = 0.
@@ -928,7 +928,7 @@ have prim_w e: 0 < e < p -> p.-primitive_root (w ^+ e).
 have /cyclicP[a defAutZ]: cyclic (Aut 'Z(S)) by rewrite Aut_prime_cyclic ?ozp.
 have phi_unitP (i : 'I_p.-1): (i.+1%:R : 'Z_#[z]) \in GRing.unit.
   by rewrite unitZpE ?order_gt1 // ozp prime_coprime // -lt0n !modIp'.
-pose ephi i := invm (injm_Zpm a) (Zp_unitm (FinRing.Unit _ (phi_unitP i))).
+pose ephi i := invm (injm_Zpm a) (Zp_unitm (FinRing.Unit (phi_unitP i))).
 pose j : 'Z_#[z] := val (invm (injm_Zp_unitm z) a).
 have co_j_p: coprime j p.
   rewrite coprime_sym /j; case: (invm _ a) => /=.

--- a/mathcomp/field/falgebra.v
+++ b/mathcomp/field/falgebra.v
@@ -525,27 +525,20 @@ Qed.
 
 Definition is_aspace U := has_algid U && (U * U <= U)%VS.
 Structure aspace := ASpace {asval :> {vspace aT}; _ : is_aspace asval}.
-Definition aspace_of of phant aT := aspace.
-Local Notation "{ 'aspace' T }" := (aspace_of (Phant T)) : type_scope.
 
 HB.instance Definition _ := [isSub for asval].
-HB.instance Definition _ := [Equality of aspace by <:].
 HB.instance Definition _ := [Choice of aspace by <:].
 
-HB.instance Definition _ := SubType.on {aspace aT}.
-HB.instance Definition _ := Equality.on {aspace aT}.
-HB.instance Definition _ := Choice.on {aspace aT}.
-
-Definition clone_aspace U (A : {aspace aT}) :=
-  fun algU & phant_id algU (valP A) =>  @ASpace U algU : {aspace aT}.
+Definition clone_aspace U (A : aspace) :=
+  fun algU & phant_id algU (valP A) =>  @ASpace U algU : aspace.
 
 Fact aspace1_subproof : is_aspace 1.
 Proof. by rewrite /is_aspace prod1v -memvE has_algid1 memv_line. Qed.
-Canonical aspace1 : {aspace aT} := ASpace aspace1_subproof.
+Canonical aspace1 : aspace := ASpace aspace1_subproof.
 
 Lemma aspacef_subproof : is_aspace fullv.
 Proof. by rewrite /is_aspace subvf has_algid1 ?memvf. Qed.
-Canonical aspacef : {aspace aT} := ASpace aspacef_subproof.
+Canonical aspacef : aspace := ASpace aspacef_subproof.
 
 Lemma polyOver1P p :
   reflect (exists q, p = map_poly (in_alg aT) q) (p \is a polyOver 1%VS).
@@ -561,11 +554,11 @@ End FalgebraTheory.
 
 Delimit Scope aspace_scope with AS.
 Bind Scope aspace_scope with aspace.
-Bind Scope aspace_scope with aspace_of.
 Arguments asval {K aT} a%AS.
+Arguments aspace [K]%type aT%type.
 Arguments clone_aspace [K aT U%VS A%AS algU] _.
 
-Notation "{ 'aspace' T }" := (aspace_of (Phant T)) : type_scope.
+Notation "{ 'aspace' T }" := (aspace T) : type_scope.
 Notation "A * B" := (prodv A B) : vspace_scope.
 Notation "A ^+ n" := (expv A n) : vspace_scope.
 Notation "'C [ u ]" := (centraliser1_vspace u) : vspace_scope.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -92,8 +92,8 @@ Notation "[ 'fieldExtType' F 'of' L ]" := (FieldExt.clone F L%type _)
 #[deprecated(since="mathcomp 2.0.0", note="Use FieldExt.clone instead.")]
 Notation "[ 'fieldExtType' F 'of' L 'for' K ]" := (FieldExt.clone F L%type K)
   (at level 0, format "[ 'fieldExtType'  F  'of'  L  'for'  K ]") : form_scope.
-Notation "{ 'subfield' L }" := (@aspace_of _ _ (Phant L))
-  (* NB: was (@aspace_of _ (falgType _) (Phant L)) *)
+Notation "{ 'subfield' L }" := (aspace L)
+  (* NB: was (@aspace_of _ (FalgType _) (Phant L)) *)
   (at level 0, format "{ 'subfield'  L }") : type_scope.
 End FieldExtExports.
 HB.export FieldExtExports.
@@ -765,8 +765,8 @@ Section BaseField.
 
 Variables (F0 : fieldType) (F : fieldExtType F0) (L : fieldExtType F).
 
-Definition baseField_type of phant L : Type := L.
-Notation L0 := (baseField_type (Phant (FieldExt.sort L))).
+Definition baseFieldType : Type := L.
+Notation L0 := baseFieldType.
 
 HB.instance Definition _ := GRing.Field.on L0.
 
@@ -873,7 +873,7 @@ Canonical baseAspace E := ASpace (baseAspace_suproof E).
 
 End BaseField.
 
-Notation baseFieldType L := (baseField_type (Phant L)).
+Arguments baseFieldType [F0 F]%type L%type.
 
 HB.lock Definition refBaseField (F0 : fieldType) (F : fieldExtType F0)
   (L : fieldExtType F) := baseAspace (1%AS : {aspace L}).

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -1288,7 +1288,7 @@ Hypothesis irr_p : irreducible_poly p.
 Let nz_p : p != 0. Proof. exact: irredp_neq0. Qed.
 
 (* The Vector axiom requires irreducibility. *)
-Lemma min_subfx_vect : vector_axiom_def (size p).-1 (Phant subFExtend).
+Lemma min_subfx_vect : Vector.axiom (size p).-1 subFExtend.
 Proof.
 move/subfx_irreducibleP: irr_p => /=/(_ nz_p) min_p; set d := (size p).-1.
 have Dd: d.+1 = size p by rewrite polySpred.

--- a/mathcomp/fingroup/fingroup.v
+++ b/mathcomp/fingroup/fingroup.v
@@ -1172,8 +1172,8 @@ Structure group_type : Type := Group {
   _ : group_set gval
 }.
 
-Definition group_of of phant gT : predArgType := group_type.
-Local Notation groupT := (group_of (Phant gT)).
+Definition group_of : predArgType := group_type.
+Local Notation groupT := group_of.
 Identity Coercion type_of_group : group_of >-> group_type.
 
 HB.instance Definition _ := [isSub for gval].
@@ -1203,21 +1203,23 @@ Proof. by rewrite /group_set set11 mulg1 subxx. Qed.
 Canonical one_group := group group_set_one.
 Canonical set1_group := @group [set 1] group_set_one.
 
-Lemma group_setT (phT : phant gT) : group_set (setTfor phT).
+Lemma group_setT : group_set (setTfor gT).
 Proof. by apply/group_setP; split=> [|x y _ _]; rewrite inE. Qed.
 
-Canonical setT_group phT := group (group_setT phT).
+Canonical setT_group := group group_setT.
 
 End GroupSetMulProp.
 
+Arguments group_of gT%type.
 Arguments lcosetP {gT A x y}.
 Arguments lcosetsP {gT A B C}.
 Arguments rcosetP {gT A x y}.
 Arguments rcosetsP {gT A B C}.
 Arguments group_setP {gT A}.
+Arguments setT_group gT%type.
 Prenex Implicits group_set mulsgP set1gP.
 
-Notation "{ 'group' gT }" := (group_of (Phant gT))
+Notation "{ 'group' gT }" := (group_of gT)
   (at level 0, format "{ 'group'  gT }") : type_scope.
 
 Notation "[ 'group' 'of' G ]" := (clone_group (@group _ G))
@@ -1227,7 +1229,7 @@ Bind Scope Group_scope with group_type.
 Bind Scope Group_scope with group_of.
 Notation "1" := (one_group _) : Group_scope.
 Notation "[ 1 gT ]" := (1%G : {group gT}) : Group_scope.
-Notation "[ 'set' : gT ]" := (setT_group (Phant gT)) : Group_scope.
+Notation "[ 'set' : gT ]" := (setT_group gT) : Group_scope.
 
 (* These definitions come early so we can establish the Notation. *)
 HB.lock

--- a/mathcomp/fingroup/perm.v
+++ b/mathcomp/fingroup/perm.v
@@ -49,10 +49,8 @@ Variable T : finType.
 Inductive perm_type : predArgType :=
   Perm (pval : {ffun T -> T}) & injectiveb pval.
 Definition pval p := let: Perm f _ := p in f.
-Definition perm_of of phant T := perm_type.
+Definition perm_of := perm_type.
 Identity Coercion type_of_perm : perm_of >-> perm_type.
-
-Notation pT := (perm_of (Phant T)).
 
 HB.instance Definition _ := [isSub for pval].
 HB.instance Definition _ := [Finite of perm_type by <:].
@@ -63,8 +61,9 @@ by move=> f_inj; apply/injectiveP; apply: eq_inj f_inj _ => x; rewrite ffunE.
 Qed.
 
 End PermDefSection.
+Arguments perm_of T%type.
 
-Notation "{ 'perm' T }" := (perm_of (Phant T))
+Notation "{ 'perm' T }" := (perm_of T)
   (at level 0, format "{ 'perm'  T }") : type_scope.
 
 Arguments pval _ _%g.

--- a/mathcomp/fingroup/quotient.v
+++ b/mathcomp/fingroup/quotient.v
@@ -396,7 +396,7 @@ Proof. by rewrite /quotient morphpreK ?sub_im_coset. Qed.
 
 (* Variant of morhphim_ker *)
 Lemma trivg_quotient : H / H = 1.
-Proof. by rewrite -{3}ker_coset /quotient morphim_ker. Qed.
+Proof. by rewrite -[X in X / _]ker_coset /quotient morphim_ker. Qed.
 
 Lemma quotientS1 G : G \subset H -> G / H = 1.
 Proof. by move=> sGH; apply/trivgP; rewrite -trivg_quotient quotientS. Qed.
@@ -425,7 +425,9 @@ Proof. by move=> nHG; rewrite -cosetpreSK quotientGK. Qed.
 
 (* Variant of ker_trivg_morphim. *)
 Lemma quotient_sub1 A : A \subset 'N(H) -> (A / H \subset [1]) = (A \subset H).
-Proof. by move=> nHA /=; rewrite -{10}ker_coset ker_trivg_morphim nHA. Qed.
+Proof.
+by move=> nHA /=; rewrite -[gval H in RHS]ker_coset ker_trivg_morphim nHA.
+Qed.
 
 Lemma quotientSK A B :
   A \subset 'N(H) -> (A / H \subset B / H) = (A \subset H * B).

--- a/mathcomp/solvable/alt.v
+++ b/mathcomp/solvable/alt.v
@@ -28,19 +28,19 @@ Variable T : finType.
 Implicit Types (s : {perm T}) (x y z : T).
 
 (** Definitions of the alternate groups and some Properties **)
-Definition Sym of phant T : {set {perm T}} := setT.
+Definition Sym : {set {perm T}} := setT.
 
-Canonical Sym_group phT := Eval hnf in [group of Sym phT].
+Canonical Sym_group := Eval hnf in [group of Sym].
 
-Local Notation "'Sym_T" := (Sym (Phant T)) (at level 0).
+Local Notation "'Sym_T" := Sym (at level 0).
 
 Canonical sign_morph := @Morphism _ _ 'Sym_T _ (in2W (@odd_permM _)).
 
-Definition Alt of phant T := 'ker (@odd_perm T).
+Definition Alt := 'ker (@odd_perm T).
 
-Canonical Alt_group phT := Eval hnf in [group of Alt phT].
+Canonical Alt_group := Eval hnf in [group of Alt].
 
-Local Notation "'Alt_T" := (Alt (Phant T)) (at level 0).
+Local Notation "'Alt_T" := Alt (at level 0).
 
 Lemma Alt_even p : (p \in 'Alt_T) = ~~ p.
 Proof. by rewrite !inE /=; case: odd_perm. Qed.
@@ -115,13 +115,18 @@ Qed.
 
 End SymAltDef.
 
-Notation "''Sym_' T" := (Sym (Phant T))
-  (at level 8, T at level 2, format "''Sym_' T") : group_scope.
-Notation "''Sym_' T" := (Sym_group (Phant T)) : Group_scope.
+Arguments Sym T%type.
+Arguments Sym_group T%type.
+Arguments Alt T%type.
+Arguments Alt_group T%type.
 
-Notation "''Alt_' T" := (Alt (Phant T))
+Notation "''Sym_' T" := (Sym T)
+  (at level 8, T at level 2, format "''Sym_' T") : group_scope.
+Notation "''Sym_' T" := (Sym_group T) : Group_scope.
+
+Notation "''Alt_' T" := (Alt T)
   (at level 8, T at level 2, format "''Alt_' T") : group_scope.
-Notation "''Alt_' T" := (Alt_group (Phant T)) : Group_scope.
+Notation "''Alt_' T" := (Alt_group T) : Group_scope.
 
 Lemma trivial_Alt_2 (T : finType) : #|T| <= 2 -> 'Alt_T = 1.
 Proof.

--- a/mathcomp/solvable/cyclic.v
+++ b/mathcomp/solvable/cyclic.v
@@ -590,7 +590,7 @@ Proof.
 apply/subsetP=> x /setIdP[ax]; rewrite !inE -order_dvdn.
 have [a1 | nta] := eqVneq a 1; first by rewrite a1 cycle1 inE in ax.
 rewrite -order_eq1 -dvdn1; move/eqnP: (valP u) => /= <-.
-by rewrite dvdn_gcd {2}Zp_cast ?order_gt1 // order_dvdG.
+by rewrite dvdn_gcd [in X in X && _]Zp_cast ?order_gt1 // order_dvdG.
 Qed.
 
 Lemma im_cyclem : cyclem (val u) a @* <[a]> = <[a]>.

--- a/mathcomp/solvable/gseries.v
+++ b/mathcomp/solvable/gseries.v
@@ -41,7 +41,7 @@ Section GroupDefs.
 Variable gT : finGroupType.
 Implicit Types A B U V : {set gT}.
 
-Local Notation groupT := (group_of (Phant gT)).
+Local Notation groupT := (group_of gT).
 
 Definition subnormal A B :=
   (A \subset B) && (iter #|B| (fun N => generated (class_support A N)) B == A).

--- a/mathcomp/ssreflect/eqtype.v
+++ b/mathcomp/ssreflect/eqtype.v
@@ -775,10 +775,9 @@ Notation PcanEqMixin := deprecated_PcanEqMixin.
   note="Use Equality.copy T (can_type fK) instead")]
 Notation CanEqMixin := deprecated_CanEqMixin.
 
-Definition sub_type_of T (P : pred T) (sT : subType P) of phant sT : Type := sT.
-Notation sub_type T := (sub_type_of (Phant T)).
+Definition sub_type T (P : pred T) (sT : subType P) : Type := sT.
 HB.instance Definition _ T (P : pred T) (sT : subType P) :=
-  SubType.copy (sub_type sT) sT.
+  SubType.on (sub_type sT).
 
 Section SubEqType.
 

--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -120,7 +120,7 @@ Variable T : finType.
 
 Inductive set_type : predArgType := FinSet of {ffun pred T}.
 Definition finfun_of_set A := let: FinSet f := A in f.
-Definition set_of of phant T := set_type.
+Definition set_of := set_type.
 Identity Coercion type_of_set_of : set_of >-> set_type.
 
 Definition set_isSub := Eval hnf in [isNew for finfun_of_set].
@@ -133,9 +133,10 @@ Delimit Scope set_scope with SET.
 Bind Scope set_scope with set_type.
 Bind Scope set_scope with set_of.
 Open Scope set_scope.
+Arguments set_of T%type.
 Arguments finfun_of_set {T} A%SET.
 
-Notation "{ 'set' T }" := (set_of (Phant T))
+Notation "{ 'set' T }" := (set_of T)
   (at level 0, format "{ 'set'  T }") : type_scope.
 
 (* We later define several subtypes that coerce to set; for these it is       *)
@@ -218,9 +219,9 @@ by split=> [eqAB|-> //]; apply/val_inj/ffunP=> x; have:= eqAB x; rewrite unlock.
 Qed.
 
 Definition set0 := [set x : T | false].
-Definition setTfor (phT : phant T) := [set x : T | true].
+Definition setTfor := [set x : T | true].
 
-Lemma in_setT x : x \in setTfor (Phant T).
+Lemma in_setT x : x \in setTfor.
 Proof. by rewrite in_set. Qed.
 
 Lemma eqsVneq A B : eq_xor_neq A B (B == A) (A == B).
@@ -234,10 +235,11 @@ End BasicSetTheory.
 Arguments eqsVneq {T} A B, {T A B}.
 
 Arguments set0 {T}.
+Arguments setTfor T%type.
 Arguments eq_finset {T} [pA] pB eq_pAB.
 #[global] Hint Resolve in_setT : core.
 
-Notation "[ 'set' : T ]" := (setTfor (Phant T))
+Notation "[ 'set' : T ]" := (setTfor T)
   (at level 0, format "[ 'set' :  T ]") : set_scope.
 
 Notation setT := [set: _] (only parsing).
@@ -1004,7 +1006,8 @@ Arguments subUsetP {T A B C}.
 Arguments subsetDP {T A B C}.
 Arguments subsetD1P {T A B x}.
 Prenex Implicits set1.
-#[global] Hint Resolve subsetT_hint : core.
+#[global] Hint Extern 0 (is_true (subset _ (mem (pred_of_set (setTfor _))))) =>
+  solve [apply: subsetT_hint] : core.
 
 Section setOpsAlgebra.
 

--- a/mathcomp/ssreflect/generic_quotient.v
+++ b/mathcomp/ssreflect/generic_quotient.v
@@ -139,8 +139,8 @@ Section QuotientDef.
 
 Variable T : Type.
 Variable qT : quotType T.
-Definition pi_phant of phant qT := @quot_pi_subdef _ qT.
-Local Notation "\pi" := (pi_phant (Phant qT)).
+Definition pi_subdef := @quot_pi_subdef _ qT.
+Local Notation "\pi" := pi_subdef.
 
 Lemma repr_ofK : cancel (@repr_of _ _) \pi.
 Proof. exact: repr_ofK_subproof. Qed.
@@ -152,22 +152,23 @@ Arguments repr_ofK {T qT}.
 (* Protecting some symbols. *)
 (****************************)
 
-HB.lock Definition pi := pi_phant.
-HB.lock Definition mpi := pi_phant.
+HB.lock Definition pi := pi_subdef.
+HB.lock Definition mpi := pi_subdef.
 HB.lock Definition repr := repr_of.
 
 (*******************)
 (* Fancy Notations *)
 (*******************)
 
-Notation "\pi_ Q" := (@pi _ _ (Phant Q)) : quotient_scope.
-Notation "\pi" := (@pi _ _ (Phant _))  (only parsing) : quotient_scope.
+Arguments pi.body [T]%type qT%type.
+Notation "\pi_ Q" := (@pi _ Q) : quotient_scope.
+Notation "\pi" := (@pi _ _)  (only parsing) : quotient_scope.
 Notation "x == y %[mod Q ]" := (\pi_Q x == \pi_Q y) : quotient_scope.
 Notation "x = y %[mod Q ]" := (\pi_Q x = \pi_Q y) : quotient_scope.
 Notation "x != y %[mod Q ]" := (\pi_Q x != \pi_Q y) : quotient_scope.
 Notation "x <> y %[mod Q ]" := (\pi_Q x <> \pi_Q y) : quotient_scope.
 
-Local Notation "\mpi" := (@mpi _ _ (Phant _)).
+Local Notation "\mpi" := (@mpi _ _).
 Canonical mpi_unlock := Unlockable mpi.unlock.
 Canonical pi_unlock := Unlockable pi.unlock.
 Canonical repr_unlock := Unlockable repr.unlock.
@@ -326,12 +327,10 @@ Notation "[ 'eqQuotType' e 'of' Q ]" := (EqQuotient.clone _ e Q%type _)
 (* - get the subType structure and maybe declare it Canonical.            *)
 (**************************************************************************)
 
-
-Definition quot_type_subdef T (qT : quotType T) of phant qT : Type := qT.
-Notation quot_type_of T Q := (@quot_type_subdef T _ (Phant Q)).
-Notation quot_type Q := (quot_type_subdef (Phant Q)).
-HB.instance Definition _ T (qT : quotType T) :=
-  Quotient.copy (quot_type qT) qT.
+Definition quot_type_of T (qT : quotType T) : Type := qT.
+Arguments quot_type_of T%type qT%type : clear implicits.
+Notation quot_type Q := (quot_type_of _ Q).
+HB.instance Definition _ T (qT : quotType T) := Quotient.on (quot_type qT).
 
 Module QuotSubType.
 Section QuotSubType.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -7901,11 +7901,9 @@ Module SetSubsetOrder.
 Section SetSubsetOrder.
 
 Definition type (disp : unit) (T : finType) := {set T}.
-Definition type_of (disp : unit) (T : finType) of phant T := type disp T.
-Identity Coercion type_of_type_of : type_of >-> type.
 
 Context {disp : unit} {T : finType}.
-Local Notation "{ 'subset' T }" := (type_of disp (Phant T)).
+Local Notation "{ 'subset' T }" := (type disp T).
 Implicit Type (A B C : {subset T}).
 
 Lemma le_def A B : A \subset B = (A :&: B == A).
@@ -7966,7 +7964,8 @@ Fact subset_display : unit. Proof. exact: tt. Qed.
 End SetSubsetOrder.
 
 Module Exports.
-Notation "{ 'subset' [ d ] T }" := (type_of d (Phant T))
+Arguments type disp T%type.
+Notation "{ 'subset' [ d ] T }" := (type d T)
   (at level 2, d at next level, format "{ 'subset' [ d ]  T }") : type_scope.
 Notation "{ 'subset' T }" := {subset[subset_display] T}
   (at level 2, format "{ 'subset' T }") : type_scope.


### PR DESCRIPTION
##### Motivation for this change

Cleanup phantom types now that reverse coercions make them useless.

We probably want to wait for 8.18 to be out before merging this, in order to get a better interactive experience with nicer printing.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] ~I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~ (while this would be possible, I'm not sure we want to backport that)

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.

#### Overlays (to be merged before the current PR)

- https://github.com/coq-community/coqeal/pull/84
- https://github.com/math-comp/odd-order/pull/52
- https://github.com/math-comp/multinomials/pull/85