### PR TITLE
Fixes the condition of telescope_sumn_in

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- in `bigop.v`
+  + weaken hypothesis of lemma `telescope_sumn_in`
+
 - in `zmodp.v`
   + simpler statement of `Fp_Zcast`
 

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -2480,21 +2480,22 @@ Proof. by rewrite big_const_nat -Monoid.iteropE. Qed.
 End NatConst.
 
 Lemma telescope_sumn_in n m f : n <= m ->
-  {in [pred i | n <= i <= m], {homo f : x y / x <= y}} ->
+    (forall i, n <= i < m -> f i <= f i.+1) ->
   \sum_(n <= k < m) (f k.+1 - f k) = f m - f n.
 Proof.
 move=> nm fle; rewrite (telescope_big (fun i j => f j - f i)).
   by case: ltngtP nm => // ->; rewrite subnn.
-move=> k /andP[nk km] /=; rewrite addnBAC ?fle 1?ltnW// ?subnKC// ?fle// inE.
-- by rewrite (ltnW nk) ltnW.
-- by rewrite leqnn ltnW// (ltn_trans nk).
+move=> k /andP[nk km]; rewrite /= addnBAC ?subnKC ?fle ?(ltnW nk)//.
+elim: k nk km => [//| k IHk /[!ltnS]/[1!leq_eqVlt]+ km].
+  move=> /predU1P[/[dup]nk -> | nk]; first by rewrite fle ?nk ?leqnn 1?ltnW.
+by rewrite (leq_trans (IHk _ _) (fle _ _))// ltnW// ltnW.
 Qed.
 
 Lemma telescope_sumn n m f : {homo f : x y / x <= y} ->
   \sum_(n <= k < m) (f k.+1 - f k) = f m - f n.
 Proof.
 move=> fle; case: (ltnP n m) => nm.
-apply: (telescope_sumn_in (ltnW nm)) => ? ?; exact: fle.
+  by apply: (telescope_sumn_in (ltnW nm)) => ? ?; apply: fle.
 by apply/esym/eqP; rewrite big_geq// subn_eq0 fle.
 Qed.
 


### PR DESCRIPTION
##### Motivation for this change

The condition of the lemma `telescope_sumn_in` doesn't seems what was intended and is not the most general. Indeed
the condition
```Coq
 {in [pred i | n <= i <= m], {homo f : x y / x <= y}}
```
asserts that if `i <= j` and `n <= i <= m` then `f i <= f j`. 

My feeling is that the condition should be the slightly weaker version:
```Coq
 {in [pred i | n <= i <= m] &, {homo f : x y / x <= y}}
```
which asserts that if `n <= i <= j <= m` then `f i <= f j`. 

The goal of this PR is to fix this problem. In my usecase, the condition is awkward and I replace it by the following condition:
```Coq
Lemma bounded_le_homo_in (m n : nat) f :
  (forall i, m <= i < n -> f i <= f i.+1) ->
  {in [pred i | m <= i & i <= n] &, {homo f : x y / x <= y}}.
```
I'm not sure how to name this lemma neither where to put it. As soon as we agree with the name and the placement, I'll update the changelog and finish the pull request.



<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
