### PR TITLE
Remove 2.1.0 deprecations

### DIFF
--- a/.nix/coq-overlays/multinomials/default.nix
+++ b/.nix/coq-overlays/multinomials/default.nix
@@ -1,0 +1,58 @@
+{ coq, mkCoqDerivation, mathcomp, mathcomp-finmap, mathcomp-bigenough,
+  lib, version ? null, useDune ? false }@args:
+ mkCoqDerivation {
+
+  namePrefix = [ "coq" "mathcomp" ];
+  pname = "multinomials";
+
+  owner = "math-comp";
+
+  inherit version;
+  defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ] [
+      { cases = [ (range "8.17" "8.20") (isGe "2.1.0") ];       out = "2.2.0"; }
+      { cases = [ (range "8.16" "8.18") "2.1.0" ];              out = "2.1.0"; }
+      { cases = [ (range "8.16" "8.18") "2.0.0" ];              out = "2.0.0"; }
+      { cases = [ (isGe "8.15") (range "1.15.0" "1.19.0") ];    out = "1.6.0"; }
+      { cases = [ (isGe "8.10") (range "1.13.0" "1.17.0") ];    out = "1.5.6"; }
+      { cases = [ (range "8.10" "8.16") (range "1.12.0" "1.15.0") ]; out = "1.5.5"; }
+      { cases = [ (range "8.10" "8.12") "1.12.0" ];             out = "1.5.3"; }
+      { cases = [ (range "8.7" "8.12")  "1.11.0" ];             out = "1.5.2"; }
+      { cases = [ (range "8.7" "8.11")  (range "1.8" "1.10") ]; out = "1.5.0"; }
+      { cases = [ (range "8.7" "8.10")  (range "1.8" "1.10") ]; out = "1.4"; }
+      { cases = [ "8.6"                 (range "1.6" "1.7") ];  out = "1.1"; }
+    ] null;
+  release = {
+    "2.2.0".sha256 = "sha256-Cie6paweITwPZy6ej9+qIvHFWknVR382uJPW927t/fo=";
+    "2.1.0".sha256 = "sha256-QT91SBJ6DXhyg4j/okTvPP6yj2DnnPbnSlJ/p8pvZbY=";
+    "2.0.0".sha256 = "sha256-2zWHzMBsO2j8EjN7CgCmKQcku9Be8aVlme0LD5p4ab8=";
+    "1.6.0".sha256 = "sha256-lEM+sjqajIOm1c3lspHqcSIARgMR9RHbTQH4veHLJfU=";
+    "1.5.6".sha256 = "sha256-cMixgc34T9Ic6v+tYmL49QUNpZpPV5ofaNuHqblX6oY=";
+    "1.5.5".sha256 = "sha256-VdXA51vr7DZl/wT/15YYMywdD7Gh91dMP9t7ij47qNQ=";
+    "1.5.4".sha256 = "0s4sbh4y88l125hdxahr56325hdhxxdmqmrz7vv8524llyv3fciq";
+    "1.5.3".sha256 = "1462x40y2qydjd2wcg8r6qr8cx3xv4ixzh2h8vp9h7arylkja1qd";
+    "1.5.2".sha256 = "15aspf3jfykp1xgsxf8knqkxv8aav2p39c2fyirw7pwsfbsv2c4s";
+    "1.5.1".sha256 = "13nlfm2wqripaq671gakz5mn4r0xwm0646araxv0nh455p9ndjs3";
+    "1.5.0".sha256 = "064rvc0x5g7y1a0nip6ic91vzmq52alf6in2bc2dmss6dmzv90hw";
+    "1.5.0".rev    = "1.5";
+    "1.4".sha256   = "0vnkirs8iqsv8s59yx1fvg1nkwnzydl42z3scya1xp1b48qkgn0p";
+    "1.3".sha256   = "0l3vi5n094nx3qmy66hsv867fnqm196r8v605kpk24gl0aa57wh4";
+    "1.2".sha256   = "1mh1w339dslgv4f810xr1b8v2w7rpx6fgk9pz96q0fyq49fw2xcq";
+    "1.1".sha256   = "1q8alsm89wkc0lhcvxlyn0pd8rbl2nnxg81zyrabpz610qqjqc3s";
+    "1.0".sha256   = "1qmbxp1h81cy3imh627pznmng0kvv37k4hrwi2faa101s6bcx55m";
+  };
+
+  useDuneifVersion = v: lib.versions.isGe "1.5.3" v && lib.versions.isGe v "2.2.0";
+
+  preConfigure = ''
+    patchShebangs configure || true
+  '';
+
+  propagatedBuildInputs =
+    [ mathcomp.ssreflect mathcomp.algebra mathcomp-finmap mathcomp.fingroup mathcomp-bigenough ];
+
+  meta = {
+    description = "Coq/SSReflect Library for Monoidal Rings and Multinomials";
+    license = lib.licenses.cecill-c;
+  };
+}
+// lib.optionalAttrs (args?useDune) { inherit useDune; }

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -239,6 +239,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + `ceilD` -> `real_ceilD`
   + `ceil_floor` -> `real_ceil_floor`
 
