### PR TITLE
Remove infer HB attribute

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -201,6 +201,12 @@ in `qfpoly.v`
   + make `[Order of T by <:]` compatible with the SubOrder hierarchy
 - in `ssralg.v`
   + implicits of `natr1` and `nat1r`
+  + implicits of `Linear.type`, use the `{linear _ -> _}` notation
+    for compatibility
+  + implicits of `RMorphism.type`, use the `{rmorphism _ -> _}`
+    notation for compatibility
+  + implicits of `LRMorphism.type`, use the `{lrmorphism _ -> _}`
+    notation for compatibility
 
 ### Renamed
 

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -151,7 +151,7 @@ Notation "[ 'finFieldType' 'of' T ]" := (Field.clone T%type _)
 End FieldExports.
 HB.export FieldExports.
 
-#[infer(R), short(type="finLmodType")]
+#[short(type="finLmodType")]
 HB.structure Definition Lmodule (R : ringType) :=
   {M of GRing.Lmodule R M & Finite M}.
 
@@ -162,7 +162,7 @@ Notation "[ 'finLmodType' R 'of' T ]" := (Lmodule.clone R T%type _)
 End LmoduleExports.
 HB.export LmoduleExports.
 
-#[infer(R), short(type="finLalgType")]
+#[short(type="finLalgType")]
 HB.structure Definition Lalgebra (R : ringType) :=
   {M of GRing.Lalgebra R M & Finite M}.
 
@@ -174,7 +174,7 @@ Notation "[ 'finLalgType' R 'of' T ]" := (Lalgebra.clone R T%type _)
 End LalgebraExports.
 HB.export LalgebraExports.
 
-#[infer(R), short(type="finAlgType")]
+#[short(type="finAlgType")]
 HB.structure Definition Algebra (R : ringType) :=
   {M of GRing.Algebra R M & Finite M}.
 
@@ -185,7 +185,7 @@ Notation "[ 'finAlgType' R 'of' T ]" := (Algebra.clone R T%type _)
 End AlgebraExports.
 HB.export AlgebraExports.
 
-#[infer(R), short(type="finUnitAlgType")]
+#[short(type="finUnitAlgType")]
 HB.structure Definition UnitAlgebra (R : unitRingType) :=
   {M of GRing.UnitAlgebra R M & Finite M}.
 
@@ -386,33 +386,33 @@ HB.end.
 HB.instance Definition _ (R : ringType) (M : Lmodule.type R) :=
   [finGroupMixin of M for +%R].
 
-Coercion Lmodule_to_baseFinGroup (R : ringType) (M : Lmodule.type_ R) :=
+Coercion Lmodule_to_baseFinGroup (R : ringType) (M : Lmodule.type R) :=
   BaseFinGroup.clone M _.
-Coercion Lmodule_to_finGroup (R : ringType) (M : Lmodule.type_ R) : finGroupType :=
+Coercion Lmodule_to_finGroup (R : ringType) (M : Lmodule.type R) : finGroupType :=
   FinGroup.clone (M : Type) _.
 
 #[export, non_forgetful_inheritance]
 HB.instance Definition _ (R : ringType) (M : Lalgebra.type R) :=
   [finGroupMixin of M for +%R].
-Coercion Lalgebra_to_baseFinGroup (R : ringType) (M : Lalgebra.type_ R) :=
+Coercion Lalgebra_to_baseFinGroup (R : ringType) (M : Lalgebra.type R) :=
   BaseFinGroup.clone M _.
-Coercion Lalgebra_to_finGroup (R : ringType) (M : Lalgebra.type_ R) :=
+Coercion Lalgebra_to_finGroup (R : ringType) (M : Lalgebra.type R) :=
   FinGroup.clone M _.
 
 #[export, non_forgetful_inheritance]
 HB.instance Definition _ (R : ringType) (M : Algebra.type R) :=
   [finGroupMixin of M for +%R].
