### PR TITLE
Change the scope of function notations in order.v and ssralg.v to `function_scope`

### DIFF
--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -1862,14 +1862,14 @@ End LiftedScale.
 (* in Coq 8.2 it gets precedence when GRing.Theory is not imported.         *)
 Local Notation in_alg_loc A := (in_alg_head A) (only parsing).
 
-Local Notation "\0" := (null_fun _) : ring_scope.
-Local Notation "f \+ g" := (add_fun f g) : ring_scope.
-Local Notation "f \- g" := (sub_fun f g) : ring_scope.
-Local Notation "\- f" := (opp_fun f) : ring_scope.
-Local Notation "a \*: f" := (scale_fun a f) : ring_scope.
-Local Notation "x \*o f" := (mull_fun x f) : ring_scope.
-Local Notation "x \o* f" := (mulr_fun x f) : ring_scope.
-Local Notation "f \* g" := (mul_fun f g) : ring_scope.
+Local Notation "\0" := (null_fun _) : function_scope.
+Local Notation "f \+ g" := (add_fun f g) : function_scope.
+Local Notation "f \- g" := (sub_fun f g) : function_scope.
+Local Notation "\- f" := (opp_fun f) : function_scope.
+Local Notation "a \*: f" := (scale_fun a f) : function_scope.
+Local Notation "x \*o f" := (mull_fun x f) : function_scope.
+Local Notation "x \o* f" := (mulr_fun x f) : function_scope.
+Local Notation "f \* g" := (mul_fun f g) : function_scope.
 
 Arguments null_fun {_} V _ /.
 Arguments in_alg_head {_} A _ /.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -1310,8 +1310,8 @@ Notation "[ 'arg' 'max_' ( i > i0 ) F ]" := [arg max_(i > i0 | true) F]
   (at level 0, i, i0 at level 10,
    format "[ 'arg'  'max_' ( i  >  i0 )  F ]") : order_scope.
 
-Notation "f \min g" := (min_fun f g) : order_scope.
-Notation "f \max g" := (max_fun f g) : order_scope.
+Notation "f \min g" := (min_fun f g) : function_scope.
+Notation "f \max g" := (max_fun f g) : function_scope.
 
 Notation leLHS := (X in (X <= _)%O)%pattern.
 Notation leRHS := (X in (_ <= X)%O)%pattern.


### PR DESCRIPTION
##### Motivation for this change

Fix #978

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [x] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

##### Overlay (to ber merged before the current PR):

* https://github.com/math-comp/analysis/pull/1137

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
