### PR TITLE
Remove unused section variables `k : unit`

### DIFF
--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -1857,7 +1857,7 @@ Section AdditiveTheory.
 
 Section Properties.
 
-Variables (U V : nmodType) (k : unit) (f : {additive U -> V}).
+Variables (U V : nmodType) (f : {additive U -> V}).
 
 Lemma raddf0 : f 0 = 0.
 Proof. exact: semi_additive_subproof.1. Qed.
@@ -1945,7 +1945,7 @@ End MulFun.
 
 Section Properties.
 
-Variables (U V : zmodType) (k : unit) (f : {additive U -> V}).
+Variables (U V : zmodType) (f : {additive U -> V}).
 
 Lemma raddfN : {morph f : x / - x}.
 Proof.
@@ -2043,7 +2043,7 @@ Section RmorphismTheory.
 
 Section Properties.
 
-Variables (R S : semiRingType) (k : unit) (f : {rmorphism R -> S}).
+Variables (R S : semiRingType) (f : {rmorphism R -> S}).
 
 Lemma rmorph0 : f 0 = 0. Proof. exact: raddf0. Qed.
 Lemma rmorphD : {morph f : x y / x + y}. Proof. exact: raddfD. Qed.
@@ -2103,7 +2103,7 @@ End Projections.
 
 Section Properties.
 
-Variables (R S : ringType) (k : unit) (f : {rmorphism R -> S}).
+Variables (R S : ringType) (f : {rmorphism R -> S}).
 
 Lemma rmorphN : {morph f : x / - x}. Proof. exact: raddfN. Qed.
 Lemma rmorphB : {morph f: x y / x - y}. Proof. exact: raddfB. Qed.
@@ -2264,7 +2264,7 @@ Variable R : ringType.
 
 Section GenericProperties.
 
-Variables (U : lmodType R) (V : zmodType) (s : R -> V -> V) (k : unit).
+Variables (U : lmodType R) (V : zmodType) (s : R -> V -> V).
 Variable f : {linear U -> V | s}.
 
 Lemma linear0 : f 0 = 0. Proof. exact: raddf0. Qed.
@@ -2432,7 +2432,7 @@ HB.export LRMorphismExports.
 Section LRMorphismTheory.
 
 Variables (R : ringType) (A B : lalgType R) (C : ringType) (s : R -> C -> C).
-Variables (k : unit) (f : {lrmorphism A -> B}) (g : {lrmorphism B -> C | s}).
+Variables (f : {lrmorphism A -> B}) (g : {lrmorphism B -> C | s}).
 
 #[export] HB.instance Definition _ := RMorphism.on (@idfun A).
 #[export] HB.instance Definition _ := RMorphism.on (g \o f).

--- a/mathcomp/solvable/gfunctor.v
+++ b/mathcomp/solvable/gfunctor.v
@@ -146,7 +146,7 @@ Definition monotonic :=
 
 (* Self-expanding composition, and modulo *)
 
-Variables (k : unit) (F1 F2 : object_map).
+Variables (F1 F2 : object_map).
 
 Definition comp : object_map := fun gT A => F1 (F2 A).
 


### PR DESCRIPTION
##### Motivation for this change

In `ssralg`, these variables were used for declaring that `locked_with` applied to a homomorphism is a homomorphism. It seems that these instances have been removed during the port to HB. We can also remove these variables.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- ~[ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
