### PR TITLE
Replace `fun_scope` with `function_scope`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -23,6 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Notations declared in the `fun_scope` are now declared in the
+  `function_scope`.
+
 - in `finset.v`
   + generalized lemmas `big_set0` and `big_set` from semigroups
     to arbitrary binary operators
@@ -105,6 +108,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + definition `aspace_of` (phantom trick now useless with reverse coercions)
 
 ### Deprecated
+
+- in `ssrfun.v`
+  + notation scope `fun_scope`, use `function_scope` instead
 
 - in `vector.v`
   + notation `vector_axiom`, use `Vector.axiom` instead

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -603,7 +603,7 @@ End NmodExports.
 HB.export NmodExports.
 
 Local Notation "0" := (@zero _) : ring_scope.
-Local Notation "+%R" := (@add _) : fun_scope.
+Local Notation "+%R" := (@add _) : function_scope.
 Local Notation "x + y" := (add x y) : ring_scope.
 
 Definition natmul V x n := nosimpl iterop _ n +%R x (@zero V).
@@ -937,7 +937,7 @@ Definition rreg R x := injective ((@mul R)^~ x).
 
 Local Notation "1" := (@one _) : ring_scope.
 Local Notation "n %:R" := (1 *+ n) : ring_scope.
-Local Notation "*%R" := (@mul _) : fun_scope.
+Local Notation "*%R" := (@mul _) : function_scope.
 Local Notation "x * y" := (mul x y) : ring_scope.
 Local Notation "x ^+ n" := (exp x n) : ring_scope.
 
@@ -1628,7 +1628,7 @@ Notation "[ 'lmodType' R 'of' T ]" := (Lmodule.clone R T%type _)
 End LmodExports.
 HB.export LmodExports.
 
-Local Notation "*:%R" := (@scale _ _) : fun_scope.
+Local Notation "*:%R" := (@scale _ _) : function_scope.
 Local Notation "a *: v" := (scale a v) : ring_scope.
 
 Section LmoduleTheory.
@@ -6124,7 +6124,7 @@ Arguments GRing.one : clear implicits.
 Notation "0" := (@zero _) : ring_scope.
 Notation "-%R" := (@opp _) : ring_scope.
 Notation "- x" := (opp x) : ring_scope.
-Notation "+%R" := (@add _) : fun_scope.
+Notation "+%R" := (@add _) : function_scope.
 Notation "x + y" := (add x y) : ring_scope.
 Notation "x - y" := (add x (- y)) : ring_scope.
 Notation "x *+ n" := (natmul x n) : ring_scope.
@@ -6139,14 +6139,14 @@ Notation "n %:R" := (natmul 1 n) : ring_scope.
 Arguments GRing.char R%type.
 Notation "[ 'char' R ]" := (GRing.char R) : ring_scope.
 Notation Frobenius_aut chRp := (Frobenius_aut chRp).
-Notation "*%R" := (@mul _) : fun_scope.
+Notation "*%R" := (@mul _) : function_scope.
 Notation "x * y" := (mul x y) : ring_scope.
 Notation "x ^+ n" := (exp x n) : ring_scope.
 Notation "x ^-1" := (inv x) : ring_scope.
 Notation "x ^- n" := (inv (x ^+ n)) : ring_scope.
 Notation "x / y" := (mul x y^-1) : ring_scope.
 
-Notation "*:%R" := (@scale _ _) : fun_scope.
+Notation "*:%R" := (@scale _ _) : function_scope.
 Notation "a *: m" := (scale a m) : ring_scope.
 Notation "k %:A" := (scale k 1) : ring_scope.
 Notation "\0" := (null_fun _) : ring_scope.

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -524,7 +524,7 @@ Definition intmul (R : zmodType) (x : R) (n : int) := nosimpl
     | Negz n => (x *- (n.+1))%R
   end.
 
-Notation "*~%R" := (@intmul _) (at level 0, format " *~%R") : fun_scope.
+Notation "*~%R" := (@intmul _) (at level 0, format " *~%R") : function_scope.
 Notation "x *~ n" := (intmul x n)
   (at level 40, left associativity, format "x  *~  n") : ring_scope.
 Notation intr := ( *~%R 1).

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -189,31 +189,31 @@ Notation normr := norm.
 
 Notation ler := (@Order.le ring_display _) (only parsing).
 Notation "@ 'ler' R" := (@Order.le ring_display R)