-Coercion Algebra_to_baseFinGroup (R : ringType) (M : Algebra.type_ R) :=
+Coercion Algebra_to_baseFinGroup (R : ringType) (M : Algebra.type R) :=
   BaseFinGroup.clone M _.
-Coercion Algebra_to_finGroup (R : ringType) (M : Algebra.type_ R) :=
+Coercion Algebra_to_finGroup (R : ringType) (M : Algebra.type R) :=
   FinGroup.clone M _.
 
 #[export, non_forgetful_inheritance]
 HB.instance Definition _ (R : unitRingType) (M : UnitAlgebra.type R) :=
   [finGroupMixin of M for +%R].
-Coercion UnitAlgebra_to_baseFinGroup (R : unitRingType) (M : UnitAlgebra.type_ R) :=
+Coercion UnitAlgebra_to_baseFinGroup (R : unitRingType) (M : UnitAlgebra.type R) :=
   BaseFinGroup.clone M _.
-Coercion UnitAlgebra_to_finGroup (R : unitRingType) (M : UnitAlgebra.type_ R) :=
+Coercion UnitAlgebra_to_finGroup (R : unitRingType) (M : UnitAlgebra.type R) :=
   FinGroup.clone M _.
 
 Module RegularExports.

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -1612,7 +1612,7 @@ HB.mixin Record Zmodule_isLmodule (R : ringType) V of Zmodule V := {
   scalerDr : right_distributive scale +%R;
   scalerDl : forall v, {morph scale^~ v: a b / a + b}
 }.
-#[infer(R), short(type="lmodType")]
+#[short(type="lmodType")]
 HB.structure Definition Lmodule (R : ringType) :=
   {M of Zmodule M & Zmodule_isLmodule R M}.
 
@@ -1716,7 +1716,7 @@ End LmoduleTheory.
 HB.mixin Record Lmodule_isLalgebra R V of Ring V & Lmodule R V := {
   scalerAl : forall (a : R) (u v : V), a *: (u * v) = (a *: u) * v
 }.
-#[infer(R), short(type="lalgType")]
+#[short(type="lalgType")]
 HB.structure Definition Lalgebra R :=
   {A of Lmodule_isLalgebra R A & Ring A & Lmodule R A}.
 
@@ -1789,7 +1789,7 @@ HB.mixin Record isSemiAdditive (U V : nmodType) (apply : U -> V) := {
   semi_additive_subproof : semi_additive apply;
 }.
 
-#[infer(U,V),mathcomp(axiom="semi_additive")]
+#[mathcomp(axiom="semi_additive")]
 HB.structure Definition Additive (U V : nmodType) :=
   {f of isSemiAdditive U V f}.
 
@@ -2055,7 +2055,6 @@ HB.mixin Record isMultiplicative (R S : semiRingType) (f : R -> S) := {
   rmorphism_subproof : multiplicative f
 }.
 
-#[infer(R,S)]
 HB.structure Definition RMorphism (R S : semiRingType) :=
   {f of @Additive R S f & isMultiplicative R S f}.
 (* FIXME: remove the @ once
@@ -2232,7 +2231,6 @@ HB.mixin Record isScalable (R : ringType) (U : lmodType R) (V : zmodType)
   linear_subproof : scalable_for s f;
 }.
 
-#[infer(R,U,V)]
 HB.structure Definition Linear (R : ringType) (U : lmodType R) (V : zmodType)
     (s : R -> V -> V) :=
   {f of @Additive U V f & isScalable R U V s f}.
@@ -2273,7 +2271,7 @@ Definition apply_deprecated (phUV : phant (U -> V)) := @Linear.sort R U V s.
 #[deprecated(since="mathcomp 2.0", note="Use Linear.sort instead.")]
 Notation apply := apply_deprecated.
 (* Support for right-to-left rewriting with the generic linearZ rule. *)
