### PR TITLE
memo about merge policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,9 @@
 <!-- if this PR fixes an issue, use "fixes #XYZ" -->
 
 <!-- you may also explain what remains to do if the fix is incomplete -->
+<!-- you can use tickboxes for clarity -->
 
-##### Things done/to do
+##### Minimal TODO list
 
 <!-- please fill in the following checklist -->
 - [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
@@ -15,6 +16,9 @@
 
 - [ ] added corresponding documentation in the headers
 - [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
+- [ ] this PR contains an optimum number of meaningful commits
+
+See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.
 
 <!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
 
@@ -35,4 +39,4 @@
 <!-- leave this note as a reminder to reviewers -->
 ##### Automatic note to reviewers
 
-Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
+Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).


### PR DESCRIPTION
##### Motivation for this change

@proux01, how about adding this to the PR template?
That might help avoid more disgracious merges in the future?

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