-  (at level 10, R at level 8, only parsing) : fun_scope.
+  (at level 10, R at level 8, only parsing) : function_scope.
 Notation ltr := (@Order.lt ring_display _) (only parsing).
 Notation "@ 'ltr' R" := (@Order.lt ring_display R)
-  (at level 10, R at level 8, only parsing) : fun_scope.
+  (at level 10, R at level 8, only parsing) : function_scope.
 Notation ger := (@Order.ge ring_display _) (only parsing).
 Notation "@ 'ger' R" := (@Order.ge ring_display R)
-  (at level 10, R at level 8, only parsing) : fun_scope.
+  (at level 10, R at level 8, only parsing) : function_scope.
 Notation gtr := (@Order.gt ring_display _) (only parsing).
 Notation "@ 'gtr' R" := (@Order.gt ring_display R)
-  (at level 10, R at level 8, only parsing) : fun_scope.
+  (at level 10, R at level 8, only parsing) : function_scope.
 Notation lerif := (@Order.leif ring_display _) (only parsing).
 Notation "@ 'lerif' R" := (@Order.leif ring_display R)
-  (at level 10, R at level 8, only parsing) : fun_scope.
+  (at level 10, R at level 8, only parsing) : function_scope.
 Notation lterif := (@Order.lteif ring_display _) (only parsing).
 Notation "@ 'lteif' R" := (@Order.lteif ring_display R)
-  (at level 10, R at level 8, only parsing) : fun_scope.
+  (at level 10, R at level 8, only parsing) : function_scope.
 Notation comparabler := (@Order.comparable ring_display _) (only parsing).
 Notation "@ 'comparabler' R" := (@Order.comparable ring_display R)
-  (at level 10, R at level 8, only parsing) : fun_scope.
+  (at level 10, R at level 8, only parsing) : function_scope.
 Notation maxr := (@Order.max ring_display _).
 Notation "@ 'maxr' R" := (@Order.max ring_display R)
-    (at level 10, R at level 8, only parsing) : fun_scope.
+    (at level 10, R at level 8, only parsing) : function_scope.
 Notation minr := (@Order.min ring_display _).
 Notation "@ 'minr' R" := (@Order.min ring_display R)
-  (at level 10, R at level 8, only parsing) : fun_scope.
+  (at level 10, R at level 8, only parsing) : function_scope.
 
 Section NumDomainDef.
 Context {R : numDomainType}.
@@ -278,14 +278,14 @@ Import Def.
 
 Notation "`| x |" := (norm x) : ring_scope.
 
-Notation "<=%R" := le : fun_scope.
-Notation ">=%R" := ge : fun_scope.
-Notation "<%R" := lt : fun_scope.
-Notation ">%R" := gt : fun_scope.
-Notation "<?=%R" := leif : fun_scope.
-Notation "<?<=%R" := lteif : fun_scope.
-Notation ">=<%R" := comparable : fun_scope.
-Notation "><%R" := (fun x y => ~~ (comparable x y)) : fun_scope.
+Notation "<=%R" := le : function_scope.
+Notation ">=%R" := ge : function_scope.
+Notation "<%R" := lt : function_scope.
+Notation ">%R" := gt : function_scope.
+Notation "<?=%R" := leif : function_scope.
+Notation "<?<=%R" := lteif : function_scope.
+Notation ">=<%R" := comparable : function_scope.
+Notation "><%R" := (fun x y => ~~ (comparable x y)) : function_scope.
 
 Notation "<= y" := (ge y) : ring_scope.
 Notation "<= y :> T" := (<= (y : T)) (only parsing) : ring_scope.

--- a/mathcomp/fingroup/action.v
+++ b/mathcomp/fingroup/action.v
@@ -221,7 +221,7 @@ Arguments acts_on {aT D%g rT} A%g S%g to%act.
 Arguments atrans {aT D%g rT} A%g S%g to%act.
 Arguments faithful {aT D%g rT} A%g S%g to%act.
 
-Notation "to ^*" := (setact to) (at level 2, format "to ^*") : fun_scope.
+Notation "to ^*" := (setact to) (at level 2, format "to ^*") : function_scope.
 
 Prenex Implicits orbit amove.
 