-Local Notation mapUV := (Linear.type R U V s).
+Local Notation mapUV := (@Linear.type R U V s).
 Definition map_class := mapUV.
 Definition map_at (a : R) := mapUV.
 Structure map_for a s_a := MapFor {map_for_map : mapUV; _ : s a = s_a}.
@@ -2295,7 +2293,6 @@ Notation "[ 'linear' 'of' f 'as' g ]" := (Linear.clone _ _ _ _ f%function g)
 Notation "[ 'linear' 'of' f ]" := (Linear.clone _ _ _ _ f%function _)
   (at level 0, format "[ 'linear'  'of'  f ]") : form_scope.
 (* Support for right-to-left rewriting with the generic linearZ rule. *)
-Identity Coercion lineratype_id : Linear.type >-> Linear.type_.
 Coercion Linear.map_for_map : Linear.map_for >-> Linear.type.
 Coercion Linear.unify_map_at : Linear.map_at >-> Linear.map_for.
 Canonical Linear.unify_map_at.
@@ -2462,7 +2459,6 @@ End LinearLalg.
 
 End LinearTheory.
 
-#[infer(R,A,B)]
 HB.structure Definition LRMorphism (R : ringType) (A : lalgType R) (B : ringType)
     (s : R -> B -> B) :=
   {f of @RMorphism A B f & isScalable R A B s f}.
@@ -2694,7 +2690,7 @@ End ComRingTheory.
 HB.mixin Record Lalgebra_isAlgebra (R : ringType) V of Lalgebra R V := {
   scalerAr : forall k (x y : V), k *: (x * y) = x * (k *: y);
 }.
-#[infer(R), short(type="algType")]
+#[short(type="algType")]
 HB.structure Definition Algebra (R : ringType) :=
   {A of Lalgebra_isAlgebra R A & Lalgebra R A}.
 
@@ -2721,7 +2717,7 @@ HB.instance Definition lalgebra_is_algebra : Lalgebra_isAlgebra R V :=
 
 HB.end.
 
-#[infer(R), short(type="comAlgType")]
+#[short(type="comAlgType")]
 HB.structure Definition ComAlgebra R := {V of ComRing V & Algebra R V}.
 
 Module ComAlgExports.
@@ -3122,7 +3118,7 @@ HB.instance Definition mulinverse : Ring_hasMulInverse R :=
 
 HB.end.
 
-#[infer(R), short(type="unitAlgType")]
+#[short(type="unitAlgType")]
 HB.structure Definition UnitAlgebra R := {V of Algebra R V & UnitRing V}.
 
 Module UnitAlgebraExports.
@@ -3134,7 +3130,7 @@ Notation "[ 'unitAlgType' R 'of' T ]" := (UnitAlgebra.clone R T%type _)
 End UnitAlgebraExports.
 HB.export UnitAlgebraExports.
 
-#[infer(R), short(type="comUnitAlgType")]
+#[short(type="comUnitAlgType")]
 HB.structure Definition ComUnitAlgebra R := {V of ComAlgebra R V & UnitRing V}.
 
 Module ComUnitAlgebraExports.
@@ -4581,42 +4577,42 @@ HB.mixin Record isScaleClosed (R : ringType) (V : lmodType R)
 
 (* Structures for stability properties *)
 
-#[infer(V), short(type="opprClosed")]
+#[short(type="opprClosed")]
 HB.structure Definition OppClosed V := {S of isOppClosed V S}.
 
-#[infer(V), short(type="addrClosed")]
+#[short(type="addrClosed")]
 HB.structure Definition AddClosed V := {S of isAddClosed V S}.
 
-#[infer(V), short(type="zmodClosed")]
+#[short(type="zmodClosed")]
 HB.structure Definition ZmodClosed V := {S of OppClosed V S & AddClosed V S}.
 
-#[infer(R), short(type="mulr2Closed")]
+#[short(type="mulr2Closed")]
 HB.structure Definition Mul2Closed R := {S of isMul2Closed R S}.
 
