### PR TITLE
Cherry-pick from #1125: tidy some proofs and speed-up their checking

### DIFF
--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -902,12 +902,11 @@ Qed.
 Lemma dvdp_rat_int p q : (pZtoQ p %| pZtoQ q) = (p %| q).
 Proof.
 apply/dvdpP/Pdiv.Idomain.dvdpP=> [[/= r1 Dq] | [[/= a r] nz_a Dq]]; last first.
-  exists (a%:~R^-1 *: pZtoQ r); rewrite -scalerAl -rmorphM -Dq /=.
-  by rewrite -{2}[a]intz scaler_int rmorphMz -scaler_int scalerK ?intr_eq0.
+  exists (a%:~R^-1 *: pZtoQ r).
+  by rewrite -scalerAl -rmorphM -Dq /= linearZ/= scalerK ?intr_eq0.
 have [r [a nz_a Dr1]] := rat_poly_scale r1; exists (a, r) => //=.
 apply: (map_inj_poly _ _ : injective pZtoQ) => //; first exact: intr_inj.
-rewrite -[a]intz scaler_int rmorphMz -scaler_int /= Dq Dr1.
-by rewrite -scalerAl -rmorphM scalerKV ?intr_eq0.
+by rewrite linearZ /= Dq Dr1 -scalerAl -rmorphM scalerKV ?intr_eq0.
 Qed.
 
 Lemma dvdpP_rat_int p q :
