### PR TITLE
ordS and ord_pred

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -179,7 +179,7 @@ in `qfpoly.v`
   `ordS_bij`, `ordS_inj`, `ord_pred_bij`, `ord_pred_inj`
 
 - in `zmodp.v`
-	+ lemmas `Zp_add1z, `Zp_addzN1`
+	+ lemmas `add_1_Zp`, `add_Zp_1`, `sub_Zp_1` and `add_N1_Zp`.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -173,6 +173,7 @@ in `qfpoly.v`
 
 - in `bigop.v`
   + lemma `big_condT`
+
 - in `fintype.v`
   + definitions `ordS`, `ord_pred`
   + lemmas `ordS_subproof`, `ord_pred_subproof`, `ordSK`, `ord_predK`,

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -178,6 +178,9 @@ in `qfpoly.v`
   + lemmas `ordS_subproof`, `ord_pred_subproof`, `ordSK`, `ord_predK`,
   `ordS_bij`, `ordS_inj`, `ord_pred_bij`, `ord_pred_inj`
 
+- in `zmodp.v`
+	+ lemmas `Zp_add1z, `Zp_addzN1`
+
 ### Changed
 
 - in `order.v`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -173,6 +173,10 @@ in `qfpoly.v`
 
 - in `bigop.v`
   + lemma `big_condT`
+- in `fintype.v`
+  + definitions `ordS`, `ord_pred`
+  + lemmas `ordS_subproof`, `ord_pred_subproof`, `ordSK`, `ord_predK`,
+  `ordS_bij`, `ordS_inj`, `ord_pred_bij`, `ord_pred_inj`
 
 ### Changed
 

--- a/mathcomp/algebra/zmodp.v
+++ b/mathcomp/algebra/zmodp.v
@@ -88,9 +88,19 @@ Definition Zp_inv x := if coprime p x then inZp (egcdn x p).1 else x.
 Lemma Zp_add0z : left_id Zp0 Zp_add.
 Proof. exact: valZpK. Qed.
 
+Lemma Zp_add1z x : Zp_add Zp1 x = ordS x.
+Proof. by apply: val_inj; rewrite /= modnDml. Qed.
+
 Lemma Zp_addNz : left_inverse Zp0 Zp_opp Zp_add.
 Proof.
 by move=> x; apply: val_inj; rewrite /= modnDml subnK ?modnn // ltnW.
+Qed.
+
+Lemma Zp_addzN1 x : Zp_add x (Zp_opp Zp1) = ord_pred x.
+Proof.
+apply: val_inj => /=; move: x => [x /= _]; rewrite modnDmr.
+case: p' => [|n]; first by rewrite 2!modn1.
+by rewrite [1 %% _]modn_small//= subn1 [in RHS]addnS.
 Qed.
 
 Lemma Zp_addA : associative Zp_add.

--- a/mathcomp/algebra/zmodp.v
+++ b/mathcomp/algebra/zmodp.v
@@ -88,19 +88,9 @@ Definition Zp_inv x := if coprime p x then inZp (egcdn x p).1 else x.
 Lemma Zp_add0z : left_id Zp0 Zp_add.
 Proof. exact: valZpK. Qed.
 
-Lemma Zp_add1z x : Zp_add Zp1 x = ordS x.
-Proof. by apply: val_inj; rewrite /= modnDml. Qed.
-
 Lemma Zp_addNz : left_inverse Zp0 Zp_opp Zp_add.
 Proof.
 by move=> x; apply: val_inj; rewrite /= modnDml subnK ?modnn // ltnW.
-Qed.
-
-Lemma Zp_addzN1 x : Zp_add x (Zp_opp Zp1) = ord_pred x.
-Proof.
-apply: val_inj => /=; move: x => [x /= _]; rewrite modnDmr.
-case: p' => [|n]; first by rewrite 2!modn1.
-by rewrite [1 %% _]modn_small//= subn1 [in RHS]addnS.
 Qed.
 
 Lemma Zp_addA : associative Zp_add.