-#[infer(R), short(type="mulrClosed")]
+#[short(type="mulrClosed")]
 HB.structure Definition MulClosed R := {S of Mul2Closed R S & isMul1Closed R S}.
 
-#[infer(R), short(type="smulClosed")]
+#[short(type="smulClosed")]
 HB.structure Definition SmulClosed (R : ringType) :=
   {S of OppClosed R S & MulClosed R S}.
 
-#[infer(R), short(type="semiring2Closed")]
+#[short(type="semiring2Closed")]
 HB.structure Definition Semiring2Closed (R : semiRingType) :=
   {S of AddClosed R S & Mul2Closed R S}.
 
-#[infer(R), short(type="semiringClosed")]
+#[short(type="semiringClosed")]
 HB.structure Definition SemiringClosed (R : semiRingType) :=
   {S of AddClosed R S & MulClosed R S}.
 
-#[infer(R), short(type="subringClosed")]
+#[short(type="subringClosed")]
 HB.structure Definition SubringClosed (R : ringType) :=
   {S of ZmodClosed R S & MulClosed R S}.
 
-#[infer(R), short(type="divClosed")]
+#[short(type="divClosed")]
 HB.structure Definition DivClosed (R : unitRingType) :=
   {S of MulClosed R S & isInvClosed R S}.
 
-#[infer(R), short(type="sdivClosed")]
+#[short(type="sdivClosed")]
 HB.structure Definition SdivClosed (R : unitRingType) :=
   {S of SmulClosed R S & isInvClosed R S}.
 
@@ -4628,7 +4624,7 @@ HB.structure Definition SubmodClosed (R : ringType) (V : lmodType R) :=
 HB.structure Definition SubalgClosed (R : ringType) (A : lalgType R) :=
   {S of SubringClosed A S & isScaleClosed R A S}.
 
-#[infer (R), short(type="divringClosed")]
+#[short(type="divringClosed")]
 HB.structure Definition DivringClosed (R : unitRingType) :=
   {S of SubringClosed R S & isInvClosed R S}.
 
@@ -5274,7 +5270,7 @@ Fact valZ : scalable (val : W -> _). Proof. by move=> k w; rewrite SubK. Qed.
 HB.instance Definition _ := isSubLmodule.Build R V S W valZ.
 HB.end.
 
-#[infer(R), short(type="subLalgType")]
+#[short(type="subLalgType")]
 HB.structure Definition SubLalgebra (R : ringType) (V : lalgType R) S :=
   {W of SubRing V S W & @SubLmodule R V S W & Lalgebra R W}.
 
@@ -5288,7 +5284,7 @@ Proof. by apply: val_inj; rewrite !(linearZ, rmorphM)/= linearZ scalerAl. Qed.
 HB.instance Definition _ := Lmodule_isLalgebra.Build R W scalerAl.
 HB.end.
 
-#[infer(R), short(type="subAlgType")]
+#[short(type="subAlgType")]
 HB.structure Definition SubAlgebra (R : ringType) (V : algType R) S :=
   {W of @SubLalgebra R V S W & Algebra R W}.
 

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -110,7 +110,7 @@ HB.mixin Record Zmodule_isNormed (R : POrderedZmodule.type) M
   normrN : forall x, norm (- x) = norm x;
 }.
 
-#[short(type="normedZmodType"), infer(R)]
+#[short(type="normedZmodType")]
 HB.structure Definition NormedZmodule (R : porderZmodType) :=
   { M of Zmodule_isNormed R M & GRing.Zmodule M }.
 Arguments norm {R M} x : rename.

--- a/mathcomp/algebra/vector.v
+++ b/mathcomp/algebra/vector.v
@@ -107,7 +107,7 @@ HB.mixin Record Lmodule_hasFinDim (R : ringType) (V : Type) of GRing.Lmodule R V
   { dim : nat;
     vector_subdef : vector_axiom_def dim (Phant V) }.
 
