### PR TITLE
add classic_sigW and classic_ex

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -49,6 +49,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `ssralg.v`
   + lemmas `prodM_comm`, `prodMl_comm`, `prodMr_comm`, `prodrMl`, `prodrMr`
 
+- in `ssrbool.v`
+  + lemmas `classic_sigW`, `classic_ex`
 
 ### Changed
 

--- a/mathcomp/ssreflect/ssrbool.v
+++ b/mathcomp/ssreflect/ssrbool.v
@@ -95,3 +95,14 @@ Proof. by case: b1 b2 => [] []. Qed.
 Lemma relpre_trans {T' T : Type} {leT : rel T} {f : T' -> T} :
   transitive leT -> transitive (relpre f leT).
 Proof. by move=> + y x z; apply. Qed.
+
+Lemma classic_sigW T (P : T -> Prop) :
+  classically (exists x, P x) <-> classically ({x | P x}).
+Proof. by split; apply: classic_bind => -[x Px]; apply/classicW; exists x. Qed.
+
+Lemma classic_ex T (P : T -> Prop) :
+  ~ (forall x, ~ P x) -> classically (exists x, P x).
+Proof.
+move=> NfNP; apply/classicP => exPF; apply: NfNP => x Px.
+by apply: exPF; exists x.
+Qed.


### PR DESCRIPTION
##### Motivation for this change

Backports `classic_sigW` and `classic_ex` from mathcomp/Abel.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~~[ ] added corresponding documentation in the headers~~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
