### PR TITLE
Cleanup backport and close `fun_scope`

### DIFF
--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -34,6 +34,7 @@ with builtins; with (import <nixpkgs> {}).lib;
 
   bundles = let
     master = [
+      "coq-bits"
       "coqeal"
       "coquelicot"
       "fourcolor"
@@ -55,7 +56,6 @@ with builtins; with (import <nixpkgs> {}).lib;
       "extructures"
     ];
     hierarchy-builder = [
-      "coq-bits"
       "mathcomp-classical"
       "mathcomp-analysis"
     ];

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -26,6 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Notations declared in the `fun_scope` are now declared in the
   `function_scope`.
 
+- in `ssrfun.v`
+  + `%FUN` is changed from the delimiter of `fun_scope` to that of
+    `function_scope`
+  + `fun_scope` is closed
+
 - in `finset.v`
   + generalized lemmas `big_set0` and `big_set` from semigroups
     to arbitrary binary operators

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -14,54 +14,56 @@ From Coq Require Export ssrbool.
 (* `can_mono_in`.                                                             *)
 (******************************************************************************)
 
-(******************)
-(* v8.15 addtions *)
-(******************)
-
-Section ReflectCombinators.
-
-Variables (P Q : Prop) (p q : bool).
-
-Hypothesis rP : reflect P p.
-Hypothesis rQ : reflect Q q.
-
-Lemma negPP : reflect (~ P) (~~ p).
-Proof. by apply:(iffP negP); apply: contra_not => /rP. Qed.
-
-Lemma andPP : reflect (P /\ Q) (p && q).
-Proof. by apply: (iffP andP) => -[/rP ? /rQ ?]. Qed.
-
-Lemma orPP : reflect (P \/ Q) (p || q).
-Proof. by apply: (iffP orP) => -[/rP ?|/rQ ?]; tauto. Qed.
-
-Lemma implyPP : reflect (P -> Q) (p ==> q).
-Proof. by apply: (iffP implyP) => pq /rP /pq /rQ. Qed.
-
-End ReflectCombinators.
-Arguments negPP {P p}.
-Arguments andPP {P Q p q}.
-Arguments orPP {P Q p q}.
-Arguments implyPP {P Q p q}.
-Prenex Implicits negPP andPP orPP implyPP.
-
-(*******************)
-(* v8.16 additions *)
-(*******************)
-
-(******************************************************************************)
-(*          pred_oapp T D := [pred x | oapp (mem D) false x]                  *)
-(******************************************************************************)
-
-Lemma mono1W_in (aT rT : predArgType) (f : aT -> rT) (aD : {pred aT})
-    (aP : pred aT) (rP : pred rT) :
-  {in aD, {mono f : x / aP x >-> rP x}} ->
-  {in aD, {homo f : x / aP x >-> rP x}}.
-Proof. by move=> fP x xD xP; rewrite fP. Qed.
-Arguments mono1W_in [aT rT f aD aP rP].
-
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
+
+(*******************)
+(* v8.20 additions *)
+(*******************)
+
+Notation "[ 'in' A ]" := (in_mem^~ (mem A))
+  (at level 0, format "[ 'in'  A ]") : function_scope.
+
+(* The notations below are already defined in Coq.ssr.ssrbool, but we redefine*)
+(* them in different notation scopes (mostly fun_scope -> function_scope, in  *)
+(* order to replace the former with the latter).                              *)
+
+Notation "[ 'pred' : T | E ]" := (SimplPred (fun _ : T => E%B)) :
+  function_scope.
+Notation "[ 'pred' x | E ]" := (SimplPred (fun x => E%B)) : function_scope.
+Notation "[ 'pred' x | E1 & E2 ]" := [pred x | E1 && E2 ] : function_scope.
+Notation "[ 'pred' x : T | E ]" :=
+  (SimplPred (fun x : T => E%B)) (only parsing) : function_scope.
+Notation "[ 'pred' x : T | E1 & E2 ]" :=
+  [pred x : T | E1 && E2 ] (only parsing) : function_scope.
+
+Notation "[ 'rel' x y | E ]" := (SimplRel (fun x y => E%B))
+  (only parsing) : function_scope.
+Notation "[ 'rel' x y : T | E ]" :=
+  (SimplRel (fun x y : T => E%B)) (only parsing) : function_scope.
+
+Notation "[ 'mem' A ]" :=
+  (pred_of_simpl (simpl_of_mem (mem A))) (only parsing) : function_scope.
+
+Notation "[ 'pred' x 'in' A ]" := [pred x | x \in A] : function_scope.
+Notation "[ 'pred' x 'in' A | E ]" := [pred x | x \in A & E] : function_scope.
+Notation "[ 'pred' x 'in' A | E1 & E2 ]" :=
+  [pred x | x \in A & E1 && E2 ] : function_scope.
+
+Notation "[ 'rel' x y 'in' A & B | E ]" :=
+  [rel x y | (x \in A) && (y \in B) && E] : function_scope.
+Notation "[ 'rel' x y 'in' A & B ]" :=
+  [rel x y | (x \in A) && (y \in B)] : function_scope.
+Notation "[ 'rel' x y 'in' A | E ]" := [rel x y in A & A | E] : function_scope.
+Notation "[ 'rel' x y 'in' A ]" := [rel x y in A & A] : function_scope.
+
+(* Both bodies and the scope have been changed for the following notations.   *)
+Notation "[ 'predI' A & B ]" := (predI [in A] [in B]) : function_scope.
+Notation "[ 'predU' A & B ]" := (predU [in A] [in B]) : function_scope.
+Notation "[ 'predD' A & B ]" := (predD [in A] [in B]) : function_scope.
+Notation "[ 'predC' A ]" := (predC [in A]) : function_scope.
+Notation "[ 'preim' f 'of' A ]" := (preim f [in A]) : function_scope.
 
 (*******************)
 (* v8.17 additions *)