-#[mathcomp(axiom="vector_axiom_def"), infer(R), short(type="vectType")]
+#[mathcomp(axiom="vector_axiom_def"), short(type="vectType")]
 HB.structure Definition Vector (R : ringType) :=
   { V of Lmodule_hasFinDim R V & GRing.Lmodule R V }.
 
@@ -119,7 +119,7 @@ Arguments dim {R} s.
 (* FIXME: S/space and H/hom were defined behind the module Vector *
  * Perhaps we should change their names to avoid conflits.        *)
 Section OtherDefs.
-Local Coercion dim : Vector.type_ >-> nat.
+Local Coercion dim : Vector.type >-> nat.
 Inductive space (K : fieldType) (vT : Vector.type K) (phV : phant vT) :=
   Space (mx : 'M[K]_vT) & <<mx>>%MS == mx.
 Inductive hom (R : ringType) (vT wT : Vector.type R) :=
@@ -155,7 +155,7 @@ Module VectorInternalTheory.
 
 Section Iso.
 Variables (R : ringType) (vT rT : vectType R).
-Local Coercion dim : Vector.type_ >-> nat.
+Local Coercion dim : Vector.type >-> nat.
 
 Fact v2r_subproof : vector_axiom vT vT. Proof. exact: vector_subdef. Qed.
 Definition v2r := s2val v2r_subproof.
@@ -182,7 +182,7 @@ End Iso.
 
 Section Vspace.
 Variables (K : fieldType) (vT : vectType K).
-Local Coercion dim : Vector.type_ >-> nat.
+Local Coercion dim : Vector.type >-> nat.
 
 Definition b2mx n (X : n.-tuple vT) := \matrix_i v2r (tnth X i).
 Lemma b2mxK n (X : n.-tuple vT) i : r2v (row i (b2mx X)) = X`_i.
@@ -1069,7 +1069,7 @@ have lin_f: linear f.
   move=> k u v; rewrite scaler_sumr -big_split; apply: eq_bigr => i _.
   by rewrite /= scalerA -scalerDl linearP.
 pose flM := GRing.isLinear.Build _ _ _ _ f lin_f.
-pose fL : GRing.Linear.type _ _ _ _ := HB.pack f flM.
+pose fL : GRing.Linear.type _ _ := HB.pack f flM.
 exists fL => freeX eq_szX.
 apply/esym/(@eq_from_nth _ 0); rewrite ?size_map eq_szX // => i ltiX.
 rewrite (nth_map 0) //= /f (bigD1 (Ordinal ltiX)) //=.
@@ -1947,7 +1947,7 @@ have r2pK : cancel r2p p2r by move=> w; rewrite /p2r !r2vK hsubmxK.
 have p2rK : cancel p2r r2p by case=> u v; rewrite /r2p row_mxKl row_mxKr !v2rK.
 have r2p_lin: linear r2p by move=> a u v; congr (_ , _); rewrite /= !linearP.
 pose r2plM := GRing.isLinear.Build _ _ _ _ r2p r2p_lin.
-pose r2pL : GRing.Linear.type _ _ _ _ := HB.pack r2p r2plM.
+pose r2pL : GRing.Linear.type _ _ := HB.pack r2p r2plM.
 by exists p2r; [apply: (@can2_linear _ _ _ r2pL) | exists r2p].
 Qed.
 HB.instance Definition _ := Lmodule_hasFinDim.Build _ (vT1 * vT2)%type
@@ -1995,7 +1995,7 @@ Lemma vsolve_eqP (U : {vspace vT}) :
 Proof.
 have lhsZ: linear lhsf by move=> a u v; apply/ffunP=> i; rewrite !ffunE linearP.
 pose lhslM := GRing.isLinear.Build _ _ _ _ lhsf lhsZ.
-pose lhsL : GRing.Linear.type _ _ _ _ := HB.pack lhsf lhslM.
+pose lhsL : GRing.Linear.type _ _ := HB.pack lhsf lhslM.
 apply: (iffP memv_imgP) => [] [u Uu sol_u]; exists u => //.
   by move=> i; rewrite -[tnth rhs i]ffunE sol_u (lfunE lhsL) ffunE.
 by apply/ffunP=> i; rewrite (lfunE lhsL) !ffunE sol_u.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -80,7 +80,7 @@ Unset Printing Implicit Defensive.
 Local Open Scope ring_scope.
 Import GRing.Theory.
 
-#[infer(R), short(type="fieldExtType")]
+#[short(type="fieldExtType")]
 HB.structure Definition FieldExt (R : ringType) := {T of Falgebra R T &
   GRing.Ring_hasCommutativeMul T & GRing.Field T}.
 
@@ -662,7 +662,7 @@ have r2v_lin: linear r2v.
   move=> a u v; rewrite /r2v scaler_sumr -big_split /=; apply: eq_bigr => i _.
   by rewrite scalerA -scalerDl !mxE.
 pose r2vlM := GRing.isLinear.Build _ _ _ _ r2v r2v_lin.
-pose r2vL : GRing.Linear.type _ _ _ _ := HB.pack r2v r2vlM.
+pose r2vL : GRing.Linear.type _ _ := HB.pack r2v r2vlM.
 have v2rP x: {r : 'rV[K_F]_n | x = r2v r}.
   apply: sig_eqW; have /memv_sumP[y Fy ->]: x \in SbL by rewrite defL memvf.
   have /fin_all_exists[r Dr] i: exists r, y i = r *: (bL`_i : L_F).

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -356,7 +356,7 @@ HB.mixin Record FieldExt_isSplittingField (F : fieldType) L of FieldExt F L := {
   splittingFieldP_subproof : splitting_field_axiom L
 }.
 