--- a/mathcomp/ssreflect/eqtype.v
+++ b/mathcomp/ssreflect/eqtype.v
@@ -394,9 +394,9 @@ Arguments predD1P {T x y b}.
 Prenex Implicits pred1 pred2 pred3 pred4 predU1 predC1 predD1.
 
 Notation "[ 'predU1' x & A ]" := (predU1 x [in A])
-  (at level 0, format "[ 'predU1'  x  &  A ]") : fun_scope.
+  (at level 0, format "[ 'predU1'  x  &  A ]") : function_scope.
 Notation "[ 'predD1' A & x ]" := (predD1 [in A] x)
-  (at level 0, format "[ 'predD1'  A  &  x ]") : fun_scope.
+  (at level 0, format "[ 'predD1'  A  &  x ]") : function_scope.
 
 (* Lemmas for reflected equality and functions.   *)
 
@@ -490,21 +490,21 @@ Arguments app_fdelta {aT rT%type} df%FUN_DELTA f z.
 Notation "[ 'fun' z : T => F 'with' d1 , .. , dn ]" :=
   (SimplFunDelta (fun z : T =>
      app_fdelta d1%FUN_DELTA .. (app_fdelta dn%FUN_DELTA  (fun _ => F)) ..))
-  (at level 0, z name, only parsing) : fun_scope.
+  (at level 0, z name, only parsing) : function_scope.
 
 Notation "[ 'fun' z => F 'with' d1 , .. , dn ]" :=
   (SimplFunDelta (fun z =>
      app_fdelta d1%FUN_DELTA .. (app_fdelta dn%FUN_DELTA (fun _ => F)) ..))
   (at level 0, z name, format
    "'[hv' [ '[' 'fun'  z  => '/ '  F ']' '/'  'with'  '[' d1 , '/'  .. , '/'  dn ']' ] ']'"
-   ) : fun_scope.
+   ) : function_scope.
 
 Notation "[ 'eta' f 'with' d1 , .. , dn ]" :=
   (SimplFunDelta (fun _ =>
      app_fdelta d1%FUN_DELTA .. (app_fdelta dn%FUN_DELTA f) ..))
   (at level 0, format
   "'[hv' [ '[' 'eta' '/ '  f ']' '/'  'with'  '[' d1 , '/'  .. , '/'  dn ']' ] ']'"
-  ) : fun_scope.
+  ) : function_scope.
 
 (* Various EqType constructions.                                         *)
 
@@ -841,7 +841,7 @@ Definition predX T1 T2 (p1 : pred T1) (p2 : pred T2) :=
   [pred z | p1 z.1 & p2 z.2].
 
 Notation "[ 'predX' A1 & A2 ]" := (predX [in A1] [in A2])
-  (at level 0, format "[ 'predX'  A1  &  A2 ]") : fun_scope.
+  (at level 0, format "[ 'predX'  A1  &  A2 ]") : function_scope.
 
 Section OptionEqType.
 

--- a/mathcomp/ssreflect/finfun.v
+++ b/mathcomp/ssreflect/finfun.v
@@ -114,13 +114,13 @@ Canonical finfun_unlock := Unlockable finfun.unlock.
 Arguments finfun {aT rT} g.
 
 Notation "[ 'ffun' x : aT => E ]" := (finfun (fun x : aT => E))
-  (at level 0, x name) : fun_scope.
+  (at level 0, x name) : function_scope.
 
 Notation "[ 'ffun' x => E ]" := (@finfun _ (fun=> _) (fun x => E))
-  (at level 0, x name, format "[ 'ffun'  x  =>  E ]") : fun_scope.
+  (at level 0, x name, format "[ 'ffun'  x  =>  E ]") : function_scope.
 
 Notation "[ 'ffun' => E ]" := [ffun _ => E]
