### PR TITLE
Generalize count_merge from eqType to Type

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `zmodp.v`
   + simpler statement of `Fp_Zcast`
 
+- in `path.v`
+  + generalized `count_merge` from `eqType` to `Type`
+
 ### Renamed
 
 ### Removed

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -926,12 +926,16 @@ rewrite /sort; move: [::] {2}_.+1 (ltnSn (size s)./2) => ss n.
 by elim: n => // n IHn in ss s *; case: s => [|x [|y s]] //= /IHn->.
 Qed.
 
-Lemma size_merge s1 s2 : size (merge s1 s2) = size (s1 ++ s2).
+Lemma count_merge (p : pred T) s1 s2 :
+  count p (merge s1 s2) = count p (s1 ++ s2).
 Proof.
-rewrite size_cat; elim: s1 s2 => // x s1 IH1.
+rewrite count_cat; elim: s1 s2 => // x s1 IH1.
 elim=> //= [|y s2 IH2]; first by rewrite addn0.
-by case: leT; rewrite /= ?IH1 ?IH2 !addnS.
+by case: leT; rewrite /= ?IH1 ?IH2 !addnA [_ + p y]addnAC [p x + p y]addnC.
 Qed.
+
+Lemma size_merge s1 s2 : size (merge s1 s2) = size (s1 ++ s2).
+Proof. exact: (count_merge predT). Qed.
 
 Lemma allrel_merge s1 s2 : allrel leT s1 s2 -> merge s1 s2 = s1 ++ s2.
 Proof.
@@ -1100,11 +1104,7 @@ Section EqSortSeq.
 Variables (T : eqType) (leT : rel T).
 
 Lemma perm_merge s1 s2 : perm_eql (merge leT s1 s2) (s1 ++ s2).
-Proof.
-apply/permPl; rewrite perm_sym; elim: s1 s2 => //= x1 s1 IHs1.
-elim; rewrite ?cats0 //= => x2 s2 IHs2.
-by case: ifP; last rewrite (perm_catCA (_ :: _) [:: x2]); rewrite perm_cons.
-Qed.
+Proof. by apply/permPl/permP => ?; rewrite count_merge. Qed.
 
 Lemma mem_merge s1 s2 : merge leT s1 s2 =i s1 ++ s2.
 Proof. by apply: perm_mem; rewrite perm_merge. Qed.
@@ -1127,9 +1127,6 @@ Lemma mem_sort s : sort leT s =i s. Proof. exact/perm_mem/permPl/perm_sort. Qed.
 
 Lemma sort_uniq s : uniq (sort leT s) = uniq s.
 Proof. exact/perm_uniq/permPl/perm_sort. Qed.
-
-Lemma count_merge p s1 s2 : count p (merge leT s1 s2) = count p (s1 ++ s2).
-Proof. exact/permP/permPl/perm_merge. Qed.
 
 Lemma eq_count_merge (p : pred T) s1 s1' s2 s2' :
   count p s1 = count p s1' -> count p s2 = count p s2' ->


### PR DESCRIPTION
##### Motivation for this change

Lemma `count_merge` does not require an `eqType`. Thanks to this generalization, `size_cat` and `perm_merge` become immediate consequences of `count_merge`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
