### PR TITLE
Remove deprecation notations introduced in MathComp 2.0.0

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -232,6 +232,145 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `binomial.v`
   + lemma `textbook_triangular_sum`
 
+- in `eqtype.v`
+  + notations `[eqType of T]`, `[eqType of T for C]`, and `[eqMixin of T by <:]`
+  + notations `sub`, `subK`, `sub_spec`, and `subP`
+  + notations `InjEqMixin`, `PcanEqMixin`, and `CanEqMixin`
+
+- in `choice.v`
+  + notations `[hasChoice of T]`, `[choiceType of T]`,
+    `[choiceType of T for C]`, and `[choiceMixin of T by <:]`
+  + notations `[isCountable of T]`, `[countType of T]`,
+    `[countType of T for C]`, `[countMixin of T by <:]`, and
+    `[subCountType of T]`
+  + notations `CanChoiceMixin`, `PcanChoiceMixin`, `CanCountMixin`, and
+    `PcanCountMixin`
+
+- in `fintype.v`
+  + notations `[finType of T]`, `[finType of T for C]`, `[subFinType of T]`,
+    `[finMixin of T by <:]`
+  + notations `EnumMixin`, `UniqMixin`, `CountMixin`, `FinMixin`,
+    `UniqFinMixin`, `PcanFinMixin`, and `CanFinMixin`
+
+- in `generic_quotient.v`
+  + notations `[quotType of Q]` and `[eqQuotType e of Q]`
+
+- in `order.v`
+  + notations `[porderType of T]`, `[porderType of T with disp]`,
+    `[porderType of T for cT]`, and `[porderType of T for cT with disp]`
+  + notations `[latticeType of T]`, `[latticeType of T with disp]`,
+    `[latticeType of T for cT]`, and `[latticeType of T for cT with disp]`
+  + notations `[bLatticeType of T]` and `[bLatticeType of T for cT]`
+  + notation `[bDistrLatticeType of T]`
+  + notation `[tbDistrLatticeType of T]`
+  + notation `[finPOrderType of T]`
+  + notation `[finLatticeType of T]`
+  + notation `[finDistrLatticeType of T]`
+  + notation `[finCDistrLatticeType of T]`
+  + notation `[finOrderType of T]`
+  + notations `sub`, `subKI`, `subIK`, `subxx`, `subKU`, `subUK`, `subUx`,
+    `sub_eq0`, `meet_eq0E_sub`, `eq_sub`, `subxU`, `subx0`, `sub0x`, `subIx`,
+    `subxI`, `subBx`, `subxB`, `disj_subl`, `disj_subr`, `sub1x`, `subE`,
+    `tnth_sub`, and `subEtpred`
+  + notations `PcanPartial`, `CanPartial`, `PcanTotal`, `CanTotal`,
+    `MonoTotalMixin`, `PcanPOrderMixin`, `CanPOrderMixin`, `PcanOrderMixin`,
+    `CanOrderMixin`, `IsoLatticeMixin`, `IsoDistrLatticeMixin`
+
+- in `fingroup.v`
+  + notations `[finGroupType of T]` and `[baseFinGroupType of T]`
+
+- in `ssralg.v`
+  + notations `[nmodType of T for cT]` and `[nmodType of T]`
+  + notation ZmodMixin
+  + notations `[zmodType of T for cT]` and `[zmodType of T]`
+  + notations `[semiRingType of T]` and `[semiRingType of T for cT]`
+  + notations `[ringType of T]` and `[ringType of T for cT]`
+  + notations `[lmodType R of T]` and `[lmodType R of T for cT]`
+  + notations `[lalgType R of T]` and `[lalgType R of T for cT]`
+  + notations `[comSemiRingType of T]` and `[comSemiRingType of T for cT]`
+  + notations `[comRingType of T]` and `[comRingType of T for cT]`
+  + notations `[algType R of T]` and `[algType R of T for cT]`
+  + notation `[comAlgType R of T]`
+  + notations `[unitRingType of T]` and `[unitRingType of T for cT]`
+  + notation `[comUnitRingType of T]`
+  + notation `[unitAlgType R of T]`
+  + notation `[comUnitAlgType R of T]`
+  + notations `[idomainType of T]` and `[idomainType of T for cT]`
+  + notations `[fieldType of T]` and `[fieldType of T for cT]`
+  + notations `[decFieldType of T]` and `[decFieldType of T for cT]`
+  + notations `[closedFieldType of T]` and `[closedFieldType of T for cT]`
+  + definition `Additive.apply_deprecated`
+  + notation `Additive.apply`
+  + notations `[additive of f]` and `[additive of f as g]`
+  + notations `[rmorphism of f]` and `[rmorphism of f as g]`
+  + definition `Linear.apply_deprecated`
+  + notation `Linear.apply`
+  + notations `[linear of f]` and `[linear of f as g]`
+  + definition `LRMorphism.apply_deprecated`
+  + notation `LRMorphism.apply`
+  + notation `[lrmorphism of f]`
+
+- in `ring_quotient.v`
+  + notation `[zmodQuotType z, o & a of Q]`
+  + notation `[ringQuotType o & m of Q]`
+  + notation `[unitRingQuotType u & i of Q]`
+
+- in `countalg.v`
+  + notation `[countNmodType of T]`
+  + notation `[countZmodType of T]`
+  + notation `[countSemiRingType of T]`
+  + notation `[countRingType of T]`
+  + notation `[countComSemiRingType of T]`
+  + notation `[countComRingType of T]`
+  + notation `[countUnitRingType of T]`
+  + notation `[countComUnitRingType of T]`
+  + notation `[countIdomainType of T]`
+  + notation `[countFieldType of T]`
+  + notation `[countDecFieldType of T]`
+  + notation `[countClosedFieldType of T]`
+
+- in `finalg.v`
+  + notation `[finNmodType of T]`
+  + notation `[finZmodType of T]`
+  + notation `[finSemiRingType of T]`
+  + notation `[finRingType of T]`
+  + notation `[finComSemiRingType of T]`
+  + notation `[finComRingType of T]`
+  + notation `[finUnitRingType of T]`
+  + notation `[finComUnitRingType of T]`
+  + notation `[finIntegralDomainType of T]`
+  + notation `[finFieldType of T]`
+  + notation `[finLmodType R of T]`
+  + notation `[finLalgType R of T]`
+  + notation `[finAlgType R of T]`
+  + notation `[finUnitAlgType R of T]`
+
+- in `ssrnum.v`
+  + notations `[numDomainType of T]` and `[numDomainType of T for cT]`
+  + notation `[numFieldType of T]`
+  + notations `[numClosedFieldType of T]` and `[numClosedFieldType of T for cT]`
+  + notation `[realDomainType of T]`
+  + notation `[realFieldType of T]`
+  + notations `[rcfType of T]` and `[rcfType of T for cT]`
+  + notations `[archiFieldType of T]` and `[archiFieldType of T for cT]`
+
+- in `rat.v`
+  + lemma `divq_eq_deprecated`
+
+- in `vector.v`
+  + notations `[vectType R of T]` and `[vectType R of T for cT]`
+
+- in `falgebra.v`
+  + notations `[FalgType F of L]` and `[FalgType F of L for L']`
+  + notation `FalgUnitRingType`
+
+- in `fieldext.v`
+  + notations `[fieldExtType F of L]` and `[fieldExtType F of L for K]`
+
+- in `galois.v`
+  + notations `[splittingFieldType F of L]` and
+    `[splittingFieldType F of L for K]`
+
 ### Deprecated
 
 - in `ssreflect.v`

--- a/mathcomp/algebra/countalg.v
+++ b/mathcomp/algebra/countalg.v
@@ -39,135 +39,41 @@ Import GRing.Theory.
 
 #[short(type="countNmodType")]
 HB.structure Definition Nmodule := {M of GRing.Nmodule M & Countable M}.
-Module NmoduleExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use CountRing.Nmodule.clone instead.")]
-Notation "[ 'countNmodType' 'of' T ]" := (Nmodule.clone T _)
-  (at level 0, format "[ 'countNmodType'  'of'  T ]") : form_scope.
-End NmoduleExports.
-HB.export NmoduleExports.
 
 #[short(type="countZmodType")]
 HB.structure Definition Zmodule := {M of GRing.Zmodule M & Countable M}.
-Module ZmoduleExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use CountRing.Zmodule.clone instead.")]
-Notation "[ 'countZmodType' 'of' T ]" := (Zmodule.clone T%type _)
-  (at level 0, format "[ 'countZmodType'  'of'  T ]") : form_scope.
-End ZmoduleExports.
-HB.export ZmoduleExports.
 
 #[short(type="countSemiRingType")]
 HB.structure Definition SemiRing := {R of GRing.SemiRing R & Countable R}.
 
-Module SemiRingExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use CountRing.SemiRing.clone instead.")]
-Notation "[ 'countSemiRingType' 'of' T ]" :=
-  (SemiRing.clone T _) (* NB: was (do_pack pack T) *)
-      (at level 0, format "[ 'countSemiRingType'  'of'  T ]") : form_scope.
-End SemiRingExports.
-HB.export SemiRingExports.
-
 #[short(type="countRingType")]
 HB.structure Definition Ring := {R of GRing.Ring R & Countable R}.
-
-Module RingExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use CountRing.Ring.clone instead.")]
-Notation "[ 'countRingType' 'of' T ]" :=
-  (Ring.clone T%type _) (* NB: was (do_pack pack T) *)
-      (at level 0, format "[ 'countRingType'  'of'  T ]") : form_scope.
-End RingExports.
-HB.export RingExports.
 
 #[short(type="countComSemiRingType")]
 HB.structure Definition ComSemiRing := {R of GRing.ComSemiRing R & Countable R}.
 
-Module ComSemiRingExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use CountRing.ComSemiRing.clone instead.")]
-Notation "[ 'countComSemiRingType' 'of' T ]" := (ComSemiRing.clone T _)
-  (at level 0, format "[ 'countComSemiRingType'  'of'  T ]") : form_scope.
-End ComSemiRingExports.
-HB.export ComSemiRingExports.
-
 #[short(type="countComRingType")]
 HB.structure Definition ComRing := {R of GRing.ComRing R & Countable R}.
