### PR TITLE
rm 2.0.0 deprecation warnings

### DIFF
--- a/mathcomp/field/qfpoly.v
+++ b/mathcomp/field/qfpoly.v
@@ -137,7 +137,7 @@ Lemma card_qfpoly : #|{poly %/ h with hI}| = #|R| ^ (size h).-1.
 Proof. by rewrite card_monic_qpoly ?hI. Qed.
 
 Lemma card_qfpoly_gt1 : 1 < #|{poly %/ h with hI}|.
-Proof. by have := card_finRing_gt1 [finRingType of {poly %/ h with hI}]. Qed.
+Proof. by have := card_finRing_gt1 {poly %/ h with hI}. Qed.
 
 End FinField.
 
@@ -420,7 +420,7 @@ Proof.
 move=> /ltnW size_gt1.
 rewrite /plogp.
 case (boolP (primitive_poly p)) => // Hh; first by apply: qlogp_lt.
-by rewrite ltn_predRL (card_finRing_gt1 [finRingType of {poly %/ p}]).
+by rewrite ltn_predRL (card_finRing_gt1 {poly %/ p}).
 Qed.
 
 Lemma plogp_X (p q : {poly F}) :


### PR DESCRIPTION
##### Motivation for this change

I just noticed two deprecation warnings in qfpoly.v

##### Things done/to do

<!-- please fill in the following checklist -->
~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~
~~- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)=~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

~~- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~~

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