@@ -151,53 +153,10 @@ Lemma if_add b1 b2 T (x y : T) :
   (if b1 (+) b2 then x else y) = (if b1 then if b2 then y else x else if b2 then x else y).
 Proof. by case: b1 b2 => [] []. Qed.
 
-(********************)
-(* Future additions *)
-(********************)
-
-Notation "[ 'in' A ]" := (in_mem^~ (mem A))
-  (at level 0, format "[ 'in'  A ]") : function_scope.
+(**********************)
+(* not yet backported *)
+(**********************)
 
 Lemma relpre_trans {T' T : Type} {leT : rel T} {f : T' -> T} :
   transitive leT -> transitive (relpre f leT).
 Proof. by move=> + y x z; apply. Qed.
-
-(* The notations below are already defined in Coq.ssr.ssrbool, but we redefine*)
-(* them in different notation scopes (mostly fun_scope -> function_scope, in  *)
-(* order to replace the former with the latter).                              *)
-
-Notation "[ 'pred' : T | E ]" := (SimplPred (fun _ : T => E%B)) :
-  function_scope.
-Notation "[ 'pred' x | E ]" := (SimplPred (fun x => E%B)) : function_scope.
-Notation "[ 'pred' x | E1 & E2 ]" := [pred x | E1 && E2 ] : function_scope.
-Notation "[ 'pred' x : T | E ]" :=
-  (SimplPred (fun x : T => E%B)) (only parsing) : function_scope.
-Notation "[ 'pred' x : T | E1 & E2 ]" :=
-  [pred x : T | E1 && E2 ] (only parsing) : function_scope.
-
-Notation "[ 'rel' x y | E ]" := (SimplRel (fun x y => E%B))
-  (only parsing) : function_scope.
-Notation "[ 'rel' x y : T | E ]" :=
-  (SimplRel (fun x y : T => E%B)) (only parsing) : function_scope.
-
-Notation "[ 'mem' A ]" :=
-  (pred_of_simpl (simpl_of_mem (mem A))) (only parsing) : function_scope.
-
-Notation "[ 'pred' x 'in' A ]" := [pred x | x \in A] : function_scope.
-Notation "[ 'pred' x 'in' A | E ]" := [pred x | x \in A & E] : function_scope.
-Notation "[ 'pred' x 'in' A | E1 & E2 ]" :=
-  [pred x | x \in A & E1 && E2 ] : function_scope.
-
-Notation "[ 'rel' x y 'in' A & B | E ]" :=
-  [rel x y | (x \in A) && (y \in B) && E] : function_scope.
-Notation "[ 'rel' x y 'in' A & B ]" :=
-  [rel x y | (x \in A) && (y \in B)] : function_scope.
-Notation "[ 'rel' x y 'in' A | E ]" := [rel x y in A & A | E] : function_scope.
-Notation "[ 'rel' x y 'in' A ]" := [rel x y in A & A] : function_scope.
-
-(* Both bodies and the scope have been changed for the following notations.   *)
-Notation "[ 'predI' A & B ]" := (predI [in A] [in B]) : function_scope.
-Notation "[ 'predU' A & B ]" := (predU [in A] [in B]) : function_scope.
-Notation "[ 'predD' A & B ]" := (predD [in A] [in B]) : function_scope.
-Notation "[ 'predC' A ]" := (predC [in A]) : function_scope.
-Notation "[ 'preim' f 'of' A ]" := (preim f [in A]) : function_scope.

--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -6,7 +6,7 @@ Global Set Asymmetric Patterns.
 Global Set Bullet Behavior "None".
 
 (******************************************************************************)
-(* Local additions:                                                           *)
+(* v8.20 additions:                                                           *)
 (*                                                                            *)
 (* [elaborate x] == triggers coq elaboration to fill the holes of the term x  *)
 (*                  The main use case is to trigger typeclass inference in    *)

--- a/mathcomp/ssreflect/ssrfun.v
+++ b/mathcomp/ssreflect/ssrfun.v
@@ -71,6 +71,7 @@ Notation sval := (@proj1_sig _ _).
 (* them in different notation scopes (mostly fun_scope -> function_scope, in  *)
 (* order to replace the former with the latter).                              *)
 