+- in `ssrint.v`
+  + `mulrzDr` -> `mulrzDl`
+  + `mulrzDl` -> `mulrzDr`
+
 ### Removed
 
 - in `seq.v`
@@ -329,6 +333,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `ler_eexpz2l`, `ltr_eexpz2l`, `eqr_expz2`, `exprz_pmulzl`,
     `leq_add_dist`, `leqif_add_distz`, `leqif_add_dist` (deprecated
     since 1.17)
+  + notation `polyC_mulrz` (deprecated since 2.1.0)
 
 - in `fraction.v`
   + notation `tofracX` (deprecated since 1.17)
@@ -354,6 +359,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `polydiv.v`
   + definition `gcdp_rec`, use `gcdp` directly
+  + notation `modp_mod` (deprecated since 2.1.0)
 
 - in `nilpotent.v`
   + definition `lower_central_at_rec`, use `lower_central_at` directly
@@ -408,6 +414,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + notations `PcanPartial`, `CanPartial`, `PcanTotal`, `CanTotal`,
     `MonoTotalMixin`, `PcanPOrderMixin`, `CanPOrderMixin`, `PcanOrderMixin`,
     `CanOrderMixin`, `IsoLatticeMixin`, `IsoDistrLatticeMixin`
+  + notations `comparable_le_minr`, `comparable_le_minl`, `comparable_lt_minl`,
+    `comparable_lt_minr`, `comparable_le_maxr`, `comparable_le_maxl`,
+    `comparable_lt_maxr`, `comparable_lt_maxl`, `le_maxl`, `le_maxr`,
+    `lt_maxl`, `lt_maxr`, `lt_minr`, `lt_minl`, `le_minr`, `le_minl`
+    (deprecated since 2.1.0)
 
 - in `fingroup.v`
   + notations `[finGroupType of T]` and `[baseFinGroupType of T]`
@@ -477,6 +488,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + notation `[finLalgType R of T]`
   + notation `[finAlgType R of T]`
   + notation `[finUnitAlgType R of T]`
+  + notation `finIntegralDomainType` (deprecated since 2.1.0)
 
 - in `ssrnum.v`
   + notations `[numDomainType of T]` and `[numDomainType of T for cT]`

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -72,9 +72,6 @@ HB.structure Definition ComUnitRing := {R of GRing.ComUnitRing R & Finite R}.
 #[short(type="finIdomainType")]
 HB.structure Definition IntegralDomain :=
   {R of GRing.IntegralDomain R & Finite R}.
-#[deprecated(since="mathcomp 2.1.0",
-  note="Use finIdomainType (not available in mathcomp 2.0.0).")]
-Notation finIntegralDomainType := finIdomainType.
 
 #[short(type="finFieldType")]
 HB.structure Definition Field := {R of GRing.Field R & Finite R}.
