### PR TITLE
morphisms: use richer types in combination with HB.pack

### DIFF
--- a/mathcomp/field/algebraics_fundamentals.v
+++ b/mathcomp/field/algebraics_fundamentals.v
@@ -339,7 +339,7 @@ have QtoQ z x: x \in sQ z -> {Qxz : 'AHom(Q x, Q z) | morph_ofQ x z Qxz}.
   have QxzaM := GRing.isAdditive.Build _ _ _ Qxza.
   have QxzmM := GRing.isMultiplicative.Build _ _ _ Qxzm.
   have QxzlM := GRing.isScalable.Build _ _ _ _ _ (rat_linear Qxza).
-  pose QxzLRM : GRing.LRMorphism.type _ _ _ _ := HB.pack Qxz QxzaM QxzmM QxzlM.
+  pose QxzLRM : {lrmorphism _ -> _} := HB.pack Qxz QxzaM QxzmM QxzlM.
   by exists (linfun_ahom QxzLRM) => u; rewrite lfunE QxzE.
 pose sQs z s := all (mem (sQ z)) s.
 have inQsK z s: sQs z s -> map (ofQ z) (map (inQ z) s) = s.

--- a/mathcomp/field/algnum.v
+++ b/mathcomp/field/algnum.v
@@ -226,7 +226,7 @@ pose nu0aM := GRing.isAdditive.Build Qn Qn nu0 nu0a.
 pose nu0mM := GRing.isMultiplicative.Build Qn Qn nu0 nu0m.
 pose nu0RM : GRing.RMorphism.type _ _ := HB.pack nu0 nu0aM nu0mM.
 pose nu0lM := GRing.isScalable.Build rat Qn Qn *:%R nu0 (fmorph_numZ nu0RM).
-pose nu0LRM : GRing.LRMorphism.type _ _ _ _ := HB.pack nu0 nu0aM nu0mM nu0lM.
+pose nu0LRM : {lrmorphism _ -> _} := HB.pack nu0 nu0aM nu0mM nu0lM.
 by exists nu0LRM.
 Qed.
 
@@ -396,7 +396,7 @@ have ext1 mu0 x : {mu1 | exists y, x = Sinj mu1 y
     pose in01aM := GRing.isAdditive.Build _ _ in01 in01a.
     pose in01mM := GRing.isMultiplicative.Build _ _ in01 in01m.
     pose in01lM := GRing.isScalable.Build _ _  _ _ in01 in01l.
-    pose in01LRM : GRing.LRMorphism.type _ _ _ _ := HB.pack in01
+    pose in01LRM : {lrmorphism _ -> _} := HB.pack in01
       in01aM in01mM in01lM.
     by exists in01LRM.
   have {z zz Dz px} Dx: exists xx, x = QrC xx.
@@ -431,15 +431,14 @@ have ext1 mu0 x : {mu1 | exists y, x = Sinj mu1 y
     by rewrite rmorphB /= map_polyX map_polyC.
   have [f1 aut_f1 Df1]:= kHom_extends (sub1v (ASpace algK)) hom_f Qpr splitQr.
   pose f1mM := GRing.isMultiplicative.Build _ _ f1 (kHom_lrmorphism aut_f1).
-  pose nu : GRing.LRMorphism.type _ _ _ _ := HB.pack (fun_of_lfun f1) f1mM.
+  pose nu : {lrmorphism _ -> _} := HB.pack (fun_of_lfun f1) f1mM.
   exists (SubAut Qr QrC nu) => //; exists in01 => //= y.
   by rewrite -Df -Df1 //; apply/memK; exists y.
 have phiZ: scalable phi.
   move=> a y; do 2!rewrite -mulr_algl -in_algE; rewrite -[a]divq_num_den.
   by rewrite fmorph_div rmorphM [X in X * _]fmorph_div !rmorph_int.
 pose philM := GRing.isScalable.Build _ _ _ _ phi phiZ.
-pose phiLRM : GRing.LRMorphism.type _ _ _ _ :=
-  HB.pack (GRing.RMorphism.sort phi) philM.
+pose phiLRM : {lrmorphism _ -> _} := HB.pack (GRing.RMorphism.sort phi) philM.
 pose fix ext n :=
   if n is i.+1 then oapp (fun x => s2val (ext1 (ext i) x)) (ext i) (unpickle i)
   else SubAut Qs QsC phiLRM.
@@ -478,7 +477,7 @@ have num : multiplicative nu.
   by rewrite (fmorph_inj _ Dx) !rmorphM /= -!nu_inj Dx1 Dx2.
 pose nuaM := GRing.isAdditive.Build _ _ nu nua.
 pose numM := GRing.isMultiplicative.Build _ _ nu num.
-pose nuRM : GRing.RMorphism.type _ _ := HB.pack nu nuaM numM.
+pose nuRM : {rmorphism _ -> _} := HB.pack nu nuaM numM.
 by exists nuRM => x; rewrite /= (nu_inj 0).
 Qed.
 

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -1388,8 +1388,7 @@ have tol_mul : multiplicative (toL : {poly F} -> aL).
     apply: toPinj; rewrite !toL_K // modp_mul -!(mulrC r) modp_mul.
 pose toLlM := GRing.isLinear.Build _ _ _ _ toL tol_lin.
 pose toLmM := GRing.isMultiplicative.Build _ _ _ tol_mul.
-pose toLLRM : GRing.LRMorphism.type _ _ _ _ :=
-  HB.pack (toL : {poly F} -> aL) toLlM toLmM.
+pose toLLRM : {lrmorphism _ -> feL} := HB.pack toL toLlM toLmM.
 by exists toLLRM.
 Qed.
 

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -400,7 +400,7 @@ have fZ: scalable f.
 pose faM := GRing.isAdditive.Build _ _ f fA.
 pose fmM := GRing.isMultiplicative.Build _ _ f fM.
 pose flM := GRing.isScalable.Build _ _ _ _ f fZ.
-pose fLRM : GRing.LRMorphism.type _ _ _ _ := HB.pack f faM fmM flM.
+pose fLRM : {lrmorphism _ -> _} := HB.pack f faM fmM flM.
 have /kAut_to_gal[alpha galLalpha Dalpha]: kAut 1 {:L} (linfun fLRM).
   rewrite kAutfE; apply/kHomP; split=> [x y _ _ | x /idfP]; rewrite !lfunE //=.
   exact: (rmorphM fLRM).

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -548,8 +548,7 @@ have{irr_q} [Lz [inLz [z qz0]]]: {Lz : fieldExtType F &
     move=> a u v; rewrite -(@mulr_algl F Lz) baseField_scaleE.
     by rewrite -{1}mulr_algl rmorphD rmorphM -lock.
   pose inLzLlM := GRing.isLinear.Build _ _ _ _ _ inLzL_linear.
-  pose inLzLL : GRing.Linear.type _ _ _ _ :=
-    HB.pack (locked inLz : _ -> _) inLzLlM.
+  pose inLzLL : {linear _ -> _} := HB.pack (locked inLz : _ -> _) inLzLlM.
   have ihLzZ: ahom_in {:L} (linfun inLzLL).
     by apply/ahom_inP; split=> [u v|]; rewrite !lfunE (rmorphM, rmorph1).
   exists Lz, (AHom ihLzZ), z; congr (root _ z): qz0.


### PR DESCRIPTION
The upcoming version of Coq-Elpi "typechecks more" and this makes some uses of HB.pack fail.
While I investigate exactly what the problem is, this seems a good workaround, and I want to check here if it works with the current version of Coq-Elpi.

In short: `{lrmorphism _ -> _}` is more informative (hence simpler to unify) than `GRing.LRMorphism.type _ _ _ _` because it unfolds to `GRing.LRMorphism.type _ _ _ *:%R`.