### PR TITLE
add intrN

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- in `ssrint.v`
+  + lemma `intrN`
+
 ### Changed
 
 - in `zmodp.v`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - in `ssrint.v`
-  + lemma `intrN`
+  + lemmas `intrN`, `intrB`
 
 ### Changed
 

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -685,6 +685,9 @@ Lemma intrN n : (- n)%:~R = - n%:~R :> R. Proof. exact: mulrNz. Qed.
 Lemma intrD m n : (m + n)%:~R = m%:~R + n%:~R :> R.
 Proof. exact: mulrzDr_tmp. Qed.
 
+Lemma intrB m n : (m - n)%:~R = m%:~R - n%:~R :> R.
+Proof. by rewrite intrD intrN. Qed.
+
 Lemma intrM m n : (m * n)%:~R = m%:~R * n%:~R :> R.
 Proof. by rewrite mulrzA -mulrzr. Qed.
 

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -680,6 +680,8 @@ Proof. by rewrite mulNrz mulrNz opprK. Qed.
 Lemma mulrbz x (b : bool) : x *~ b = (if b then x else 0).
 Proof. by case: b. Qed.
 
+Lemma intrN n : (- n)%:~R = - n%:~R :> R. Proof. by rewrite mulrNz. Qed.
+
 Lemma intrD m n : (m + n)%:~R = m%:~R + n%:~R :> R.
 Proof. exact: mulrzDr_tmp. Qed.
 

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -680,7 +680,7 @@ Proof. by rewrite mulNrz mulrNz opprK. Qed.
 Lemma mulrbz x (b : bool) : x *~ b = (if b then x else 0).
 Proof. by case: b. Qed.
 
-Lemma intrN n : (- n)%:~R = - n%:~R :> R. Proof. by rewrite mulrNz. Qed.
+Lemma intrN n : (- n)%:~R = - n%:~R :> R. Proof. exact: mulrNz. Qed.
 
 Lemma intrD m n : (m + n)%:~R = m%:~R + n%:~R :> R.
 Proof. exact: mulrzDr_tmp. Qed.


### PR DESCRIPTION
##### Motivation for this change

I regularly forget that this is achieved by `mulrNz`.
Since there is `intrD` and `intrM`, we could also have `intrN`.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
