### PR TITLE
add big_condT

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -171,6 +171,9 @@ in `qfpoly.v`
 - in `ssrnat.v`
   + lemma `addn_eq1`
 
+- in `bigop.v`
+  + lemma `big_condT`
+
 ### Changed
 
 - in `order.v`

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -985,10 +985,9 @@ Lemma big_map_id J (h : J -> R) r (P : pred R) :
      = \big[op/idx]_(j <- r | P (h j)) h j.
 Proof. exact: big_map. Qed.
 
-Lemma big_condT (J : finType) (r : seq J) (A : {pred J}) F :
+Lemma big_condT (J : finType) (A : {pred J}) F :
   \big[op/idx]_(i in A | true) F i = \big[op/idx]_(i in A) F i.
 Proof. by apply: eq_bigl => i; exact: andbT. Qed.
-
 (* The following lemmas can be used to localise extensionality to a specific  *)
 (* index sequence. This is done by ssreflect rewriting, before applying       *)
 (* congruence or induction lemmas.                                            *)

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -988,6 +988,7 @@ Proof. exact: big_map. Qed.
 Lemma big_condT (J : finType) (A : {pred J}) F :
   \big[op/idx]_(i in A | true) F i = \big[op/idx]_(i in A) F i.
 Proof. by apply: eq_bigl => i; exact: andbT. Qed.
+
 (* The following lemmas can be used to localise extensionality to a specific  *)
 (* index sequence. This is done by ssreflect rewriting, before applying       *)
 (* congruence or induction lemmas.                                            *)

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -985,6 +985,10 @@ Lemma big_map_id J (h : J -> R) r (P : pred R) :
      = \big[op/idx]_(j <- r | P (h j)) h j.
 Proof. exact: big_map. Qed.
 
+Lemma big_condT (J : finType) (r : seq J) (A : {pred J}) F :
+  \big[op/idx]_(i in A | true) F i = \big[op/idx]_(i in A) F i.
+Proof. by apply: eq_bigl => i; exact: andbT. Qed.
+
 (* The following lemmas can be used to localise extensionality to a specific  *)
 (* index sequence. This is done by ssreflect rewriting, before applying       *)
 (* congruence or induction lemmas.                                            *)


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

Adds `big_condT` to `bigop.v`, which is believed to be more beginner friendly. I am not sure of the placement, though. It is a trivial consequence of `big_mkcondr` but does not require a `Monoid._law` structure. Yet it requires a finite index type, so it does not fit in section `SeqExtension` with e.g. `big_andbC`. Also, it could be generalized to `big_andbT` (which would not be as beginner friendly as `big_condT`).

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
