### PR TITLE
improve deprecation message

### DIFF
--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -1823,7 +1823,8 @@ Notation polyC_mulrz := polyCMz (only parsing).
 #[deprecated(since="mathcomp 2.1.0",
              note="Require archimedean.v and use Num.nat instead.")]
 Notation Znat := (Num.Def.nat_num : qualifier 1 int) (only parsing).
-#[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
+#[deprecated(since="mathcomp 2.1.0",
+             note="Require archimedean.v and use natrP instead.")]
 Notation Znat_def := mc_2_0.Znat_def (only parsing).
 #[deprecated(since="mathcomp 2.1.0", note="Require archimedean.v.")]
 Notation ZnatP := mc_2_0.ZnatP (only parsing).


### PR DESCRIPTION
##### Motivation for this change

Moreover, `Znat_def` has been deprecated without the obvious replacement:
```coq
Lemma natr_def (n : int) : (n \is a Num.nat) = (0 <= n)%R.
Proof. by []. Qed.
```
Should this lemma be added back?


##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~
~~- [ ] tried to abide by the [contribution `guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)`~~
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
