### PR TITLE
generalize zmodp operations

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -217,6 +217,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `meetsP_seq`, `meetsP`, `le_meets`, `meets_setU`, `meets_seq`
     generalized from `tLatticeType` to `tMeetSemilatticeType`
 
+- in `zmodp.v`
+  + definitions `Zp_opp`, `Zp_add`, `Zp_mul`, `Zp_inv`
+	 generalized from `'I_p.+1` to `'I_p`.
+  + lemmas `Zp_addA`, `Zp_addC`, `Zp_mulC`, `Zp_mulA`, `Zp_mul_addr`,
+	 `Zp_mul_addl`, `Zp_inv_out`
+	 generalized from `'I_p.+1` to `'I_p`.
+
 ### Renamed
 
 - in `binomial.v`

--- a/mathcomp/algebra/zmodp.v
+++ b/mathcomp/algebra/zmodp.v
@@ -117,6 +117,11 @@ Proof. by rewrite /Zp_inv => /negPf->. Qed.
 
 End Generic.
 
+Arguments Zp_opp {p}.
+Arguments Zp_add {p}.
+Arguments Zp_mul {p}.
+Arguments Zp_inv {p}.
+
 Variable p' : nat.
 Local Notation p := p'.+1.
 
@@ -135,37 +140,37 @@ Definition Zp1 := inZp 1.
 
 (* Additive group structure. *)
 
-Lemma Zp_add0z : left_id Zp0 (@Zp_add p).
+Lemma Zp_add0z : left_id Zp0 Zp_add.
 Proof. by move=> x; apply: val_inj; rewrite /= modZp. Qed.
 
-Lemma Zp_addNz : left_inverse Zp0 (@Zp_opp p) (@Zp_add p).
+Lemma Zp_addNz : left_inverse Zp0 Zp_opp Zp_add.
 Proof.
 by move=> x; apply: val_inj; rewrite /= modnDml subnK ?modnn // ltnW.
 Qed.
 
 HB.instance Definition _ :=
-  GRing.isZmodule.Build 'I_p (@Zp_addA p) (@Zp_addC p) Zp_add0z Zp_addNz.
+  GRing.isZmodule.Build 'I_p (@Zp_addA _) (@Zp_addC _) Zp_add0z Zp_addNz.
 
 HB.instance Definition _ := [finGroupMixin of 'I_p for +%R].
 
 (* Ring operations *)
 
-Lemma Zp_mul1z : left_id Zp1 (@Zp_mul p).
+Lemma Zp_mul1z : left_id Zp1 Zp_mul.
 Proof. by move=> x; apply: val_inj; rewrite /= modnMml mul1n modZp. Qed.
 
-Lemma Zp_mulz1 : right_id Zp1 (@Zp_mul p).
+Lemma Zp_mulz1 : right_id Zp1 Zp_mul.
 Proof. by move=> x; rewrite Zp_mulC Zp_mul1z. Qed.
 
-Lemma Zp_mulVz x : coprime p x -> (@Zp_mul p) (Zp_inv x) x = Zp1.
+Lemma Zp_mulVz x : coprime p x -> Zp_mul (Zp_inv x) x = Zp1.
 Proof.
 move=> co_p_x; apply: val_inj; rewrite /Zp_inv co_p_x /= modnMml.
 by rewrite -(chinese_modl co_p_x 1 0) /chinese addn0 mul1n mulnC.
 Qed.
 
-Lemma Zp_mulzV x : coprime p x -> (@Zp_mul p) x (Zp_inv x) = Zp1.
+Lemma Zp_mulzV x : coprime p x -> Zp_mul x (Zp_inv x) = Zp1.
 Proof. by move=> Ux; rewrite /= Zp_mulC Zp_mulVz. Qed.
 
-Lemma Zp_intro_unit x y : (@Zp_mul p) y x = Zp1 -> coprime p x.
+Lemma Zp_intro_unit x y : Zp_mul y x = Zp1 -> coprime p x.
 Proof.
 case=> yx1; have:= coprimen1 p.
 by rewrite -coprime_modr -yx1 coprime_modr coprimeMr; case/andP.

--- a/mathcomp/solvable/extremal.v
+++ b/mathcomp/solvable/extremal.v
@@ -272,8 +272,7 @@ have [cycF ffulF]: cyclic F /\ [faithful F, on 'Ohm_1(G) | [Aut G]].
   have natZqp u: (u%:R : 'Z_q)%:R = u %:R :> 'F_p.
     by rewrite val_Zp_nat // -Fp_nat_mod // modn_dvdm ?Fp_nat_mod.
   have m0M: {in A &, {morph fm0 : a b / a * b}}.
-    move=> a b Aa Ab; apply: val_inj; rewrite /= -natrM mM //.
-    by rewrite -[(_ * _)%R]Zp_nat natZqp.
+    by move=> a b Aa Ab; apply: val_inj; rewrite /= -natrM mM //= -val_Zp_nat.
   pose m0 : {morphism A >-> {unit 'F_p}} := Morphism m0M.
   have im_m0: m0 @* A = [set: {unit 'F_p}].
     apply/setP=> [[/= u Uu]]; rewrite in_setT morphimEdom; apply/imsetP.


### PR DESCRIPTION
##### Motivation for this change

Generalizes the operations on ordinals in `zmodp.v` so that `opp`, `add`, `mul` and `inv` are defined on the ordinal `I_0`.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