@@ -343,10 +340,6 @@ End FinRing.
 
 Import FinRing.
 HB.reexport.
-
-#[deprecated(since="mathcomp 2.1.0",
-  note="Use finIdomainType (not available in mathcomp 2.0.0).")]
-Notation finIntegralDomainType := finIdomainType.
 
 Lemma card_finRing_gt1 (R : finRingType) : 1 < #|R|.
 Proof. by rewrite (cardD1 0) (cardD1 1) !inE GRing.oner_neq0. Qed.

--- a/mathcomp/algebra/polydiv.v
+++ b/mathcomp/algebra/polydiv.v
@@ -2454,9 +2454,6 @@ Arguments gcdp : simpl never.
 #[global] Hint Resolve dvdp_mull dvdp_mulr dvdpp dvdp0 : core.
 Arguments dvdp_exp_XsubCP {R p c n}.
 
-#[deprecated(since="mathcomp 2.1.0", note="Use modp_id instead.")]
-Notation modp_mod := modp_id.
-
 End CommonIdomain.
 
 Module Idomain.

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -555,7 +555,7 @@ Proof. by rewrite !mulrzA_C mulrC. Qed.
 
 Fact mulr1z (x : M) : x *~ 1 = x. Proof. by []. Qed.
 
-Fact mulrzDl_tmp m : {morph ( *~%R^~ m : M -> M) : x y / x + y}.
+Fact mulrzDl m : {morph ( *~%R^~ m : M -> M) : x y / x + y}.
 Proof.
 by elim: m=> [|m _|m _] x y;
   rewrite ?addr0 /intmul //= ?mulrnDl // opprD.
@@ -572,7 +572,7 @@ rewrite -{2}[m](@subnKC n)// mulrnDr addrAC subrr add0r.
 by rewrite subzn.
 Qed.
 
-Fact mulrzDr_tmp x : {morph *~%R x : m n / m + n}.
+Fact mulrzDr x : {morph *~%R x : m n / m + n}.
 Proof.
 elim=> [|m _|m _]; elim=> [|n _|n _]; rewrite /intmul //=;
 rewrite -?(opprD) ?(add0r, addr0, mulrnDr, subn0) //.
@@ -583,7 +583,7 @@ Qed.
 
 HB.instance Definition _ := GRing.Zmodule.on M^z.  (* FIXME, the error message below "nomsg" when we forget this line is not very helpful *)
 HB.instance Definition _ := @GRing.Zmodule_isLmodule.Build _ M^z
-  (fun n x => x *~ n) mulrzA_C mulr1z mulrzDl_tmp mulrzDr_tmp.
+  (fun n x => x *~ n) mulrzA_C mulr1z mulrzDl mulrzDr.
 
 Lemma scalezrE n x : n *: (x : M^z) = x *~ n. Proof. by []. Qed.
 
@@ -625,10 +625,10 @@ HB.instance Definition _ (x : M) := GRing.isAdditive.Build int M ( *~%R x)
 
 End ZintLmod.
 
-#[deprecated(since="mathcomp 2.1.0", note="Use mulrzDr_tmp instead. mulrzDl will be renamed mulrzDr in the future.")]
-Notation mulrzDl := mulrzDr_tmp.
-#[deprecated(since="mathcomp 2.1.0", note="Use mulrzDl_tmp instead. mulrzDr will be renamed mulrzDl in the future.")]
-Notation mulrzDr := mulrzDl_tmp.
+#[deprecated(since="mathcomp 2.3.0", note="Use mulrzDl instead.")]
+Notation mulrzDl_tmp := mulrzDl.
+#[deprecated(since="mathcomp 2.3.0", note="Use mulrzDr instead.")]
+Notation mulrzDr_tmp := mulrzDr.
 
 Lemma ffunMzE (I : finType) (M : zmodType) (f : {ffun I -> M}) z x :
   (f *~ z) x = f x *~ z.