-
-Module ComRingExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use CountRing.ComRing.clone instead.")]
-Notation "[ 'countComRingType' 'of' T ]" := (ComRing.clone T%type _)
-  (at level 0, format "[ 'countComRingType'  'of'  T ]") : form_scope.
-End ComRingExports.
-HB.export ComRingExports.
 
 #[short(type="countUnitRingType")]
 HB.structure Definition UnitRing := {R of GRing.UnitRing R & Countable R}.
 
-Module UnitRingExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use CountRing.UnitRing.clone instead.")]
-Notation "[ 'countUnitRingType' 'of' T ]" := (UnitRing.clone T%type _)
-  (at level 0, format "[ 'countUnitRingType'  'of'  T ]") : form_scope.
-End UnitRingExports.
-HB.export UnitRingExports.
-
 #[short(type="countComUnitRingType")]
 HB.structure Definition ComUnitRing := {R of GRing.ComUnitRing R & Countable R}.
-
-Module ComUnitRingExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use CountRing.ComUnitRing.clone instead.")]
-Notation "[ 'countComUnitRingType' 'of' T ]" := (ComUnitRing.clone T%type _)
-  (at level 0, format "[ 'countComUnitRingType'  'of'  T ]") : form_scope.
-End ComUnitRingExports.
-HB.export ComUnitRingExports.
 
 #[short(type="countIdomainType")]
 HB.structure Definition IntegralDomain :=
   {R of GRing.IntegralDomain R & Countable R}.
 
-Module IntegralDomainExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use CountRing.IntegralDomain.clone instead.")]
-Notation "[ 'countIdomainType' 'of' T ]" := (IntegralDomain.clone T%type _)
-  (at level 0, format "[ 'countIdomainType'  'of'  T ]") : form_scope.
-End IntegralDomainExports.
-HB.export IntegralDomainExports.
-
 #[short(type="countFieldType")]
 HB.structure Definition Field := {R of GRing.Field R & Countable R}.
-
-Module FieldExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use CountRing.Field.clone instead.")]
-Notation "[ 'countFieldType' 'of' T ]" := (Field.clone T%type _)
-  (at level 0, format "[ 'countFieldType'  'of'  T ]") : form_scope.
-End FieldExports.
-HB.export FieldExports.
 
 #[short(type="countDecFieldType")]
 HB.structure Definition DecidableField :=
   {R of GRing.DecidableField R & Countable R}.
 
-Module DecidableFieldExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use CountRing.DecidableField.clone instead.")]
-Notation "[ 'countDecFieldType' 'of' T ]" := (DecidableField.clone T%type _)
-  (at level 0, format "[ 'countDecFieldType'  'of'  T ]") : form_scope.
-End DecidableFieldExports.
-HB.export DecidableFieldExports.
-
 #[short(type="countClosedFieldType")]
 HB.structure Definition ClosedField := {R of GRing.ClosedField R & Countable R}.
-
-Module ClosedFieldExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use CountRing.ClosedField.clone instead.")]
-Notation "[ 'countClosedFieldType' 'of' T ]" := (ClosedField.clone T%type _)
-  (at level 0, format "[ 'countClosedFieldType'  'of'  T ]") : form_scope.
-End ClosedFieldExports.
-HB.export ClosedFieldExports.
 
 #[export]
 HB.instance Definition _ (R : countNmodType) := Nmodule.on R^o.

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -41,21 +41,10 @@ Import GRing.Theory.
 #[short(type="finNmodType")]
 HB.structure Definition Nmodule := {M of GRing.Nmodule M & Finite M}.
 
-Module NmoduleExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use FinRing.Nmodule.clone instead.")]
-Notation "[ 'finNmodType' 'of' T ]" := (Nmodule.clone T _)
-  (at level 0, format "[ 'finNmodType'  'of'  T ]") : form_scope.
-End NmoduleExports.
-HB.export NmoduleExports.
-
 #[short(type="finZmodType")]
 HB.structure Definition Zmodule := {M of GRing.Zmodule M & Finite M}.
 
 Module ZmoduleExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinRing.Zmodule.clone instead.")]
-Notation "[ 'finZmodType' 'of' T ]" := (Zmodule.clone T%type _)
-  (at level 0, format "[ 'finZmodType'  'of'  T ]") : form_scope.
 Notation "[ 'finGroupMixin' 'of' R 'for' +%R ]" :=
     (isMulGroup.Build R (@addrA _) (@add0r _) (@addNr _))
   (at level 0, format "[ 'finGroupMixin'  'of'  R  'for'  +%R ]") : form_scope.
@@ -65,66 +54,20 @@ HB.export ZmoduleExports.
 #[short(type="finSemiRingType")]
 HB.structure Definition SemiRing := {R of GRing.SemiRing R & Finite R}.
 
-Module SemiRingExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use FinRing.SemiRing.clone instead.")]
-Notation "[ 'finSemiRingType' 'of' T ]" := (SemiRing.clone T _)
-  (at level 0, format "[ 'finSemiRingType'  'of'  T ]") : form_scope.
-End SemiRingExports.
-HB.export SemiRingExports.
-
 #[short(type="finRingType")]
 HB.structure Definition Ring := {R of GRing.Ring R & Finite R}.
-
-Module RingExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinRing.Ring.clone instead.")]
-Notation "[ 'finRingType' 'of' T ]" := (Ring.clone T%type _)
-  (at level 0, format "[ 'finRingType'  'of'  T ]") : form_scope.
-End RingExports.
-HB.export RingExports.
 
 #[short(type="finComSemiRingType")]
 HB.structure Definition ComSemiRing := {R of GRing.ComSemiRing R & Finite R}.
 
-Module ComSemiRingExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use FinRing.ComSemiRing.clone instead.")]
-Notation "[ 'finComSemiRingType' 'of' T ]" := (ComSemiRing.clone T _)
-  (at level 0, format "[ 'finComSemiRingType'  'of'  T ]") : form_scope.
-End ComSemiRingExports.
-HB.export ComSemiRingExports.
-
 #[short(type="finComRingType")]
 HB.structure Definition ComRing := {R of GRing.ComRing R & Finite R}.
-
-Module ComRingExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinRing.ComRing.clone instead.")]
-Notation "[ 'finComRingType' 'of' T ]" := (ComRing.clone T%type _)
-  (at level 0, format "[ 'finComRingType'  'of'  T ]") : form_scope.
-End ComRingExports.
-HB.export ComRingExports.
 
 #[short(type="finUnitRingType")]
 HB.structure Definition UnitRing := {R of GRing.UnitRing R & Finite R}.
 
-Module UnitRingExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use FinRing.UnitRing.clone instead.")]
-Notation "[ 'finUnitRingType' 'of' T ]" := (UnitRing.clone T%type _)
-  (at level 0, format "[ 'finUnitRingType'  'of'  T ]") : form_scope.
-End UnitRingExports.
-HB.export UnitRingExports.
-
 #[short(type="finComUnitRingType")]
 HB.structure Definition ComUnitRing := {R of GRing.ComUnitRing R & Finite R}.
-
-Module ComUnitRingExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use FinRing.ComUnitRing.clone instead.")]
-Notation "[ 'finComUnitRingType' 'of' T ]" := (ComUnitRing.clone T%type _)
-  (at level 0, format "[ 'finComUnitRingType'  'of'  T ]") : form_scope.
-End ComUnitRingExports.
-HB.export ComUnitRingExports.
 
 #[short(type="finIdomainType")]
 HB.structure Definition IntegralDomain :=
@@ -133,69 +76,24 @@ HB.structure Definition IntegralDomain :=
   note="Use finIdomainType (not available in mathcomp 2.0.0).")]
 Notation finIntegralDomainType := finIdomainType.
 
-Module IntegralDomainExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use FinRing.IntegralDomain.clone instead.")]
-Notation "[ 'finIntegralDomainType' 'of' T ]" := (IntegralDomain.clone T%type _)
-  (at level 0, format "[ 'finIntegralDomainType'  'of'  T ]") : form_scope.
-End IntegralDomainExports.
-HB.export IntegralDomainExports.
-
 #[short(type="finFieldType")]
 HB.structure Definition Field := {R of GRing.Field R & Finite R}.
-
-Module FieldExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinRing.Field.clone instead.")]
-Notation "[ 'finFieldType' 'of' T ]" := (Field.clone T%type _)
-  (at level 0, format "[ 'finFieldType'  'of'  T ]") : form_scope.
-End FieldExports.
-HB.export FieldExports.
 
 #[short(type="finLmodType")]
 HB.structure Definition Lmodule (R : ringType) :=
   {M of GRing.Lmodule R M & Finite M}.
 
-Module LmoduleExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinRing.Lmodule.clone instead.")]
-Notation "[ 'finLmodType' R 'of' T ]" := (Lmodule.clone R T%type _)
-  (at level 0, format "[ 'finLmodType'  R  'of'  T ]") : form_scope.
-End LmoduleExports.
-HB.export LmoduleExports.
-
 #[short(type="finLalgType")]
 HB.structure Definition Lalgebra (R : ringType) :=
   {M of GRing.Lalgebra R M & Finite M}.
-
-Module LalgebraExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use FinRing.Lalgebra.clone instead.")]
-Notation "[ 'finLalgType' R 'of' T ]" := (Lalgebra.clone R T%type _)
-  (at level 0, format "[ 'finLalgType'  R  'of'  T ]") : form_scope.
-End LalgebraExports.
-HB.export LalgebraExports.
 
 #[short(type="finAlgType")]
 HB.structure Definition Algebra (R : ringType) :=
   {M of GRing.Algebra R M & Finite M}.
 
-Module AlgebraExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinRing.Algebra.clone instead.")]
-Notation "[ 'finAlgType' R 'of' T ]" := (Algebra.clone R T%type _)
-  (at level 0, format "[ 'finAlgType'  R  'of'  T ]") : form_scope.
-End AlgebraExports.
-HB.export AlgebraExports.
-
 #[short(type="finUnitAlgType")]
 HB.structure Definition UnitAlgebra (R : unitRingType) :=
   {M of GRing.UnitAlgebra R M & Finite M}.
-
-Module UnitAlgebraExports.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use FinRing.UnitAlgebra.clone instead.")]
-Notation "[ 'finUnitAlgType' R 'of' T ]" := (UnitAlgebra.clone R T%type _)
-  (at level 0, format "[ 'finUnitAlgType'  R  'of'  T ]") : form_scope.
-End UnitAlgebraExports.
-HB.export UnitAlgebraExports.
 
 (* Group structures *)
 

