### PR TITLE
Fix the scope of arguments of intmul

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -212,6 +212,11 @@ in `qfpoly.v`
   + implicits of `LRMorphism.type`, use the `{lrmorphism _ -> _}`
     notation for compatibility
 
+- in `ssrint.v`
+  + scope of second argument of `intmul` changed from `ring_scope` to
+    `int_scope` so that `42%:~R` parses as `(Posz 42)%:~R` rather than
+    `42%:R%:~R`
+
 ### Renamed
 
 - in `algC.v`

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -516,6 +516,8 @@ Notation ltz_add1r := ltz1D.
 Notation ltz_addr1 := ltzD1.
 
 Bind Scope ring_scope with int.
+(* Uncomment the following line once we require Coq >= 8.17 *)
+(* #[add_top] Bind Scope int_scope with int. *)
 
 (* definition of intmul *)
 Definition intmul (R : zmodType) (x : R) (n : int) := nosimpl
@@ -523,6 +525,9 @@ Definition intmul (R : zmodType) (x : R) (n : int) := nosimpl
     | Posz n => (x *+ n)%R
     | Negz n => (x *- (n.+1))%R
   end.
+(* Remove the following line once we require Coq >= 8.17 (the above
+   "Bind Scope" commands will make it useless) *)
+Arguments intmul [R] x%R n%Z.
 
 Notation "*~%R" := (@intmul _) (at level 0, format " *~%R") : fun_scope.
 Notation "x *~ n" := (intmul x n)


### PR DESCRIPTION
So that 42%:~R parses to (intmul 1 (Posz 42))
rather than (intmul 1 (GRing.natmul 1 42)).

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [x] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