+Close Scope fun_scope.
 Open Scope function_scope.
 
 Notation "f ^~ y" := (fun x => f x y) : function_scope.

--- a/mathcomp/ssreflect/ssrfun.v
+++ b/mathcomp/ssreflect/ssrfun.v
@@ -2,11 +2,6 @@ From mathcomp Require Import ssreflect.
 From Coq Require Export ssrfun.
 From mathcomp Require Export ssrnotations.
 
-Definition injective2 (rT aT1 aT2 : Type) (f : aT1 -> aT2 -> rT) :=
-  forall (x1 x2 : aT1) (y1 y2 : aT2), f x1 y1 = f x2 y2 -> (x1 = x2) * (y1 = y2).
-
-Arguments injective2 [rT aT1 aT2] f.
-
 (*******************)
 (* v8.17 additions *)
 (*******************)
@@ -68,23 +63,9 @@ Qed.
 
 Notation sval := (@proj1_sig _ _).
 
-(**********************)
-(* not yet backported *)
-(**********************)
-
-Lemma inj_omap {aT rT : Type} (f : aT -> rT) :
-  injective f -> injective (omap f).
-Proof. by move=> injf [?|] [?|] //= [/injf->]. Qed.
-
-Lemma omap_id {T : Type} (x : option T) : omap id x = x.
-Proof. by case: x. Qed.
-
-Lemma eq_omap {aT rT : Type} (f g : aT -> rT) : f =1 g -> omap f =1 omap g.
-Proof. by move=> Ef [?|] //=; rewrite Ef. Qed.
-
-Lemma omapK {aT rT : Type} (f : aT -> rT) (g : rT -> aT) :
-  cancel f g -> cancel (omap f) (omap g).
-Proof. by move=> fK [?|] //=; rewrite fK. Qed.
+(*******************)
+(* v8.20 additions *)
+(*******************)
 
 (* The notations below are already defined in Coq.ssr.ssrfun, but we redefine *)
 (* them in different notation scopes (mostly fun_scope -> function_scope, in  *)
@@ -126,3 +107,26 @@ Notation "@ 'id' T" := (fun x : T => x)
 
 Notation "@ 'sval'" := (@proj1_sig) (at level 10, only parsing) :
   function_scope.
+
+(**********************)
+(* not yet backported *)
+(**********************)
+
+Definition injective2 (rT aT1 aT2 : Type) (f : aT1 -> aT2 -> rT) :=
+  forall (x1 x2 : aT1) (y1 y2 : aT2), f x1 y1 = f x2 y2 -> (x1 = x2) * (y1 = y2).
+
+Arguments injective2 [rT aT1 aT2] f.
+
+Lemma inj_omap {aT rT : Type} (f : aT -> rT) :
+  injective f -> injective (omap f).
+Proof. by move=> injf [?|] [?|] //= [/injf->]. Qed.
+
+Lemma omap_id {T : Type} (x : option T) : omap id x = x.
+Proof. by case: x. Qed.
+
+Lemma eq_omap {aT rT : Type} (f g : aT -> rT) : f =1 g -> omap f =1 omap g.
+Proof. by move=> Ef [?|] //=; rewrite Ef. Qed.
+
+Lemma omapK {aT rT : Type} (f : aT -> rT) (g : rT -> aT) :
+  cancel f g -> cancel (omap f) (omap g).
+Proof. by move=> fK [?|] //=; rewrite fK. Qed.

--- a/mathcomp/ssreflect/ssrfun.v
+++ b/mathcomp/ssreflect/ssrfun.v
@@ -71,7 +71,6 @@ Notation sval := (@proj1_sig _ _).
 (* them in different notation scopes (mostly fun_scope -> function_scope, in  *)
 (* order to replace the former with the latter).                              *)
 
-Close Scope fun_scope.
 Open Scope function_scope.
 
 Notation "f ^~ y" := (fun x => f x y) : function_scope.
@@ -112,6 +111,9 @@ Notation "@ 'sval'" := (@proj1_sig) (at level 10, only parsing) :
 (**********************)
 (* not yet backported *)
 (**********************)
+
+Delimit Scope function_scope with FUN.
+Close Scope fun_scope.
 
 Definition injective2 (rT aT1 aT2 : Type) (f : aT1 -> aT2 -> rT) :=
   forall (x1 x2 : aT1) (y1 y2 : aT2), f x1 y1 = f x2 y2 -> (x1 = x2) * (y1 = y2).


### PR DESCRIPTION
##### Motivation for this change

This PR cleans up `ssreflect.v`, `ssrfun.v`, and `ssrbool.v` following the recent backport to Coq (coq/coq#18374), and closes `fun_scope` following the discussion in #1131.

Overlay PRs:
- coq-community/bits#23
- coq-community/gaia#17
- math-comp/analysis#1115
- math-comp/finmap#109
- math-comp/multinomials#86

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [x] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