@@ -1042,7 +1041,7 @@ Lemma dec_Qint_span (vT : vectType rat) m (s : m.-tuple vT) v :
 Proof.
 have s_s (i : 'I_m): s`_i \in <<s>>%VS by rewrite memv_span ?memt_nth.
 have s_Zs a: \sum_(i < m) s`_i *~ a i \in <<s>>%VS.
-  by rewrite memv_suml // => i _; rewrite -scaler_int memvZ.
+  by apply/rpred_sum => i _; apply/rpredMz.
 case s_v: (v \in <<s>>%VS); last by right=> [[a Dv]]; rewrite Dv s_Zs in s_v.
 pose S := \matrix_(i < m, j < _) coord (vbasis <<s>>) j s`_i.
 pose r := \rank S; pose k := (m - r)%N; pose Em := erefl m; pose Ek := erefl k.
@@ -1100,12 +1099,12 @@ case Zv: (map_mx denq (vv *m pinvmx T) == const_mx 1).
       by have /eqP/rowP/(_ i)/[!mxE]-> := Zv; rewrite mulr1.
     by rewrite -(mulmxA _ _ S) mulmxKpV ?mxE // -eqST submx_full.
   rewrite (coord_vbasis (s_Zs _)); apply: eq_bigr => j _; congr (_ *: _).
-  rewrite linear_sum mxE; apply: eq_bigr => i _.
-  by rewrite -scaler_int linearZ [a]lock !mxE ffunE.
+  rewrite linear_sum mxE; apply: eq_bigr => /= i _.
+  by rewrite mxE mulrzl mxE ffunE raddfMz.
 right=> [[a Dv]]; case/eqP: Zv; apply/rowP.
 have ->: vv = map_mx intr (\row_i a i) *m S.
   apply/rowP=> j; rewrite !mxE Dv linear_sum.
-  by apply: eq_bigr => i _; rewrite -scaler_int linearZ !mxE.
+  by apply: eq_bigr => i _; rewrite !mxE raddfMz mulrzl.
 rewrite -defS -2!mulmxA; have ->: T *m pinvmx T = 1%:M.
   have uT: row_free T by rewrite /row_free -eqST.
   by apply: (row_free_inj uT); rewrite mul1mx mulmxKpV.

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -3208,7 +3208,7 @@ Variable f : {linear 'rV[R]_m -> 'rV[R]_n}.
 
 Lemma mul_rV_lin1 u : u *m lin1_mx f = f u.
 Proof.
-rewrite {2}[u]matrix_sum_delta big_ord1 linear_sum; apply/rowP=> i.
+rewrite [u in RHS]matrix_sum_delta big_ord1 linear_sum; apply/rowP=> i.
 by rewrite mxE summxE; apply: eq_bigr => j _; rewrite linearZ !mxE.
 Qed.
 

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -298,17 +298,15 @@ have le_p'_dp: size p' <= dp.
 have le_q'_dq: size q' <= dq.
   have [-> | nz_q'] := eqVneq q' 0; first by rewrite size_poly0.
   by rewrite /dq -(size_scale q nz_k) q'r size_mul // addnC -def_r leq_addl.
-exists (row_mx (- c *: poly_rV q') (k *: poly_rV p')).
-  apply: contraNneq r_nz; rewrite -row_mx0; case/eq_row_mx=> q0 p0.
-  have{} p0: p = 0.
-    apply/eqP; rewrite -size_poly_eq0 -(size_scale p nz_c) p'r.
-    rewrite -(size_scale _ nz_k) scalerAl -(poly_rV_K le_p'_dp) -linearZ p0.
-    by rewrite linear0 mul0r size_poly0.
-  rewrite /r p0 gcd0p -size_poly_eq0 -(size_scale q nz_k) q'r.
-  rewrite -(size_scale _ nz_c) scalerAl -(poly_rV_K le_q'_dq) -linearZ.
-  by rewrite -[c]opprK scaleNr q0 oppr0 linear0 mul0r size_poly0.
-rewrite mul_row_col scaleNr mulNmx !mul_rV_lin1 /= !linearZ /= !poly_rV_K //.
-by rewrite !scalerCA p'r q'r mulrCA addNr.
+exists (row_mx (- c *: poly_rV q') (k *: poly_rV p')); last first.
+  rewrite mul_row_col scaleNr mulNmx !mul_rV_lin1 /= 2!linearZ /= !poly_rV_K //.
+  by rewrite !scalerCA p'r q'r mulrCA addNr.
+apply: contraNneq r_nz; rewrite -row_mx0 => /eq_row_mx[/eqP].
+rewrite scaleNr oppr_eq0 gcdp_eq0 -!size_poly_eq0 => /eqP q0 p0.
+rewrite -(size_scale p nz_c) -(size_scale (c *: p) nz_k) p'r.
+rewrite -(size_scale q nz_k) -(size_scale (k *: q) nz_c) q'r !scalerAl.
+rewrite -(poly_rV_K le_p'_dp) -(poly_rV_K le_q'_dq).
+by rewrite -2![_ *: rVpoly _]linearZ p0 q0 !linear0 mul0r size_poly0.
 Qed.
 
 Section HornerMx.
@@ -345,7 +343,7 @@ Lemma horner_rVpoly m (u : 'rV_m) :
 Proof.
 rewrite mulmx_sum_row linear_sum [rVpoly u]poly_def rmorph_sum.
 apply: eq_bigr => i _.
-by rewrite valK /= !linearZ rmorphXn /= horner_mx_X rowK /= mxvecK.
+by rewrite valK /= !linearZ rmorphXn /= horner_mx_X rowK mxvecK.
 Qed.
 
 End OneMatrix.

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -1582,7 +1582,7 @@ Lemma derivMNn n p : (p *- n)^`() = p^`() *- n.
 Proof. exact: linearMNn. Qed.
 
 Lemma derivZ c p : (c *: p)^`() = c *: p^`().
-Proof. by rewrite linearZ. Qed.
+Proof. exact: linearZ. Qed.
 
 Lemma deriv_mulC c p : (c%:P * p)^`() = c%:P * p^`().
 Proof. by rewrite !mul_polyC derivZ. Qed.
@@ -2627,7 +2627,7 @@ Proof.
 have cxid: commr_rmorph idfun x by apply: mulrC.
 have evalE : horner_eval x =1 horner_morph cxid.
   by move=> p; congr _.[x]; rewrite map_poly_id.
-by move=> c p q; rewrite !evalE rmorphD /= linearZ.
+by move=> c p q; rewrite !evalE linearP.
 Qed.
 
 Fact horner_eval_is_multiplicative x : multiplicative (horner_eval x).

--- a/mathcomp/algebra/vector.v
+++ b/mathcomp/algebra/vector.v
@@ -2340,11 +2340,8 @@ apply/memv_imgP/submxP => [[u _ ->]|[u /(canRL (rVofK _)) ->//]].
 by exists (vecof e u); rewrite ?memvf// -hom_vecof.
 Qed.
 
-Lemma leigenspaceE f a :
-   leigenspace f a = vsof e (eigenspace (mxof e e f) a).
-Proof.
-by rewrite /leigenspace /eigenspace lker_ker linearB linearZ/= mxof1// scalemx1.
-Qed.
+Lemma leigenspaceE f a : leigenspace f a = vsof e (eigenspace (mxof e e f) a).
+Proof. by rewrite [LHS]lker_ker linearB linearZ/= mxof1// scalemx1. Qed.
 
 End eigen.
 End passmx.

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -108,12 +108,8 @@ Proof. by []. Qed.
 Lemma trowb_is_linear n1 m2 n2 (B : 'M_(m2,n2)) : linear (@trowb n1 m2 n2 B).
 Proof.
 elim: n1=> [|n1 IH] //= k A1 A2 /=; first by rewrite scaler0 add0r.
-rewrite linearD /= linearZ.
--apply/matrixP=> i j.
-rewrite !mxE.
-case: split=> a.
-  by rewrite !mxE mulrDl mulrA.
-by rewrite linearD /= linearZ IH !mxE.
+rewrite !linearD /= !linearZ /= IH 2!mxE.
+by rewrite scalerDl -scalerA -add_row_mx -scale_row_mx.
 Qed.
 
 HB.instance Definition _ n1 m2 n2 B :=
@@ -231,10 +227,9 @@ Proof.
 elim: m n A B => [|m IH] n A B //=.
   by rewrite [A]flatmx0 mxtrace0 mul0r.
 rewrite tprod_tr -block_mxEv mxtrace_block IH.
-rewrite linearZ /= -mulrDl; congr (_ * _).
-rewrite -trace_mx11 .
+rewrite linearZ/= -mulrDl -trace_mx11; congr (_ * _).
 pose A1 := A : 'M_(1 + m).
-rewrite -{3}[A](@submxK _ 1 m 1 m A1).
+rewrite -[A in RHS](@submxK _ 1 m 1 m A1).
 by rewrite (@mxtrace_block _ _ _ (ulsubmx A1)).
 Qed.
 
@@ -532,7 +527,7 @@ Lemma xcfun_repr n rG A : xcfun (@cfRepr n rG) A = \tr (gring_op rG A).
 Proof.
 rewrite gring_opE [gring_row A]row_sum_delta !linear_sum /xcfun !mxE.
 apply: eq_bigr => i _; rewrite !mxE /= !linearZ cfunE enum_valP /=.
-by congr (_ * \tr _) => {A} /=; rewrite /gring_mx /= -rowE rowK mxvecK.
+by congr (_ * \tr _); rewrite {A}/gring_mx /= -rowE rowK mxvecK.
 Qed.
 
 End Char.

--- a/mathcomp/character/inertia.v
+++ b/mathcomp/character/inertia.v
@@ -581,7 +581,7 @@ Lemma cfConjgRes_norm phi y :
   y \in 'N(K) -> y \in 'N(H) -> ('Res[K, H] phi ^ y)%CF = 'Res (phi ^ y)%CF.
 Proof.
 move=> nKy nHy; have [sKH | not_sKH] := boolP (K \subset H); last first.
-  by rewrite !cfResEout // linearZ rmorph1 cfConjg1.
+  by rewrite !cfResEout // rmorph_alg cfConjg1.
 by apply/cfun_inP=> x Kx; rewrite !(cfConjgE, cfResE) ?memJ_norm ?groupV.
 Qed.
 
@@ -647,7 +647,7 @@ Lemma cfConjgMorph (phi : 'CF(f @* H)) y :
   y \in D -> y \in 'N(H) -> (cfMorph phi ^ y)%CF = cfMorph (phi ^ f y).
 Proof.
 move=> Dy nHy; have [sHD | not_sHD] := boolP (H \subset D); last first.
-  by rewrite !cfMorphEout // linearZ rmorph1 cfConjg1.
+  by rewrite !cfMorphEout // rmorph_alg cfConjg1.
 apply/cfun_inP=> x Gx; rewrite !(cfConjgE, cfMorphE) ?memJ_norm ?groupV //.
   by rewrite morphJ ?morphV ?groupV // (subsetP sHD).
 by rewrite (subsetP (morphim_norm _ _)) ?mem_morphim.
@@ -723,7 +723,7 @@ Proof.
 move=> nKy nHy; have keryK: (K \subset cfker (phi ^ y)) = (K \subset cfker phi).
   by rewrite cfker_conjg // -{1}(normP nKy) conjSg.
 have [kerK | not_kerK] := boolP (K \subset cfker phi); last first.
-  by rewrite !cfQuoEout ?linearZ ?rmorph1 ?cfConjg1 ?keryK.
+  by rewrite !cfQuoEout ?rmorph_alg ?cfConjg1 ?keryK.
 apply/cfun_inP=> _ /morphimP[x nKx Hx ->].
 have nHyb: coset K y \in 'N(H / K) by rewrite inE -morphimJ ?(normP nHy).
 rewrite !(cfConjgE, cfQuoEnorm) ?keryK // ?in_setI ?Hx //.

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -783,9 +783,8 @@ End GringMx.
 
 Lemma gring_mxK : cancel (gring_mx aG) gring_row.
 Proof.
-move=> a; rewrite /gring_mx /= mulmx_sum_row !linear_sum.
-rewrite {2}[a]row_sum_delta; apply: eq_bigr => i _.
-rewrite !linearZ /= /gring_row !(rowK, mxvecK).
+move=> a; rewrite /gring_mx /= mulmx_sum_row !linear_sum /= [RHS]row_sum_delta.
+apply: eq_bigr => i _; rewrite 2!linearZ /= /gring_row !(rowK, mxvecK).
 by rewrite gring_indexK // mul1g gring_valK.
 Qed.
 
@@ -1276,10 +1275,10 @@ Qed.
 
 Lemma envelop_mxM A B : (A \in E_G -> B \in E_G -> A *m B \in E_G)%MS.
 Proof.
-case/envelop_mxP=> a ->{A}; case/envelop_mxP=> b ->{B}.
+move=> {A B} /envelop_mxP[a ->] /envelop_mxP[b ->].
 rewrite mulmx_suml !linear_sum summx_sub //= => x Gx.
 rewrite !linear_sum summx_sub //= => y Gy.
-rewrite -scalemxAl !(linearZ, scalemx_sub) //= -repr_mxM //.
+rewrite -scalemxAl 3!linearZ !scalemx_sub//= -repr_mxM //.
 by rewrite envelop_mx_id ?groupM.
 Qed.
 
@@ -1315,7 +1314,7 @@ Lemma hom_envelop_mxC m f (W : 'M_(m, n)) A :
   (W <= dom_hom_mx f -> A \in E_G -> W *m A *m f = W *m f *m A)%MS.
 Proof.
 move/hom_mxP=> cWfG /envelop_mxP[a ->]; rewrite !linear_sum mulmx_suml.
-by apply: eq_bigr => x Gx; rewrite !linearZ -scalemxAl /= cWfG.
+by apply: eq_bigr => x Gx /=; rewrite -2!scalemxAr -scalemxAl cWfG.
 Qed.
 
 Lemma dom_hom_invmx f :
@@ -2329,7 +2328,7 @@ apply: (iffP row_fullP) => [[E' E'G] | [_ [a_ a_G]]].
   apply: (can_inj mxvecK); rewrite -{1}[mxvec B]mulmx1 -{}E'G mulmxA.
   move: {B E'}(_ *m E') => u; apply/rowP=> j.
   rewrite linear_sum (reindex h) //= mxE summxE.
-  by apply: eq_big => [k| k _]; rewrite ?Gh // enum_valK_in mxE linearZ !mxE.
+  by apply: eq_big => [k| k _]; rewrite ?Gh // enum_valK_in linearZ !mxE.
 exists (\matrix_(j, i) a_ (h i) (vec_mx (row j 1%:M))).
 apply/row_matrixP=> i; rewrite -[row i 1%:M]vec_mxK {}[vec_mx _]a_G.
 apply/rowP=> j; rewrite linear_sum (reindex h) //= 2!mxE summxE.
@@ -2783,8 +2782,7 @@ split=> [] [_ nzU simU].
   rewrite -(in_submodK sVU) -val_submod1 val_submodS.
   rewrite -(genmxE (in_submod U V)) simU ?genmxE ?submx1 //=.
     by rewrite (eqmx_module _ (genmxE _)) in_submod_module.
-  rewrite -submx0 genmxE -val_submodS in_submodK //.
-  by rewrite linear0 eqmx0 submx0.
+  by rewrite -submx0 genmxE -val_submodS in_submodK // linear0 eqmx0 submx0.
 apply/mx_irrP; rewrite lt0n mxrank_eq0; split=> // V modV.
 rewrite -(inj_eq val_submod_inj) linear0 -(eqmx_eq0 (genmxE _)) => nzV.
 rewrite -sub1mx -val_submodS val_submod1 -(genmxE (val_submod V)).
@@ -3974,7 +3972,7 @@ apply/rowP=> k /[1!mxE].
 have [x Gx def_k] := imsetP (enum_valP k).
 transitivity (@gring_proj F _ G x (vec_mx 0) 0 0); last first.
   by rewrite !linear0 !mxE.
-rewrite -{}v0 !linear_sum (bigD1 k) //= !linearZ /= rowK mxvecK def_k.
+rewrite -{}v0 !linear_sum (bigD1 k) //= 2!linearZ /= rowK mxvecK def_k.
 rewrite linear_sum (bigD1 x) ?class_refl //= gring_projE // eqxx.
 rewrite !big1 ?addr0 ?mxE ?mulr1 // => [k' | y /andP[xGy ne_yx]]; first 1 last.
   by rewrite gring_projE ?(groupCl Gx xGy) // eq_sym (negPf ne_yx).
@@ -4007,10 +4005,10 @@ rewrite !linear_sum {xG GxG}def_xG; apply: eq_big  => [y | xy] /=.
 case/imsetP=> y Gy ->{xy}; rewrite linearZ; congr (_ *: _).
 move/(canRL (repr_mxK aG Gy)): (centgmxP cGa y Gy); have Gy' := groupVr Gy.
 move/(congr1 (gring_proj x)); rewrite -mulmxA mulmx_suml !linear_sum.
-rewrite (bigD1 x Gx) big1 => [|z /andP[Gz]]; rewrite !linearZ /=; last first.
+rewrite (bigD1 x Gx) big1 => [|z /andP[Gz]]; rewrite linearZ /=; last first.
   by rewrite eq_sym gring_projE // => /negPf->; rewrite scaler0.
 rewrite gring_projE // eqxx scalemx1 (bigD1 (x ^ y)%g) ?groupJ //=.
-rewrite big1 => [|z /andP[Gz]]; rewrite -scalemxAl !linearZ /=.
+rewrite big1 => [|z /andP[Gz]]; rewrite -scalemxAl 2!linearZ /=.
   rewrite !addr0 -!repr_mxM ?groupM // mulgA mulKVg mulgK => /rowP/(_ 0).
   by rewrite gring_projE // eqxx scalemx1 !mxE.
 rewrite eq_sym -(can_eq (conjgKV y)) conjgK conjgE invgK.
@@ -4055,7 +4053,7 @@ apply/rV_subP=> v /rfix_mxP cGv.
 have /envelop_mxP[a def_v]: (gring_mx aG v \in R_G)%MS.
   by rewrite vec_mxK submxMl.
 suffices ->: v = a 1%g *: gring_row (gset_mx G) by rewrite scalemx_sub.
-rewrite -linearZ  scaler_sumr -[v]gring_mxK def_v; congr (gring_row _).
+rewrite -linearZ scaler_sumr -[v]gring_mxK def_v; congr (gring_row _).
 apply: eq_bigr => x Gx; congr (_ *: _).
 move/rowP/(_ 0): (congr1 (gring_proj x \o gring_mx aG) (cGv x Gx)).
 rewrite /= gring_mxJ // def_v mulmx_suml !linear_sum (bigD1 1%g) //=.
@@ -4268,7 +4266,7 @@ case/mx_rsim_def=> f [f' _ hom_f] ne_iG_j RjA.
 transitivity (f *m in_submod _ (val_submod 1%:M *m A) *m f').
   have{RjA}: (A \in R_G)%MS by rewrite -Wedderburn_sum (sumsmx_sup j).
   case/envelop_mxP=> a ->{A}; rewrite !(linear_sum, mulmx_suml).
-  by apply: eq_bigr => x Gx; rewrite !linearZ /= -scalemxAl -hom_f ?gring_opG.
+  by apply: eq_bigr => x Gx; rewrite 4!linearZ /= -scalemxAl -hom_f ?gring_opG.
 rewrite (_ : _ *m A = 0) ?(linear0, mul0mx) //.
 apply/row_matrixP=> i; rewrite row_mul row0 -[row _ _]gring_mxK -gring_row_mul.
 rewrite (Wedderburn_mulmx0 ne_iG_j) ?linear0 // genmxE mem_gring_mx.
@@ -4340,7 +4338,7 @@ have <-: (gring_mx aG (val_submod (v *m (f *m gring_op rG A *m f')))) = 0.
   by rewrite (eqP opA0) !(mul0mx, linear0).
 have: (A \in R_G)%MS by rewrite -Wedderburn_sum (sumsmx_sup iG).
 case/envelop_mxP=> a ->; rewrite !(linear_sum, mulmx_suml) /=; apply/eqP.
-apply: eq_bigr=> x Gx; rewrite !linearZ -scalemxAl !linearZ /=.
+apply: eq_bigr=> x Gx; rewrite 3!linearZ -scalemxAl 3!linearZ /=.
 by rewrite gring_opG // -hom_f // val_submodJ // gring_mxJ.
 Qed.
 
@@ -4370,7 +4368,7 @@ rewrite -(mxrankMfree _ inj_f); symmetry; rewrite -(eqmxMfull _ inj_f).
 have /envelop_mxP[e ->{i}]: ('e_i \in R_G)%MS.
   by rewrite -Wedderburn_sum (sumsmx_sup i) ?Wedderburn_id_mem.
 congr (\rank _ != _); rewrite !(mulmx_suml, linear_sum); apply: eq_bigr => x Gx.
-by rewrite !linearZ -scalemxAl /= !gring_opG ?hom_f.
+by rewrite 3!linearZ -scalemxAl /= !gring_opG ?hom_f.
 Qed.
 
 Lemma irr_reprK i : irr_comp (irr_repr i) = i.
@@ -5337,7 +5335,7 @@ have ->: A ^+ k *m mxval x^-1 = mxval (groot ^+ k / x).
   by rewrite mxvalM rmorphXn /= mxval_groot.
 rewrite [mxval _]horner_rVpoly; move: {k u x}(val _) => u.
 rewrite (mulmx_sum_row u) !linear_sum summx_sub //= => k _.
-rewrite !linearZ scalemx_sub //= rowK mxvecK -rowE.
+rewrite 2!linearZ scalemx_sub //= rowK mxvecK -rowE.
 by apply: eq_row_sub (mxvec_index i k) _; rewrite rowK mxvecE mxE.
 Qed.
 
@@ -5381,7 +5379,7 @@ Proof. by apply: (canLR in_genK); rewrite in_gen0. Qed.
 Lemma in_genN : {morph in_gen : W / - W}.
 Proof.
 move=> W; apply/matrixP=> i j; apply: val_inj.
-by rewrite !mxE !(mulNmx, linearN).
+by rewrite !mxE 4!(mulNmx, linearN).
 Qed.
 
 Lemma val_genN : {morph val_gen : W / - W}.
@@ -5535,7 +5533,7 @@ apply/row_subP=> i0; rewrite -val_gen_row row_mul; move: {i0 u}(row _ u) => u.
 rewrite mulmx_sum_row val_gen_sum summx_sub // => i _.
 rewrite val_genZ [mxval _]horner_rVpoly [_ *m Ad]mulmx_sum_row.
 rewrite !linear_sum summx_sub // => k _.
-rewrite !linearZ scalemx_sub {u}//= rowK mxvecK val_gen_row.
+rewrite 2!linearZ scalemx_sub {u}//= rowK mxvecK val_gen_row.
 by apply: (eq_row_sub (mxvec_index i k)); rewrite rowK mxvecE mxE.
 Qed.
 

--- a/mathcomp/field/algnum.v
+++ b/mathcomp/field/algnum.v
@@ -420,7 +420,7 @@ have ext1 mu0 x : {mu1 | exists y, x = Sinj mu1 y
   have hom_f: kHom 1 (ASpace algK) f.
     apply/kHomP; split=> [_ _ /memK[y1 ->] /memK[y2 ->] |_ /vlineP[a ->]].
       by rewrite -rmorphM !Df !rmorphM.
-    by rewrite -(rmorph1 in01) -linearZ /= Df /= {1}linearZ /= rmorph1.
+    by rewrite -(rmorph_alg in01) Df /= !rmorph_alg.
   pose pr := map_poly (in_alg Qr) p.
   have Qpr: pr \is a polyOver 1%VS.
     by apply/polyOverP=> i; rewrite coef_map memvZ ?memv_line.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -1332,7 +1332,7 @@ suffices [L dimL [toPF [toL toPF_K toL_K]]]:
     by rewrite map_poly0 horner0 linear0 mod0p.
   rewrite rmorphD rmorphM /= map_polyX map_polyC hornerMXaddC linearD /=.
   rewrite linearZ /= -(rmorph1 toL) toL_K -modpZl alg_polyC modpD.
-  congr (_ + _); rewrite -toL_K rmorphM /= -/z; congr (toPF (_ * z)).
+  congr (_ + _); rewrite -toL_K rmorphM -/z; congr (toPF (_ * z)).
   by apply: (can_inj toPF_K); rewrite toL_K.
 pose toL q : vL := poly_rV (q %% p); pose toPF (x : vL) := rVpoly x.
 have toL_K q : toPF (toL q) = q %% p.

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -197,8 +197,7 @@ Proof. by move=> a b; rewrite /kHomf !raddfB hornerD hornerN. Qed.
 
 Fact kHomExtend_scalable_subproof : scalable kHomf.
 Proof.
-move=> k a; rewrite /kHomf !linearZ /=.
-rewrite -[rhs in _ = rhs]mulr_algl -hornerZ; congr _.[_].
+move=> k a; rewrite /kHomf linearZ /= -[RHS]mulr_algl -hornerZ; congr _.[_].
 by apply/polyP => i; rewrite !(coefZ, coef_map) /= !mulr_algl linearZ.
 Qed.
 HB.instance Definition _ := @GRing.isAdditive.Build _ _ kHomf
@@ -567,11 +566,11 @@ have [f homLf fxz]: exists2 f : 'End(Lz), kHom 1 imL f & f (inLz x) = z.
     have [q2 Dq2]: exists q2, q1z = map_poly inLz q2.
       exists (\poly_(i < size q1z) (sval (sig_eqW (F0q1z i)))%:A).
       rewrite -{1}[q1z]coefK; apply/polyP=> i; rewrite coef_map !{1}coef_poly.
-      by case: sig_eqW => a; case: ifP; rewrite /= ?rmorph0 ?linearZ ?rmorph1.
+      by case: sig_eqW => a; case: ifP; rewrite /= ?rmorph0 ?rmorph_alg.
     rewrite Dq2 dvdp_map minPoly_dvdp //.
       apply/polyOverP=> i; have[a] := F0q1z i.
-      rewrite -(rmorph1 inLz) -linearZ.
-      by rewrite Dq2 coef_map => /fmorph_inj->; rewrite rpredZ ?mem1v.
+      rewrite -(rmorph_alg inLz) Dq2 coef_map /= => /fmorph_inj->.
+      exact/rpredZ/mem1v.
     by rewrite -(fmorph_root inLz) -Dq2 root_minPoly.
   have q1z_z: root q1z z.
     rewrite !root_factor_theorem in qz0 *.

--- a/mathcomp/field/separable.v
+++ b/mathcomp/field/separable.v
@@ -469,13 +469,10 @@ Fact extendDerivation_scalable_subproof E (adjEx := Fadjoin_poly E x) :
   let body y (p := adjEx y) := (map_poly D p).[x] + p^`().[x] * Dx E in
   scalable body.
 Proof.
-move: Dx => C /= a u.
-rewrite /adjEx linearZ /= -mul_polyC derivM derivC mul0r add0r -/adjEx.
-rewrite !hornerE /= -scalerAl mul1r raddfD /=.
-have ->: map_poly D (a%:A%:P * adjEx u) = a%:A%:P * map_poly D (adjEx u).
-  apply/polyP=> i; rewrite !mul_polyC !coef_map !coefZ !mulr_algl /= linearZ.
-  by rewrite coef_map.
-by rewrite !hornerE !mulr_algl -scalerAl.
+move: Dx => C /= a u; rewrite /adjEx linearZ /= derivZ -/adjEx.
+rewrite hornerE -[RHS]mulr_algl mulrDr mulrA -[in RHS]hornerZ.
+congr (_.[x] + _); apply/polyP=> i.
+by rewrite coefZ !coef_map coefZ !mulr_algl /= linearZ.
 Qed.
 
 Section DerivationLinear.


### PR DESCRIPTION
##### Motivation for this change

This PR aims to mitigate some performance issues related to the `linear` lemmas and clarify whether they are caused by the introduction of the new structures by #1125 or not. (The answer seems to be yes and no.)

##### Minimal TODO list

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
