### PR TITLE
Remove Program Definition

### DIFF
--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -5385,21 +5385,22 @@ Let inU v Sv : U := Sub v Sv.
 Let meetU (u1 u2 : U) : U := inU (opredI (valP u1) (valP u2)).
 Let joinU (u1 u2 : U) : U := inU (opredU (valP u1) (valP u2)).
 
-(* remove uses of program definition *)
-Obligation Tactic := idtac.
-
-Program Definition latticeU := @POrder_isLattice.Build d' U meetU joinU
-  _ _ _ _ _ _ _.
-Next Obligation. by move=> x y; apply: val_inj; rewrite !SubK meetC. Qed.
-Next Obligation. by move=> x y; apply: val_inj; rewrite !SubK joinC. Qed.
-Next Obligation. by move=> x y z; apply: val_inj; rewrite !SubK meetA. Qed.
-Next Obligation. by move=> x y z; apply: val_inj; rewrite !SubK joinA. Qed.
-Next Obligation. by move=> y x; apply: val_inj; rewrite !SubK joinKI. Qed.
-Next Obligation. by move=> y x; apply: val_inj; rewrite !SubK meetKU. Qed.
-Next Obligation.
-by move=> x y; rewrite leEsub -(inj_eq val_inj) SubK leEmeet.
-Qed.
-HB.instance Definition _ := latticeU.
+Let meetUC : commutative meetU.
+Proof. by move=> x y; apply: val_inj; rewrite !SubK meetC. Qed.
+Let joinUC : commutative joinU.
+Proof. by move=> x y; apply: val_inj; rewrite !SubK joinC. Qed.
+Let meetUA : associative meetU.
+Proof. by move=> x y z; apply: val_inj; rewrite !SubK meetA. Qed.
+Let joinUA : associative joinU.
+Proof. by move=> x y z; apply: val_inj; rewrite !SubK joinA. Qed.
+Lemma joinUKI y x : meetU x (joinU x y) = x.
+Proof. by apply: val_inj; rewrite !SubK joinKI. Qed.
+Let meetUKU y x : joinU x (meetU x y) = x.
+Proof. by apply: val_inj; rewrite !SubK meetKU. Qed.
+Let le_meetU x y : (x <= y) = (meetU x y == x).
+Proof. by rewrite leEsub -(inj_eq val_inj) SubK leEmeet. Qed.
+HB.instance Definition _ := POrder_isLattice.Build d' U
+  meetUC joinUC meetUA joinUA joinUKI meetUKU le_meetU.
 
 Fact valI : meet_morphism (val : U -> T).
 Proof. by move=> x y; rewrite !SubK. Qed.


### PR DESCRIPTION
Felt on this while trying to compile MC without the stdlib.

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] ~I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~ (those instances of `Program` were introduced in MC2)

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
