### PR TITLE
Remove warnings introduced in https://github.com/math-comp/math-comp/pull/1185

### DIFF
--- a/mathcomp/field/algnum.v
+++ b/mathcomp/field/algnum.v
@@ -567,7 +567,7 @@ Lemma Aint1 : 1 \in Aint. Proof. exact: Aint_int 1. Qed.
 
 Lemma Aint_unity_root n x : (n > 0)%N -> n.-unity_root x -> x \in Aint.
 Proof.
-move=> n_gt0 xn1; apply: root_monic_Aint xn1 (monic_Xn_sub_1 _ n_gt0) _.
+move=> n_gt0 xn1; apply: root_monic_Aint xn1 (monicXnsubC _ n_gt0) _.
 by apply/polyOverP=> i; rewrite coefB coefC -mulrb coefXn /= rpredB ?rpred_nat.
 Qed.
 

--- a/mathcomp/field/cyclotomic.v
+++ b/mathcomp/field/cyclotomic.v
@@ -122,10 +122,10 @@ Local Notation intCK := (@intrKfloor algC).
 Lemma C_prim_root_exists n : (n > 0)%N -> {z : algC | n.-primitive_root z}.
 Proof.
 pose p : {poly algC} := 'X^n - 1; have [r Dp] := closed_field_poly_normal p.
-move=> n_gt0; apply/sigW; rewrite (monicP _) ?monic_Xn_sub_1 // scale1r in Dp.
+move=> n_gt0; apply/sigW; rewrite (monicP _) ?monicXnsubC // scale1r in Dp.
 have rn1: all n.-unity_root r by apply/allP=> z; rewrite -root_prod_XsubC -Dp.
 have sz_r: (n < (size r).+1)%N.
-  by rewrite -(size_prod_XsubC r id) -Dp size_Xn_sub_1.
+  by rewrite -(size_prod_XsubC r id) -Dp size_XnsubC.
 have [|z] := hasP (has_prim_root n_gt0 rn1 _ sz_r); last by exists z.
 by rewrite -separable_prod_XsubC -Dp separable_Xn_sub_1 // pnatr_eq0 -lt0n.
 Qed.
@@ -177,7 +177,7 @@ have [r def_zn]: exists r, cyclotomic z n = pZtoC r.
     apply: (map_inj_poly (intr_inj : injective ZtoQ)) => //.
     rewrite map_polyZ mapXn1 Dr0 Dr -scalerAl scalerKV ?intr_eq0 //.
     by rewrite rmorphM.
-  by rewrite zprimitiveZ // zprimitive_monic ?monic_Xn_sub_1 ?mapXn1.
+  by rewrite zprimitiveZ // zprimitive_monic ?monicXnsubC ?mapXn1.
 rewrite floorpK; last by apply/polyOverP=> i; rewrite def_zn coef_map /=.
 pose f e (k : 'I_n) := Ordinal (ltn_pmod (k * e) n_gt0).
 have [e Dz0] := prim_rootP prim_z (prim_expr_order prim_z0).

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -542,7 +542,7 @@ have m_gt0 := ltnW m_gt1; have m1_gt0: m.-1 > 0 by rewrite -ltnS prednK.
 pose q := 'X^m - 'X; have Dq R: q R = ('X^m.-1 - 1) * ('X - 0).
   by rewrite subr0 mulrBl mul1r -exprSr prednK.
 have /FinSplittingFieldFor[/= L splitLq]: q 'F_p != 0.
-  by rewrite Dq monic_neq0 ?rpredM ?monicXsubC ?monic_Xn_sub_1.
+  by rewrite Dq monic_neq0 ?rpredM ?monicXsubC ?monicXnsubC.
 rewrite [_^%:A]rmorphB rmorphXn /= map_polyX -/(q L) in splitLq.
 have charL: p \in [char L] by rewrite char_lalg char_Fp.
 pose Fm := FinFieldExtType L; exists Fm => //.


### PR DESCRIPTION
Remove warnings introduced in https://github.com/math-comp/math-comp/pull/1185

Sorry, I wasn't careful enough when merging it.

Cc @Tragicus for information

By the way, we have an inconsistency in the use of `_` between `monicXnsubC`, `size_XnsubC` but it was already present with , for instance, `derivXsubC`, `root_XsubC` so it seems to require more effort to fix.