### PR TITLE
feat: Use the latest coqorg/coq:8.18.0 within mathcomp-dev CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,8 +102,7 @@ coq-8.17:
   extends: .opam-build-once
 
 coq-8.18:
-  # to be replaced with .opam-build-once when 8.18.0 available
-  extends: .opam-build
+  extends: .opam-build-once
 
 # coq-8.19: # to uncomment when 8.19+rc1 available
 #   # to be replaced with .opam-build-once when 8.19.0 available
@@ -165,8 +164,7 @@ test-coq-8.17:
     COQ_VERSION: "8.17"
 
 test-coq-8.18:
-  # to be replaced with .test-once when 8.18.0 available
-  extends: .test
+  extends: .test-once
   variables:
     COQ_VERSION: "8.18"
 
@@ -410,8 +408,7 @@ mathcomp-dev_coq-8.17:
   extends: .docker-deploy-once
 
 mathcomp-dev_coq-8.18:
-  # to be replaced with .docker-deploy-once when 8.18.0 available
-  extends: .docker-deploy
+  extends: .docker-deploy-once
 
 # mathcomp-dev_coq-8.19: # to uncomment when 8.19+rc1 available
 #   # to be replaced with .docker-deploy-once when 8.19.0 available


### PR DESCRIPTION
##### Motivation for this change

Follows-up of: https://github.com/coq-community/docker-coq/commit/23097615ee0089991685ecc2b4066bd75b5a92c8

Cc @proux01 @CohenCyril @palmskog FYI

If no one objects, I'll merge this tiny PR on this Friday noon UTC+2.

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.