### PR TITLE
Handle new Coq 8.19 warnings

### DIFF
--- a/mathcomp/Make
+++ b/mathcomp/Make
@@ -107,3 +107,5 @@ ssreflect/tuple.v
 -arg -w -arg +deprecated-hint-rewrite-without-locality
 -arg -w -arg -elpi.add-const-for-axiom-or-sectionvar
 -arg -w -arg -opaque-let
+-arg -w -arg -argument-scope-delimiter
+-arg -w -arg -overwriting-delimiting-key

--- a/mathcomp/_CoqProject
+++ b/mathcomp/_CoqProject
@@ -10,3 +10,5 @@
 -arg -w -arg +deprecated-hint-rewrite-without-locality
 -arg -w -arg -elpi.add-const-for-axiom-or-sectionvar
 -arg -w -arg -opaque-let
+-arg -w -arg -argument-scope-delimiter
+-arg -w -arg -overwriting-delimiting-key

--- a/mathcomp/algebra/Make
+++ b/mathcomp/algebra/Make
@@ -31,3 +31,5 @@ zmodp.v
 -arg -w -arg +deprecated-hint-without-locality
 -arg -w -arg +deprecated-hint-rewrite-without-locality
 -arg -w -arg -opaque-let
+-arg -w -arg -argument-scope-delimiter
+-arg -w -arg -overwriting-delimiting-key

--- a/mathcomp/character/Make
+++ b/mathcomp/character/Make
@@ -18,3 +18,5 @@ vcharacter.v
 -arg -w -arg +deprecated-hint-without-locality
 -arg -w -arg +deprecated-hint-rewrite-without-locality
 -arg -w -arg -opaque-let
+-arg -w -arg -argument-scope-delimiter
+-arg -w -arg -overwriting-delimiting-key

--- a/mathcomp/field/Make
+++ b/mathcomp/field/Make
@@ -22,3 +22,5 @@ qfpoly.v
 -arg -w -arg +deprecated-hint-without-locality
 -arg -w -arg +deprecated-hint-rewrite-without-locality
 -arg -w -arg -opaque-let
+-arg -w -arg -argument-scope-delimiter
+-arg -w -arg -overwriting-delimiting-key

--- a/mathcomp/fingroup/Make
+++ b/mathcomp/fingroup/Make
@@ -19,3 +19,5 @@ quotient.v
 -arg -w -arg +deprecated-hint-without-locality
 -arg -w -arg +deprecated-hint-rewrite-without-locality
 -arg -w -arg -opaque-let
+-arg -w -arg -argument-scope-delimiter
+-arg -w -arg -overwriting-delimiting-key

--- a/mathcomp/solvable/Make
+++ b/mathcomp/solvable/Make
@@ -30,3 +30,5 @@ sylow.v
 -arg -w -arg +deprecated-hint-without-locality
 -arg -w -arg +deprecated-hint-rewrite-without-locality
 -arg -w -arg -opaque-let
+-arg -w -arg -argument-scope-delimiter
+-arg -w -arg -overwriting-delimiting-key

--- a/mathcomp/ssreflect/Make
+++ b/mathcomp/ssreflect/Make
@@ -34,3 +34,5 @@ order.v
 -arg -w -arg +deprecated-hint-without-locality
 -arg -w -arg +deprecated-hint-rewrite-without-locality
 -arg -w -arg -opaque-let
+-arg -w -arg -argument-scope-delimiter
+-arg -w -arg -overwriting-delimiting-key

--- a/mathcomp/ssreflect/ssrfun.v
+++ b/mathcomp/ssreflect/ssrfun.v
@@ -1,6 +1,9 @@
 From mathcomp Require Import ssreflect.
 From Coq Require Export ssrfun.
 From mathcomp Require Export ssrnotations.
+#[export] Set Warnings "-overwriting-delimiting-key".
+(* because there is some Set Warnings "overwriting-delimiting-key".
+   somewhere in the above *)
 
 (*******************)
 (* v8.17 additions *)
@@ -112,6 +115,7 @@ Notation "@ 'sval'" := (@proj1_sig) (at level 10, only parsing) :
 (* not yet backported *)
 (**********************)
 
+#[export] Set Warnings "-hiding-delimiting-key".
 Delimit Scope function_scope with FUN.
 Close Scope fun_scope.
 

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -5,6 +5,9 @@ From mathcomp Require Import ssreflect ssrfun ssrbool eqtype.
 Require Import BinNat.
 Require BinPos Ndec.
 Require Export Ring.
+#[export] Set Warnings "-overwriting-delimiting-key".
+(* because there is some Set Warnings "overwriting-delimiting-key".
+   somewhere in the above *)
 
 (******************************************************************************)
 (* A version of arithmetic on nat (natural numbers) that is better suited to  *)


### PR DESCRIPTION
Porting of https://github.com/math-comp/math-comp/pull/1155 from mathcomp-1 branch.