### PR TITLE
Parse negative number constants in ssralg

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -195,6 +195,10 @@ in `qfpoly.v`
 - in `zmodp.v`
 	+ lemmas `add_1_Zp`, `add_Zp_1`, `sub_Zp_1` and `add_N1_Zp`.
 
+- in `ssralg.v`
+  + support for negative constant (like `-42`) in the `Number
+    Notation` in `ring_scope`
+
 ### Changed
 
 - in `order.v`

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -540,32 +540,6 @@ Proof. by []. Qed.
 Lemma nmulrn (R : zmodType) (x : R) (n : nat) : x *- n = x *~ - n%:Z.
 Proof. by case: n=> [] //; rewrite ?oppr0. Qed.
 
-Variant Iintmul := IIntmul : Ione -> int -> Iintmul.
-
-Definition parse (x : Number.int) : Iintmul :=
-  let i :=
-    match x with
-    | Number.IntDecimal (Decimal.Pos u) => Posz (Nat.of_uint u)
-    | Number.IntDecimal (Decimal.Neg u) => Negz (Nat.of_uint u).-1
-    | Number.IntHexadecimal (Hexadecimal.Pos u) => Posz (Nat.of_hex_uint u)
-    | Number.IntHexadecimal (Hexadecimal.Neg u) => Negz (Nat.of_hex_uint u).-1
-    end in
-  IIntmul IOne i.
-
-Definition print (x : Iintmul) : Number.int :=
-  match x with
-  | IIntmul IOne (Posz n) => Number.IntDecimal (Decimal.Pos (Nat.to_uint n))
-  | IIntmul IOne (Negz n) => Number.IntDecimal (Decimal.Neg (Nat.to_uint n.+1))
-  end.
-
-Arguments GRing.one {_}.
-Set Warnings "-via-type-remapping,-via-type-mismatch".
-Number Notation Idummy_placeholder parse print (via Iintmul
-  mapping [[intmul] => IIntmul, [GRing.one] => IOne])
-  : ring_scope.
-Set Warnings "via-type-remapping,via-type-mismatch".
-Arguments GRing.one : clear implicits.
-
 Section ZintLmod.
 
 Definition zmodule (M : Type) : Type := M.

--- a/mathcomp/field/algC.v
+++ b/mathcomp/field/algC.v
@@ -69,7 +69,7 @@ Lemma nz2: 2 != 0 :> L.
 Proof.
   apply/eqP=> char2; apply: conj_nt => e; apply/eqP/idPn=> eJ.
   have opp_id x: - x = x :> L.
-    by apply/esym/eqP; rewrite -addr_eq0 -mulr2n -mulr_natl pmulrn char2 mul0r.
+    by apply/esym/eqP; rewrite -addr_eq0 -mulr2n -mulr_natl char2 mul0r.
   have{} char2: 2%N \in [char L] by apply/eqP.
   without loss{eJ} eJ: e / conj e = e + 1.
     move/(_ (e / (e + conj e))); apply.
@@ -636,7 +636,7 @@ Definition CintrE :=
    =^~ (@ler_int CnF, @ltr_int CnF, (inj_eq (@intr_inj CnF)))).
 
 Let nz2 : 2 != 0 :> algC.
-Proof. by rewrite -(rmorph0 ( *~%R 1)) -CintrE. Qed.
+Proof. by rewrite pnatr_eq0. Qed.
 
 (* Conjugation and norm. *)
 


### PR DESCRIPTION
Before this commit

```Coq
From mathcomp Require Import ssralg.
Local Open Scope ring_scope.

Check -3.
```

was failing with

Error: Cannot interpret this number as a value of type Idummy_placeholder

one needed to import ssrint to get

```Coq
From mathcomp Require Import ssralg ssrint.
Local Open Scope ring_scope.

Check -3.  (* (-3)%:~R *)
```

Now we have

```Coq
From mathcomp Require Import ssralg.
Local Open Scope ring_scope.

Check -3.  (* - (3%:R) *)
```

which is not exactly the same (we don't have `intmul` (notation `%:~R`) in ssralg) but is convertible.

Also removes the number notation in ssrint which made `3` being read as aither `3%:R` when only ssralg was imported or `3%:~R` when ssrint was imported.

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~ (behave the same as `- <number>` both unary `-` and `<number>` already documented)
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [x] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
