### PR TITLE
Redefine the archimedean mixin to include the floor/ceil functions

### DIFF
--- a/algebra/archimedean.v
+++ b/algebra/archimedean.v
@@ -49,24 +49,27 @@ Local Open Scope ring_scope.
 Import Order.TTheory GRing.Theory Num.Theory.
 
 Module Num.
-Import ssrnum.Num.
+Import Num.Def.
 
-HB.mixin Record NumDomain_isArchimedean R of NumDomain R := {
-  truncn_subdef : R -> nat;
-  nat_num_subdef : pred R;
+HB.mixin Record NumDomain_hasFloorCeilTruncn R of Num.NumDomain R := {
+  floor : R -> int;
+  ceil  : R -> int;
+  truncn : R -> nat;
   int_num_subdef : pred R;
-  truncn_subproof :
+  nat_num_subdef : pred R;
+  floor_subproof :
     forall x,
-      if 0 <= x then (truncn_subdef x)%:R <= x < (truncn_subdef x).+1%:R
-      else truncn_subdef x == 0%N;
-  nat_num_subproof : forall x, nat_num_subdef x = ((truncn_subdef x)%:R == x);
-  int_num_subproof :
-    forall x, int_num_subdef x = nat_num_subdef x || nat_num_subdef (- x);
+      if x \is Rreal then (floor x)%:~R <= x < (floor x + 1)%:~R
+      else floor x == 0;
+  ceil_subproof : forall x, ceil x = - floor (- x);
+  truncn_subproof : forall x, truncn x = if floor x is Posz n then n else 0;
+  int_num_subproof : forall x, reflect (exists n, x = n%:~R) (int_num_subdef x);
+  nat_num_subproof : forall x, reflect (exists n, x = n%:R) (nat_num_subdef x);
 }.
 
 #[short(type="archiNumDomainType")]
 HB.structure Definition ArchiNumDomain :=
-  { R of NumDomain_isArchimedean R & NumDomain R }.
+  { R of NumDomain_hasFloorCeilTruncn R & Num.NumDomain R }.
 
 Module ArchiNumDomainExports.
 Bind Scope ring_scope with ArchiNumDomain.sort.
@@ -75,7 +78,7 @@ HB.export ArchiNumDomainExports.
 
 #[short(type="archiNumFieldType")]
 HB.structure Definition ArchiNumField :=
-  { R of NumDomain_isArchimedean R & NumField R }.
+  { R of NumDomain_hasFloorCeilTruncn R & Num.NumField R }.
 
 Module ArchiNumFieldExports.
 Bind Scope ring_scope with ArchiNumField.sort.
@@ -84,7 +87,7 @@ HB.export ArchiNumFieldExports.
 
 #[short(type="archiClosedFieldType")]
 HB.structure Definition ArchiClosedField :=
-  { R of NumDomain_isArchimedean R & ClosedField R }.
+  { R of NumDomain_hasFloorCeilTruncn R & Num.ClosedField R }.
 
 Module ArchiClosedFieldExports.
 Bind Scope ring_scope with ArchiClosedField.sort.
@@ -93,7 +96,7 @@ HB.export ArchiClosedFieldExports.
 
 #[short(type="archiRealDomainType")]
 HB.structure Definition ArchiRealDomain :=
-  { R of NumDomain_isArchimedean R & RealDomain R }.
+  { R of NumDomain_hasFloorCeilTruncn R & Num.RealDomain R }.
 
 Module ArchiRealDomainExports.
 Bind Scope ring_scope with ArchiRealDomain.sort.
@@ -102,7 +105,7 @@ HB.export ArchiRealDomainExports.
 
 #[short(type="archiRealFieldType")]
 HB.structure Definition ArchiRealField :=
-  { R of NumDomain_isArchimedean R & RealField R }.
+  { R of NumDomain_hasFloorCeilTruncn R & Num.RealField R }.
 
 Module ArchiRealFieldExports.
 Bind Scope ring_scope with ArchiRealField.sort.
@@ -111,87 +114,70 @@ HB.export ArchiRealFieldExports.
 
 #[short(type="archiRcfType")]
 HB.structure Definition ArchiRealClosedField :=
-  { R of NumDomain_isArchimedean R & RealClosedField R }.
+  { R of NumDomain_hasFloorCeilTruncn R & Num.RealClosedField R }.
 
 Module ArchiRealClosedFieldExports.
 Bind Scope ring_scope with ArchiRealClosedField.sort.
 End ArchiRealClosedFieldExports.
 HB.export ArchiRealClosedFieldExports.
 
-Module Import Def.
-Export ssrnum.Num.Def.
 Section Def.
 Context {R : archiNumDomainType}.
-Implicit Types x : R.
 
-Definition truncn : R -> nat := @truncn_subdef R.
 Definition nat_num : qualifier 1 R := [qualify a x : R | nat_num_subdef x].
 Definition int_num : qualifier 1 R := [qualify a x : R | int_num_subdef x].
-
-Local Lemma truncnP x :
-  if 0 <= x then (truncn x)%:R <= x < (truncn x).+1%:R else truncn x == 0%N.
-Proof. exact: truncn_subproof. Qed.
-
-Local Lemma truncn_itv x : 0 <= x -> (truncn x)%:R <= x < (truncn x).+1%:R.
-Proof. by move=> x_ge0; move: (truncnP x); rewrite x_ge0. Qed.
-
-Local Fact floor_subproof x :
-  {m | if x \is Rreal then m%:~R <= x < (m + 1)%:~R else m == 0}.
-Proof.
-have [Rx | _] := boolP (x \is Rreal); last by exists 0.
-without loss x_ge0: x Rx / x >= 0.
-  have [x_ge0 | /ltW x_le0] := real_ge0P Rx; first exact.
-  case/(_ (- x)) => [||m]; rewrite ?rpredN ?oppr_ge0 //.
-  rewrite lerNr ltrNl -!rmorphN opprD /= le_eqVlt.
-  case: eqP => [-> _ | _ /andP[lt_x_m lt_m_x]].
-    by exists (- m); rewrite lexx rmorphD ltrDl ltr01.
-  by exists (- m - 1); rewrite (ltW lt_m_x) subrK.
-by exists (Posz (truncn x)); rewrite addrC -intS -!pmulrn truncn_itv.
-Qed.
-
-Definition floor x := sval (floor_subproof x).
-Definition ceil x := - floor (- x).
-Definition archi_bound x := (truncn `|x|).+1.
+Definition bound (x : R) := (truncn `|x|).+1.
 
 End Def.
-#[deprecated(since="mathcomp 2.4.0", note="Renamed to truncn.")]
-Notation trunc := truncn.
-End Def.
 
-Arguments truncn {R} : simpl never.
+Arguments floor {R} : rename, simpl never.
+Arguments ceil {R} : rename, simpl never.
+Arguments truncn {R} : rename, simpl never.
 Arguments nat_num {R} : simpl never.
 Arguments int_num {R} : simpl never.
+
+#[deprecated(since="mathcomp 2.4.0", note="Renamed to truncn.")]
+Notation trunc := truncn.
+
+Module Def.
+Export ssrnum.Num.Def.
 
 Notation truncn := truncn.
 #[deprecated(since="mathcomp 2.4.0", note="Renamed to truncn.")]
 Notation trunc := truncn.
 Notation floor := floor.
-Notation ceil := ceil.
-Notation bound := archi_bound.
+Notation ceil  := ceil.
+Notation nat_num := nat_num.
+Notation int_num := int_num.
+Notation archi_bound := bound.
+
+End Def.
 
 Module intArchimedean.
 Section intArchimedean.
 
 Implicit Types n : int.
 
-Let truncn n : nat := if n is Posz n' then n' else 0%N.
+Lemma floorP n : if n \is Rreal then n%:~R <= n < (n + 1)%:~R else n == 0.
+Proof. by rewrite num_real !intz ltzD1 lexx. Qed.
 
-Lemma truncnP n :
-  if 0 <= n then (truncn n)%:R <= n < (truncn n).+1%:R else truncn n == 0%N.
-Proof. by case: n => //= n; rewrite !natz intS ltz1D lexx. Qed.
+Lemma intrP n : reflect (exists m, n = m%:~R) true.
+Proof. by apply: ReflectT; exists n; rewrite intz. Qed.
 
-Lemma is_natE n : (0 <= n) = ((truncn n)%:R == n).
-Proof. by case: n => //= n; rewrite natz eqxx. Qed.
-
-Lemma is_intE n : true = (0 <= n) || (0 <= - n).
-Proof. by case: n. Qed.
+Lemma natrP n : reflect (exists m, n = m%:R) (0 <= n).
+Proof.
+apply: (iffP idP); last by case=> m ->; rewrite ler0n.
+by case: n => // n _; exists n; rewrite natz.
+Qed.
 
 End intArchimedean.
 End intArchimedean.
 
 #[export]
-HB.instance Definition _ := NumDomain_isArchimedean.Build int
-  intArchimedean.truncnP intArchimedean.is_natE intArchimedean.is_intE.
+HB.instance Definition _ :=
+  @NumDomain_hasFloorCeilTruncn.Build int id id _ xpredT Rnneg_pred
+    intArchimedean.floorP (fun=> esym (opprK _)) (fun=> erefl)
+    intArchimedean.intrP intArchimedean.natrP.
 
 Module Import Theory.
 Export ssrnum.Num.Theory.
@@ -204,107 +190,53 @@ Implicit Types x y z : R.
 Local Notation truncn := (@truncn R).
 Local Notation floor := (@floor R).
 Local Notation ceil := (@ceil R).
-Local Notation nat_num := (@nat_num R).
-Local Notation int_num := (@int_num R).
+Local Notation nat_num := (@Def.nat_num R).
+Local Notation int_num := (@Def.int_num R).
 
-(* truncn and nat_num *)
+Local Lemma floorP x :
+  if x \is Rreal then (floor x)%:~R <= x < (floor x + 1)%:~R else floor x == 0.
+Proof. exact: floor_subproof. Qed.
 
-Definition truncn_itv x : 0 <= x -> (truncn x)%:R <= x < (truncn x).+1%:R :=
-  @Def.truncn_itv R x.
+Lemma floorNceil x : floor x = - ceil (- x).
+Proof. by rewrite ceil_subproof !opprK. Qed.
 
-Lemma natrEtruncn x : (x \is a nat_num) = ((truncn x)%:R == x).
-Proof. exact: nat_num_subproof. Qed.
+Lemma ceilNfloor x : ceil x = - floor (- x).
+Proof. exact: ceil_subproof. Qed.
 
-Lemma archi_boundP x : 0 <= x -> x < (archi_bound x)%:R.
-Proof.
-move=> x_ge0; case/truncn_itv/andP: (normr_ge0 x) => _.
-exact/le_lt_trans/real_ler_norm/ger0_real.
-Qed.
-
-Lemma truncn_def x n : n%:R <= x < n.+1%:R -> truncn x = n.
-Proof.
-case/andP=> lemx ltxm1; apply/eqP; rewrite eqn_leq -ltnS -[(n <= _)%N]ltnS.
-have/truncn_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lemx; apply: ler0n.
-by rewrite -!(ltr_nat R) 2?(@le_lt_trans _ _ x).
-Qed.
-
-Lemma natrK : cancel (GRing.natmul 1) truncn.
-Proof. by move=> m; apply: truncn_def; rewrite ler_nat ltr_nat ltnS leqnn. Qed.
-
-Lemma truncnK : {in nat_num, cancel truncn (GRing.natmul 1)}.
-Proof. by move=> x; rewrite natrEtruncn => /eqP. Qed.
-
-Lemma truncn0 : truncn 0 = 0%N. Proof. exact: natrK 0%N. Qed.
-Lemma truncn1 : truncn 1 = 1%N. Proof. exact: natrK 1%N. Qed.
-#[local] Hint Resolve truncn0 truncn1 : core.
-
-Lemma natr_nat n : n%:R \is a nat_num. Proof. by rewrite natrEtruncn natrK. Qed.
-#[local] Hint Resolve natr_nat : core.
+Lemma truncEfloor x : truncn x = if floor x is Posz n then n else 0.
+Proof. exact: truncn_subproof. Qed.
 
 Lemma natrP x : reflect (exists n, x = n%:R) (x \is a nat_num).
-Proof.
-apply: (iffP idP) => [|[n ->]]; rewrite // natrEtruncn => /eqP <-.
-by exists (truncn x).
-Qed.
+Proof. exact: nat_num_subproof. Qed.
 
-Lemma truncn_le x : (truncn x)%:R <= x = (0 <= x).
-Proof. by have := Def.truncnP x; case: ifP => [+ /andP[] | + /eqP->//]. Qed.
+Lemma intrP x : reflect (exists m, x = m%:~R) (x \is a int_num).
+Proof. exact: int_num_subproof. Qed.
 
-Lemma real_truncnS_gt x : x \is Rreal -> x < (truncn x).+1%:R.
-Proof. by move/real_ge0P => [/truncn_itv/andP[]|/lt_le_trans->]. Qed.
+(* int_num and nat_num *)
 
-Lemma truncn_ge_nat x n : 0 <= x -> (n <= truncn x)%N = (n%:R <= x).
-Proof.
-move=> /truncn_itv /andP[letx ltxt1]; apply/idP/idP => lenx.
-  by apply: le_trans letx; rewrite ler_nat.
-by rewrite -ltnS -(ltr_nat R); apply: le_lt_trans ltxt1.
-Qed.
+Lemma intr_int m : m%:~R \is a int_num. Proof. by apply/intrP; exists m. Qed.
+Lemma natr_nat n : n%:R \is a nat_num. Proof. by apply/natrP; exists n. Qed.
+#[local] Hint Resolve intr_int natr_nat : core.
 
-Lemma truncn_gt_nat x n : (n < truncn x)%N = (n.+1%:R <= x).
-Proof.
-have := Def.truncnP x; case: ifP => [x0 _ | x0 /eqP->].
-  by rewrite truncn_ge_nat.
-by rewrite ltn0; apply/esym/(contraFF _ x0)/le_trans.
-Qed.
-
-Lemma truncn_lt_nat x n : 0 <= x -> (truncn x < n)%N = (x < n%:R).
-Proof. by move=> ?; rewrite real_ltNge ?ger0_real// ltnNge truncn_ge_nat. Qed.
-
-Lemma real_truncn_le_nat x n : x \is real -> (truncn x <= n)%N = (x < n.+1%:R).
-Proof. by move=> ?; rewrite real_ltNge// leqNgt truncn_gt_nat. Qed.
-
-Lemma truncn_eq x n : 0 <= x -> (truncn x == n) = (n%:R <= x < n.+1%:R).
-Proof.
-by move=> xr; apply/eqP/idP => [<-|]; [exact: truncn_itv|exact: truncn_def].
-Qed.
-
-Lemma le_truncn : {homo truncn : x y / x <= y >-> (x <= y)%N}.
-Proof.
-move=> x y lexy; move: (Def.truncnP x) (Def.truncnP y).
-case: ifP => [x0 /andP[letx _] | x0 /eqP->//].
-case: ifP => [y0 /andP[_] | y0 /eqP->]; [|by rewrite (le_trans x0 lexy) in y0].
-by move=> /(le_lt_trans lexy) /(le_lt_trans letx); rewrite ltr_nat ltnS.
-Qed.
-
-Lemma truncnD :
-  {in nat_num & Rnneg, {morph truncn : x y / x + y >-> (x + y)%N}}.
-Proof.
-move=> _ y /natrP[n ->] y_ge0; apply: truncn_def.
-by rewrite -addnS !natrD !natrK lerD2l ltrD2l truncn_itv.
-Qed.
-
-Lemma truncnM : {in nat_num &, {morph truncn : x y / x * y >-> (x * y)%N}}.
-Proof. by move=> _ _ /natrP[n1 ->] /natrP[n2 ->]; rewrite -natrM !natrK. Qed.
-
-Lemma truncnX n : {in nat_num, {morph truncn : x / x ^+ n >-> (x ^ n)%N}}.
-Proof. by move=> _ /natrP[n1 ->]; rewrite -natrX !natrK. Qed.
+Lemma rpred_int_num (S : subringClosed R) x : x \is a int_num -> x \in S.
+Proof. by move=> /intrP[n ->]; rewrite rpred_int. Qed.
 
 Lemma rpred_nat_num (S : semiringClosed R) x : x \is a nat_num -> x \in S.
 Proof. by move=> /natrP[n ->]; apply: rpred_nat. Qed.
 
+Lemma int_num0 : 0 \is a int_num. Proof. exact: (intr_int 0). Qed.
+Lemma int_num1 : 1 \is a int_num. Proof. exact: (intr_int 1). Qed.
 Lemma nat_num0 : 0 \is a nat_num. Proof. exact: (natr_nat 0). Qed.
 Lemma nat_num1 : 1 \is a nat_num. Proof. exact: (natr_nat 1). Qed.
-#[local] Hint Resolve nat_num0 nat_num1 : core.
+#[local] Hint Resolve int_num0 int_num1 nat_num0 nat_num1 : core.
+
+Fact int_num_subring : subring_closed int_num.
+Proof.
+by split=> // _ _ /intrP[n ->] /intrP[m ->]; rewrite -(intrB, intrM).
+Qed.
+#[export]
+HB.instance Definition _ := GRing.isSubringClosed.Build R int_num_subdef
+  int_num_subring.
 
 Fact nat_num_semiring : semiring_closed nat_num.
 Proof.
@@ -314,86 +246,84 @@ Qed.
 HB.instance Definition _ := GRing.isSemiringClosed.Build R nat_num_subdef
   nat_num_semiring.
 
-Lemma Rreal_nat : {subset nat_num <= Rreal}.
-Proof. by move=> _ /natrP[m ->]. Qed.
+Lemma Rreal_nat : {subset nat_num <= Rreal}. Proof. exact: rpred_nat_num. Qed.
+
+Lemma intr_nat : {subset nat_num <= int_num}.
+Proof. by move=> _ /natrP[n ->]; rewrite pmulrn intr_int. Qed.
+
+Lemma Rreal_int : {subset int_num <= Rreal}. Proof. exact: rpred_int_num. Qed.
+
+Lemma intrE x : (x \is a int_num) = (x \is a nat_num) || (- x \is a nat_num).
+Proof.
+apply/idP/orP => [/intrP[[n|n] ->]|[]/intr_nat]; rewrite ?rpredN //.
+  by left; apply/natrP; exists n.
+by rewrite NegzE intrN opprK; right; apply/natrP; exists n.+1.
+Qed.
+
+Lemma intr_normK x : x \is a int_num -> `|x| ^+ 2 = x ^+ 2.
+Proof. by move/Rreal_int/real_normK. Qed.
 
 Lemma natr_normK x : x \is a nat_num -> `|x| ^+ 2 = x ^+ 2.
 Proof. by move/Rreal_nat/real_normK. Qed.
 
-Lemma truncn_gt0 x : (0 < truncn x)%N = (1 <= x).
-Proof.
-have := Def.truncnP x; case: ifP => [x0 | x0 /eqP<-].
-  by rewrite truncn_ge_nat.
-by rewrite ltnn; apply/esym/(contraFF _ x0)/le_trans.
-Qed.
-
-Lemma truncn0Pn x : reflect (truncn x = 0%N) (~~ (1 <= x)).
-Proof. by rewrite -truncn_gt0 -eqn0Ngt; apply: eqP. Qed.
+Lemma natr_norm_int x : x \is a int_num -> `|x| \is a nat_num.
+Proof. by move=> /intrP[m ->]; rewrite -intr_norm rpred_nat_num ?natr_nat. Qed.
 
 Lemma natr_ge0 x : x \is a nat_num -> 0 <= x.
 Proof. by move=> /natrP[n ->]; apply: ler0n. Qed.
 
 Lemma natr_gt0 x : x \is a nat_num -> (0 < x) = (x != 0).
-Proof. by move=> /natrP[n ->]; rewrite pnatr_eq0 ltr0n lt0n. Qed.
+Proof. by move/natr_ge0; case: comparableP. Qed.
+
+Lemma natrEint x : (x \is a nat_num) = (x \is a int_num) && (0 <= x).
+Proof.
+apply/idP/andP=> [Nx | [Zx x_ge0]]; first by rewrite intr_nat ?natr_ge0.
+by rewrite -(ger0_norm x_ge0) natr_norm_int.
+Qed.
+
+Lemma intrEge0 x : 0 <= x -> (x \is a int_num) = (x \is a nat_num).
+Proof. by rewrite natrEint andbC => ->. Qed.
+
+Lemma intrEsign x : x \is a int_num -> x = (-1) ^+ (x < 0)%R * `|x|.
+Proof. by move/Rreal_int/realEsign. Qed.
 
 Lemma norm_natr x : x \is a nat_num -> `|x| = x.
 Proof. by move/natr_ge0/ger0_norm. Qed.
 
-Lemma sum_truncnK I r (P : pred I) F : (forall i, P i -> F i \is a nat_num) ->
-  (\sum_(i <- r | P i) truncn (F i))%:R = \sum_(i <- r | P i) F i.
+Lemma natr_exp_even x n : ~~ odd n -> x \is a int_num -> x ^+ n \is a nat_num.
 Proof.
-by move=> natr; rewrite -sumrMnr; apply: eq_bigr => i Pi; rewrite truncnK ?natr.
+move=> n_oddF x_intr.
+by rewrite natrEint rpredX //= real_exprn_even_ge0 // Rreal_int.
 Qed.
 
-Lemma prod_truncnK I r (P : pred I) F : (forall i, P i -> F i \is a nat_num) ->
-  (\prod_(i <- r | P i) truncn (F i))%:R = \prod_(i <- r | P i) F i.
+Lemma norm_intr_ge1 x : x \is a int_num -> x != 0 -> 1 <= `|x|.
 Proof.
-by move=> natr; rewrite natr_prod; apply: eq_bigr => i Pi; rewrite truncnK ?natr.
+rewrite -normr_eq0 => /natr_norm_int/natrP[n ->].
+by rewrite pnatr_eq0 ler1n lt0n.
 Qed.
 
-Lemma natr_sum_eq1 (I : finType) (P : pred I) (F : I -> R) :
-     (forall i, P i -> F i \is a nat_num) -> \sum_(i | P i) F i = 1 ->
-   {i : I | [/\ P i, F i = 1 & forall j, j != i -> P j -> F j = 0]}.
+Lemma sqr_intr_ge1 x : x \is a int_num -> x != 0 -> 1 <= x ^+ 2.
 Proof.
-move=> natF /eqP; rewrite -sum_truncnK// -[1]/1%:R eqr_nat => /sum_nat_eq1 exi.
-have [i /and3P[Pi /eqP f1 /forallP a]] : {i : I | [&& P i, truncn (F i) == 1
-    & [forall j : I, ((j != i) ==> P j ==> (truncn (F j) == 0))]]}.
-  apply/sigW; have [i [Pi /eqP f1 a]] := exi; exists i; apply/and3P; split=> //.
-  by apply/forallP => j; apply/implyP => ji; apply/implyP => Pj; apply/eqP/a.
-exists i; split=> [//||j ji Pj]; rewrite -[LHS]truncnK ?natF ?f1//; apply/eqP.
-by rewrite -[0]/0%:R eqr_nat; apply: implyP Pj; apply: implyP ji; apply: a.
+by move=> Zx nz_x; rewrite -intr_normK // expr_ge1 ?normr_ge0 ?norm_intr_ge1.
 Qed.
 
-Lemma natr_mul_eq1 x y :
-  x \is a nat_num -> y \is a nat_num -> (x * y == 1) = (x == 1) && (y == 1).
-Proof. by do 2!move/truncnK <-; rewrite -natrM !pnatr_eq1 muln_eq1. Qed.
-
-Lemma natr_prod_eq1 (I : finType) (P : pred I) (F : I -> R) :
-    (forall i, P i -> F i \is a nat_num) -> \prod_(i | P i) F i = 1 ->
-  forall i, P i -> F i = 1.
+Lemma intr_ler_sqr x : x \is a int_num -> x <= x ^+ 2.
 Proof.
-move=> natF /eqP; rewrite -prod_truncnK// -[1]/1%:R eqr_nat prod_nat_seq_eq1.
-move/allP => a i Pi; apply/eqP; rewrite -[F i]truncnK ?natF// eqr_nat.
-by apply: implyP Pi; apply: a; apply: mem_index_enum.
+move=> Zx; have [-> | nz_x] := eqVneq x 0; first by rewrite expr0n.
+apply: le_trans (_ : `|x| <= _); first by rewrite real_ler_norm ?Rreal_int.
+by rewrite -intr_normK // ler_eXnr // norm_intr_ge1.
 Qed.
 
 (* floor and int_num *)
 
-Local Lemma floorP x :
-  if x \is Rreal then (floor x)%:~R <= x < (floor x + 1)%:~R else floor x == 0.
-Proof. by rewrite /floor; case: Def.floor_subproof. Qed.
-
-Lemma intrE x : (x \is a int_num) = (x \is a nat_num) || (- x \is a nat_num).
-Proof. exact: int_num_subproof. Qed.
-
 Lemma real_floor_itv x : x \is Rreal -> (floor x)%:~R <= x < (floor x + 1)%:~R.
-Proof. by case: (x \is _) (floorP x). Qed.
+Proof. by case: ifP (floorP x). Qed.
 
 Lemma real_floor_le x : x \is Rreal -> (floor x)%:~R <= x.
-Proof. by move=> /real_floor_itv /andP[]. Qed.
+Proof. by case/real_floor_itv/andP. Qed.
 
 Lemma real_floorD1_gt x : x \is Rreal -> x < (floor x + 1)%:~R.
-Proof. by move=> /real_floor_itv /andP[]. Qed.
+Proof. by case/real_floor_itv/andP. Qed.
 
 Lemma floor_def x m : m%:~R <= x < (m + 1)%:~R -> floor x = m.
 Proof.
@@ -436,21 +366,9 @@ Qed.
 Lemma intrKfloor : cancel intr floor.
 Proof. by move=> m; apply: floor_def; rewrite lexx rmorphD ltrDl ltr01. Qed.
 
-Lemma intr_int m : m%:~R \is a int_num.
-Proof. by rewrite intrE; case: m => n; rewrite ?opprK natr_nat ?orbT. Qed.
-#[local] Hint Resolve intr_int : core.
-
 Lemma natr_int n : n%:R \is a int_num.
 Proof. by rewrite intrE natr_nat. Qed.
 #[local] Hint Resolve natr_int : core.
-
-Lemma intrP x : reflect (exists m, x = m%:~R) (x \is a int_num).
-Proof.
-apply: (iffP idP) => [x_int | [m -> //]].
-rewrite -[x]opprK; move: x_int; rewrite intrE.
-move=> /orP[] /natrP[n ->]; first by exists n; rewrite opprK.
-by exists (- n%:R); rewrite mulrNz mulrz_nat.
-Qed.
 
 Lemma intrEfloor x : x \is a int_num = ((floor x)%:~R == x).
 Proof.
@@ -511,31 +429,43 @@ have := floorP x; case: ifP => [xr _ | xr /eqP->]; rewrite ?eqxx/=.
 by apply/esym/(contraFF _ xr) => /orP[]; [exact: ltr0_real|exact: ger1_real].
 Qed.
 
+Lemma floorpK : {in polyOver int_num, cancel (map_poly floor) (map_poly intr)}.
+Proof.
+move=> p /(all_nthP 0) Zp; apply/polyP=> i.
+rewrite coef_map coef_map_id0 //= -[p]coefK coef_poly.
+by case: ifP => [/Zp/floorK // | _]; rewrite floor0.
+Qed.
+
+Lemma floorpP (p : {poly R}) :
+  p \is a polyOver int_num -> {q | p = map_poly intr q}.
+Proof. by exists (map_poly floor p); rewrite floorpK. Qed.
+
 (* ceil and int_num *)
 
 Lemma real_ceil_itv x : x \is Rreal -> (ceil x - 1)%:~R < x <= (ceil x)%:~R.
 Proof.
-by move=> Rx; rewrite -opprD !mulrNz ltrNl lerNr andbC real_floor_itv ?realN.
+rewrite ceilNfloor -opprD !intrN ltrNl lerNr andbC -realN.
+exact: real_floor_itv.
 Qed.
 
 Lemma real_ceilB1_lt x : x \is Rreal -> (ceil x - 1)%:~R < x.
-Proof. by move=> /real_ceil_itv /andP[]. Qed.
+Proof. by case/real_ceil_itv/andP. Qed.
 
 Lemma real_ceil_ge x : x \is Rreal -> x <= (ceil x)%:~R.
-Proof. by move=> /real_ceil_itv /andP[]. Qed.
+Proof. by case/real_ceil_itv/andP. Qed.
 
 Lemma ceil_def x m : (m - 1)%:~R < x <= m%:~R -> ceil x = m.
 Proof.
-move=> Hx; apply/eqP; rewrite eqr_oppLR; apply/eqP/floor_def.
-by rewrite lerNr ltrNl andbC -!mulrNz opprD opprK.
+rewrite -ltrN2 -lerN2 andbC -!intrN opprD opprK ceilNfloor.
+by move=> /floor_def ->; rewrite opprK.
 Qed.
 
 (* TODO: rename to real_ceil_le_int,
    once the currently deprecated one has been removed *)
 Lemma real_ceil_le_int_tmp x n : x \is Rreal -> (ceil x <= n) = (x <= n%:~R).
 Proof.
-rewrite -realN; move=> /(real_floor_ge_int_tmp (- n)).
-by rewrite mulrNz lerNl => ->; rewrite lerN2.
+rewrite ceilNfloor lerNl -realN => /real_floor_ge_int_tmp ->.
+by rewrite intrN lerN2.
 Qed.
 
 #[deprecated(since="mathcomp 2.4.0", note="Use real_ceil_le_int_tmp instead.")]
@@ -556,13 +486,13 @@ Qed.
 (* TODO: rename to le_ceil,
    once the currently deprecated one has been removed *)
 Lemma le_ceil_tmp : {homo ceil : x y / x <= y}.
-Proof. by move=> x y lexy; rewrite /ceil lerN2 le_floor ?lerN2. Qed.
+Proof. by move=> x y lexy; rewrite !ceilNfloor lerN2 le_floor ?lerN2. Qed.
 
 Lemma intrKceil : cancel intr ceil.
-Proof. by move=> m; apply/eqP; rewrite eqr_oppLR -mulrNz intrKfloor. Qed.
+Proof. by move=> m; rewrite ceilNfloor -intrN intrKfloor opprK. Qed.
 
 Lemma intrEceil x : x \is a int_num = ((ceil x)%:~R == x).
-Proof. by rewrite mulrNz eqr_oppLR -intrEfloor !intrE opprK orbC. Qed.
+Proof. by rewrite -rpredN intrEfloor -eqr_oppLR -intrN -ceilNfloor. Qed.
 
 Lemma ceilK : {in int_num, cancel ceil intr}.
 Proof. by move=> z; rewrite intrEceil => /eqP. Qed.
@@ -573,15 +503,15 @@ Lemma ceil1 : ceil 1 = 1. Proof. exact: intrKceil 1. Qed.
 
 Lemma real_ceilDzr : {in int_num & Rreal, {morph ceil : x y / x + y}}.
 Proof.
-move=> _ y /intrP[m ->] Ry; apply: ceil_def.
-by rewrite -addrA 3!rmorphD /= intrKceil lerD2l ltrD2l -rmorphD real_ceil_itv.
+move=> x y x_int y_real.
+by rewrite ceilNfloor opprD real_floorDzr ?rpredN // opprD -!ceilNfloor.
 Qed.
 
 Lemma real_ceilDrz : {in Rreal & int_num, {morph ceil : x y / x + y}}.
 Proof. by move=> x y xr yz; rewrite addrC real_ceilDzr // addrC. Qed.
 
 Lemma ceilN : {in int_num, {morph ceil : x / - x}}.
-Proof. by move=> _ /intrP[m ->]; rewrite -rmorphN !intrKceil. Qed.
+Proof. by move=> ? ?; rewrite !ceilNfloor !opprK floorN. Qed.
 
 Lemma ceilM : {in int_num &, {morph ceil : x y / x * y}}.
 Proof.
@@ -592,110 +522,176 @@ Lemma ceilX n : {in int_num, {morph ceil : x / x ^+ n}}.
 Proof. by move=> _ /intrP[m ->]; rewrite -rmorphXn !intrKceil. Qed.
 
 Lemma real_ceil_ge0 x : x \is Rreal -> (0 <= ceil x) = (-1 < x).
-Proof. by move=> ?; rewrite oppr_ge0 real_floor_le0 ?realN// ltrNl. Qed.
+Proof.
+by move=> ?; rewrite ceilNfloor oppr_ge0 real_floor_le0 ?realN 1?ltrNl.
+Qed.
 
 Lemma ceil_lt0 x : (ceil x < 0) = (x <= -1).
-Proof. by rewrite oppr_lt0 floor_gt0 lerNr. Qed.
+Proof. by rewrite ceilNfloor oppr_lt0 floor_gt0 lerNr. Qed.
 
 Lemma real_ceil_le0 x : x \is Rreal -> (ceil x <= 0) = (x <= 0).
 Proof. by move=> ?; rewrite real_ceil_le_int_tmp. Qed.
 
 Lemma ceil_gt0 x : (ceil x > 0) = (x > 0).
-Proof. by rewrite oppr_gt0 floor_lt0 oppr_lt0. Qed.
+Proof. by rewrite ceilNfloor oppr_gt0 floor_lt0 oppr_lt0. Qed.
 
 Lemma ceil_neq0 x : (ceil x != 0) = (x <= -1) || (x > 0).
-Proof. by rewrite oppr_eq0 floor_neq0 oppr_lt0 lerNr orbC. Qed.
+Proof. by rewrite ceilNfloor oppr_eq0 floor_neq0 oppr_lt0 lerNr orbC. Qed.
 
 Lemma real_ceil_floor x : x \is Rreal ->
   ceil x = floor x + (~~ (x \is a int_num)).
 Proof.
 case Ix: (x \is a int_num) => Rx /=.
-  by apply/eqP; rewrite addr0 eqr_oppLR floorN.
+  by apply/eqP; rewrite addr0 ceilNfloor eqr_oppLR floorN.
 apply/ceil_def; rewrite addrK; move: (real_floor_itv Rx).
 by rewrite le_eqVlt -intrEfloor Ix /= => /andP[-> /ltW].
 Qed.
-
-Lemma rpred_int_num (S : subringClosed R) x : x \is a int_num -> x \in S.
-Proof. by move=> /intrP[n ->]; rewrite rpred_int. Qed.
-
-Lemma int_num0 : 0 \is a int_num. Proof. by rewrite intrE nat_num0. Qed.
-Lemma int_num1 : 1 \is a int_num. Proof. by rewrite intrE nat_num1. Qed.
-#[local] Hint Resolve int_num0 int_num1 : core.
-
-Fact int_num_subring : subring_closed int_num.
-Proof.
-by split=> // _ _ /intrP[n ->] /intrP[m ->]; rewrite -?mulrzBr -?intrM intr_int.
-Qed.
-#[export]
-HB.instance Definition _ := GRing.isSubringClosed.Build R int_num_subdef
-  int_num_subring.
-
-Lemma intr_nat : {subset nat_num <= int_num}.
-Proof. by move=> ?; rewrite intrE => ->. Qed.
-
-Lemma Rreal_int : {subset int_num <= Rreal}. Proof. exact: rpred_int_num. Qed.
-
-Lemma intr_normK x : x \is a int_num -> `|x| ^+ 2 = x ^+ 2.
-Proof. by move/Rreal_int/real_normK. Qed.
-
-Lemma intrEsign x : x \is a int_num -> x = (-1) ^+ (x < 0)%R * `|x|.
-Proof. by move/Rreal_int/realEsign. Qed.
-
-Lemma natr_norm_int x : x \is a int_num -> `|x| \is a nat_num.
-Proof. by move=> /intrP[m ->]; rewrite -intr_norm rpred_nat_num ?natr_nat. Qed.
-
-Lemma natrEint x : (x \is a nat_num) = (x \is a int_num) && (0 <= x).
-Proof.
-apply/idP/andP=> [Nx | [Zx x_ge0]]; first by rewrite intr_nat ?natr_ge0.
-by rewrite -(ger0_norm x_ge0) natr_norm_int.
-Qed.
-
-Lemma intrEge0 x : 0 <= x -> (x \is a int_num) = (x \is a nat_num).
-Proof. by rewrite natrEint andbC => ->. Qed.
-
-Lemma natr_exp_even x n : ~~ odd n -> x \is a int_num -> x ^+ n \is a nat_num.
-Proof.
-move=> n_oddF x_intr.
-by rewrite natrEint rpredX //= real_exprn_even_ge0 // Rreal_int.
-Qed.
-
-Lemma norm_intr_ge1 x : x \is a int_num -> x != 0 -> 1 <= `|x|.
-Proof.
-rewrite -normr_eq0 => /natr_norm_int/natrP[n ->].
-by rewrite pnatr_eq0 ler1n lt0n.
-Qed.
-
-Lemma sqr_intr_ge1 x : x \is a int_num -> x != 0 -> 1 <= x ^+ 2.
-Proof.
-by move=> Zx nz_x; rewrite -intr_normK // expr_ge1 ?normr_ge0 ?norm_intr_ge1.
-Qed.
-
-Lemma intr_ler_sqr x : x \is a int_num -> x <= x ^+ 2.
-Proof.
-move=> Zx; have [-> | nz_x] := eqVneq x 0; first by rewrite expr0n.
-apply: le_trans (_ : `|x| <= _); first by rewrite real_ler_norm ?Rreal_int.
-by rewrite -intr_normK // ler_eXnr // norm_intr_ge1.
-Qed.
-
-Lemma floorpK : {in polyOver int_num, cancel (map_poly floor) (map_poly intr)}.
-Proof.
-move=> p /(all_nthP 0) Zp; apply/polyP=> i.
-rewrite coef_map coef_map_id0 //= -[p]coefK coef_poly.
-by case: ifP => [/Zp/floorK // | _]; rewrite floor0.
-Qed.
-
-Lemma floorpP (p : {poly R}) :
-  p \is a polyOver int_num -> {q | p = map_poly intr q}.
-Proof. by exists (map_poly floor p); rewrite floorpK. Qed.
 
 (* Relating Cnat and oldCnat. *)
 
 Lemma truncn_floor x : truncn x = if 0 <= x then `|floor x|%N else 0%N.
 Proof.
-case: ifP => [x_ge0 | x_ge0F]; last first.
-  by apply/truncn0Pn; apply/contraFN: x_ge0F; apply/le_trans.
-apply/truncn_def; rewrite !pmulrn intS addrC abszE; have/le_floor := x_ge0.
-by rewrite floor0 => /normr_idP ->; exact/real_floor_itv/ger0_real.
+move: (floorP x); rewrite truncEfloor realE.
+have [/le_floor|_]/= := boolP (0 <= x); first by rewrite floor0; case: floor.
+by case: ifP => [/le_floor|_ /eqP->//]; rewrite floor0; case: floor => [[]|].
+Qed.
+
+(* trunc and nat_num *)
+
+Local Lemma truncnP x :
+  if 0 <= x then (truncn x)%:R <= x < (truncn x).+1%:R else truncn x == 0%N.
+Proof.
+rewrite truncn_floor.
+case: (boolP (0 <= x)) => //= /[dup] /le_floor + /ger0_real/real_floor_itv.
+by rewrite floor0; case: (floor x) => // n _; rewrite absz_nat addrC -intS.
+Qed.
+
+Lemma truncn_itv x : 0 <= x -> (truncn x)%:R <= x < (truncn x).+1%:R.
+Proof. by move=> x_ge0; move: (truncnP x); rewrite x_ge0. Qed.
+
+Lemma truncn_le x : (truncn x)%:R <= x = (0 <= x).
+Proof. by have := (truncnP x); case: ifP => [+ /andP[] | + /eqP->//]. Qed.
+
+Lemma real_truncnS_gt x : x \is Rreal -> x < (truncn x).+1%:R.
+Proof. by move/real_ge0P => [/truncn_itv/andP[]|/lt_le_trans->]. Qed.
+
+Lemma truncn_def x n : n%:R <= x < n.+1%:R -> truncn x = n.
+Proof.
+case/andP=> lemx ltxm1; apply/eqP; rewrite eqn_leq -ltnS -[(n <= _)%N]ltnS.
+have/truncn_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lemx; apply: ler0n.
+by rewrite -!(ltr_nat R) 2?(@le_lt_trans _ _ x).
+Qed.
+
+Lemma truncn_ge_nat x n : 0 <= x -> (n <= truncn x)%N = (n%:R <= x).
+Proof.
+move=> /truncn_itv /andP[letx ltxt1]; apply/idP/idP => lenx.
+  by apply: le_trans letx; rewrite ler_nat.
+by rewrite -ltnS -(ltr_nat R); apply: le_lt_trans ltxt1.
+Qed.
+
+Lemma truncn_gt_nat x n : (n < truncn x)%N = (n.+1%:R <= x).
+Proof.
+have := truncnP x; case: ifP => [x0 _ | x0 /eqP->].
+  by rewrite truncn_ge_nat.
+by rewrite ltn0; apply/esym/(contraFF _ x0)/le_trans.
+Qed.
+
+Lemma truncn_lt_nat x n : 0 <= x -> (truncn x < n)%N = (x < n%:R).
+Proof. by move=> ?; rewrite real_ltNge ?ger0_real// ltnNge truncn_ge_nat. Qed.
+
+Lemma real_truncn_le_nat x n : x \is Rreal -> (truncn x <= n)%N = (x < n.+1%:R).
+Proof. by move=> ?; rewrite real_ltNge// leqNgt truncn_gt_nat. Qed.
+
+Lemma truncn_eq x n : 0 <= x -> (truncn x == n) = (n%:R <= x < n.+1%:R).
+Proof.
+by move=> xr; apply/eqP/idP => [<-|]; [exact: truncn_itv|exact: truncn_def].
+Qed.
+
+Lemma le_truncn : {homo truncn : x y / x <= y >-> (x <= y)%N}.
+Proof.
+move=> x y lexy; move: (truncnP x) (truncnP y).
+case: ifP => [x0 /andP[letx _] | x0 /eqP->//].
+case: ifP => [y0 /andP[_] | y0 /eqP->]; [|by rewrite (le_trans x0 lexy) in y0].
+by move=> /(le_lt_trans lexy) /(le_lt_trans letx); rewrite ltr_nat ltnS.
+Qed.
+
+Lemma natrK : cancel (GRing.natmul 1) truncn.
+Proof. by move=> m; apply: truncn_def; rewrite ler_nat ltr_nat ltnS leqnn. Qed.
+
+Lemma natrEtruncn x : (x \is a nat_num) = ((truncn x)%:R == x).
+Proof.
+by apply/natrP/eqP => [[n ->]|<-]; [rewrite natrK | exists (truncn x)].
+Qed.
+
+Lemma archi_boundP x : 0 <= x -> x < (bound x)%:R.
+Proof.
+move=> x_ge0; case/truncn_itv/andP: (normr_ge0 x) => _.
+exact/le_lt_trans/real_ler_norm/ger0_real.
+Qed.
+
+Lemma truncnK : {in nat_num, cancel truncn (GRing.natmul 1)}.
+Proof. by move=> x; rewrite natrEtruncn => /eqP. Qed.
+
+Lemma truncn0 : truncn 0 = 0%N. Proof. exact: natrK 0%N. Qed.
+Lemma truncn1 : truncn 1 = 1%N. Proof. exact: natrK 1%N. Qed.
+#[local] Hint Resolve truncn0 truncn1 : core.
+
+Lemma truncnD :
+  {in nat_num & Rnneg, {morph truncn : x y / x + y >-> (x + y)%N}}.
+Proof.
+move=> _ y /natrP[n ->] y_ge0; apply: truncn_def.
+by rewrite -addnS !natrD !natrK lerD2l ltrD2l truncn_itv.
+Qed.
+
+Lemma truncnM : {in nat_num &, {morph truncn : x y / x * y >-> (x * y)%N}}.
+Proof. by move=> _ _ /natrP[n1 ->] /natrP[n2 ->]; rewrite -natrM !natrK. Qed.
+
+Lemma truncnX n : {in nat_num, {morph truncn : x / x ^+ n >-> (x ^ n)%N}}.
+Proof. by move=> _ /natrP[n1 ->]; rewrite -natrX !natrK. Qed.
+
+Lemma truncn_gt0 x : (0 < truncn x)%N = (1 <= x).
+Proof.
+case: ifP (truncnP x) => [le0x /andP[lemx ltxm1] | le0x /eqP ->]; last first.
+  by apply/esym; apply/contraFF/le_trans: le0x.
+apply/idP/idP => [m_gt0 | x_ge1]; first by apply: le_trans lemx; rewrite ler1n.
+by rewrite -ltnS -(ltr_nat R) (le_lt_trans x_ge1).
+Qed.
+
+Lemma truncn0Pn x : reflect (truncn x = 0%N) (~~ (1 <= x)).
+Proof. by rewrite -truncn_gt0 -eqn0Ngt; apply: eqP. Qed.
+
+Lemma sum_truncnK I r (P : pred I) F : (forall i, P i -> F i \is a nat_num) ->
+  (\sum_(i <- r | P i) truncn (F i))%:R = \sum_(i <- r | P i) F i.
+Proof. by rewrite natr_sum => natr; apply: eq_bigr => i /natr /truncnK. Qed.
+
+Lemma prod_truncnK I r (P : pred I) F : (forall i, P i -> F i \is a nat_num) ->
+  (\prod_(i <- r | P i) truncn (F i))%:R = \prod_(i <- r | P i) F i.
+Proof. by rewrite natr_prod => natr; apply: eq_bigr => i /natr /truncnK. Qed.
+
+Lemma natr_sum_eq1 (I : finType) (P : pred I) (F : I -> R) :
+     (forall i, P i -> F i \is a nat_num) -> \sum_(i | P i) F i = 1 ->
+   {i : I | [/\ P i, F i = 1 & forall j, j != i -> P j -> F j = 0]}.
+Proof.
+move=> natF /eqP; rewrite -sum_truncnK// -[1]/1%:R eqr_nat => /sum_nat_eq1 exi.
+have [i /and3P[Pi /eqP f1 /forallP a]] : {i : I | [&& P i, truncn (F i) == 1
+    & [forall j : I, ((j != i) ==> P j ==> (truncn (F j) == 0))]]}.
+  apply/sigW; have [i [Pi /eqP f1 a]] := exi; exists i; apply/and3P; split=> //.
+  by apply/forallP => j; apply/implyP => ji; apply/implyP => Pj; apply/eqP/a.
+exists i; split=> [//||j ji Pj]; rewrite -[LHS]truncnK ?natF ?f1//; apply/eqP.
+by rewrite -[0]/0%:R eqr_nat; apply: implyP Pj; apply: implyP ji; apply: a.
+Qed.
+
+Lemma natr_mul_eq1 x y :
+  x \is a nat_num -> y \is a nat_num -> (x * y == 1) = (x == 1) && (y == 1).
+Proof. by do 2!move/truncnK <-; rewrite -natrM !pnatr_eq1 muln_eq1. Qed.
+
+Lemma natr_prod_eq1 (I : finType) (P : pred I) (F : I -> R) :
+    (forall i, P i -> F i \is a nat_num) -> \prod_(i | P i) F i = 1 ->
+  forall i, P i -> F i = 1.
+Proof.
+move=> natF /eqP; rewrite -prod_truncnK// -[1]/1%:R eqr_nat prod_nat_seq_eq1.
+move/allP => a i Pi; apply/eqP; rewrite -[F i]truncnK ?natF// eqr_nat.
+by apply: implyP Pi; apply: a; apply: mem_index_enum.
 Qed.
 
 (* predCmod *)
@@ -795,7 +791,7 @@ Section ArchiRealDomainTheory.
 Variables (R : archiRealDomainType).
 Implicit Type x : R.
 
-Lemma upper_nthrootP x i : (archi_bound x <= i)%N -> x < 2%:R ^+ i.
+Lemma upper_nthrootP x i : (bound x <= i)%N -> x < 2%:R ^+ i.
 Proof.
 case/truncn_itv/andP: (normr_ge0 x) => _ /ltr_normlW xlt le_b_i.
 by rewrite (lt_le_trans xlt) // -natrX ler_nat (ltn_trans le_b_i) // ltn_expl.
@@ -894,15 +890,13 @@ Notation le_ceil := ceil_ge.
 
 Section ArchiNumFieldTheory.
 
-Variable R : archiNumFieldType.
-
 (* autLmodC *)
-Implicit Type nu : {rmorphism R -> R}.
+Variables (R : archiNumFieldType) (nu : {rmorphism R -> R}).
 
-Lemma natr_aut nu x : (nu x \is a nat_num) = (x \is a nat_num).
+Lemma natr_aut x : (nu x \is a nat_num) = (x \is a nat_num).
 Proof. by apply/idP/idP=> /[dup] ? /(aut_natr nu) => [/fmorph_inj <-| ->]. Qed.
 
-Lemma intr_aut nu x : (nu x \is a int_num) = (x \is a int_num).
+Lemma intr_aut x : (nu x \is a int_num) = (x \is a int_num).
 Proof. by rewrite !intrE -rmorphN !natr_aut. Qed.
 
 End ArchiNumFieldTheory.
@@ -933,8 +927,87 @@ End ZnatPred.
 
 End Theory.
 
-HB.factory Record NumDomain_bounded_isArchimedean R of NumDomain R := {
-  archi_bound_subproof : archimedean_axiom R
+(* Factories *)
+
+HB.factory Record NumDomain_hasTruncn R of Num.NumDomain R := {
+  trunc : R -> nat;
+  nat_num : pred R;
+  int_num : pred R;
+  truncP : forall x,
+    if 0 <= x then (trunc x)%:R <= x < (trunc x).+1%:R else trunc x == 0;
+  natrE : forall x, nat_num x = ((trunc x)%:R == x);
+  intrE : forall x, int_num x = nat_num x || nat_num (- x);
+}.
+
+Module NumDomain_isArchimedean.
+Notation Build R := (NumDomain_hasTruncn.Build R).
+End NumDomain_isArchimedean.
+
+HB.builders Context R of NumDomain_hasTruncn R.
+
+Fact trunc_itv x : 0 <= x -> (trunc x)%:R <= x < (trunc x).+1%:R.
+Proof. by move=> x_ge0; move: (truncP x); rewrite x_ge0. Qed.
+
+Definition floor (x : R) : int :=
+  if 0 <= x then Posz (trunc x)
+  else if x < 0 then - Posz (trunc (- x) + ~~ int_num x) else 0.
+
+Fact floorP x :
+  if x \is Rreal then (floor x)%:~R <= x < (floor x + 1)%:~R else floor x == 0.
+Proof.
+rewrite /floor intrE !natrE negb_or realE.
+case: (comparableP x 0) (@trunc_itv x) => //=;
+  try by rewrite -PoszD addn1 -pmulrn => _ ->.
+move=> x_lt0 _; move: (truncP x); rewrite lt_geF // => /eqP ->.
+rewrite gt_eqF //=; move: x_lt0.
+rewrite [_ + 1]addrC -opprB !intrN lerNl ltrNr andbC -oppr_gt0.
+move: {x}(- x) => x x_gt0; rewrite PoszD -addrA -PoszD.
+have ->: Posz ((trunc x)%:R != x) - 1 = - Posz ((trunc x)%:R == x) by case: eqP.
+have := trunc_itv (ltW x_gt0); rewrite le_eqVlt.
+case: eqVneq => /=; last first.
+  by rewrite subr0 addn1 -!pmulrn => _ /andP[-> /ltW ->].
+by rewrite intrB mulr1z addn0 -!pmulrn => -> _; rewrite gtrBl lexx andbT.
+Qed.
+
+Fact truncE x : trunc x = if floor x is Posz n then n else 0.
+Proof.
+rewrite /floor.
+case: (comparableP x 0) (truncP x) => [+ /eqP ->| |_ /eqP ->|] //=.
+by case: (_ + _)%N.
+Qed.
+
+Fact trunc_def x n : n%:R <= x < n.+1%:R -> trunc x = n.
+Proof.
+case/andP=> lemx ltxm1; apply/eqP; rewrite eqn_leq -ltnS -[(n <= _)%N]ltnS.
+have/trunc_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lemx; apply: ler0n.
+by rewrite -!(ltr_nat R) 2?(@le_lt_trans _ _ x).
+Qed.
+
+Fact natrK : cancel (GRing.natmul 1) trunc.
+Proof. by move=> m; apply: trunc_def; rewrite ler_nat ltr_nat ltnS leqnn. Qed.
+
+Fact intrP x : reflect (exists n, x = n%:~R) (int_num x).
+Proof.
+rewrite intrE !natrE; apply: (iffP idP) => [|[n ->]]; last first.
+  by case: n => n; rewrite ?NegzE ?opprK natrK eqxx // orbT.
+rewrite -eqr_oppLR !pmulrn -intrN.
+by move=> /orP[] /eqP<-; [exists (trunc x) | exists (- Posz (trunc (- x)))].
+Qed.
+
+Fact natrP x : reflect (exists n, x = n%:R) (nat_num x).
+Proof.
+rewrite natrE.
+by apply: (iffP eqP) => [<-|[n ->]]; [exists (trunc x) | rewrite natrK].
+Qed.
+
+HB.instance Definition _ :=
+  @NumDomain_hasFloorCeilTruncn.Build R floor _ trunc int_num nat_num
+    floorP (fun=> erefl) truncE intrP natrP.
+
+HB.end.
+
+HB.factory Record NumDomain_bounded_isArchimedean R of Num.NumDomain R := {
+  archi_bound_subproof : Num.archimedean_axiom R
 }.
 
 HB.builders Context R of NumDomain_bounded_isArchimedean R.
@@ -964,7 +1037,7 @@ HB.builders Context R of NumDomain_bounded_isArchimedean R.
   by case: ifP => x_ge0; rewrite ?(ifT _ _ x_ge0) ?(ifF _ _ x_ge0) // hn.
   Qed.
 
-  HB.instance Definition _ := NumDomain_isArchimedean.Build R
+  HB.instance Definition _ := NumDomain_hasTruncn.Build R
     truncnP (fun => erefl) (fun => erefl).
 HB.end.
 

--- a/algebra/rat.v
+++ b/algebra/rat.v
@@ -933,7 +933,7 @@ move=> x; apply: floor_def; apply/andP; split.
 Qed.
 
 Lemma ceil_rat : {mono (@ratr F) : x / Num.ceil x}.
-Proof. by move=> x; rewrite /Num.ceil -rmorphN floor_rat. Qed.
+Proof. by move=> x; rewrite !ceilNfloor -rmorphN floor_rat. Qed.
 
 End InParchiField.
 

--- a/doc/changelog/01-added/1250-archimedean-mixin.md
+++ b/doc/changelog/01-added/1250-archimedean-mixin.md
@@ -1,0 +1,4 @@
+- in `archimedean.v`
+  + lemmas `floorNceil`, `ceilNfloor`, `truncEfloor`, `intrP`
+    ([#1250](https://github.com/math-comp/math-comp/pull/1250), by
+    Pierre Roux).

--- a/doc/changelog/02-changed/1250-archimedean-mixin.md
+++ b/doc/changelog/02-changed/1250-archimedean-mixin.md
@@ -1,0 +1,4 @@
+- in `archimedean.v`
+  + definition of `ceil` (use lemma `ceilNfloor` explicitly)
+    ([#1250](https://github.com/math-comp/math-comp/pull/1250),
+    by Pierre Roux).

--- a/doc/changelog/03-renamed/1250-archimedean-mixin.md
+++ b/doc/changelog/03-renamed/1250-archimedean-mixin.md
@@ -1,0 +1,4 @@
+- in `archimedean.v`
+  + `NumDomain_isArchimedean.Build` -> `NumDomain_hasTruncn.Build`
+    ([#1250](https://github.com/math-comp/math-comp/pull/1250),
+    by Pierre Roux).


### PR DESCRIPTION
~Based on: https://github.com/math-comp/math-comp/pull/1359~ (merged)

##### Motivation for this change

This PR changes the archimedean mixin to include the floor and ceil functions in its definition.

One benefit is that the floor and ceil functions for `int` are now definitionally the identity function. Instead, we lose another definitional property `ceil x = -floor (- x)`, and we should explicitly use the `ceilEfloor` lemma (which should probably be renamed... what about `ceilNfloor`?) to perform this rewriting.

Currently, we cannot redefine the archimedean structure instances for `rat` using `intdiv` by taking advantage of this PR, since `intdiv` depends on `rat`.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).

#### Overlay (to be merged before the current PR)

* https://github.com/math-comp/analysis/pull/1545