@@ -263,6 +253,24 @@ Notation "''F_' p" := 'Z_(pdiv p)
   (at level 8, p at level 2, format "''F_' p") : type_scope.
 
 Arguments natr_Zp {p'} x.
+
+Section ZpRing.
+
+Import GRing.Theory.
+
+Lemma add_1_Zp p (x : 'Z_p) : 1 + x = ordS x.
+Proof. by case: p => [|[|p]] in x *; apply/val_inj. Qed.
+
+Lemma add_Zp_1 p (x : 'Z_p) : x + 1 = ordS x.
+Proof. by rewrite addrC add_1_Zp. Qed.
+
+Lemma sub_Zp_1 p (x : 'Z_p) : x - 1 = ord_pred x.
+Proof. by apply: (addIr 1); rewrite addrNK add_Zp_1 ord_predK. Qed.
+
+Lemma add_N1_Zp p (x : 'Z_p) : -1 + x = ord_pred x.
+Proof. by rewrite addrC sub_Zp_1. Qed.
+
+End ZpRing.
 
 Section Groups.
 

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -1839,17 +1839,15 @@ Definition ord_pred n (i : 'I_n) := Ordinal (ord_pred_subproof i).
 Lemma ordSK n : cancel (@ordS n) (@ord_pred n).
 Proof.
 move=> [i ilt]; apply/val_inj => /=.
-rewrite modnS; case /boolP: (n %| i.+1) => [/(dvdn_leq (@ltn0Sn i))nle|_ /=].
-  have /eqP ->: n == i.+1 by rewrite eqn_leq nle.
-  by rewrite add0n modn_small.
-by rewrite modnDr modn_mod modn_small.
+case: (ltngtP i.+1 n) ilt => // [ismall|<-]; last by rewrite modnn/= modn_small.
+by rewrite [i.+1 %% n]modn_small// addSn/= modnDr modn_small// ltnW.
 Qed.
 
 Lemma ord_predK n : cancel (@ord_pred n) (@ordS n).
 Proof.
 move=> [[|i] ilt]; apply/val_inj => /=.
-  by rewrite add0n [n.-1 %% n]modn_small ?ltn_predL// (ltn_predK ilt) modnn.
-by rewrite modnDr [i %% n]modn_small ?modn_small// (leq_trans (leqnSn i.+1)).
+  by rewrite [n.-1 %% n]modn_small// prednK// modnn.
+by rewrite modnDr [i %% n]modn_small ?modn_small// ltnW.
 Qed.
 
 Lemma ordS_bij n : bijective (@ordS n).

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -2,7 +2,7 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import path.
+From mathcomp Require Import path div.
 
 (******************************************************************************)
 (*                             Finite types                                   *)
@@ -54,6 +54,10 @@ From mathcomp Require Import path.
 (*  cast_ord eq_n_m i == the element j : 'I_m with the same value as i : 'I_n *)
 (*                       given eq_n_m : n = m (indeed, i : nat and j : nat    *)
 (*                       are convertible)                                     *)
+(*           ordS n i == the successor of i : 'I_n along the cyclic structure *)
+(*                       of 'I_n, reduces in nat to i.+1 %% n                 *)
+(*       ord_pred n i == the predecessor of i : 'I_n along the cyclic         *)
+(*                       structure of 'I_n, reduces in nat to (i + n).-1 %% n *)
 (* widen_ord le_n_m i == a j : 'I_m with the same value as i : 'I_n, given    *)
 (*                       le_n_m : n <= m                                      *)
 (*          rev_ord i == the complement to n.-1 of i : 'I_n, such that        *)
@@ -1823,6 +1827,42 @@ Proof. by move=> i; apply: val_inj. Qed.
 
 Lemma cast_ord_inj n1 n2 eq_n : injective (@cast_ord n1 n2 eq_n).
 Proof. exact: can_inj (cast_ordK eq_n). Qed.
+
+Fact ordS_subproof n (i : 'I_n) : i.+1 %% n < n.
+Proof. by case: n i => [|n] [m m_lt]//=; rewrite ltn_pmod. Qed.
+Definition ordS n (i : 'I_n) := Ordinal (ordS_subproof i).
+
+Fact ord_pred_subproof n (i : 'I_n) : (i + n).-1 %% n < n.
+Proof. by case: n i => [|n] [m m_lt]//=; rewrite ltn_pmod. Qed.
+Definition ord_pred n (i : 'I_n) := Ordinal (ord_pred_subproof i).
+
+Lemma ordSK n : cancel (@ordS n) (@ord_pred n).
+Proof.
+move=> [i ilt]; apply/val_inj => /=.
+rewrite modnS; case /boolP: (n %| i.+1) => [/(dvdn_leq (@ltn0Sn i))nle|_ /=].
+  have /eqP ->: n == i.+1 by rewrite eqn_leq nle.
+  by rewrite add0n modn_small.
+by rewrite modnDr modn_mod modn_small.
+Qed.
+
+Lemma ord_predK n : cancel (@ord_pred n) (@ordS n).
+Proof.
+move=> [[|i] ilt]; apply/val_inj => /=.
+  by rewrite add0n [n.-1 %% n]modn_small ?ltn_predL// (ltn_predK ilt) modnn.
+by rewrite modnDr [i %% n]modn_small ?modn_small// (leq_trans (leqnSn i.+1)).
+Qed.
+
+Lemma ordS_bij n : bijective (@ordS n).
+Proof. exact: (Bijective (@ordSK n) (@ord_predK n)). Qed.
+
+Lemma ordS_inj n : injective (@ordS n).
+Proof. exact: (bij_inj (ordS_bij n)). Qed.
+
+Lemma ord_pred_bij n : bijective (@ord_pred n).
+Proof. exact (Bijective (@ord_predK n) (@ordSK n)). Qed.
+
+Lemma ord_pred_inj n : injective (@ord_pred n).
+Proof. exact: (bij_inj (ord_pred_bij n)). Qed.
 
 Lemma rev_ord_proof n (i : 'I_n) : n - i.+1  < n.
 Proof. by case: n i => [|n] [i lt_i_n] //; rewrite ltnS subSS leq_subr. Qed.

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -1839,8 +1839,8 @@ Definition ord_pred n (i : 'I_n) := Ordinal (ord_pred_subproof i).
 Lemma ordSK n : cancel (@ordS n) (@ord_pred n).
 Proof.
 move=> [i ilt]; apply/val_inj => /=.
-case: (ltngtP i.+1 n) ilt => // [ismall|<-]; last by rewrite modnn/= modn_small.
-by rewrite [i.+1 %% n]modn_small// addSn/= modnDr modn_small// ltnW.
+case: (ltngtP i.+1) (ilt) => // [Silt|<-]; last by rewrite modnn/= modn_small.
+by rewrite [i.+1 %% n]modn_small// addSn/= modnDr modn_small.
 Qed.
 
 Lemma ord_predK n : cancel (@ord_pred n) (@ordS n).


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

Defines ordS and ord_pred with a few lemmas (they cancel each other and are bijective and injective). They are intended to help accessing list elements, in particular when their elements are meant to form a cyclic structure.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [x] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
