### PR TITLE
chore(ci): Add exception for certain jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,7 @@ stages:
       - schedules
     variables:
       - $CRON_MODE == "nightly"
+      - $CRON_MODE == "minimal"
 
 make-coq-latest:
   extends: .make-build
@@ -149,6 +150,7 @@ coq-dev:
       - schedules
     variables:
       - $CRON_MODE == "nightly"
+      - $CRON_MODE == "minimal"
 
 test-coq-8.18:
   extends: .test-once
@@ -199,6 +201,7 @@ test-coq-dev:
 #       - schedules
 #     variables:
 #       - $CRON_MODE == "nightly"
+#       - $CRON_MODE == "minimal"
 # 
 # # Guidelines to add a library to mathcomp CI:
 # # - Add a hidden job (starting with a .) .ci-lib that extends the .ci job,


### PR DESCRIPTION
##### Motivation for this change

This commit just amounts to reducing the CI usage for automatic rebuilds of mathcomp-dev images according to the docker-coq propagate strategy:
https://github.com/coq-community/docker-coq/blob/81a90f97032067297f95d828a84da70914f0e8b9/images.yml#L25-L41

**TL;DR:** do not run "make-coq-latest" nor "test-coq-8.XX" jobs in this case, but still run "test-coq-dev" which could break despite a successful mathcomp build in the first stage.

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).