-  (at level 0, format "[ 'ffun' =>  E ]") : fun_scope.
+  (at level 0, format "[ 'ffun' =>  E ]") : function_scope.
 
 (* Example outcommented.
 (* Examples of using finite functions as containers in recursive inductive    *)
@@ -344,7 +344,7 @@ Lemma supportE x y f : (x \in support_for y f) = (f x != y). Proof. by []. Qed.
 End Support.
 
 Notation "y .-support" := (support_for y)
-  (at level 2, format "y .-support") : fun_scope.
+  (at level 2, format "y .-support") : function_scope.
 
 Section EqTheory.
 

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -245,7 +245,7 @@ From mathcomp Require Import finset.
 (* orders and lattices together with their default printed notation (as       *)
 (* displayed by Check).                                                       *)
 (*                                                                            *)
-(* For porderType T (in fun_scope):                                           *)
+(* For porderType T (in function_scope):                                      *)
 (*   <=%O    == @Order.le          d T                                        *)
 (*   <%O     == @Order.lt          d T                                        *)
 (*   >=<%O   == @Order.comparable  d T                                        *)
@@ -1232,14 +1232,14 @@ Arguments max_fun {_ _ _} f g _ /.
 
 Module Import POSyntax.
 
-Notation "<=%O" := le : fun_scope.
-Notation ">=%O" := ge : fun_scope.
-Notation "<%O" := lt : fun_scope.
-Notation ">%O" := gt : fun_scope.
-Notation "<?=%O" := leif : fun_scope.
-Notation "<?<=%O" := lteif : fun_scope.
-Notation ">=<%O" := comparable : fun_scope.
-Notation "><%O" := (fun x y => ~~ (comparable x y)) : fun_scope.
+Notation "<=%O" := le : function_scope.
+Notation ">=%O" := ge : function_scope.
+Notation "<%O" := lt : function_scope.
+Notation ">%O" := gt : function_scope.
+Notation "<?=%O" := leif : function_scope.
+Notation "<?<=%O" := lteif : function_scope.
+Notation ">=<%O" := comparable : function_scope.
+Notation "><%O" := (fun x y => ~~ (comparable x y)) : function_scope.
 
 Notation "<= y" := (ge y) : order_scope.
 Notation "<= y :> T" := (<= (y : T)) (only parsing) : order_scope.
@@ -1691,14 +1691,14 @@ Notation dual_top := (@top (dual_display _) _).
 Module Import DualSyntax.
 
 Notation "T ^d" := (dual T) (at level 2, format "T ^d") : type_scope.
-Notation "<=^d%O" := dual_le : fun_scope.
-Notation ">=^d%O" := dual_ge : fun_scope.
-Notation "<^d%O" := dual_lt : fun_scope.
-Notation ">^d%O" := dual_gt : fun_scope.
-Notation "<?=^d%O" := dual_leif : fun_scope.
-Notation "<?<=^d%O" := dual_lteif : fun_scope.
-Notation ">=<^d%O" := dual_comparable : fun_scope.
-Notation "><^d%O" := (fun x y => ~~ dual_comparable x y) : fun_scope.
+Notation "<=^d%O" := dual_le : function_scope.
+Notation ">=^d%O" := dual_ge : function_scope.
+Notation "<^d%O" := dual_lt : function_scope.
+Notation ">^d%O" := dual_gt : function_scope.
+Notation "<?=^d%O" := dual_leif : function_scope.
+Notation "<?<=^d%O" := dual_lteif : function_scope.
+Notation ">=<^d%O" := dual_comparable : function_scope.
+Notation "><^d%O" := (fun x y => ~~ dual_comparable x y) : function_scope.
 
 Notation "<=^d y" := (>=^d%O y) : order_scope.
 Notation "<=^d y :> T" := (<=^d (y : T)) (only parsing) : order_scope.
@@ -6008,20 +6008,20 @@ Module DvdSyntax.
 
 Notation dvd := (@le dvd_display _).
 Notation "@ 'dvd' T" :=
-  (@le dvd_display T) (at level 10, T at level 8, only parsing) : fun_scope.
+  (@le dvd_display T) (at level 10, T at level 8, only parsing) : function_scope.
 Notation sdvd := (@lt dvd_display _).
 Notation "@ 'sdvd' T" :=
-  (@lt dvd_display T) (at level 10, T at level 8, only parsing) : fun_scope.
+  (@lt dvd_display T) (at level 10, T at level 8, only parsing) : function_scope.
 
 Notation "x %| y" := (dvd x y) : order_scope.
 Notation "x %<| y" := (sdvd x y) : order_scope.
 
 Notation gcd := (@meet dvd_display _).
 Notation "@ 'gcd' T" :=
-  (@meet dvd_display T) (at level 10, T at level 8, only parsing) : fun_scope.
+  (@meet dvd_display T) (at level 10, T at level 8, only parsing) : function_scope.
 Notation lcm := (@join dvd_display _).
 Notation "@ 'lcm' T" :=
-  (@join dvd_display T) (at level 10, T at level 8, only parsing) : fun_scope.
+  (@join dvd_display T) (at level 10, T at level 8, only parsing) : function_scope.
 
 Notation nat0 := (@top dvd_display _).
 Notation nat1 := (@bottom dvd_display _).
@@ -6271,15 +6271,15 @@ Fact prod_display : unit. Proof. by []. Qed.
 
 Module Import ProdSyntax.
 
-Notation "<=^p%O" := (@le prod_display _) : fun_scope.
-Notation ">=^p%O" := (@ge prod_display _)  : fun_scope.
-Notation ">=^p%O" := (@ge prod_display _)  : fun_scope.
-Notation "<^p%O" := (@lt prod_display _) : fun_scope.
-Notation ">^p%O" := (@gt prod_display _) : fun_scope.
-Notation "<?=^p%O" := (@leif prod_display _) : fun_scope.
-Notation ">=<^p%O" := (@comparable prod_display _) : fun_scope.
+Notation "<=^p%O" := (@le prod_display _) : function_scope.
+Notation ">=^p%O" := (@ge prod_display _)  : function_scope.
+Notation ">=^p%O" := (@ge prod_display _)  : function_scope.
+Notation "<^p%O" := (@lt prod_display _) : function_scope.
+Notation ">^p%O" := (@gt prod_display _) : function_scope.
+Notation "<?=^p%O" := (@leif prod_display _) : function_scope.
+Notation ">=<^p%O" := (@comparable prod_display _) : function_scope.
 Notation "><^p%O" := (fun x y => ~~ (@comparable prod_display _ x y)) :
-  fun_scope.
+  function_scope.
 
 Notation "<=^p y" := (>=^p%O y) : order_scope.
 Notation "<=^p y :> T" := (<=^p (y : T)) (only parsing) : order_scope.
@@ -6388,15 +6388,15 @@ Fact lexi_display : unit. Proof. by []. Qed.
 
 Module Import LexiSyntax.
 
-Notation "<=^l%O" := (@le lexi_display _) : fun_scope.
-Notation ">=^l%O" := (@ge lexi_display _) : fun_scope.
-Notation ">=^l%O" := (@ge lexi_display _) : fun_scope.
-Notation "<^l%O" := (@lt lexi_display _) : fun_scope.
-Notation ">^l%O" := (@gt lexi_display _) : fun_scope.
-Notation "<?=^l%O" := (@leif lexi_display _) : fun_scope.
-Notation ">=<^l%O" := (@comparable lexi_display _) : fun_scope.
+Notation "<=^l%O" := (@le lexi_display _) : function_scope.
+Notation ">=^l%O" := (@ge lexi_display _) : function_scope.
+Notation ">=^l%O" := (@ge lexi_display _) : function_scope.
+Notation "<^l%O" := (@lt lexi_display _) : function_scope.
+Notation ">^l%O" := (@gt lexi_display _) : function_scope.
+Notation "<?=^l%O" := (@leif lexi_display _) : function_scope.
+Notation ">=<^l%O" := (@comparable lexi_display _) : function_scope.
 Notation "><^l%O" := (fun x y => ~~ (@comparable lexi_display _ x y)) :
-  fun_scope.
+  function_scope.
 
 Notation "<=^l y" := (>=^l%O y) : order_scope.
 Notation "<=^l y :> T" := (<=^l (y : T)) (only parsing) : order_scope.

--- a/mathcomp/ssreflect/prime.v
+++ b/mathcomp/ssreflect/prime.v
@@ -1050,7 +1050,7 @@ Lemma negnK pi : pi^'^' =i pi.
 Proof. by move=> p; apply: negbK. Qed.
 
 Lemma eq_negn pi1 pi2 : pi1 =i pi2 -> pi1^' =i pi2^'.
-Proof. by move=> eq_pi n; rewrite !inE eq_pi. Qed.
+Proof. by move=> eq_pi n; rewrite inE eq_pi. Qed.
 
 Lemma eq_piP m n : \pi(m) =i \pi(n) <-> \pi(m) = \pi(n).
 Proof.

--- a/mathcomp/ssreflect/prime.v
+++ b/mathcomp/ssreflect/prime.v
@@ -1050,7 +1050,7 @@ Lemma negnK pi : pi^'^' =i pi.
 Proof. by move=> p; apply: negbK. Qed.
 
 Lemma eq_negn pi1 pi2 : pi1 =i pi2 -> pi1^' =i pi2^'.
-Proof. by move=> eq_pi n; rewrite inE eq_pi. Qed.
+Proof. by move=> eq_pi n; rewrite !inE eq_pi. Qed.
 
 Lemma eq_piP m n : \pi(m) =i \pi(n) <-> \pi(m) = \pi(n).
 Proof.

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -158,12 +158,46 @@ Proof. by case: b1 b2 => [] []. Qed.
 Notation "[ 'in' A ]" := (in_mem^~ (mem A))
   (at level 0, format "[ 'in'  A ]") : function_scope.
 
+Lemma relpre_trans {T' T : Type} {leT : rel T} {f : T' -> T} :
+  transitive leT -> transitive (relpre f leT).
+Proof. by move=> + y x z; apply. Qed.
+
+(* The notations below are already defined in Coq.ssr.ssrbool, but we redefine*)
+(* them in different notation scopes (mostly fun_scope -> function_scope, in  *)
+(* order to replace the former with the latter).                              *)
+
+Notation "[ 'pred' : T | E ]" := (SimplPred (fun _ : T => E%B)) :
+  function_scope.
+Notation "[ 'pred' x | E ]" := (SimplPred (fun x => E%B)) : function_scope.
+Notation "[ 'pred' x | E1 & E2 ]" := [pred x | E1 && E2 ] : function_scope.
+Notation "[ 'pred' x : T | E ]" :=
+  (SimplPred (fun x : T => E%B)) (only parsing) : function_scope.
+Notation "[ 'pred' x : T | E1 & E2 ]" :=
+  [pred x : T | E1 && E2 ] (only parsing) : function_scope.
+
+Notation "[ 'rel' x y | E ]" := (SimplRel (fun x y => E%B))
+  (only parsing) : function_scope.
+Notation "[ 'rel' x y : T | E ]" :=
+  (SimplRel (fun x y : T => E%B)) (only parsing) : function_scope.
+
+Notation "[ 'mem' A ]" :=
+  (pred_of_simpl (simpl_of_mem (mem A))) (only parsing) : function_scope.
+
+Notation "[ 'pred' x 'in' A ]" := [pred x | x \in A] : function_scope.
+Notation "[ 'pred' x 'in' A | E ]" := [pred x | x \in A & E] : function_scope.
+Notation "[ 'pred' x 'in' A | E1 & E2 ]" :=
+  [pred x | x \in A & E1 && E2 ] : function_scope.
+
+Notation "[ 'rel' x y 'in' A & B | E ]" :=
+  [rel x y | (x \in A) && (y \in B) && E] : function_scope.
+Notation "[ 'rel' x y 'in' A & B ]" :=
+  [rel x y | (x \in A) && (y \in B)] : function_scope.
+Notation "[ 'rel' x y 'in' A | E ]" := [rel x y in A & A | E] : function_scope.
+Notation "[ 'rel' x y 'in' A ]" := [rel x y in A & A] : function_scope.
+
+(* Both bodies and the scope have been changed for the following notations.   *)
 Notation "[ 'predI' A & B ]" := (predI [in A] [in B]) : function_scope.
 Notation "[ 'predU' A & B ]" := (predU [in A] [in B]) : function_scope.
 Notation "[ 'predD' A & B ]" := (predD [in A] [in B]) : function_scope.
 Notation "[ 'predC' A ]" := (predC [in A]) : function_scope.
 Notation "[ 'preim' f 'of' A ]" := (preim f [in A]) : function_scope.
-
-Lemma relpre_trans {T' T : Type} {leT : rel T} {f : T' -> T} :
-  transitive leT -> transitive (relpre f leT).
-Proof. by move=> + y x z; apply. Qed.

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -156,13 +156,13 @@ Proof. by case: b1 b2 => [] []. Qed.
 (********************)
 
 Notation "[ 'in' A ]" := (in_mem^~ (mem A))
-  (at level 0, format "[ 'in'  A ]") : fun_scope.
+  (at level 0, format "[ 'in'  A ]") : function_scope.
 
-Notation "[ 'predI' A & B ]" := (predI [in A] [in B]) : fun_scope.
-Notation "[ 'predU' A & B ]" := (predU [in A] [in B]) : fun_scope.
-Notation "[ 'predD' A & B ]" := (predD [in A] [in B]) : fun_scope.
-Notation "[ 'predC' A ]" := (predC [in A]) : fun_scope.
-Notation "[ 'preim' f 'of' A ]" := (preim f [in A]) : fun_scope.
+Notation "[ 'predI' A & B ]" := (predI [in A] [in B]) : function_scope.
+Notation "[ 'predU' A & B ]" := (predU [in A] [in B]) : function_scope.
+Notation "[ 'predD' A & B ]" := (predD [in A] [in B]) : function_scope.
+Notation "[ 'predC' A ]" := (predC [in A]) : function_scope.
+Notation "[ 'preim' f 'of' A ]" := (preim f [in A]) : function_scope.
 
 Lemma relpre_trans {T' T : Type} {leT : rel T} {f : T' -> T} :
   transitive leT -> transitive (relpre f leT).

--- a/mathcomp/ssreflect/ssrfun.v
+++ b/mathcomp/ssreflect/ssrfun.v
@@ -66,8 +66,6 @@ Qed.
 (* v8.18 additions *)
 (*******************)
 
-(* this change of order has also been PRed to Coq PR 17249 *)
-Notation "@ 'sval'" := (@proj1_sig) (at level 10, format "@ 'sval'").
 Notation sval := (@proj1_sig _ _).
 
 (**********************)
@@ -87,3 +85,44 @@ Proof. by move=> Ef [?|] //=; rewrite Ef. Qed.
 Lemma omapK {aT rT : Type} (f : aT -> rT) (g : rT -> aT) :
   cancel f g -> cancel (omap f) (omap g).
 Proof. by move=> fK [?|] //=; rewrite fK. Qed.
+
+(* The notations below are already defined in Coq.ssr.ssrfun, but we redefine *)
+(* them in different notation scopes (mostly fun_scope -> function_scope, in  *)
+(* order to replace the former with the latter).                              *)
+
+Open Scope function_scope.
+
+Notation "f ^~ y" := (fun x => f x y) : function_scope.
+Notation "@^~ x" := (fun f => f x) : function_scope.
+
+Notation "[ 'fun' : T => E ]" := (SimplFun (fun _ : T => E)) : function_scope.
+Notation "[ 'fun' x => E ]" := (SimplFun (fun x => E)) : function_scope.
+Notation "[ 'fun' x y => E ]" := (fun x => [fun y => E]) : function_scope.
+Notation "[ 'fun' x : T => E ]" := (SimplFun (fun x : T => E))
+  (only parsing) : function_scope.
+Notation "[ 'fun' x y : T => E ]" := (fun x : T => [fun y : T => E])
+  (only parsing) : function_scope.
+Notation "[ 'fun' ( x : T ) y => E ]" := (fun x : T => [fun y => E])
+  (only parsing) : function_scope.
+Notation "[ 'fun' x ( y : T ) => E ]" := (fun x => [fun y : T => E])
+  (only parsing) : function_scope.
+Notation "[ 'fun' ( x : T ) ( y : U ) => E ]" := (fun x : T => [fun y : U => E])
+  (only parsing) : function_scope.
+
+Notation "f1 =1 f2" := (eqfun f1 f2) : type_scope.
+Notation "f1 =1 f2 :> A" := (f1 =1 (f2 : A)) : type_scope.
+Notation "f1 =2 f2" := (eqrel f1 f2) : type_scope.
+Notation "f1 =2 f2 :> A" := (f1 =2 (f2 : A)) : type_scope.
+
+Notation "f1 \o f2" := (comp f1 f2) : function_scope.
+Notation "f1 \; f2" := (catcomp f1 f2) : function_scope.
+
+Notation "[ 'eta' f ]" := (fun x => f x) : function_scope.
+
+Notation "'fun' => E" := (fun _ => E) : function_scope.
+
+Notation "@ 'id' T" := (fun x : T => x)
+  (at level 10, T at level 8, only parsing) : function_scope.
+
+Notation "@ 'sval'" := (@proj1_sig) (at level 10, only parsing) :
+  function_scope.


### PR DESCRIPTION
##### Motivation for this change

Fix #1130.

Overlays:
- coq-community/coqeal#85
- math-comp/analysis#1111

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [x] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