@@ -1818,8 +1818,6 @@ Proof. by case: m => m; constructor; [exists m | case]. Qed.
 
 End mc_2_0.
 
-#[deprecated(since="mathcomp 2.1.0", note="Use polyCMz instead.")]
-Notation polyC_mulrz := polyCMz (only parsing).
 #[deprecated(since="mathcomp 2.1.0",
              note="Require archimedean.v and use Num.nat instead.")]
 Notation Znat := (Num.Def.nat_num : qualifier 1 int) (only parsing).

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -4390,39 +4390,6 @@ Proof. exact: total_homo_mono_in. Qed.
 
 End TotalMonotonyTheory.
 
-#[deprecated(since="mathcomp 2.1.0", note="Use comparable_le_min instead.")]
-Notation comparable_le_minr := comparable_le_min.
-#[deprecated(since="mathcomp 2.1.0", note="Use comparable_ge_min instead.")]
-Notation comparable_le_minl := comparable_ge_min.
-#[deprecated(since="mathcomp 2.1.0", note="Use comparable_gt_min instead.")]
-Notation comparable_lt_minl := comparable_gt_min.
-#[deprecated(since="mathcomp 2.1.0", note="Use comparable_lt_min instead.")]
-Notation comparable_lt_minr := comparable_lt_min.
-#[deprecated(since="mathcomp 2.1.0", note="Use comparable_le_max instead.")]
-Notation comparable_le_maxr := comparable_le_max.
-#[deprecated(since="mathcomp 2.1.0", note="Use comparable_ge_max instead.")]
-Notation comparable_le_maxl := comparable_ge_max.
-#[deprecated(since="mathcomp 2.1.0", note="Use comparable_lt_max instead.")]
-Notation comparable_lt_maxr := comparable_lt_max.
-#[deprecated(since="mathcomp 2.1.0", note="Use comparable_gt_max instead.")]
-Notation comparable_lt_maxl := comparable_gt_max.
-#[deprecated(since="mathcomp 2.1.0", note="Use ge_max instead.")]
-Notation le_maxl := ge_max.
-#[deprecated(since="mathcomp 2.1.0", note="Use le_max instead.")]
-Notation le_maxr := le_max.
-#[deprecated(since="mathcomp 2.1.0", note="Use gt_max instead.")]
-Notation lt_maxl := gt_max.
-#[deprecated(since="mathcomp 2.1.0", note="Use lt_max instead.")]
-Notation lt_maxr := lt_max.
-#[deprecated(since="mathcomp 2.1.0", note="Use lt_min instead.")]
-Notation lt_minr := lt_min.
-#[deprecated(since="mathcomp 2.1.0", note="Use gt_min instead.")]
-Notation lt_minl := gt_min.
-#[deprecated(since="mathcomp 2.1.0", note="Use le_min instead.")]
-Notation le_minr := le_min.
-#[deprecated(since="mathcomp 2.1.0", note="Use ge_min instead.")]
-Notation le_minl := ge_min.
-
 End TotalTheory.
 
 Module Import CDistrLatticeTheory.


### PR DESCRIPTION
##### Motivation for this change

This PR removes the deprecation notations introduced in MathComp 2.1.0, except those removed by #1237, and finishes the renaming of `mulrzDl` and `mulrzDr`.

##### PR overlays

- coq-community/apery#25

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 1.X

<!-- If this PR targets `master` and if it is merged, the merged commit may be
     cherry-picked on the branch `mathcomp-1` if possible.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `mathcomp-1` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: MC-1 port to record divergences between `master` and `mathcomp-1` -->

- ~[ ] I added the label `TODO: MC-1 port` to make sure someone ports this PR to
      the `mathcomp-1` branch **or** I already opened an issue or PR (please cross reference).~

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