--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -589,10 +589,6 @@ set x := (n, d); rewrite -[n]/x.1 -[d]/x.2 -fracqE.
 by case: fracqP => [_|k fx k_neq0] /=; constructor.
 Qed.
 
-Lemma divq_eq_deprecated (nx dx ny dy : rat) :
-  dx != 0 -> dy != 0 -> (nx / dx == ny / dy) = (nx * dy == ny * dx).
-Proof. exact: eqr_div. Qed.
-
 Variant rat_spec (* (x : rat) *) : rat -> int -> int -> Type :=
   Rat_spec (n : int) (d : nat)  & coprime `|n| d.+1
   : rat_spec (* x  *) (n%:Q / d.+1%:Q) n d.+1.

--- a/mathcomp/algebra/ring_quotient.v
+++ b/mathcomp/algebra/ring_quotient.v
@@ -116,14 +116,6 @@ Canonical pi_add_quot_morph zqT := PiMorph2 (@pi_addr _ _ _ _ _ zqT).
 
 End ZModQuotient.
 
-Module ZModQuotientExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use ZmodQuotient.clone instead.")]
-Notation "[ 'zmodQuotType' z , o & a 'of' Q ]" :=
-  (ZmodQuotient.clone _ _ z o%function a%function Q%type _)
-  (at level 0, format "[ 'zmodQuotType'  z ,  o  &  a  'of'  Q ]") : form_scope.
-End ZModQuotientExports.
-HB.export ZModQuotientExports.
-
 Section PiAdditive.
 
 Variables (V : zmodType) (equivV : rel V) (zeroV : V).
@@ -166,13 +158,6 @@ Canonical pi_one_quot_morph rqT := PiMorph (@pi_oner _ _ _ _ _ _ _ rqT).
 Canonical pi_mul_quot_morph rqT := PiMorph2 (@pi_mulr _ _ _ _ _ _ _ rqT).
 
 End ringQuotient.
-Module RingQuotientExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use RingQuotient.clone instead.")]
-Notation "[ 'ringQuotType' o & m 'of' Q ]" :=
-  (RingQuotient.clone _ _ _ _ _ o m%function Q%type _)
-  (at level 0, format "[ 'ringQuotType'  o  &  m  'of'  Q ]") : form_scope.
-End RingQuotientExports.
-HB.export RingQuotientExports.
 
 Section PiRMorphism.
 
@@ -211,14 +196,6 @@ Canonical pi_unit_quot_morph urqT := PiMono1 (@pi_unitr _ _ _ _ _ _ _ _ _ urqT).
 Canonical pi_inv_quot_morph urqT := PiMorph1 (@pi_invr _ _ _ _ _ _ _ _ _ urqT).
 
 End UnitRingQuot.
-
-Module UnitRingQuotientExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use RingQuotient.clone instead.")]
-Notation "[ 'unitRingQuotType' u & i 'of' Q ]" :=
-  (UnitRingQuotient.clone _ _ _ _ _ _ _ u i%function Q%type _)
-  (at level 0, format "[ 'unitRingQuotType'  u  &  i  'of'  Q ]") : form_scope.
-End UnitRingQuotientExports.
-HB.export UnitRingQuotientExports.
 
 Definition proper_ideal (R : ringType) (S : {pred R}) : Prop :=
   1 \notin S /\ forall a, {in S, forall u, a * u \in S}.

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -591,14 +591,6 @@ HB.structure Definition Nmodule := {V of isNmodule V & Choice V}.
 
 Module NmodExports.
 Bind Scope ring_scope with Nmodule.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.Nmodule.clone instead.")]
-Notation "[ 'nmodType' 'of' T 'for' cT ]" := (Nmodule.clone T cT)
-  (at level 0, format "[ 'nmodType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.Nmodule.clone instead.")]
-Notation "[ 'nmodType' 'of' T ]" :=  (Nmodule.clone T _)
-  (at level 0, format "[ 'nmodType'  'of'  T ]") : form_scope.
 End NmodExports.
 HB.export NmodExports.
 
@@ -726,14 +718,6 @@ HB.end.
 
 Module ZmodExports.
 Bind Scope ring_scope with Zmodule.sort.
-#[deprecated(since="mathcomp 2.0.0", note="use GRing.isZmodule.Build instead")]
-Notation ZmodMixin V := (isZmodule.Build V).
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Zmodule.clone instead.")]
-Notation "[ 'zmodType' 'of' T 'for' cT ]" := (Zmodule.clone T cT)
-  (at level 0, format "[ 'zmodType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Zmodule.clone instead.")]
-Notation "[ 'zmodType' 'of' T ]" :=  (Zmodule.clone T _)
-  (at level 0, format "[ 'zmodType'  'of'  T ]") : form_scope.
 End ZmodExports.
 HB.export ZmodExports.
 
@@ -922,12 +906,6 @@ HB.end.
 
 Module SemiRingExports.
 Bind Scope ring_scope with SemiRing.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.SemiRing.clone instead.")]
-Notation "[ 'semiRingType' 'of' T 'for' cT ]" := (SemiRing.clone T cT)
-  (at level 0, format "[ 'semiRingType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.SemiRing.clone instead.")]
-Notation "[ 'semiRingType' 'of' T ]" := (SemiRing.clone T _)
-  (at level 0, format "[ 'semiRingType'  'of'  T ]") : form_scope.
 End SemiRingExports.
 HB.export SemiRingExports.
 
@@ -1350,12 +1328,6 @@ HB.end.
 
 Module RingExports.
 Bind Scope ring_scope with Ring.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Ring.clone instead.")]
-Notation "[ 'ringType' 'of' T 'for' cT ]" := (Ring.clone T cT)
-  (at level 0, format "[ 'ringType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Ring.clone instead.")]
-Notation "[ 'ringType' 'of' T ]" := (Ring.clone T _)
-  (at level 0, format "[ 'ringType'  'of'  T ]") : form_scope.
 End RingExports.
 HB.export RingExports.
 
@@ -1643,12 +1615,6 @@ Arguments scalerA [R s] (a b)%ring_scope v.
 
 Module LmodExports.
 Bind Scope ring_scope with Lmodule.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Lmodule.clone instead.")]
-Notation "[ 'lmodType' R 'of' T 'for' cT ]" := (Lmodule.clone R T%type cT)
-  (at level 0, format "[ 'lmodType'  R  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Lmodule.clone instead.")]
-Notation "[ 'lmodType' R 'of' T ]" := (Lmodule.clone R T%type _)
-  (at level 0, format "[ 'lmodType'  R  'of'  T ]") : form_scope.
 End LmodExports.
 HB.export LmodExports.
 
@@ -1743,12 +1709,6 @@ HB.structure Definition Lalgebra R :=
 
 Module LalgExports.
 Bind Scope ring_scope with Lalgebra.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Lalgebra.clone instead.")]
-Notation "[ 'lalgType' R 'of' T 'for' cT ]" := (Lalgebra.clone R T%type cT)
-  (at level 0, format "[ 'lalgType'  R  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Lalgebra.clone instead.")]
-Notation "[ 'lalgType' R 'of' T ]" := (Lalgebra.clone R T%type _)
-  (at level 0, format "[ 'lalgType'  R  'of'  T ]") : form_scope.
 End LalgExports.
 HB.export LalgExports.
 
@@ -1838,19 +1798,7 @@ HB.instance Definition _ := isSemiAdditive.Build U V apply (conj raddf0 raddfD).
 HB.end.
 
 Module AdditiveExports.
-Module Additive.
-Definition apply_deprecated (U V : nmodType) (phUV : phant (U -> V)) :=
-  @Additive.sort U V.
-#[deprecated(since="mathcomp 2.0", note="Use Additive.sort instead.")]
-Notation apply := apply_deprecated.
-End Additive.
 Notation "{ 'additive' U -> V }" := (Additive.type U%type V%type) : type_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Additive.clone instead.")]
-Notation "[ 'additive' 'of' f 'as' g ]" := (Additive.clone _ _ f%function g)
-  (at level 0, format "[ 'additive'  'of'  f  'as'  g ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Additive.clone instead.")]
-Notation "[ 'additive' 'of' f ]" := (Additive.clone _ _ f%function _)
-  (at level 0, format "[ 'additive'  'of'  f ]") : form_scope.
 End AdditiveExports.
 HB.export AdditiveExports.
 
@@ -2088,13 +2036,6 @@ HB.structure Definition RMorphism (R S : semiRingType) :=
 Module RMorphismExports.
 Notation "{ 'rmorphism' U -> V }" := (RMorphism.type U%type V%type)
   : type_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.RMorphism.clone instead.")]
-Notation "[ 'rmorphism' 'of' f 'as' g ]" := (RMorphism.clone _ _ f%function g)
-  (at level 0, format "[ 'rmorphism'  'of'  f  'as'  g ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.RMorphism.clone instead.")]
-Notation "[ 'rmorphism' 'of' f ]" := (RMorphism.clone _ _ f%function _)
-  (at level 0, format "[ 'rmorphism'  'of'  f ]") : form_scope.
 End RMorphismExports.
 HB.export RMorphismExports.
 
@@ -2291,9 +2232,6 @@ Notation scalar f := (linear_for *%R f).
 Module Linear.
 Section Linear.
 Variables (R : ringType) (U : lmodType R) (V : zmodType) (s : R -> V -> V).
-Definition apply_deprecated (phUV : phant (U -> V)) := @Linear.sort R U V s.
-#[deprecated(since="mathcomp 2.0", note="Use Linear.sort instead.")]
-Notation apply := apply_deprecated.
 (* Support for right-to-left rewriting with the generic linearZ rule. *)
 Local Notation mapUV := (@Linear.type R U V s).
 Definition map_class := mapUV.
@@ -2310,12 +2248,6 @@ Notation "{ 'linear' U -> V }" := {linear U%type -> V%type | *:%R}
   : type_scope.
 Notation "{ 'scalar' U }" := {linear U -> _ | *%R}
   (at level 0, format "{ 'scalar'  U }") : type_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Linear.clone instead.")]
-Notation "[ 'linear' 'of' f 'as' g ]" := (Linear.clone _ _ _ _ f%function g)
-  (at level 0, format "[ 'linear'  'of'  f  'as'  g ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Linear.clone instead.")]
-Notation "[ 'linear' 'of' f ]" := (Linear.clone _ _ _ _ f%function _)
-  (at level 0, format "[ 'linear'  'of'  f ]") : form_scope.
 (* Support for right-to-left rewriting with the generic linearZ rule. *)
 Coercion Linear.map_for_map : Linear.map_for >-> Linear.type.
 Coercion Linear.unify_map_at : Linear.map_at >-> Linear.map_for.
@@ -2490,20 +2422,10 @@ HB.structure Definition LRMorphism (R : ringType) (A : lalgType R) (B : ringType
    https://github.com/math-comp/hierarchy-builder/issues/319 is fixed *)
 
 Module LRMorphismExports.
-Module LRMorphism.
-Definition apply_deprecated (R : ringType) (A : lalgType R) (B : ringType)
-  (s : R -> B -> B) (phAB : phant (A -> B)) := @LRMorphism.sort R A B s.
-#[deprecated(since="mathcomp 2.0", note="Use LRMorphism.sort instead.")]
-Notation apply := apply_deprecated.
-End LRMorphism.
 Notation "{ 'lrmorphism' A -> B | s }" := (@LRMorphism.type _ A%type B%type s)
   : type_scope.
 Notation "{ 'lrmorphism' A -> B }" := {lrmorphism A%type -> B%type | *:%R}
   : type_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.LRMorphism.clone instead.")]
-Notation "[ 'lrmorphism' 'of' f ]" := (LRMorphism.clone _ _ _ _ f%function _)
-  (at level 0, format "[ 'lrmorphism'  'of'  f ]") : form_scope.
 End LRMorphismExports.
 HB.export LRMorphismExports.
 
@@ -2529,14 +2451,6 @@ HB.structure Definition ComSemiRing :=
 
 Module ComSemiRingExports.
 Bind Scope ring_scope with ComSemiRing.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.ComSemiRing.clone instead.")]
-Notation "[ 'comSemiRingType' 'of' T 'for' cT ]" := (ComSemiRing.clone T cT)
-  (at level 0, format "[ 'comSemiRingType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.ComSemiRing.clone instead.")]
-Notation "[ 'comSemiRingType' 'of' T ]" := (ComSemiRing.clone T _)
-  (at level 0, format "[ 'comSemiRingType'  'of'  T ]") : form_scope.
 End ComSemiRingExports.
 HB.export ComSemiRingExports.
 
@@ -2628,14 +2542,6 @@ HB.end.
 
 Module ComRingExports.
 Bind Scope ring_scope with ComRing.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.ComSemiRing.clone instead.")]
-Notation "[ 'comRingType' 'of' T 'for' cT ]" := (ComRing.clone T%type cT)
-  (at level 0, format "[ 'comRingType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.ComSemiRing.clone instead.")]
-Notation "[ 'comRingType' 'of' T ]" := (ComRing.clone T%type _)
-  (at level 0, format "[ 'comRingType'  'of'  T ]") : form_scope.
 End ComRingExports.
 HB.export ComRingExports.
 
@@ -2728,13 +2634,6 @@ HB.structure Definition Algebra (R : ringType) :=
 
 Module AlgExports.
 Bind Scope ring_scope with Algebra.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Algebra.clone instead.")]
-Notation "[ 'algType' R 'of' T 'for' cT ]" := (Algebra.clone R T%type cT)
-  (at level 0, format "[ 'algType'  R  'of'  T  'for'  cT ]")
-  : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Algebra.clone instead.")]
-Notation "[ 'algType' R 'of' T ]" := (Algebra.clone R T%type _)
-  (at level 0, format "[ 'algType'  R  'of'  T ]") : form_scope.
 End AlgExports.
 HB.export AlgExports.
 
@@ -2754,10 +2653,6 @@ HB.structure Definition ComAlgebra R := {V of ComRing V & Algebra R V}.
 
 Module ComAlgExports.
 Bind Scope ring_scope with ComAlgebra.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.ComAlgebra.clone instead.")]
-Notation "[ 'comAlgType' R 'of' T ]" := (ComAlgebra.clone R T%type _)
-  (at level 0, format "[ 'comAlgType'  R  'of'  T ]") : form_scope.
 End ComAlgExports.
 HB.export ComAlgExports.
 
@@ -2832,12 +2727,6 @@ HB.structure Definition UnitRing := {R of Ring_hasMulInverse R & Ring R}.
 
 Module UnitRingExports.
 Bind Scope ring_scope with UnitRing.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.UnitRing.clone instead.")]
-Notation "[ 'unitRingType' 'of' T 'for' cT ]" := (UnitRing.clone T%type cT)
-  (at level 0, format "[ 'unitRingType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.UnitRing.clone instead.")]
-Notation "[ 'unitRingType' 'of' T ]" := (UnitRing.clone T%type _)
-  (at level 0, format "[ 'unitRingType'  'of'  T ]") : form_scope.
 End UnitRingExports.
 HB.export UnitRingExports.
 
@@ -3119,10 +3008,6 @@ HB.structure Definition ComUnitRing := {R of ComRing R & UnitRing R}.
 
 Module ComUnitRingExports.
 Bind Scope ring_scope with ComUnitRing.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.ComUnitRing.clone instead.")]
-Notation "[ 'comUnitRingType' 'of' T ]" := (ComUnitRing.clone T%type _)
-  (at level 0, format "[ 'comUnitRingType'  'of'  T ]") : form_scope.
 End ComUnitRingExports.
 HB.export ComUnitRingExports.
 
@@ -3153,10 +3038,6 @@ HB.structure Definition UnitAlgebra R := {V of Algebra R V & UnitRing V}.
 
 Module UnitAlgebraExports.
 Bind Scope ring_scope with UnitAlgebra.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.UnitAlgebra.clone instead.")]
-Notation "[ 'unitAlgType' R 'of' T ]" := (UnitAlgebra.clone R T%type _)
-  (at level 0, format "[ 'unitAlgType'  R  'of'  T ]") : form_scope.
 End UnitAlgebraExports.
 HB.export UnitAlgebraExports.
 
@@ -3165,10 +3046,6 @@ HB.structure Definition ComUnitAlgebra R := {V of ComAlgebra R V & UnitRing V}.
 
 Module ComUnitAlgebraExports.
 Bind Scope ring_scope with UnitAlgebra.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.ComUnitAlgebra.clone instead.")]
-Notation "[ 'comUnitAlgType' R 'of' T ]" := (ComUnitAlgebra.clone R T%type _)
-  (at level 0, format "[ 'comUnitAlgType'  R  'of'  T ]") : form_scope.
 End ComUnitAlgebraExports.
 HB.export ComUnitAlgebraExports.
 
@@ -3948,14 +3825,6 @@ HB.structure Definition IntegralDomain :=
 
 Module IntegralDomainExports.
 Bind Scope ring_scope with IntegralDomain.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.IntegralDomain.clone instead.")]
-Notation "[ 'idomainType' 'of' T 'for' cT ]" := (IntegralDomain.clone T%type cT)
-  (at level 0, format "[ 'idomainType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.IntegralDomain.clone instead.")]
-Notation "[ 'idomainType' 'of' T ]" := (IntegralDomain.clone T%type _)
-  (at level 0, format "[ 'idomainType'  'of'  T ]") : form_scope.
 End IntegralDomainExports.
 HB.export IntegralDomainExports.
 
@@ -4093,12 +3962,6 @@ HB.structure Definition Field := { R of IntegralDomain R & UnitRing_isField R }.
 
 Module FieldExports.
 Bind Scope ring_scope with Field.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Field.clone instead.")]
-Notation "[ 'fieldType' 'of' T 'for' cT ]" := (Field.clone T%type cT)
-  (at level 0, format "[ 'fieldType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use GRing.Field.clone instead.")]
-Notation "[ 'fieldType' 'of' T ]" := (Field.clone T%type _)
-  (at level 0, format "[ 'fieldType'  'of'  T ]") : form_scope.
 End FieldExports.
 HB.export FieldExports.
 
@@ -4331,14 +4194,6 @@ HB.structure Definition DecidableField := { F of Field F & Field_isDecField F }.
 
 Module DecFieldExports.
 Bind Scope ring_scope with DecidableField.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.DecidableField.clone instead.")]
-Notation "[ 'decFieldType' 'of' T 'for' cT ]" := (DecidableField.clone T%type cT)
-  (at level 0, format "[ 'decFieldType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.DecidableField.clone instead.")]
-Notation "[ 'decFieldType' 'of' T ]" := (DecidableField.clone T%type _)
-  (at level 0, format "[ 'decFieldType'  'of'  T ]") : form_scope.
 End DecFieldExports.
 HB.export DecFieldExports.
 
@@ -4532,14 +4387,6 @@ HB.structure Definition ClosedField :=
 
 Module ClosedFieldExports.
 Bind Scope ring_scope with ClosedField.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.ClosedField.clone instead.")]
-Notation "[ 'closedFieldType' 'of' T 'for' cT ]" := (ClosedField.clone T%type cT)
-  (at level 0, format "[ 'closedFieldType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use GRing.ClosedField.clone instead.")]
-Notation "[ 'closedFieldType' 'of' T ]" := (ClosedField.clone T%type _)
-  (at level 0, format "[ 'closedFieldType'  'of'  T ]") : form_scope.
 End ClosedFieldExports.
 HB.export ClosedFieldExports.
 

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -150,12 +150,6 @@ Arguments ger_leVge {_} [x y] : rename.
 
 Module NumDomainExports.
 Bind Scope ring_scope with NumDomain.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use Num.NumDomain.clone instead.")]
-Notation "[ 'numDomainType' 'of' T 'for' cT ]" := (NumDomain.clone T%type cT)
-  (at level 0, format "[ 'numDomainType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Num.NumDomain.clone instead.")]
-Notation "[ 'numDomainType' 'of' T ]" := (NumDomain.clone T%type _)
-  (at level 0, format "[ 'numDomainType'  'of'  T ]") : form_scope.
 End NumDomainExports.
 HB.export NumDomainExports.
 
@@ -358,9 +352,6 @@ HB.structure Definition NumField := { R of GRing.UnitRing_isField R &
 
 Module NumFieldExports.
 Bind Scope ring_scope with NumField.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use Num.NumField.clone instead.")]
-Notation "[ 'numFieldType' 'of' T ]" := (NumField.clone T%type _)
-  (at level 0, format "[ 'numFieldType'  'of'  T ]") : form_scope.
 End NumFieldExports.
 HB.export NumFieldExports.
 
@@ -377,13 +368,6 @@ HB.structure Definition ClosedField :=
 
 Module ClosedFieldExports.
 Bind Scope ring_scope with ClosedField.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use Num.ClosedField.clone instead.")]
-Notation "[ 'numClosedFieldType' 'of' T 'for' cT ]" := (ClosedField.clone T%type cT)
-  (at level 0, format "[ 'numClosedFieldType'  'of'  T  'for' cT ]") :
-                                                         form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Num.ClosedField.clone instead.")]
-Notation "[ 'numClosedFieldType' 'of' T ]" := (ClosedField.clone T%type _)
-  (at level 0, format "[ 'numClosedFieldType'  'of'  T ]") : form_scope.
 End ClosedFieldExports.
 HB.export ClosedFieldExports.
 
@@ -393,9 +377,6 @@ HB.structure Definition RealDomain :=
 
 Module RealDomainExports.
 Bind Scope ring_scope with RealDomain.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use Num.RealDomain.clone instead.")]
-Notation "[ 'realDomainType' 'of' T ]" := (RealDomain.clone T%type _)
-  (at level 0, format "[ 'realDomainType'  'of'  T ]") : form_scope.
 End RealDomainExports.
 HB.export RealDomainExports.
 
@@ -405,9 +386,6 @@ HB.structure Definition RealField :=
 
 Module RealFieldExports.
 Bind Scope ring_scope with RealField.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use Num.RealField.clone instead.")]
-Notation "[ 'realFieldType' 'of' T ]" := (RealField.clone T%type _)
-  (at level 0, format "[ 'realFieldType'  'of'  T ]") : form_scope.
 End RealFieldExports.
 HB.export RealFieldExports.
 
@@ -421,14 +399,6 @@ HB.structure Definition RealClosedField :=
 
 Module RealClosedFieldExports.
 Bind Scope ring_scope with RealClosedField.sort.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use Num.RealClosedField.clone instead.")]
-Notation "[ 'rcfType' 'of' T 'for' cT ]" := (RealClosedField.clone T%type cT)
-  (at level 0, format "[ 'rcfType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use Num.RealClosedField.clone instead.")]
-Notation "[ 'rcfType' 'of' T ]" :=  (RealClosedField.clone T%type _)
-  (at level 0, format "[ 'rcfType'  'of'  T ]") : form_scope.
 End RealClosedFieldExports.
 HB.export RealClosedFieldExports.
 
@@ -473,14 +443,6 @@ Module ArchiFieldExports.
 Bind Scope ring_scope with ArchiField.sort.
 #[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
 Notation archiFieldType := archiFieldType (only parsing).
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use Num.ArchiField.clone instead.")]
-Notation "[ 'archiFieldType' 'of' T 'for' cT ]" := (ArchiField.clone T%type cT)
-  (at level 0, format "[ 'archiFieldType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use Num.ArchiField.clone instead.")]
-Notation "[ 'archiFieldType' 'of' T ]" := (ArchiField.clone T%type _)
-  (at level 0, format "[ 'archiFieldType'  'of'  T ]") : form_scope.
 End ArchiFieldExports.
 HB.export ArchiFieldExports.
 

--- a/mathcomp/algebra/vector.v
+++ b/mathcomp/algebra/vector.v
@@ -148,12 +148,6 @@ End OtherDefs.
 
 Module Import VectorExports.
 Bind Scope ring_scope with Vector.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use Vector.clone instead.")]
-Notation "[ 'vectType' R 'of' T 'for' cT ]" := (Vector.clone R T%type cT)
-  (at level 0, format "[ 'vectType'  R  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Vector.clone instead.")]
-Notation "[ 'vectType' R 'of' T ]" := (Vector.clone R T%type _)
-  (at level 0, format "[ 'vectType'  R  'of'  T ]") : form_scope.
 
 Arguments space [K] vT%type.
 

--- a/mathcomp/field/falgebra.v
+++ b/mathcomp/field/falgebra.v
@@ -132,14 +132,6 @@ HB.end.
 
 Module FalgebraExports.
 Bind Scope ring_scope with sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use Falgebra.clone instead.")]
-Notation "[ 'FalgType' F 'of' L ]" := (Falgebra.clone F L%type _)
-  (at level 0, format "[ 'FalgType'  F  'of'  L ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Falgebra.clone instead.")]
-Notation "[ 'FalgType' F 'of' L 'for' L' ]" := (Falgebra.clone F L%type L')
-  (at level 0, format "[ 'FalgType'  F  'of'  L  'for'  L' ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Algebra_isFalgebra.Build instead.")]
-Notation FalgUnitRingType T := (Algebra_isFalgebra.Build _ T).
 End FalgebraExports.
 HB.export FalgebraExports.
 

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -86,12 +86,6 @@ HB.structure Definition FieldExt (R : ringType) := {T of Falgebra R T &
 
 Module FieldExtExports.
 Bind Scope ring_scope with FieldExt.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use FieldExt.clone instead.")]
-Notation "[ 'fieldExtType' F 'of' L ]" := (FieldExt.clone F L%type _)
-  (at level 0, format "[ 'fieldExtType'  F  'of'  L ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use FieldExt.clone instead.")]
-Notation "[ 'fieldExtType' F 'of' L 'for' K ]" := (FieldExt.clone F L%type K)
-  (at level 0, format "[ 'fieldExtType'  F  'of'  L  'for'  K ]") : form_scope.
 Notation "{ 'subfield' L }" := (aspace L)
   (* NB: was (@aspace_of _ (FalgType _) (Phant L)) *)
   (at level 0, format "{ 'subfield'  L }") : type_scope.

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -363,15 +363,6 @@ HB.structure Definition SplittingField F :=
 
 Module SplittingFieldExports.
 Bind Scope ring_scope with SplittingField.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use SplittingField.clone instead.")]
-Notation "[ 'splittingFieldType' F 'of' L 'for' K ]" :=
-  (SplittingField.clone F L%type K)
-  (at level 0, format "[ 'splittingFieldType'  F  'of'  L  'for'  K ]")
-  : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use SplittingField.clone instead.")]
-Notation "[ 'splittingFieldType' F 'of' L ]" :=
-  (SplittingField.clone F L%type _)
-  (at level 0, format "[ 'splittingFieldType'  F  'of'  L ]") : form_scope.
 End SplittingFieldExports.
 HB.export SplittingFieldExports.
 

--- a/mathcomp/fingroup/fingroup.v
+++ b/mathcomp/fingroup/fingroup.v
@@ -231,9 +231,6 @@ HB.structure Definition BaseFinGroup := { G of isMulBaseGroup G & Finite G }.
 Module BaseFinGroupExports.
 Bind Scope group_scope with BaseFinGroup.arg_sort.
 Bind Scope group_scope with BaseFinGroup.sort.
-#[deprecated(since="mathcomp 2.0.0", note="Use BaseFinGroup.clone instead.")]
-Notation "[ 'baseFinGroupType' 'of' T ]" := (@BaseFinGroup.clone T%type _)
-  (at level 0, format "[ 'baseFinGroupType'  'of'  T ]") : form_scope.
 End BaseFinGroupExports.
 HB.export BaseFinGroupExports.
 
@@ -268,9 +265,6 @@ HB.structure Definition FinGroup :=
   { G of BaseFinGroup_isGroup G & BaseFinGroup G }.
 
 Module FinGroupExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinGroup.clone instead.")]
-Notation "[ 'finGroupType' 'of' T ]" := (@FinGroup.clone T%type _)
-  (at level 0, format "[ 'finGroupType'  'of'  T ]") : form_scope.
 Bind Scope group_scope with FinGroup.sort.
 End FinGroupExports.
 HB.export FinGroupExports.

--- a/mathcomp/ssreflect/choice.v
+++ b/mathcomp/ssreflect/choice.v
@@ -303,16 +303,6 @@ Module Export ChoiceNamespace.
   End Choice.
 End ChoiceNamespace.
 
-#[deprecated(since="mathcomp 2.0.0", note="Use Choice.on instead.")]
-Notation "[ 'hasChoice' 'of' T ]" := (Choice.on _ : hasChoice T%type)
-  (at level 0, format "[ 'hasChoice'  'of'  T ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Choice.clone instead.")]
-Notation "[ 'choiceType' 'of' T 'for' C ]" := (Choice.clone T%type C)
-  (at level 0, format "[ 'choiceType'  'of'  T  'for'  C ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Choice.clone instead.")]
-Notation "[ 'choiceType' 'of' T ]" := (Choice.clone T%type _)
-  (at level 0, format "[ 'choiceType'  'of'  T ]") : form_scope.
-
 Section ChoiceTheory.
 
 Implicit Type T : choiceType.
@@ -492,10 +482,6 @@ HB.instance Definition _ T :=
   Choice.copy (GenTree.tree T) (pcan_type (GenTree.codeK T)).
 
 End ChoiceTheory.
-#[deprecated(since="mathcomp 2.0.0", note="Use Choice.copy with can_type or CanHasChoice.")]
-Notation CanChoiceMixin := CanHasChoice.
-#[deprecated(since="mathcomp 2.0.0", note="Use Choice.copy with pcan_type or PCanHasChoice.")]
-Notation PcanChoiceMixin := PCanHasChoice.
 
 #[short(type="subChoiceType")]
 HB.structure Definition SubChoice T (P : pred T) :=
@@ -504,9 +490,6 @@ HB.structure Definition SubChoice T (P : pred T) :=
 Prenex Implicits xchoose choose.
 Notation "[ 'Choice' 'of' T 'by' <: ]" := (Choice.copy T%type (sub_type T%type))
   (at level 0, format "[ 'Choice'  'of'  T  'by'  <: ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use [Choice of _ by <:] instead.")]
-Notation "[ 'choiceMixin' 'of' T 'by' <: ]" := [Choice of T%type by <:]
-  (at level 0, format "[ 'choiceMixin'  'of'  T  'by'  <: ]") : form_scope.
 
 HB.instance Definition _ (T : choiceType) (P : pred T) :=
   [Choice of {x | P x} by <:].
@@ -520,16 +503,6 @@ Arguments Choice_isCountable.axioms_ T%type_scope.
 
 #[short(type="countType")]
 HB.structure Definition Countable := { T of Choice T & Choice_isCountable T }.
-
-#[deprecated(since="mathcomp 2.0.0", note="Use Countable.on instead.")]
-Notation "[ 'isCountable' 'of' T ]" := (Countable.on T%type : Choice_isCountable T%type)
-  (at level 0, format "[ 'isCountable'  'of'  T ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Countable.clone instead.")]
-Notation "[ 'countType' 'of' T 'for' cT ]" := (Countable.clone T%type cT)
-(at level 0, format "[ 'countType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Countable.clone instead.")]
-Notation "[ 'countType' 'of' T ]" := (Countable.clone T%type _)
-  (at level 0, format "[ 'countType'  'of'  T ]") : form_scope.
 
 HB.factory Record isCountable (T : Type) : Type := {
   pickle : T -> nat;
@@ -584,17 +557,10 @@ Proof. by move=> s; rewrite /unpickle_seq CodeSeq.codeK (map_pK pickleK). Qed.
 HB.instance Definition _ := isCountable.Build (seq T) pickle_seqK.
 
 End CountableTheory.
-#[deprecated(since="mathcomp 2.0.0", note="Use Countable.copy with can_type or CanIsCountable.")]
-Notation CanCountMixin := CanIsCountable.
-#[deprecated(since="mathcomp 2.0.0", note="Use Countable.copy with pcan_type or PCanIsCountable")]
-Notation PcanCountMixin := PCanIsCountable.
 
 Notation "[ 'Countable' 'of' T 'by' <: ]" :=
     (Countable.copy T%type (sub_type T%type))
   (at level 0, format "[ 'Countable'  'of'  T  'by'  <: ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use [Countable of _ by <:] instead.")]
-Notation "[ 'countMixin' 'of' T 'by' <: ]" := [Countable of T%type by <:]
-  (at level 0, format "[ 'countMixin'  'of'  T  'by'  <: ]") : form_scope.
 
 Arguments pickle_inv {T} n.
 Arguments pickleK {T} x : rename.
@@ -604,11 +570,6 @@ Arguments pickle_invK {T} n : rename.
 #[short(type="subCountType")]
 HB.structure Definition SubCountable T (P : pred T) :=
   { sT of Countable sT & isSub T P sT}.
-
-(* This assumes that T has both countType and subType structures. *)
-#[deprecated(since="mathcomp 2.0.0", note="Use SubCountable.clone instead.")]
-Notation "[ 'subCountType' 'of' T ]" := (SubCountable.clone _ _ T%type _)
-  (at level 0, format "[ 'subCountType'  'of'  T ]") : form_scope.
 
 Section TagCountType.
 

--- a/mathcomp/ssreflect/eqtype.v
+++ b/mathcomp/ssreflect/eqtype.v
@@ -139,13 +139,6 @@ HB.mixin Record hasDecEq T := { eq_op : rel T; eqP : eq_axiom eq_op }.
 #[mathcomp(axiom="eq_axiom"), short(type="eqType")]
 HB.structure Definition Equality := { T of hasDecEq T }.
 
-#[deprecated(since="mathcomp 2.0.0", note="Use Equality.clone instead.")]
-Notation "[ 'eqType' 'of' T 'for' C ]" := (Equality.clone T%type C)
-  (at level 0, format "[ 'eqType'  'of'  T  'for'  C ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Equality.clone instead.")]
-Notation "[ 'eqType' 'of' T ]" := (Equality.clone T%type _)
-  (at level 0, format "[ 'eqType'  'of'  T ]") : form_scope.
-
 (* eqE is a generic lemma that can be used to fold back recursive comparisons *)
 (* after using partial evaluation to simplify comparisons on concrete         *)
 (* instances. The eqE lemma can be used e.g. like so: rewrite !eqE /= -!eqE.  *)
@@ -570,9 +563,6 @@ Notation val := (isSub.val_subdef (SubType.on _)).
 Notation "\val" := (isSub.val_subdef (SubType.on _)) (only parsing).
 Notation "\val" := (isSub.val_subdef _) (only printing).
 
-#[deprecated(since="mathcomp 2.0.0", note="Use Sub instead.")]
-Notation sub := Sub.
-
 #[short(type="subEqType")]
 HB.structure Definition SubEquality T (P : pred T) :=
   { sT of Equality sT & isSub T P sT}.
@@ -663,13 +653,6 @@ Qed.
 End Theory.
 
 End SubType.
-
-#[deprecated(since="mathcomp 2.0.0", note="Use SubK instead.")]
-Notation subK := SubK.
-#[deprecated(since="mathcomp 2.0.0", note="Use Sub_spec instead.")]
-Notation sub_spec := Sub_spec.
-#[deprecated(since="mathcomp 2.0.0", note="Use SubP instead.")]
-Notation subP := SubP.
 
 (* Arguments val {T P sT} u : rename. *)
 Arguments Sub {T P sT} x Px : rename.
@@ -792,16 +775,6 @@ Definition deprecated_CanEqMixin g (fK : cancel f g) :=
 
 End TransferEqType.
 
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use Equality.copy T (inj_type f_inj) instead")]
-Notation InjEqMixin := deprecated_InjEqMixin.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use Equality.copy T (pcan_type fK) instead")]
-Notation PcanEqMixin := deprecated_PcanEqMixin.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use Equality.copy T (can_type fK) instead")]
-Notation CanEqMixin := deprecated_CanEqMixin.
-
 Definition sub_type T (P : pred T) (sT : subType P) : Type := sT.
 HB.instance Definition _ T (P : pred T) (sT : subType P) :=
   SubType.on (sub_type sT).
@@ -825,9 +798,6 @@ Arguments val_eqP {T P sT x y}.
 
 Notation "[ 'Equality' 'of' T 'by' <: ]" := (Equality.copy T%type (sub_type T%type))
   (at level 0, format "[ 'Equality'  'of'  T  'by'  <: ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use [Equality of _ by <:] instead.")]
-Notation "[ 'eqMixin' 'of' T 'by' <: ]" := [Equality of T%type by <:]
-  (at level 0, format "[ 'eqMixin'  'of'  T  'by'  <: ]") : form_scope.
 
 HB.instance Definition _ := Equality.copy void (pcan_type (of_voidK unit)).
 HB.instance Definition _ (T : eqType) (P : pred T) :=

--- a/mathcomp/ssreflect/fintype.v
+++ b/mathcomp/ssreflect/fintype.v
@@ -179,19 +179,12 @@ Module Finite.
 HB.lock Definition enum T := isFinite.enum_subdef (Finite.class T).
 
 Notation axiom := finite_axiom.
-#[deprecated(since="mathcomp 2.0.0", note="Use isFinite.Build instead.")]
-Notation EnumMixin m := (@isFinite.Build _ _ m).
 
 Lemma uniq_enumP (T : eqType) e : uniq e -> e =i T -> axiom e.
 Proof. by move=> Ue sT x; rewrite count_uniq_mem ?sT. Qed.
 
 Section WithCountType.
-Variable (T : countType).
-
-Definition UniqMixin_deprecated e Ue (eT : e =i T) :=
-  @isFinite.Build T e (uniq_enumP Ue eT).
-
-Variable n : nat.
+Variable (T : countType) (n : nat).
 
 Definition count_enum := pmap (@pickle_inv T) (iota 0 n).
 
@@ -203,15 +196,7 @@ apply: uniq_enumP (pmap_uniq (@pickle_invK T) (iota_uniq _ _)) _ => x.
 by rewrite mem_pmap -pickleK_inv map_f // mem_iota ubT.
 Qed.
 
-Definition CountMixin_deprecated := @isFinite.Build _ _ count_enumP.
-
 End WithCountType.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use isFinite.Build and Finite.uniq_enumP instead.")]
-Notation UniqMixin := UniqMixin_deprecated.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use isFinite.Build and Finite.count_enumP instead.")]
-Notation CountMixin := CountMixin_deprecated.
 End Finite.
 Canonical finEnum_unlock := Unlockable Finite.enum.unlock.
 End FiniteNES.
@@ -239,18 +224,6 @@ HB.instance Definition _ := isCountable.Build fT fin_pickleK.
 HB.instance Definition _ := isFinite.Build fT f.
 
 End CanonicalFinType.
-
-#[deprecated(since="mathcomp 2.0.0", note="Use isFinite.Build instead.")]
-Notation FinMixin x := (@isFinite.Build _ _ x).
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use isFinite.Build with Finite.uniq_enumP instead.")]
-Notation UniqFinMixin := Finite.UniqMixin_deprecated.
-#[deprecated(since="mathcomp 2.0.0", note="Use Finite.clone instead.")]
-Notation "[ 'finType' 'of' T 'for' cT ]" := (Finite.clone T%type cT)
-  (at level 0, format "[ 'finType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Finite.clone instead.")]
-Notation "[ 'finType' 'of' T ]" := (Finite.clone T%type _)
-  (at level 0, format "[ 'finType'  'of'  T ]") : form_scope.
 
 (* Workaround for the silly syntactic uniformity restriction on coercions;    *)
 (* this avoids a cross-dependency between finset.v and prime.v for the        *)
@@ -1443,13 +1416,6 @@ Definition CanIsFinite g (fK : cancel f g) := PCanIsFinite (can_pcan fK).
 
 End TransferFinTypeFromCount.
 
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use pcan_type instead or PCanIsFInite.")]
-Notation PcanFinMixin := PCanIsFinite.
-#[deprecated(since="mathcomp 2.0.0",
-  note="Use can_type instead or CanIsFinite.")]
-Notation CanFinMixin := CanIsFinite.
-
 Section TransferFinType.
 
 Variables (eT : Type) (fT : finType) (f : eT -> fT).
@@ -1479,10 +1445,6 @@ by apply/codomP/idP=> [[u ->]|Px]; last exists (Sub x Px); rewrite ?valP ?SubK.
 Qed.
 
 End SubFinType.
-
-#[deprecated(since="mathcomp 2.0.0", note="Use SubFinite.clone instead.")]
-Notation "[ 'subFinType' 'of' T ]" := (SubFinite.clone _ _ T%type _)
-  (at level 0, format "[ 'subFinType'  'of'  T ]") : form_scope.
 
 HB.factory Record SubCountable_isFinite (T : finType) P (sT : Type)
   of SubCountable T P sT := { }.
@@ -1516,9 +1478,6 @@ HB.instance Definition _ (T : finType) (P : pred T) (sT : subType P) :=
 
 Notation "[ 'Finite' 'of' T 'by' <: ]" := (Finite.copy T%type (sub_type T%type))
   (at level 0, format "[ 'Finite'  'of'  T  'by'  <: ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use [Finite of _ by <:] instead.")]
-Notation "[ 'finMixin' 'of' T 'by' <: ]" := [Finite of T%type by <:]
-  (at level 0, format "[ 'finMixin'  'of'  T  'by'  <: ]") : form_scope.
 
 Section SubCountable_isFiniteTheory.
 

--- a/mathcomp/ssreflect/generic_quotient.v
+++ b/mathcomp/ssreflect/generic_quotient.v
@@ -173,10 +173,6 @@ Canonical mpi_unlock := Unlockable mpi.unlock.
 Canonical pi_unlock := Unlockable pi.unlock.
 Canonical repr_unlock := Unlockable repr.unlock.
 
-#[deprecated(since="mathcomp 2.0.0", note="Use Quotient.clone instead.")]
-Notation "[ 'quotType' 'of' Q ]" := (Quotient.clone _ Q%type _)
- (at level 0, format "[ 'quotType'  'of'  Q ]") : form_scope.
-
 Arguments repr {T qT} x.
 
 (************************)
@@ -314,10 +310,6 @@ HB.structure Definition EqQuotient T eq_quot_op :=
 
 Canonical pi_eq_quot_mono T eq_quot_op eqT :=
   PiMono2 (@pi_eq_quot T eq_quot_op eqT).
-
-#[deprecated(since="mathcomp 2.0.0", note="Use EqQuotient.clone instead.")]
-Notation "[ 'eqQuotType' e 'of' Q ]" := (EqQuotient.clone _ e Q%type _)
- (at level 0, format "[ 'eqQuotType'  e  'of'  Q ]") : form_scope.
 
 (**************************************************************************)
 (* Even if a quotType is a natural subType, we do not make this subType   *)

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -1138,20 +1138,6 @@ HB.end.
 
 Module POrderExports.
 Arguments le_trans {d s} [_ _ _].
-#[deprecated(since="mathcomp 2.0.0", note="Use POrder.clone instead.")]
-Notation "[ 'porderType' 'of' T 'for' cT ]" := (POrder.clone _ T%type cT)
-  (at level 0, format "[ 'porderType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use POrder.clone instead.")]
-Notation "[ 'porderType' 'of' T 'for' cT 'with' disp ]" :=
-  (POrder.clone disp T%type cT)
-  (at level 0, format "[ 'porderType'  'of'  T  'for'  cT  'with'  disp ]") :
-  form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use POrder.clone instead.")]
-Notation "[ 'porderType' 'of' T ]" := (POrder.clone _ T%type _)
-  (at level 0, format "[ 'porderType'  'of'  T ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use POrder.clone instead.")]
-Notation "[ 'porderType' 'of' T 'with' disp ]" := (POrder.clone disp T%type _)
-  (at level 0, format "[ 'porderType'  'of'  T  'with' disp ]") : form_scope.
 End POrderExports.
 HB.export POrderExports.
 (* Bind Scope order_scope with POrder.sort. *)
@@ -1388,24 +1374,6 @@ HB.mixin Record POrder_isLattice d (T : Type) of POrder d T := {
 HB.structure Definition Lattice d :=
   { T of POrder_isLattice d T & POrder d T }.
 
-Module LatticeExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use Lattice.clone instead.")]
-Notation "[ 'latticeType' 'of' T 'for' cT ]" := (Lattice.clone _ T%type cT)
-  (at level 0, format "[ 'latticeType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Lattice.clone instead.")]
-Notation "[ 'latticeType' 'of' T 'for' cT 'with' disp ]" :=
-  (Lattice.clone disp T%type cT)
-  (at level 0, format "[ 'latticeType'  'of'  T  'for'  cT  'with'  disp ]") :
-  form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Lattice.clone instead.")]
-Notation "[ 'latticeType' 'of' T ]" := (Lattice.clone _ T%type _)
-  (at level 0, format "[ 'latticeType'  'of'  T ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use Lattice.clone instead.")]
-Notation "[ 'latticeType' 'of' T 'with' disp ]" := (Lattice.clone disp T%type _)
-  (at level 0, format "[ 'latticeType'  'of'  T  'with' disp ]") : form_scope.
-End LatticeExports.
-HB.export LatticeExports.
-
 Section LatticeDef.
 Context {disp : unit} {T : latticeType disp}.
 
@@ -1461,16 +1429,6 @@ HB.mixin Record hasBottom d (T : Type) of POrder d T := {
 HB.structure Definition BPOrder d := { T of hasBottom d T & POrder d T }.
 #[short(type="bLatticeType")]
 HB.structure Definition BLattice d := { T of hasBottom d T & Lattice d T }.
-
-Module BLatticeExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use BLattice.clone instead.")]
-Notation "[ 'bLatticeType' 'of' T 'for' cT ]" := (BLattice.clone _ T%type cT)
-  (at level 0, format "[ 'bLatticeType'  'of'  T  'for'  cT ]") : form_scope.
-#[deprecated(since="mathcomp 2.0.0", note="Use BLattice.clone instead.")]
-Notation "[ 'bLatticeType' 'of' T ]" := (BLattice.clone _ T%type _)
-  (at level 0, format "[ 'bLatticeType'  'of'  T ]") : form_scope.
-End BLatticeExports.
-HB.export BLatticeExports.
 
 Module BLatticeSyntax.
 Notation "\bot" := bottom : order_scope.
@@ -1561,23 +1519,9 @@ HB.structure Definition DistrLattice d :=
 HB.structure Definition BDistrLattice d :=
   { T of hasBottom d T & DistrLattice d T}.
 
-Module BDistrLatticeExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use BDistrLattice.clone instead.")]
-Notation "[ 'bDistrLatticeType' 'of' T ]" := (BDistrLattice.clone _ T%type _)
-  (at level 0, format "[ 'bDistrLatticeType'  'of'  T ]") : form_scope.
-End BDistrLatticeExports.
-HB.export BDistrLatticeExports.
-
 #[short(type="tbDistrLatticeType")]
 HB.structure Definition TBDistrLattice d :=
   { T of TBLattice d T & BDistrLattice d T }.
-
-Module TBDistrLatticeExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use TBDistrLattice.clone instead.")]
-Notation "[ 'tbDistrLatticeType' 'of' T ]" := (TBDistrLattice.clone _ T%type _)
-  (at level 0, format "[ 'tbDistrLatticeType'  'of'  T ]") : form_scope.
-End TBDistrLatticeExports.
-HB.export TBDistrLatticeExports.
 
 #[key="T"]
 HB.mixin Record hasRelativeComplement d (T : Type) of BDistrLattice d T := {
@@ -1589,11 +1533,6 @@ HB.mixin Record hasRelativeComplement d (T : Type) of BDistrLattice d T := {
 #[short(type="cbDistrLatticeType")]
 HB.structure Definition CBDistrLattice d :=
   { T of hasRelativeComplement d T & BDistrLattice d T }.
-
-#[deprecated(since="mathcomp 2.0.0", note="Use diff instead.")]
-Notation sub := diff.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffKI instead.")]
-Notation subKI := diffKI.
 
 Module Import CBDistrLatticeSyntax.
 Notation "x `\` y" := (diff x y) : order_scope.
@@ -1628,55 +1567,20 @@ HB.structure Definition Total d :=
 #[short(type="finPOrderType")]
 HB.structure Definition FinPOrder d := { T of Finite T & POrder d T }.
 
-Module FinPOrderExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use BLattice.clone instead.")]
-Notation "[ 'finPOrderType' 'of' T ]" := (FinPOrder.clone _ T%type _ )
-  (at level 0, format "[ 'finPOrderType'  'of'  T ]") : form_scope.
-End FinPOrderExports.
-HB.export FinPOrderExports.
-
 #[short(type="finLatticeType")]
 HB.structure Definition FinLattice d := { T of Finite T & TBLattice d T }. (* FIXME *)
-
-Module FinLatticeExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinLattice.clone instead.")]
-Notation "[ 'finLatticeType' 'of' T ]" := (FinLattice.clone _ T%type _ )
-  (at level 0, format "[ 'finLatticeType'  'of'  T ]") : form_scope.
-End FinLatticeExports.
-HB.export FinLatticeExports.
 
 #[short(type="finDistrLatticeType")]
 HB.structure Definition FinDistrLattice d :=
   { T of Finite T & TBDistrLattice d T }.
 
-Module FinDistrLatticeExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinDistrLattice.clone instead.")]
-Notation "[ 'finDistrLatticeType' 'of' T ]" := (FinDistrLattice.clone _ T%type _ )
-  (at level 0, format "[ 'finDistrLatticeType'  'of'  T ]") : form_scope.
-End FinDistrLatticeExports.
-HB.export FinDistrLatticeExports.
-
 #[short(type="finCDistrLatticeType")]
 HB.structure Definition FinCDistrLattice d :=
   { T of Finite T & CTBDistrLattice d T }.
 
-Module FinCDistrLatticeExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinCDistrLattice.clone instead.")]
-Notation "[ 'finCDistrLatticeType' 'of' T ]" := (FinCDistrLattice.clone _ T%type _ )
-  (at level 0, format "[ 'finCDistrLatticeType'  'of'  T ]") : form_scope.
-End FinCDistrLatticeExports.
-HB.export FinCDistrLatticeExports.
-
 #[short(type="finOrderType")]
 HB.structure Definition FinTotal d :=
   { T of Total d T & FinDistrLattice d T }.
-
-Module FinTotalExports.
-#[deprecated(since="mathcomp 2.0.0", note="Use FinTotal.clone instead.")]
-Notation "[ 'finOrderType' 'of' T ]" := (FinTotal.clone _ T%type _ )
-  (at level 0, format "[ 'finOrderType'  'of'  T ]") : form_scope.
-End FinTotalExports.
-HB.export FinTotalExports.
 
 (********)
 (* DUAL *)
@@ -4196,8 +4100,6 @@ Proof. exact: diffKI. Qed.
 
 Lemma diffIK x y : (x `\` y) `&` y = \bot.
 Proof. by rewrite meetC diffKI. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffIK instead.")]
-Notation subIK := diffIK.
 
 Lemma meetIB z x y : (z `&` y) `&` (x `\` y) = \bot.
 Proof. by rewrite -meetA diffKI meetx0. Qed.
@@ -4222,8 +4124,6 @@ Proof. by rewrite -{2}[x](joinIB y) lexU2 // lexx orbT. Qed.
 Hint Resolve leBx : core.
 
 Lemma diffxx x : x `\` x = \bot. Proof. by have := diffKI x x; rewrite meet_r. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffxx instead.")]
-Notation subxx := diffxx.
 
 Lemma leBl z x y : x <= y -> x `\` z <= y `\` z.
 Proof.
@@ -4236,13 +4136,9 @@ Proof.
 apply/eqP; rewrite eq_le leU2 //= leUx leUl.
 by apply/meet_idPl; have := joinIB y x; rewrite joinIl join_l.
 Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffKU instead.")]
-Notation subKU := diffKU.
 
 Lemma diffUK y x : (x `\` y) `|` y = x `|` y.
 Proof. by rewrite joinC diffKU joinC. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffUK instead.")]
-Notation subUK := diffUK.
 
 Lemma leBKU y x : y <= x -> y `|` (x `\` y) = x.
 Proof. by move=> /join_r {2}<-; rewrite diffKU. Qed.
@@ -4261,13 +4157,9 @@ Proof.
 apply/eqP; rewrite eq_le leUx !leBl ?leUr ?leUl ?andbT //.
 by rewrite leBLR joinA diffKU joinAC diffKU joinAC -joinA leUr.
 Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffUx instead.")]
-Notation subUx := diffUx.
 
 Lemma diff_eq0 x y : (x `\` y == \bot) = (x <= y).
 Proof. by rewrite -lex0 leBLR joinx0. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diff_eq0 instead.")]
-Notation sub_eq0 := diff_eq0.
 
 Lemma joinxB x y z : x `|` (y `\` z) = ((x `|` y) `\` z) `|` (x `&` z).
 Proof. by rewrite diffUx joinAC joinBI. Qed.
@@ -4286,8 +4178,6 @@ Proof.
 move=> xz; apply/idP/idP; last by move=> /meet_r <-; rewrite -meetA meetBI.
 by move=> /eqP xIy_eq0; rewrite -[x](joinIB y) xIy_eq0 join0x leBl.
 Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use meet_eq0E_sub instead.")]
-Notation meet_eq0E_sub := meet_eq0E_diff.
 
 Lemma leBRL x y z : (x <= z `\` y) = (x <= z) && (x `&` y == \bot).
 Proof.
@@ -4297,8 +4187,6 @@ Qed.
 
 Lemma eq_diff x y z : (x `\` y == z) = (z <= x <= y `|` z) && (z `&` y == \bot).
 Proof. by rewrite eq_le leBLR leBRL andbCA andbA. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use eq_sub instead.")]
-Notation eq_sub := eq_diff.
 
 Lemma diffxU x y z : z `\` (x `|` y) = (z `\` x) `&` (z `\` y).
 Proof.
@@ -4306,26 +4194,18 @@ apply/eqP; rewrite eq_le lexI !leBr ?leUl ?leUr //=.
 rewrite leBRL leIx2 ?leBx //= meetUr meetAC diffIK -meetA diffIK.
 by rewrite meet0x meetx0 joinx0.
 Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffxU instead.")]
-Notation subxU := diffxU.
 
 Lemma diffx0 x : x `\` \bot = x.
 Proof. by apply/eqP; rewrite eq_diff join0x meetx0 lexx eqxx. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffx0 instead.")]
-Notation subx0 := diffx0.
 
 Lemma diff0x x : \bot `\` x = \bot.
 Proof. by apply/eqP; rewrite eq_diff joinx0 meet0x lexx eqxx le0x. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diff0x instead.")]
-Notation sub0x := diff0x.
 
 Lemma diffIx x y z : (x `&` y) `\` z = (x `\` z) `&` (y `\` z).
 Proof.
 apply/eqP; rewrite eq_diff joinIr ?leI2 ?diffKU ?leUr ?leBx //=.
 by rewrite -meetA diffIK meetx0.
 Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffIx instead.")]
-Notation subIx := diffIx.
 
 Lemma meetxB x y z : x `&` (y `\` z) = (x `&` y) `\` z.
 Proof. by rewrite diffIx -{1}[x](joinBI z) meetUl meetIB joinx0. Qed.
@@ -4339,24 +4219,18 @@ apply/eqP; rewrite eq_diff leUx !leBx //= joinIl joinA joinCA !diffKU.
 rewrite joinCA -joinA [_ `|` x]joinC ![x `|` _]join_l //.
 by rewrite -joinIl leUr /= meetUl {1}[_ `&` z]meetC ?meetBI joinx0.
 Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffxI instead.")]
-Notation subxI := diffxI.
 
 Lemma diffBx x y z : (x `\` y) `\` z = x `\` (y `|` z).
 Proof.
 apply/eqP; rewrite eq_diff leBr ?leUl //=.
 by rewrite diffxU joinIr diffKU -joinIr meet_l ?leUr //= -meetA diffIK meetx0.
 Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffBx instead.")]
-Notation subBx := diffBx.
 
 Lemma diffxB x y z : x `\` (y `\` z) = (x `\` y) `|` (x `&` z).
 Proof.
 rewrite -[y in RHS](joinIB z) diffxU joinIl diffxI -joinA joinBI join_r //.
 by rewrite joinBx meetKU meetA meetAC diffIK meet0x joinx0 meet_r.
 Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffxB instead.")]
-Notation subxB := diffxB.
 
 Lemma joinBK x y : (y `|` x) `\` x = (y `\` x).
 Proof. by rewrite diffUx diffxx joinx0. Qed.
@@ -4372,13 +4246,9 @@ Proof. by rewrite meetC => /disj_le. Qed.
 
 Lemma disj_diffl x y : x `&` y == \bot -> x `\` y = x.
 Proof. by move=> dxy; apply/eqP; rewrite eq_diff dxy lexx leUr. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use disj_diffl instead.")]
-Notation disj_subl := disj_diffl.
 
 Lemma disj_diffr x y : x `&` y == \bot -> y `\` x = y.
 Proof. by rewrite meetC => /disj_diffl. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use disj_diffr instead.")]
-Notation disj_subr := disj_diffr.
 
 Lemma lt0B x y : x < y -> \bot < y `\` x.
 Proof. by move=> ?; rewrite lt_leAnge le0x leBLR joinx0 /= lt_geF. Qed.
@@ -4398,13 +4268,9 @@ Proof. exact: complE. Qed.
 
 Lemma diff1x x : \top `\` x = ~` x.
 Proof. by rewrite complE. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diff1x instead.")]
