### PR TITLE
Fix (generalize) the `comSemiRingType` instance for `prod`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -211,6 +211,7 @@ in `qfpoly.v`
     notation for compatibility
   + implicits of `LRMorphism.type`, use the `{lrmorphism _ -> _}`
     notation for compatibility
+  + fixed (generalized) the `comSemiRingType` instance for `prod`
 
 ### Renamed
 

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -6487,22 +6487,26 @@ HB.instance Definition _ := isMultiplicative.Build (R1 * R2)%type R2 snd
 
 End PairSemiRing.
 
-#[export]
-HB.instance Definition _ (R1 R2 : ringType) :=
-  SemiRing.copy (R1 * R1)%type (R1 * R1)%type.
+Section PairComSemiRing.
 
-Section PairComRing.
-
-Variables R1 R2 : comRingType.
+Variables R1 R2 : comSemiRingType.
 
 Fact pair_mulC : commutative (@mul_pair R1 R2).
 Proof. by move=> x y; congr (_, _); apply: mulrC. Qed.
 
 #[export]
-HB.instance Definition _ := Ring_hasCommutativeMul.Build (R1 * R2)%type
+HB.instance Definition _ := SemiRing_hasCommutativeMul.Build (R1 * R2)%type
   pair_mulC.
 
-End PairComRing.
+End PairComSemiRing.
+
+#[export]
+HB.instance Definition _ (R1 R2 : ringType) :=
+  SemiRing.copy (R1 * R1)%type (R1 * R1)%type.
+
+#[export]
+HB.instance Definition _ (R1 R2 : comRingType) :=
+  SemiRing.copy (R1 * R1)%type (R1 * R1)%type.
 
 Section PairLmod.
 


### PR DESCRIPTION
##### Motivation for this change

This instance should expect `comSemiRingType` instances as arguments, while it was expecting `comRingType` instances instead.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- ~[ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- ~[ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
