### PR TITLE
Fix the notation scope of function notations in ssralg (#978)

### DIFF
--- a/algebra/ssralg.v
+++ b/algebra/ssralg.v
@@ -7130,14 +7130,14 @@ Notation "x / y" := (mul x y^-1) : ring_scope.
 Notation "*:%R" := (@scale _ _) : function_scope.
 Notation "a *: m" := (scale a m) : ring_scope.
 Notation "k %:A" := (scale k 1) : ring_scope.
-Notation "\0" := (null_fun _) : ring_scope.
-Notation "f \+ g" := (add_fun f g) : ring_scope.
-Notation "f \- g" := (sub_fun f g) : ring_scope.
-Notation "\- f" := (opp_fun f) : ring_scope.
-Notation "a \*: f" := (scale_fun a f) : ring_scope.
-Notation "x \*o f" := (mull_fun x f) : ring_scope.
-Notation "x \o* f" := (mulr_fun x f) : ring_scope.
-Notation "f \* g" := (mul_fun f g) : ring_scope.
+Notation "\0" := (null_fun _) : function_scope.
+Notation "f \+ g" := (add_fun f g) : function_scope.
+Notation "f \- g" := (sub_fun f g) : function_scope.
+Notation "\- f" := (opp_fun f) : function_scope.
+Notation "a \*: f" := (scale_fun a f) : function_scope.
+Notation "x \*o f" := (mull_fun x f) : function_scope.
+Notation "x \o* f" := (mulr_fun x f) : function_scope.
+Notation "f \* g" := (mul_fun f g) : function_scope.
 
 Arguments mull_fun {_ _}  a f _ /.
 Arguments mulr_fun {_ _} a f _ /.


### PR DESCRIPTION
##### Motivation for this change

Fix #978.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