-Notation sub1x := diff1x.
 
 Lemma diffE x y : x `\` y = x `&` ~` y.
 Proof. by rewrite complE meetxB meetx1. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffE instead.")]
-Notation subE := diffE.
 
 Lemma complK : involutive (@compl _ L).
 Proof. by move=> x; rewrite !complE diffxB diffxx meet1x join0x. Qed.
@@ -4840,11 +4706,6 @@ End CancelPartial.
 Notation PCanIsPartial := CancelPartial.Pcan.
 Notation CanIsPartial := CancelPartial.Can.
 
-#[deprecated(since="mathcomp 2.0.0", note="Use PCanIsPartial.")]
-Notation PcanPartial := CancelPartial.Pcan.
-#[deprecated(since="mathcomp 2.0.0", note="Use CanIsPartial.")]
-Notation CanPartial := CancelPartial.Can.
-
 #[export]
 HB.instance Definition _ (disp : unit) (T : choiceType)
   (disp' : unit) (T' : porderType disp') (f : T -> T')
@@ -4887,11 +4748,6 @@ Definition CanIsTotal : DistrLattice_isTotal _ (can_type f_can) :=
 
 End Can.
 End CancelTotal.
-
-#[deprecated(since="mathcomp 2.0.0", note="Use PCanIsTotal.")]
-Notation PcanTotal := PCanIsTotal.
-#[deprecated(since="mathcomp 2.0.0", note="Use CanIsTotal.")]
-Notation CanTotal := CanIsTotal.
 
 HB.factory Record IsoLattice disp T of POrder disp T := {
   disp' : unit;
@@ -4946,24 +4802,6 @@ Proof. by move=> x y z; rewrite /meet /join /= !f'_can meetUl. Qed.
 HB.instance Definition _ := Lattice_Meet_isDistrLattice.Build _ T meetUl.
 
 HB.end.
-
-Module CanExports.
-#[deprecated(since="mathcomp 2.0.0", note="use Order.MonoTotal instead.")]
-Notation MonoTotalMixin d T := (MonoTotal d T).
-#[deprecated(since="mathcomp 2.0.0", note="use Order.PCanIsPartial instead.")]
-Notation PcanPOrderMixin := CancelPartial.Pcan.
-#[deprecated(since="mathcomp 2.0.0", note="use Order.CanIsPartial instead.")]
-Notation CanPOrderMixin := CancelPartial.Can.
-#[deprecated(since="mathcomp 2.0.0", note="use Order.PCanIsTotal instead.")]
-Notation PcanOrderMixin := PCanIsTotal.
-#[deprecated(since="mathcomp 2.0.0", note="use Order.CanIsTotal instead.")]
-Notation CanOrderMixin := CanIsTotal.
-#[deprecated(since="mathcomp 2.0.0", note="use Order.IsoLattice instead.")]
-Notation IsoLatticeMixin d T := (IsoLattice d T).
-#[deprecated(since="mathcomp 2.0.0", note="use Order.IsoDistrLattice instead.")]
-Notation IsoDistrLatticeMixin d T := (IsoDistrLattice d T).
-End CanExports.
-Export CanExports.
 
 (* Morphism hierarchy. *)
 
@@ -7542,8 +7380,6 @@ Proof.
 rewrite tnth_map -(tnth_map fst) -(tnth_map snd) -/unzip1 -/unzip2.
 by rewrite !(tnth_nth (tnth_default t1 i))/= unzip1_zip ?unzip2_zip ?size_tuple.
 Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use tnth_diff instead.")]
-Notation tnth_sub := tnth_diff.
 
 Lemma diffKI t1 t2 : t2 `&` diff t1 t2 = \bot.
 Proof.
@@ -7560,8 +7396,6 @@ Qed.
 Lemma diffEtprod t1 t2 :
   t1 `\` t2 = [tuple of [seq x.1 `\` x.2 | x <- zip t1 t2]].
 Proof. by []. Qed.
-#[deprecated(since="mathcomp 2.0.0", note="Use diffEtprod instead.")]
-Notation subEtprod := diffEtprod.
 
 End CBDistrLattice.
 


### PR DESCRIPTION
##### Motivation for this change

This PR removes deprecation notations introduced in MathComp 2.0. This helps us in making some files smaller.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- ~[ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
