### PR TITLE
Simplified statement of Fp_Zcast

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- in `zmodp.v`
+  + simpler statement of `Fp_Zcast`
+
 ### Renamed
 
 ### Removed

--- a/mathcomp/algebra/zmodp.v
+++ b/mathcomp/algebra/zmodp.v
@@ -336,7 +336,7 @@ Section F_prime.
 
 Hypothesis p_pr : prime p.
 
-Lemma Fp_Zcast : (Zp_trunc (pdiv p)).+2 = (Zp_trunc p).+2.
+Lemma Fp_Zcast : Zp_trunc (pdiv p) = Zp_trunc p.
 Proof. by rewrite /pdiv primes_prime. Qed.
 
 Lemma Fp_cast : (Zp_trunc (pdiv p)).+2 = p.

--- a/mathcomp/solvable/cyclic.v
+++ b/mathcomp/solvable/cyclic.v
@@ -879,7 +879,8 @@ Variable gT : finGroupType.
 
 Lemma Aut_prime_cycle_cyclic (a : gT) : prime #[a] -> cyclic (Aut <[a]>).
 Proof.
-move=> pr_a; have inj_um := injm_Zp_unitm a; have eq_a := Fp_Zcast pr_a.
+move=> pr_a; have inj_um := injm_Zp_unitm a.
+have /eq_S/eq_S eq_a := Fp_Zcast pr_a.
 pose fm := cast_ord (esym eq_a) \o val \o invm inj_um.
 apply: (@field_mul_group_cyclic _ _ _ fm) => [f g Af Ag | f Af] /=.
   by apply: val_inj; rewrite /= morphM ?im_Zp_unitm //= eq_a.


### PR DESCRIPTION
##### Motivation for this change

The statement of `Fp_Zcast` prevented rewriting such as 
```
Lemma test (p : nat) (p_pr : prime p) (a b : 'Z_(p ^ 1)) :
  a != 0 -> b != 0 -> a * b != 0.
Proof.
rewrite -Fp_Zcast // in a b *.
exact: mulf_neq0.
Qed.
```
The new simpler statement allows them.

##### Things done/to do

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [/] (doesn't apply here) added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

##### Compatibility with MathComp 1.X

- [x] I already opened a PR : https://github.com/math-comp/math-comp/pull/1172

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
