### PR TITLE
Memory issue

### DIFF
--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -900,7 +900,7 @@ case: n => [|n] in g *; first by rewrite !thinmx0.
 by rewrite /kermxpoly horner_mx_X.
 Qed.
 
-Lemma kermxpoly_min n (g : 'M_n.+1) p :
+Lemma kermxpoly_min n (g : 'M[K]_n.+1) p :
   mxminpoly g %| p -> (kermxpoly g p :=: 1)%MS.
 Proof. by rewrite /kermxpoly => /mxminpoly_minP ->; apply: kermx0. Qed.
 
@@ -1958,7 +1958,7 @@ have := dAAs B; rewrite inE BAs orbT => /(_ isT) [P Punit].
 move=> /diagonalizable_forPex[D /(simmxLR Punit)->] sePD.
 have rAeP : row_free (row_base (eigenspace A rs`_i) *m invmx P).
   by rewrite /row_free mxrankMfree ?row_free_unit ?unitmx_inv// eq_row_base.
-rewrite -conjMumx ?unitmx_inv ?row_base_free//.
+rewrite -conjMumx ?unitmx_inv ?row_base_free => [|//|//|//].
 apply/diagonalizable_conj_diag => //.
 by rewrite stablemx_comp// stablemx_unit ?unitmx_inv.
 Qed.

--- a/mathcomp/algebra/polydiv.v
+++ b/mathcomp/algebra/polydiv.v
@@ -3160,7 +3160,7 @@ have [-> | bn0] := eqVneq b 0.
   by rewrite (rmorph0 (map_poly f)) scalp0.
 rewrite unlock redivp_map lead_coef_map rmorph_unit; last first.
   by rewrite unitfE lead_coef_eq0.
-rewrite modpE divpE !map_polyZ !rmorphV ?rmorphXn // unitfE.
+rewrite modpE divpE !map_polyZ [in RHS]rmorphV ?rmorphXn // unitfE.
 by rewrite expf_neq0 // lead_coef_eq0.
 Qed.
 

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -4365,7 +4365,8 @@ Lemma irr_comp_rsim n1 n2 rG1 rG2 :
   @mx_rsim _ G n1 rG1 n2 rG2 -> irr_comp rG1 = irr_comp rG2.
 Proof.
 case=> f eq_n12; rewrite -eq_n12 in rG2 f * => inj_f hom_f.
-congr (odflt _ _); apply: eq_pick => i; rewrite -!mxrank_eq0.
+rewrite /irr_comp; apply/f_equal/eq_pick => i; rewrite -!mxrank_eq0.
+(* [congr (odflt 1%irr _)] works but is very slow *)
 rewrite -(mxrankMfree _ inj_f); symmetry; rewrite -(eqmxMfull _ inj_f).
 have /envelop_mxP[e ->{i}]: ('e_i \in R_G)%MS.
   by rewrite -Wedderburn_sum (sumsmx_sup i) ?Wedderburn_id_mem.
@@ -4382,7 +4383,7 @@ Qed.
 Lemma irr_repr'_op0 i j A :
   j != i -> (A \in 'R_j)%MS -> gring_op (irr_repr i) A = 0.
 Proof.
-by move=> neq_ij /irr_comp'_op0-> //; [apply: socle_irr | rewrite irr_reprK].
+by move=> neq_ij /irr_comp'_op0->; [|apply: socle_irr|rewrite irr_reprK].
 Qed.
 
 Lemma op_Wedderburn_id i : gring_op (irr_repr i) 'e_i = 1%:M.
@@ -5113,7 +5114,7 @@ Lemma mxval0 : mxval 0 = 0.
 Proof. by rewrite /mxval [pval _]raddf0 rmorph0. Qed.
 
 Lemma mxvalN : {morph mxval : x / - x}.
-Proof. by move=> x; rewrite /mxval [pval _]raddfN rmorphN. Qed.
+Proof. by move=> x; rewrite /mxval [pval _](@raddfN 'rV[F]_d) rmorphN. Qed.
 
 Lemma mxvalD : {morph mxval : x y / x + y}.
 Proof. by move=> x y; rewrite /mxval [pval _]raddfD rmorphD. Qed.

--- a/mathcomp/field/closed_field.v
+++ b/mathcomp/field/closed_field.v
@@ -732,7 +732,7 @@ pose EIsCountable := isCountable.Build E (pcan_pickleK (can_pcan (reprK))).
 pose Ecount : countFieldType := HB.pack E Efield EIsCountable.
 pose FtoE : {rmorphism _ -> _} := PtoE \o polyC; pose w : E := PtoE 'X.
 have defPtoE q: (map_poly FtoE q).[w] = PtoE q.
-  by rewrite map_poly_comp horner_map [_.['X]]comp_polyXr.
+  by rewrite (map_poly_comp PtoE polyC) horner_map [_.['X]]comp_polyXr.
 exists Ecount, FtoE, w => [|u].
   by rewrite /root defPtoE (PtoEd 0).
 by exists (repr u); rewrite defPtoE /= reprK.

--- a/mathcomp/field/qfpoly.v
+++ b/mathcomp/field/qfpoly.v
@@ -303,7 +303,7 @@ rewrite leq_eqVlt; apply/orP; left; apply/eqP.
 rewrite -orderE gX_order card_qfpoly -[in RHS](mk_monicE primitive_mi).
 rewrite -card_qpoly -(cardC1 (0 : {poly %/ h with primitive_mi})).
 rewrite cardsT card_sub.
-by apply: eq_card => x; rewrite unitfE.
+by apply: eq_card => x; rewrite [LHS]unitfE.
 Qed.
 
 Let pred_card_qT_gt0 : 0 < #|qT|.-1.

--- a/mathcomp/solvable/pgroup.v
+++ b/mathcomp/solvable/pgroup.v
@@ -1258,7 +1258,8 @@ Proof. by rewrite -(pHallNK pi G H); apply: sdprod_pcore_HallP. Qed.
 Lemma pcoreI pi rho G : 'O_[predI pi & rho](G) = 'O_pi('O_rho(G)).
 Proof.
 apply/eqP; rewrite eqEsubset !pcore_max //.
-- by rewrite /pgroup pnatI -!pgroupE !(pcore_pgroup, pgroupS (pcore_sub pi _)).
+- rewrite /pgroup pnatI -!pgroupE.
+  by rewrite pcore_pgroup (pgroupS (pcore_sub pi _))// pcore_pgroup.
 - by rewrite !gFnormal_trans.
 - by apply: sub_pgroup (pcore_pgroup _ _) => p /andP[].
 apply/andP; split; first by apply: sub_pcore => p /andP[].


### PR DESCRIPTION
##### Motivation for this change

This is pretty ugly but makes `cyclic.v` down from 2.8 GB to 0.6 GB on Coq 8.17.1.

Also contains a few minor (like 1% of total compilation time) performance improvements in the second commit.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] ~I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~ (the issue doesn't show (or at least is less visible) on MC-1 branch)

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
