### PR TITLE
Inductive principles on set cardinality

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- in `finset_ind.v`
+  + inductive principles `card_rect`, `card_ind`, `card_rec`.
+  + inductive principles `card2_rect`, `card2_ind`, `card2_rec`.
+  + inductive principles `subset_rect`, `subset_ind`, `subset_rec`.
+  + inductive principles `subset2_rect`, `subset2_ind`, `subset2_rec`.
+
 ### Changed
 
 ### Renamed

--- a/mathcomp/ssreflect/finset_ind.v
+++ b/mathcomp/ssreflect/finset_ind.v
@@ -1,0 +1,118 @@
+(* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
+(* Distributed under the terms of CeCILL-B.                                  *)
+From HB Require Import structures.
+From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat div seq.
+From mathcomp Require Import fintype bigop finset.
+Require Import Coq.Program.Wf.
+
+(******************************************************************************)
+(* This file defines induction principles for finite sets based on their      *)
+(* cardinality:                                                               *)
+(*                                                                            *)
+(* card_rect, card_ind, card_rec:       increasing induction on cardinality   *)
+(*                                                                            *)
+(*             (forall A, (forall B, #|B| < #|A| -> P B) -> P A)              *)
+(*           -----------------------------------------------------            *)
+(*                              forall A, P A                                 *)
+(*                                                                            *)
+(*                                                                            *)
+(*                                                                            *)
+(* card2_rect, card2_ind, card2_rec:    decreasing induction on cardinality   *)
+(*                                                                            *)
+(*             (forall A, (forall B, #|B| > #|A| -> P B) -> P A)              *)
+(*           -----------------------------------------------------            *)
+(*                              forall A, P A                                 *)
+(*                                                                            *)
+(*                                                                            *)
+(*                                                                            *)
+(* subset_rect, subset_ind, subset_rec:     increasing induction on subsets   *)
+(*                                                                            *)
+(*             (forall A, (forall B, B \proper A -> P B) -> P A)              *)
+(*           -----------------------------------------------------            *)
+(*                              forall A, P A                                 *)
+(*                                                                            *)
+(*                                                                            *)
+(*                                                                            *)
+(* subset2_rect, subset2_ind, subset2_rec:  decreasing induction on subsets   *)
+(*                                                                            *)
+(*             (forall A, (forall B, A \proper B -> P B) -> P A)              *)
+(*           -----------------------------------------------------            *)
+(*                              forall A, P A                                 *)
+(*                                                                            *)
+(*                                                                            *)
+(*                                                                            *)
+(******************************************************************************)
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+
+Section CardInduction.
+
+Context {T : finType}.
+Implicit Type A B : {set T}.
+
+Section CardRectDef.
+Context {P : {set T} -> Type}.
+Variable HA : forall A, (forall B, (#|B| < #|A|)%coq_nat -> P B) -> P A.
+
+Program Fixpoint card_rect_coq_nat (A : {set T}) {measure #|A|} : P A
+  := HA card_rect_coq_nat.
+End CardRectDef.
+
+Definition card_rect {P} (H : forall A : {set T}, (forall B : {set T}, #|B| < #|A| -> P B) -> P A) A :=
+  card_rect_coq_nat (fun A0 HB0 => H A0 (fun B H => HB0 B (elimTF ltP H))) A.
+Definition card_ind {P : _ -> Prop} := @card_rect P.
+Definition card_rec {P : _ -> Set} := @card_rect P.
+
+Section Card2RectDef.
+Context {P : {set T} -> Type}.
+Variable HA : forall A, (forall B, (#|B| > #|A|)%coq_nat -> P B) -> P A.
+
+Program Fixpoint card2_rect_coq_nat (A : {set T}) {measure (#|T|.+1 - #|A|)%N} : P A
+  := HA (fun B _ => card2_rect_coq_nat B).
+Next Obligation.
+apply/ltP ; apply: ltn_sub2l ; last by apply/ltP.
+by rewrite ltnS ; exact: max_card.
+Qed.
+End Card2RectDef.
+
+Definition card2_rect {P} (H : forall A : {set T}, (forall B : {set T}, #|B| > #|A| -> P B) -> P A) A : P A :=
+  card2_rect_coq_nat (fun A0 HB0 => H A0 (fun B H => HB0 B (elimTF ltP H))) A.
+Definition card2_ind {P : _ -> Prop} := @card2_rect P.
+Definition card2_rec {P : _ -> Set} := @card2_rect P.
+
+End CardInduction.
+
+Section SubsetInduction.
+
+Context {T : finType}.
+Implicit Type A B : {set T}.
+
+Section SubsetRectDef.
+Context {P : {set T} -> Type}.
+Variable HA : forall A, (forall B, B \proper A -> P B) -> P A.
+
+Program Fixpoint subset_rect (A : {set T}) {measure #|A|} : P A
+  := HA (fun B HB => subset_rect B (recproof:= ltP (proper_card HB))).
+End SubsetRectDef.
+
+Definition subset_ind {P : _ -> Prop} := @subset_rect P.
+Definition subset_rec {P : _ -> Set} := @subset_rect P.
+
+Section Subset2RectDef.
+Context {P : {set T} -> Type}.
+Variable HA : forall A, (forall B, A \proper B -> P B) -> P A.
+
+Program Fixpoint subset2_rect (A : {set T}) {measure (#|T|.+1 - #|A|)} : P A
+  := HA (fun B _ => subset2_rect B).
+Next Obligation.
+apply/ltP ; apply: ltn_sub2l ; last exact: proper_card.
+by rewrite ltnS ; exact: max_card.
+Qed.
+End Subset2RectDef.
+Definition subset2_ind {P : _ -> Prop} := @subset_rect P.
+Definition subset2_rec {P : _ -> Set} := @subset_rect P.
+
+End SubsetInduction.


### PR DESCRIPTION
##### Motivation for this change

Add inductive principles based on (finite) set cardinality, e.g.
```
  (forall A, (forall B, #|B| < #|A| -> P B) -> P A)    
-----------------------------------------------------           
                   forall A, P A                                 
```
It requires Coq.Program.Wf.
<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] ~I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
