### PR TITLE
Fix GitLab CI post-deploy tests & Deploy `mathcomp/mathcomp-dev:coq-8.18`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,6 +127,8 @@ coq-dev:
     - opam list
     - coqc --version
     - echo "${COQ_VERSION}"
+    # adapt to Git's patch for CVE-2022-24765 that is off-topic here
+    - git config --global --add safe.directory "${CI_PROJECT_DIR}"
     - git rev-parse --verify HEAD
     - git describe --all --long --abbrev=40 --always --dirty
     - pwd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,8 +104,12 @@ coq-8.16:
 coq-8.17:
   extends: .opam-build-once
 
-# coq-8.18: # to uncomment when 8.18+rc1 available
-#   # to be replaced with .opam-build-once when 8.18.0 available
+coq-8.18:
+  # to be replaced with .opam-build-once when 8.18.0 available
+  extends: .opam-build
+
+# coq-8.19: # to uncomment when 8.19+rc1 available
+#   # to be replaced with .opam-build-once when 8.19.0 available
 #   extends: .opam-build
 
 coq-dev:
@@ -165,11 +169,17 @@ test-coq-8.17:
   variables:
     COQ_VERSION: "8.17"
 
-# test-coq-8.18: # to uncomment when 8.18+rc1 available
-#   # to be replaced with .test-once when 8.18.0 available
+test-coq-8.18:
+  # to be replaced with .test-once when 8.18.0 available
+  extends: .test
+  variables:
+    COQ_VERSION: "8.18"
+
+# test-coq-8.19: # to uncomment when 8.19+rc1 available
+#   # to be replaced with .test-once when 8.19.0 available
 #   extends: .test
 #   variables:
-#     COQ_VERSION: "8.18"
+#     COQ_VERSION: "8.19"
 
 test-coq-dev:
   extends: .test
@@ -405,8 +415,12 @@ mathcomp-dev_coq-8.16:
 mathcomp-dev_coq-8.17:
   extends: .docker-deploy-once
 
-# mathcomp-dev_coq-8.18: # to uncomment when 8.18+rc1 available
-#   # to be replaced with .docker-deploy-once when 8.18.0 available
+mathcomp-dev_coq-8.18:
+  # to be replaced with .docker-deploy-once when 8.18.0 available
+  extends: .docker-deploy
+
+# mathcomp-dev_coq-8.19: # to uncomment when 8.19+rc1 available
+#   # to be replaced with .docker-deploy-once when 8.19.0 available
 #   extends: .docker-deploy
 
 mathcomp-dev_coq-dev:

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -11,7 +11,8 @@ build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [
   "coq" { ((>= "8.16" & < "8.19~") | (= "dev"))}
-  "coq-hierarchy-builder" { >= "1.4.0"}
+  "coq-hierarchy-builder" { >= "1.5.0"}
+  "elpi" { >= "1.17.0" }
 ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -10,7 +10,7 @@ license: "CECILL-B"
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [
-  "coq" { ((>= "8.16" & < "8.18~") | (= "dev"))}
+  "coq" { ((>= "8.16" & < "8.19~") | (= "dev"))}
   "coq-hierarchy-builder" { >= "1.4.0"}
 ]
 


### PR DESCRIPTION
##### Motivation for this change

Twofold:

* Fix post-deploy-to-Docker-Hub GitLab CI tests (not critical for external users, but much better to have a "green gitlab CI")
* Add deploy & post-deploy test for 8.18+rc1 (important for external users in coq-community or so)

##### Things done/to do

N/A

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

I (@erikmd) plan to take a look at the mathcomp-1 (gitlab) CI soonish

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.

Cc @gares @proux01 @CohenCyril 