### PR TITLE
Cleanup

### DIFF
--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -2453,9 +2453,8 @@ have{cBcE} cBncEn A: centgmx rGn A -> A *m Bn = Bn *m A.
   rewrite !rowE !mulmxA -mxvec_delta -(mul_delta_mx (0 : 'I_1)).
   rewrite mul_rV_lin mul_vec_lin /= -mulmxA; apply: (canLR vec_mxK).
   apply/row_matrixP=> i; set dj0 := delta_mx j 0.
-  pose Aij := row i \o vec_mx \o mulmxr A \o mxvec \o mulmx dj0.
-  have defAij := mul_rV_lin1 (GRing.Linear.clone _ _ _ _ Aij _).
-  rewrite /= {2}/Aij /= in defAij.
+  have /= defAij :=
+    mul_rV_lin1 (row i \o vec_mx \o mulmxr A \o mxvec \o mulmx dj0).
   rewrite -defAij row_mul -defAij -!mulmxA (cent_mxP cBcE) {k}//.
   rewrite memmx_cent_envelop; apply/centgmxP=> x Gx; apply/row_matrixP=> k.
   rewrite !row_mul !rowE !{}defAij /= -row_mul mulmxA mul_delta_mx.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -1225,8 +1225,7 @@ HB.instance Definition _ := GRing.Lalgebra_isAlgebra.Build _ subFExtend
 Fact subfx_evalZ : scalable subfx_eval.
 Proof. by move=> a q; rewrite -mul_polyC rmorphM. Qed.
 HB.instance Definition _ :=
-  GRing.isScalable.Build F {poly F} subFExtend *:%R subfx_eval
-    subfx_evalZ.
+  GRing.isScalable.Build F {poly F} subFExtend *:%R subfx_eval subfx_evalZ.
 
 Hypothesis (pz0 : root p^iota z).
 


### PR DESCRIPTION
##### Motivation for this change

These changes are extracted from #1125 but do not depend on the new structures. The main changes are as follows:
- Remove the modules enclosing regular and converse instances, and use the `#[export]` attribute instead.
- Generalize the `FrobeniusAutomorphism` section to commutative semirings.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- [ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
