### PR TITLE
ssralg and poly parts of CohenCyril's abel backport

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -36,6 +36,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `path.v`
   + lemma `count_sort`
+- in `poly.v`
+  + lemmas `coef0M`, `coef0_prod`, `polyseqXaddC`, `lead_coefXaddC`,
+    `lead_coefXnaddC`, `lead_coefXnsubC`, `size_XnaddC`, `size_XnsubC`,
+	 `monicXaddC`, `lead_coef_prod_XsubC`, `monicXnaddC`, `monicXnsubC`,
+	 `prim_root_eq0`, `polyOverXn`, `polyOverXaddC`, `polyOverXnaddC`,
+	 `polyOverXnsubC`, `prim_root_charF`, `char_prim_root`, `prim_root_pi_eq0`,
+	 `prim_root_dvd_eq0`, `prim_root_natf_neq0`, `eq_in_map_poly_id0`,
+	 `eq_in_map_poly`, `map_polyXaddC`, `map_polyXsubC`, `map_prod_XsubC`,
+	 `prod_map_poly`, `mapf_root`, `lead_coef_prod`
+
+- in `ssralg.v`
+  + lemmas `prodM_comm`, `prodMl_comm`, `prodMr_comm`, `prodrMl`, `prodrMr`
+
 
 ### Changed
 
@@ -93,6 +106,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + definition `expn_rec`, use `expn` directly
   + definition `fact_rec`, use `factorial` directly
   + definition `double_rec`, use `double` directly
+
+- in `poly.v`
+  + lemma `size_Xn_sub_1`, use `size_XnsubC` instead
+  + lemma `monic_Xn_sub_1`, use `monic_XnsubC` instead
 
 ### Infrastructure
 

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -954,6 +954,8 @@ Local Notation "\prod_ ( m <= i < n ) F" := (\big[*%R/1%R]_(m <= i < n) F%R).
 Definition char (R : semiRingType) : nat_pred :=
   [pred p | prime p & p%:R == 0 :> R].
 
+Local Notation has_char0 L := (char L =i pred0).
+
 (* Converse ring tag. *)
 Definition converse R : Type := R.
 Local Notation "R ^c" := (converse R) (at level 2, format "R ^c") : type_scope.
@@ -1145,6 +1147,26 @@ Proof. by rewrite big_const_nat -iteropE. Qed.
 Lemma prodrXr x I r P (F : I -> nat) :
   \prod_(i <- r | P i) x ^+ F i = x ^+ (\sum_(i <- r | P i) F i).
 Proof. by rewrite (big_morph _ (exprD _) (erefl _)). Qed.
+
+Lemma prodrM_comm {I : eqType} r (P : pred I) (F G : I -> R) :
+    (forall i j, P i -> P j -> comm (F i) (G j)) ->
+  \prod_(i <- r | P i) (F i * G i) =
+    \prod_(i <- r | P i) F i * \prod_(i <- r | P i) G i.
+Proof.
+move=> FG; elim: r => [|i r IHr]; rewrite !(big_nil, big_cons) ?mulr1//.
+case: ifPn => // Pi; rewrite IHr !mulrA; congr (_ * _); rewrite -!mulrA.
+by rewrite commr_prod // => j Pj; apply/commr_sym/FG.
+Qed.
+
+Lemma prodrMl_comm {I : finType} (A : pred I) (x : R) F :
+    (forall i, A i -> comm x (F i)) ->
+  \prod_(i in A) (x * F i) = x ^+ #|A| * \prod_(i in A) F i.
+Proof. by move=> xF; rewrite prodrM_comm ?prodr_const// => i j _ /xF. Qed.
+
+Lemma prodrMr_comm {I : finType} (A : pred I) (x : R) F :
+    (forall i, A i -> comm x (F i)) ->
+  \prod_(i in A) (F i * x) = \prod_(i in A) F i * x ^+ #|A|.
+Proof. by move=> xF; rewrite prodrM_comm ?prodr_const// => i j /xF. Qed.
 
 Lemma prodrMn (I : Type) (s : seq I) (P : pred I) (F : I -> R) (g : I -> nat) :
   \prod_(i <- s | P i) (F i *+ g i) =
@@ -2559,6 +2581,14 @@ Proof. by rewrite (big_morph _ (exprMn n) (expr1n _ n)). Qed.
 Lemma prodr_undup_exp_count (I : eqType) r (P : pred I) (F : I -> R) :
   \prod_(i <- undup r | P i) F i ^+ count_mem i r = \prod_(i <- r | P i) F i.
 Proof. exact: big_undup_iterop_count.  Qed.
+
+Lemma prodrMl {I : finType} (A : pred I) (x : R) F :
+  \prod_(i in A) (x * F i) = x ^+ #|A| * \prod_(i in A) F i.
+Proof. by rewrite big_split ?prodr_const. Qed.
+
+Lemma prodrMr {I : finType} (A : pred I) (x : R) F :
+  \prod_(i in A) (F i * x) = \prod_(i in A) F i * x ^+ #|A|.
+Proof. by rewrite big_split ?prodr_const. Qed.
 
 Lemma exprDn x y n :
   (x + y) ^+ n = \sum_(i < n.+1) (x ^+ (n - i) * y ^+ i) *+ 'C(n, i).
@@ -6141,6 +6171,7 @@ Notation "- 1" := (opp 1) : ring_scope.
 Notation "n %:R" := (natmul 1 n) : ring_scope.
 Arguments GRing.char R%type.
 Notation "[ 'char' R ]" := (GRing.char R) : ring_scope.
+Notation has_char0 R := (GRing.char R =i pred0).
 Notation Frobenius_aut chRp := (Frobenius_aut chRp).
 Notation "*%R" := (@mul _) : function_scope.
 Notation "x * y" := (mul x y) : ring_scope.


### PR DESCRIPTION
##### Motivation for this change

Extracts the part from https://github.com/math-comp/math-comp/pull/944 that concern ssralg.v and poly.v.
Relies on https://github.com/math-comp/math-comp/pull/1184

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~~[ ] added corresponding documentation in the headers~~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
