### PR TITLE
Uniformize the `since` field of the `deprecated` attribute

### DIFF
--- a/mathcomp/algebra/zmodp.v
+++ b/mathcomp/algebra/zmodp.v
@@ -203,10 +203,10 @@ Qed.
 (* TODO: bigop is imported after zmodp in matrix.v and intdiv.v to prevent
   these warnings from triggering. We should restore the order of imports when
   these are removed. *)
-#[deprecated(since="mathcomp 2.3", note="Use bigop.big_ord1 instead.")]
+#[deprecated(since="mathcomp 2.3.0", note="Use bigop.big_ord1 instead.")]
 Notation big_ord1 := big_ord1 (only parsing).
 
-#[deprecated(since="mathcomp 2.3", note="Use bigop.big_ord1_cond instead.")]
+#[deprecated(since="mathcomp 2.3.0", note="Use bigop.big_ord1_cond instead.")]
 Notation big_ord1_cond := big_ord1_cond (only parsing).
 
 Section ZpRing.

--- a/mathcomp/ssreflect/binomial.v
+++ b/mathcomp/ssreflect/binomial.v
@@ -283,7 +283,7 @@ elim: n => [|n IHn]; first by rewrite big_geq.
 by rewrite big_nat_recr // IHn binS bin1.
 Qed.
 
-#[deprecated(since="mathcomp 2.3", note="Use bin2_sum instead.")]
+#[deprecated(since="mathcomp 2.3.0", note="Use bin2_sum instead.")]
 Notation triangular_sum := bin2_sum (only parsing).
 
 (* textbook proof of `bin2_sum`. Should be moved out of the main
@@ -307,7 +307,7 @@ apply: eq_bigr => i _; rewrite mulnCA (mulnA a) -expnS subnSK //=.
 by rewrite (mulnC b) -2!mulnA -expnSr -mulnDl.
 Qed.
 
-#[deprecated(since="mathcomp 2.3", note="Use expnDn instead.")]
+#[deprecated(since="mathcomp 2.3.0", note="Use expnDn instead.")]
 Definition Pascal := expnDn.
 
 Lemma Vandermonde k l i :

--- a/mathcomp/ssreflect/ssreflect.v
+++ b/mathcomp/ssreflect/ssreflect.v
@@ -43,5 +43,5 @@ Class vm_compute_eq {T : Type} (x y : T) := vm_compute : x = y.
 Hint Extern 0 (@vm_compute_eq _ _ _) =>
        vm_compute; reflexivity : typeclass_instances.
 
-#[deprecated(since="mathcomp 2.3", note="Use `Arguments def : simpl never` instead (should work fine since Coq 8.18).")]
+#[deprecated(since="mathcomp 2.3.0", note="Use `Arguments def : simpl never` instead (should work fine since Coq 8.18).")]
 Notation nosimpl t := (nosimpl t).

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -203,7 +203,7 @@ Proof. exact: eq_irrelevance. Qed.
 
 Definition addn := plus.
 Arguments addn : simpl never.
-#[deprecated(since="mathcomp 2.3", note="Use addn instead.")]
+#[deprecated(since="mathcomp 2.3.0", note="Use addn instead.")]
 Definition addn_rec := addn.
 Notation "m + n" := (addn m n) : nat_scope.
 
@@ -275,7 +275,7 @@ Lemma add4n m : 4 + m = m.+4. Proof. by []. Qed.
 
 Definition subn := minus.
 Arguments subn : simpl never.
-#[deprecated(since="mathcomp 2.3", note="Use subn instead.")]
+#[deprecated(since="mathcomp 2.3.0", note="Use subn instead.")]
 Definition subn_rec := subn.
 Notation "m - n" := (subn m n) : nat_scope.
 
@@ -1074,7 +1074,7 @@ Proof. by elim: n m => /= [|n IHn] m; rewrite ?subn0 // IHn subnS. Qed.
 
 Definition muln := mult.
 Arguments muln : simpl never.
-#[deprecated(since="mathcomp 2.3", note="Use muln instead.")]
+#[deprecated(since="mathcomp 2.3.0", note="Use muln instead.")]
 Definition muln_rec := muln.
 Notation "m * n" := (muln m n) : nat_scope.
 
@@ -1230,7 +1230,7 @@ Proof. by move=> x; elim: n => //= n <-; rewrite mulSn iterD. Qed.
 
 Definition expn m n := iterop n muln m 1.
 Arguments expn : simpl never.
-#[deprecated(since="mathcomp 2.3", note="Use expn instead.")]
+#[deprecated(since="mathcomp 2.3.0", note="Use expn instead.")]
 Definition expn_rec := expn.
 Notation "m ^ n" := (expn m n) : nat_scope.
 
@@ -1329,7 +1329,7 @@ Proof. elim: m => //= m ihm x; rewrite expnS iterM; exact/eq_iter. Qed.
 
 Fixpoint factorial n := if n is n'.+1 then n * factorial n' else 1.
 Arguments factorial : simpl never.
-#[deprecated(since="mathcomp 2.3", note="Use factorial instead.")]
+#[deprecated(since="mathcomp 2.3.0", note="Use factorial instead.")]
 Definition fact_rec := factorial.
 
 Notation "n `!" := (factorial n) (at level 2, format "n `!") : nat_scope.
@@ -1405,7 +1405,7 @@ Proof. by elim: n => // n IHn; rewrite expnS oddM {}IHn orbC; case odd. Qed.
 
 Fixpoint double n := if n is n'.+1 then (double n').+2 else 0.
 Arguments double : simpl never.
-#[deprecated(since="mathcomp 2.3", note="Use double instead.")]
+#[deprecated(since="mathcomp 2.3.0", note="Use double instead.")]
 Definition double_rec := double.
 Notation "n .*2" := (double n) : nat_scope.
 


### PR DESCRIPTION
##### Motivation for this change

Since the deprecation warnings belong to a warning category like `deprecated-since-mathcomp-2.3.0` (since Coq 8.18, see coq/coq#17489) and can be configured by the `Set Warnings` command, uniformizing the format of these values is useful. For example, the user may write `-arg -w -arg +deprecated-since-mathcomp-2.1.0` to identify and remove the use of definitions deprecated in MathComp 2.1 (when dropping the support for MathComp 2.0).

I also suggest adding this policy to the Contribution Guide.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- ~[ ] this PR contains an optimum number of meaningful commits~

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- ~[ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