-#[mathcomp(axiom="splitting_field_axiom"), infer(F), short(type="splittingFieldType")]
+#[mathcomp(axiom="splitting_field_axiom"), short(type="splittingFieldType")]
 HB.structure Definition SplittingField F :=
  { T of FieldExt_isSplittingField F T & FieldExt F T }.
 

--- a/mathcomp/field/separable.v
+++ b/mathcomp/field/separable.v
@@ -545,7 +545,7 @@ have Dlin: linear Df.
   move=> a u v; rewrite /Df linearP /= -mul_polyC derivD derivM derivC.
   by rewrite mul0r add0r hornerD hornerM hornerC -scalerAl mul1r.
 pose DlinM := GRing.isLinear.Build _ _ _ _ Df Dlin.
-pose DL : GRing.Linear.type _ _ _ _ := HB.pack Df DlinM.
+pose DL : GRing.Linear.type _ _ := HB.pack Df DlinM.
 pose D := linfun DL; apply: base_separable.
 have DK_0: (K <= lker D)%VS.
   apply/subvP=> v Kv; rewrite memv_ker lfunE /= /Df Fadjoin_polyC //.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -4839,13 +4839,12 @@ HB.mixin Record isOrderMorphism d (T : porderType d) d' (T' : porderType d')
   omorph_le_subproof : order_morphism apply;
 }.
 
-#[infer(T,T')]
 HB.structure Definition OrderMorphism d (T : porderType d)
   d' (T' : porderType d') := {f of isOrderMorphism d T d' T' f}.
 
 Module OrderMorphismExports.
 Notation "{ 'omorphism' T -> T' }" :=
