### PR TITLE
lemmas that generalize invf_{g,l}{t,e}1

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemmas `intrN`, `intrB`
 
 - in `ssrnum.v`
-  + lemma `invf_plt`
+  + lemma `invf_pgt`, `invf_pge`, `invf_ngt`, `invf_nge`
+  + lemma `invf_plt`, `invf_ple`, `invf_nlt`, `invf_nle`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `ssrint.v`
   + lemmas `intrN`, `intrB`
 
+- in `ssrnum.v`
+  + lemma `invf_plt`
+
 ### Changed
 
 - in `zmodp.v`

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -3373,21 +3373,40 @@ Proof. exact: leW_nmono_in lef_nV2. Qed.
 Definition ltef_pV2 := (lef_pV2, ltf_pV2).
 Definition ltef_nV2 := (lef_nV2, ltf_nV2).
 
+Lemma invf_pgt : {in pos &, forall x y, (x < y^-1) = (y < x^-1)}.
+Proof. by move=> x y *; rewrite -[x in LHS]invrK ltf_pV2// posrE invr_gt0. Qed.
+
+Lemma invf_pge : {in pos &, forall x y, (x <= y^-1) = (y <= x^-1)}.
+Proof. by move=> x y *; rewrite -[x in LHS]invrK lef_pV2// posrE invr_gt0. Qed.
+
+Lemma invf_ngt : {in neg &, forall x y, (x < y^-1) = (y < x^-1)}.
+Proof. by move=> x y *; rewrite -[x in LHS]invrK ltf_nV2// negrE invr_lt0. Qed.
+
+Lemma invf_nge : {in neg &, forall x y, (x <= y^-1) = (y <= x^-1)}.
+Proof. by move=> x y *; rewrite -[x in LHS]invrK lef_nV2// negrE invr_lt0. Qed.
+
 Lemma invf_gt1 x : 0 < x -> (1 < x^-1) = (x < 1).
-Proof. by move=> x_gt0; rewrite -{1}[1]invr1 ltf_pV2 ?posrE ?ltr01. Qed.
+Proof. by move=> x0; rewrite invf_pgt ?invr1 ?posrE. Qed.
 
 Lemma invf_ge1 x : 0 < x -> (1 <= x^-1) = (x <= 1).
-Proof. by move=> x_lt0; rewrite -{1}[1]invr1 lef_pV2 ?posrE ?ltr01. Qed.
+Proof. by move=> x0; rewrite invf_pge ?invr1 ?posrE. Qed.
 
 Definition invf_gte1 := (invf_ge1, invf_gt1).
 
-Lemma invf_le1 x : 0 < x -> (x^-1 <= 1) = (1 <= x).
-Proof. by move=> x_gt0; rewrite -invf_ge1 ?invr_gt0 // invrK. Qed.
+Lemma invf_plt : {in pos &, forall x y, (x^-1 < y) = (y^-1 < x)}.
+Proof. by move=> x y *; rewrite -[y in LHS]invrK ltf_pV2// posrE invr_gt0. Qed.
 
-Lemma invf_plt : {in Num.pos &, forall x y, (x^-1 < y) = (y^-1 < x)}.
-Proof.
-by move=> x y ? ?; rewrite -[in LHS](@invrK _ y) ltf_pV2// posrE invr_gt0.
-Qed.
+Lemma invf_ple : {in pos &, forall x y, (x^-1 <= y) = (y^-1 <= x)}.
+Proof. by move=> x y *; rewrite -[y in LHS]invrK lef_pV2// posrE invr_gt0. Qed.
+
+Lemma invf_nlt : {in neg &, forall x y, (x^-1 < y) = (y^-1 < x)}.
+Proof. by move=> x y *; rewrite -[y in LHS]invrK ltf_nV2// negrE invr_lt0. Qed.
+
+Lemma invf_nle : {in neg &, forall x y, (x^-1 <= y) = (y^-1 <= x)}.
+Proof. by move=> x y *; rewrite -[y in LHS]invrK lef_nV2// negrE invr_lt0. Qed.
+
+Lemma invf_le1 x : 0 < x -> (x^-1 <= 1) = (1 <= x).
+Proof. by move=> x0; rewrite -invf_ple ?invr1 ?posrE. Qed.
 
 Lemma invf_lt1 x : 0 < x -> (x^-1 < 1) = (1 < x).
 Proof. by move=> x0; rewrite invf_plt ?invr1 ?posrE. Qed.

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -3384,8 +3384,13 @@ Definition invf_gte1 := (invf_ge1, invf_gt1).
 Lemma invf_le1 x : 0 < x -> (x^-1 <= 1) = (1 <= x).
 Proof. by move=> x_gt0; rewrite -invf_ge1 ?invr_gt0 // invrK. Qed.
 
+Lemma invf_plt : {in Num.pos &, forall x y, (x^-1 < y) = (y^-1 < x)}.
+Proof.
+by move=> x y ? ?; rewrite -[in LHS](@invrK _ y) ltf_pV2// posrE invr_gt0.
+Qed.
+
 Lemma invf_lt1 x : 0 < x -> (x^-1 < 1) = (1 < x).
-Proof. by move=> x_lt0; rewrite -invf_gt1 ?invr_gt0 // invrK. Qed.
+Proof. by move=> x0; rewrite invf_plt ?invr1 ?posrE. Qed.
 
 Definition invf_lte1 := (invf_le1, invf_lt1).
 Definition invf_cp1 := (invf_gte1, invf_lte1).


### PR DESCRIPTION
##### Motivation for this change

I have been wanting this lemma several times, so I propose it.
Maybe this is already available in another form.
Of course, there are variants that I can add later if this looks like a reasonable addition.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
