### PR TITLE
commented textbook_triangular_sum and renamed triangular_sum and Pascal

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -63,6 +63,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Renamed
 
+- in `binomial.v`
+  + lemma `triangular_sum` renamed as `bin2_sum`
+
 ### Removed
 
 - in `div.v`
@@ -87,6 +90,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `commutator.v`
   + definition `derived_at_rec`, use `derived_at` directly
 
+- in `binomial.v`
+  + lemma `textbook_triangular_sum`
+
 ### Deprecated
 
 - in `ssreflect.v`
@@ -110,6 +116,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `poly.v`
   + lemma `size_Xn_sub_1`, use `size_XnsubC` instead
   + lemma `monic_Xn_sub_1`, use `monic_XnsubC` instead
+
+- in `binomial.v`
+  + lemma `triangular_sum`, use `bin2_sum` instead
+  + lemma `Pascal`, use `expnDn` instead
 
 ### Infrastructure
 

--- a/mathcomp/ssreflect/binomial.v
+++ b/mathcomp/ssreflect/binomial.v
@@ -12,7 +12,7 @@ From mathcomp Require Import div fintype tuple finfun bigop prime finset.
 (*               Note that n ^_ m = 0 if m > n, and 'C(n, m) = n ^_ m %/ m`!. *)
 (*                                                                            *)
 (* In additions to the properties of these functions, we prove a few seminal  *)
-(* results such as triangular_sum, Wilson and Pascal; their proofs are good   *)
+(* results such as bin2_sum, Wilson and expnDn; their proofs are good         *)
 (* examples of how to manipulate expressions with bigops.                     *)
 (******************************************************************************)
 
@@ -277,21 +277,26 @@ suffices /Gauss_dvdr<-: coprime p (p - k) by rewrite -mul_bin_down dvdn_mulr.
 by rewrite prime_coprime // dvdn_subr 1?ltnW // gtnNdvd.
 Qed.
 
-Lemma triangular_sum n : \sum_(0 <= i < n) i = 'C(n, 2).
+Lemma bin2_sum n : \sum_(0 <= i < n) i = 'C(n, 2).
 Proof.
 elim: n => [|n IHn]; first by rewrite big_geq.
 by rewrite big_nat_recr // IHn binS bin1.
 Qed.
 
+#[deprecated(since="mathcomp 2.3", note="Use bin2_sum instead.")]
+Definition triangular_sum := bin2_sum.
+
+(* textbook proof of `bin2_sum`. Should be moved out of the main
+  library, to a dedicated "showcase" library.
 Lemma textbook_triangular_sum n : \sum_(0 <= i < n) i = 'C(n, 2).
 Proof.
 rewrite bin2; apply: canRL half_double _.
 rewrite -addnn {1}big_nat_rev -big_split big_mkord /= ?add0n.
 rewrite (eq_bigr (fun _ => n.-1)); first by rewrite sum_nat_const card_ord.
 by case: n => [|n] [i le_i_n] //=; rewrite subSS subnK.
-Qed.
+Qed. *)
 
-Theorem Pascal a b n :
+Theorem expnDn a b n :
   (a + b) ^ n = \sum_(i < n.+1) 'C(n, i) * (a ^ (n - i) * b ^ i).
 Proof.
 elim: n => [|n IHn]; rewrite big_ord_recl muln1 ?big_ord0 //.
@@ -301,7 +306,9 @@ congr (_ + _); rewrite addnA -big_split /=; congr (_ + _).
 apply: eq_bigr => i _; rewrite mulnCA (mulnA a) -expnS subnSK //=.
 by rewrite (mulnC b) -2!mulnA -expnSr -mulnDl.
 Qed.
-Definition expnDn := Pascal.
+
+#[deprecated(since="mathcomp 2.3", note="Use expnDn instead.")]
+Definition Pascal := expnDn.
 
 Lemma Vandermonde k l i :
   \sum_(j < i.+1) 'C(k, j) * 'C(l, i - j) = 'C(k + l , i).


### PR DESCRIPTION
##### Motivation for this change

Removes a duplicate lemma (`textbook_triangular_sum` vs. `triangular_sum`) and renames `triangular_sum` into `bin2_sum` and `Pascal` into `expnDn`.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