-  (OrderMorphism.type _ T%type _ T'%type) : type_scope.
+  (@OrderMorphism.type _ T%type _ T'%type) : type_scope.
 End OrderMorphismExports.
 HB.export OrderMorphismExports.
 
@@ -4907,17 +4906,14 @@ HB.mixin Record isJoinLatticeMorphism d (T : latticeType d)
   omorphU_subproof : join_morphism apply;
 }.
 
-#[infer(T,T')]
 HB.structure Definition MeetLatticeMorphism d (T : latticeType d)
     d' (T' : latticeType d') :=
   {f of isMeetLatticeMorphism d T d' T' f & @OrderMorphism d T d' T' f}.
 
-#[infer(T,T')]
 HB.structure Definition JoinLatticeMorphism d (T : latticeType d)
     d' (T' : latticeType d') :=
   {f of isJoinLatticeMorphism d T d' T' f & @OrderMorphism d T d' T' f}.
 
-#[infer(T,T')]
 HB.structure Definition LatticeMorphism d (T : latticeType d)
     d' (T' : latticeType d') :=
   {f of @MeetLatticeMorphism d T d' T' f & @JoinLatticeMorphism d T d' T' f}.
@@ -4937,11 +4933,11 @@ HB.end.
 
 Module LatticeMorphismExports.
 Notation "{ 'mlmorphism' T -> T' }" :=
-  (MeetLatticeMorphism.type _ T%type _ T'%type) : type_scope.
+  (@MeetLatticeMorphism.type _ T%type _ T'%type) : type_scope.
 Notation "{ 'jlmorphism' T -> T' }" :=
-  (JoinLatticeMorphism.type _ T%type _ T'%type) : type_scope.
+  (@JoinLatticeMorphism.type _ T%type _ T'%type) : type_scope.
 Notation "{ 'lmorphism' T -> T' }" :=
-  (LatticeMorphism.type _ T%type _ T'%type) : type_scope.
+  (@LatticeMorphism.type _ T%type _ T'%type) : type_scope.
 Notation "[ 'mlmorphism' 'of' f 'as' g ]" :=
   (MeetLatticeMorphism.clone _ _ _ _ f%function g)
   (at level 0, format "[ 'mlmorphism'  'of'  f  'as'  g ]") : form_scope.
@@ -5032,26 +5028,23 @@ HB.mixin Record isTLatticeMorphism d (T : tLatticeType d)
   omorph1_subproof : apply \top = \top;
 }.
 
-#[infer(T,T')]
 HB.structure Definition BLatticeMorphism d (T : bLatticeType d)
     d' (T' : bLatticeType d') := {f of isBLatticeMorphism d T d' T' f}.
 
-#[infer(T,T')]
 HB.structure Definition TLatticeMorphism d (T : tLatticeType d)
     d' (T' : tLatticeType d') := {f of isTLatticeMorphism d T d' T' f}.
 
-#[infer(T,T')]
 HB.structure Definition TBLatticeMorphism d (T : tbLatticeType d)
     d' (T' : tbLatticeType d') :=
   {f of @BLatticeMorphism d T d' T' f & @TLatticeMorphism d T d' T' f}.
 
 Module TBLatticeMorphismExports.
 Notation "{ 'blmorphism' T -> T' }" :=
-  (BLatticeMorphism.type _ T%type _ T'%type) : type_scope.
+  (@BLatticeMorphism.type _ T%type _ T'%type) : type_scope.
 Notation "{ 'tlmorphism' T -> T' }" :=
-  (TLatticeMorphism.type _ T%type _ T'%type) : type_scope.
+  (@TLatticeMorphism.type _ T%type _ T'%type) : type_scope.
 Notation "{ 'tblmorphism' T -> T' }" :=
-  (TBLatticeMorphism.type _ T%type _ T'%type) : type_scope.
+  (@TBLatticeMorphism.type _ T%type _ T'%type) : type_scope.
 End TBLatticeMorphismExports.
 HB.export TBLatticeMorphismExports.
 
@@ -5158,33 +5151,33 @@ HB.mixin Record isTLatticeClosed d (T : tLatticeType d) (S : {pred T}) := {
 
 (* Structures for stability properties *)
 
-#[infer(T), short(type="meetLatticeClosed")]
+#[short(type="meetLatticeClosed")]
 HB.structure Definition MeetLatticeClosed d T :=
   {S of isMeetLatticeClosed d T S}.
 
-#[infer(T), short(type="joinLatticeClosed")]
+#[short(type="joinLatticeClosed")]
 HB.structure Definition JoinLatticeClosed d T :=
   {S of isJoinLatticeClosed d T S}.
 
-#[infer(T), short(type="latticeClosed")]
+#[short(type="latticeClosed")]
 HB.structure Definition LatticeClosed d T :=
   {S of @MeetLatticeClosed d T S & @JoinLatticeClosed d T S}.
 
-#[infer(T), short(type="bLatticeClosed")]
+#[short(type="bLatticeClosed")]
 HB.structure Definition BLatticeClosed d T := {S of isBLatticeClosed d T S}.
 
-#[infer(T), short(type="bJoinLatticeClosed")]
+#[short(type="bJoinLatticeClosed")]
 HB.structure Definition BJoinLatticeClosed d T :=
   {S of isBLatticeClosed d T S & @JoinLatticeClosed d T S}.
 
-#[infer(T), short(type="tLatticeClosed")]
+#[short(type="tLatticeClosed")]
 HB.structure Definition TLatticeClosed d T := {S of isTLatticeClosed d T S}.
 
-#[infer(T), short(type="tMeetLatticeClosed")]
+#[short(type="tMeetLatticeClosed")]
 HB.structure Definition TMeetLatticeClosed d T :=
   {S of isTLatticeClosed d T S & @MeetLatticeClosed d T S}.
 
-#[infer(T), short(type="tbLatticeClosed")]
+#[short(type="tbLatticeClosed")]
 HB.structure Definition TBLatticeClosed d (T : tbLatticeType d) :=
   {S of @BLatticeClosed d T S & @TLatticeClosed d T S}.
 
@@ -5216,10 +5209,10 @@ Section LatticePred.
 
 Variables (d : unit) (T : latticeType d).
 
-Lemma opredI (S : meetLatticeClosed d T) : {in S &, forall u v, u `&` v \in S}.
+Lemma opredI (S : meetLatticeClosed T) : {in S &, forall u v, u `&` v \in S}.
 Proof. exact: opredI. Qed.
 
-Lemma opredU (S : joinLatticeClosed d T) : {in S &, forall u v, u `|` v \in S}.
+Lemma opredU (S : joinLatticeClosed T) : {in S &, forall u v, u `|` v \in S}.
 Proof. exact: opredU. Qed.
 
 End LatticePred.
@@ -5228,10 +5221,10 @@ Section BLatticePred.
 
 Variables (d : unit) (T : bLatticeType d).
 
-Lemma opred0 (S : bLatticeClosed d T) : \bot \in S.
+Lemma opred0 (S : bLatticeClosed T) : \bot \in S.
 Proof. exact: opred0. Qed.
 
-Lemma opred_joins (S : bJoinLatticeClosed d T) I r (P : pred I) F :
+Lemma opred_joins (S : bJoinLatticeClosed T) I r (P : pred I) F :
   (forall i, P i -> F i \in S) -> \join_(i <- r | P i) F i \in S.
 Proof. by move=> FS; elim/big_ind: _; [exact: opred0 | exact: opredU |]. Qed.
 
@@ -5241,10 +5234,10 @@ Section TLatticePred.
 
 Variables (d : unit) (T : tLatticeType d).
 
-Lemma opred1 (S : tLatticeClosed d T) : \top \in S.
+Lemma opred1 (S : tLatticeClosed T) : \top \in S.
 Proof. exact: opred1. Qed.
 
-Lemma opred_meets (S : tMeetLatticeClosed d T) I r (P : pred I) F :
+Lemma opred_meets (S : tMeetLatticeClosed T) I r (P : pred I) F :
   (forall i, P i -> F i \in S) -> \meet_(i <- r | P i) F i \in S.
 Proof. by move=> FS; elim/big_ind: _; [exact: opred1 | exact: opredI |]. Qed.
 


### PR DESCRIPTION
No longer needed thanks to reverse coercions (Coq >= 8.16).

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] ~I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~ (no HB in mathcomp-1)

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
