### PR TITLE
Adapt to Coq PR #18591: better refolding of addn induces "simpl never" now respected

### DIFF
--- a/mathcomp/solvable/extremal.v
+++ b/mathcomp/solvable/extremal.v
@@ -588,7 +588,7 @@ suffices{k k_gt0 le_k_n2} defGn2: <[x ^+ p]> \x <[y]> = 'Ohm_(n.-2)(G).
   have:= Ohm_dprod k defGn2; have p_xp := mem_p_elt pG (groupX p Gx).
   rewrite (Ohm_p_cycle _ p_xp) (Ohm_p_cycle _ (mem_p_elt pG Gy)) oxp oy.
   rewrite pfactorK ?(pfactorK 1) // (eqnP k_gt0) expg1 -expgM -expnS.
-  rewrite -subSn // -subSS def_n1 def_n => -> /=; rewrite subnSK // subn2.
+  rewrite -subSn // -subSS def_n1 def_n => -> /=; rewrite ?add1n subnSK // subn2.
   by apply/eqP; rewrite eqEsubset OhmS ?Ohm_sub //= -{1}Ohm_id OhmS ?Ohm_leq.
 rewrite dprodEY //=; last by apply/trivgP; rewrite -tiXY setSI ?cycleX.
 apply/eqP; rewrite eqEsubset join_subG !cycle_subG /= [in y \in _]def_n.


### PR DESCRIPTION
On subterm `3 + (n - 3)).-2`, `.-2` is asking to reduce its argument twice and the `simpl never` rule does not apply for `+`, since `+` (`addn`) is in position of argument of a destructor.

We eventually get `1 + (n - 3)` but, without coq/coq#18591, `+` is actually not refolded so we get instead `(fix f n := ... body of + ...) 1 (n - 3)`, and since `+` is not refolded, `simpl never` is bypassed, eventually leading to `(n - 3).+1`.

With coq/coq#18591, we get `1 + (n - 3)` without `+` being unfolded. Moreover, `+` is not anymore in position of a destructor, so the `simpl never` rule applies again, stopping the computation on `1 + (n - 3)`. The PR then takes this difference of behavior into account.

It is difficult to evaluate whether there would be a semantics of `/=` that would still produce the nicer `(n - 3).+1` in the given example even though `+` is `simpl never`. At the current time, I did not find one not too artificial.

If I'm correct, the change is backwards compatible and can be merged as soon as now.

##### Motivation for this change

Compatibility with Coq master.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).

#### Overlays

* https://github.com/coq-community/fourcolor/pull/58
* https://github.com/coq-community/gaia/pull/18
* https://github.com/math-comp/Abel/pull/92
* https://github.com/math-comp/odd-order/pull/55
* https://github.com/coq-community/coqeal/pull/90
* https://github.com/coq-community/graph-theory/pull/40
* https://github.com/coq-community/apery/pull/22