### PR TITLE
Structures with one operation

### DIFF
--- a/Make
+++ b/Make
@@ -84,6 +84,8 @@ ssreflect/fingraph.v
 ssreflect/finset.v
 ssreflect/fintype.v
 ssreflect/generic_quotient.v
+ssreflect/monoid.v
+ssreflect/nmodule.v
 ssreflect/order.v
 ssreflect/path.v
 ssreflect/prime.v

--- a/algebra/finalg.v
+++ b/algebra/finalg.v
@@ -175,7 +175,8 @@ Lemma zmod1gE : 1%g = 0 :> U.            Proof. by []. Qed.
 Lemma zmodVgE x : x^-1%g = - x.          Proof. by []. Qed.
 Lemma zmodMgE x y : (x * y)%g = x + y.   Proof. by []. Qed.
 Lemma zmodXgE n x : (x ^+ n)%g = x *+ n. Proof. by []. Qed.
-Lemma zmod_mulgC x y : commute x y.      Proof. exact: addrC. Qed.
+Lemma zmod_mulgC x y : commute x y.
+Proof. exact: addrC. Qed.
 Lemma zmod_abelian (A : {set U}) : abelian A.
 Proof. by apply/centsP=> x _ y _; apply: zmod_mulgC. Qed.
 

--- a/algebra/matrix.v
+++ b/algebra/matrix.v
@@ -4708,11 +4708,15 @@ Implicit Type (s : 'I_sq).
 
 Lemma mul_mxrow m n' (A : 'M[R]_(m, n')) (R_ : forall j, 'M[R]_(n', q_ j)) :
   A *m \mxrow_j R_ j= \mxrow_j (A *m R_ j).
-Proof. by apply/matrixP=> i s; rewrite !mxE; under eq_bigr do rewrite !mxE. Qed.
+Proof.
+by apply/matrixP=> i s; rewrite !mxE; under [LHS]eq_bigr do rewrite !mxE.
+Qed.
 
 Lemma mul_submxrow m n' (A : 'M[R]_(m, n')) (B : 'M[R]_(n', sq)) j :
   A *m submxrow B j= submxrow (A *m B) j.
-Proof. by apply/matrixP=> i s; rewrite !mxE; under eq_bigr do rewrite !mxE. Qed.
+Proof.
+by apply/matrixP=> i s; rewrite !mxE; under [LHS]eq_bigr do rewrite !mxE.
+Qed.
 
 End BlockRowRing.
 
@@ -4779,11 +4783,15 @@ Implicit Type (s : 'I_sp).
 
 Lemma mxcol_mul n' m (C_ : forall i, 'M[R]_(p_ i, n')) (A : 'M[R]_(n', m)) :
   \mxcol_i C_ i *m A = \mxcol_i (C_ i *m A).
-Proof. by apply/matrixP=> i s; rewrite !mxE; under eq_bigr do rewrite !mxE. Qed.
+Proof.
+by apply/matrixP=> i s; rewrite !mxE; under [LHS]eq_bigr do rewrite !mxE.
+Qed.
 
 Lemma submxcol_mul n' m (B : 'M[R]_(sp, n')) (A : 'M[R]_(n', m)) i :
   submxcol B i *m A = submxcol (B *m A) i.
-Proof. by apply/matrixP=> j s; rewrite !mxE; under eq_bigr do rewrite !mxE. Qed.
+Proof.
+by apply/matrixP=> j s; rewrite !mxE; under [LHS]eq_bigr do rewrite !mxE.
+Qed.
 
 End BlockColRing.
 

--- a/algebra/mxpoly.v
+++ b/algebra/mxpoly.v
@@ -1183,7 +1183,7 @@ have [i_lt_m1 | m1_le_i] := ltnP i m1.
 rewrite -(subnK m1_le_i) exprD -[x ^+ m1]subr0 -(rootP px0) horner_coef.
 rewrite polySpred ?monic_neq0 // -/m1 big_ord_recr /= -lead_coefE.
 rewrite opprD addrC (monicP mon_p) mul1r subrK !mulrN -mulNr !mulr_sumr.
-apply: Msum => j _; rewrite mulrA mulrACA -exprD; apply: IHn.
+apply: Msum => j _; rewrite [X in M X]mulrA mulrACA -exprD; apply: IHn.
   by rewrite -addnS addnC addnBA // leq_subLR leq_add.
 by rewrite -mulN1r; do 2!apply: (genM) => //; apply: genR.
 Qed.

--- a/algebra/poly.v
+++ b/algebra/poly.v
@@ -2,8 +2,8 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq choice.
-From mathcomp Require Import fintype bigop finset tuple.
-From mathcomp Require Import div ssralg countalg binomial.
+From mathcomp Require Import fintype bigop finset tuple div ssralg.
+From mathcomp Require Import countalg binomial.
 
 (******************************************************************************)
 (* This file provides a library for univariate polynomials over ring          *)

--- a/algebra/qpoly.v
+++ b/algebra/qpoly.v
@@ -1,10 +1,8 @@
 From HB Require Import structures.
-From mathcomp
-Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice fintype tuple.
-From mathcomp
-Require Import bigop binomial finset finfun ssralg countalg finalg poly polydiv.
-From mathcomp
-Require Import perm fingroup matrix mxalgebra mxpoly vector countalg.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype tuple bigop binomial finset finfun ssralg.
+From mathcomp Require Import countalg finalg poly polydiv perm fingroup matrix.
+From mathcomp Require Import mxalgebra mxpoly vector countalg.
 
 (******************************************************************************)
 (* This file defines the algebras R[X]/<p> and their theory.                  *)

--- a/algebra/ssralg.v
+++ b/algebra/ssralg.v
@@ -3,9 +3,10 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat div seq.
 From mathcomp Require Import choice fintype finfun bigop prime binomial.
+From mathcomp Require Export nmodule.
 
 (******************************************************************************)
-(*                 The base hierarchy of algebraic structures                 *)
+(*                            Ring-like structures                            *)
 (*                                                                            *)
 (* NB: See CONTRIBUTING.md for an introduction to HB concepts and commands.   *)
 (*                                                                            *)
@@ -14,11 +15,7 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                                                                            *)
 (* This file defines the following algebraic structures:                      *)
 (*                                                                            *)
-(*        nmodType == additive abelian monoid                                 *)
-(*                    The HB class is called Nmodule.                         *)
-(*        zmodType == additive abelian group (Nmodule with an opposite)       *)
-(*                    The HB class is called Zmodule.                         *)
-(*  pzSemiRingType == non-commutative semi rings                              *)
+(*  semiPzRingType == non-commutative semi rings                              *)
 (*                    (NModule with a multiplication)                         *)
 (*                    The HB class is called PzSemiRing.                      *)
 (*  nzSemiRingType == non-commutative non-trivial semi rings                  *)
@@ -79,12 +76,6 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                                                                            *)
 (* and their joins with subType:                                              *)
 (*                                                                            *)
-(*         subNmodType V P == join of nmodType and subType (P : pred V) such  *)
-(*                            that val is semi_additive                       *)
-(*                            The HB class is called SubNmodule.              *)
-(*         subZmodType V P == join of zmodType and subType (P : pred V)       *)
-(*                            such that val is additive                       *)
-(*                            The HB class is called SubZmodule.              *)
 (*   subPzSemiRingType R P == join of pzSemiRingType and                      *)
 (*                            subType (P : pred R) such that val is a         *)
 (*                            semiring morphism                               *)
@@ -144,9 +135,6 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                                                                            *)
 (* Morphisms between the above structures (see below for details):            *)
 (*                                                                            *)
-(*       {additive U -> V} == semi additive (resp. additive) functions between*)
-(*                            nmodType (resp. zmodType) instances U and V.    *)
-(*                            The HB class is called Additive.                *)
 (*      {rmorphism R -> S} == semi ring (resp. ring) morphism between         *)
 (*                            semiPzRingType (resp. pzRingType) instances     *)
 (*                            R and S.                                        *)
@@ -463,23 +451,6 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*   In addition to this structure hierarchy, we also develop a separate,     *)
 (* parallel hierarchy for morphisms linking these structures:                 *)
 (*                                                                            *)
-(* * Additive (semiadditive or additive functions):                           *)
-(*        nmod_morphism f <-> f of type U -> V is semi additive, i.e., f maps *)
-(*                           the Nmodule structure of U to that of V, 0 to 0  *)
-(*                           and + to +                                       *)
-(*                        := (f 0 = 0) * {morph f : x y / x + y}              *)
-(*        zmod_morphism f <-> f of type U -> V is additive, i.e., f maps the  *)
-(*                           Zmodule structure of U to that of V, 0 to 0,     *)
-(*                           - to - and + to + (equivalently, binary - to -)  *)
-(*                        := {morph f : u v / u - v}                          *)
-(*      {additive U -> V} == the interface type for a Structure (keyed on     *)
-(*                           a function f : U -> V) that encapsulates the     *)
-(*                           semi_additive property; both U and V must have   *)
-(*                           canonical nmodType instances                     *)
-(*                           When both U and V have zmodType instances, it is *)
-(*                           an additive function.                            *)
-(*                        := GRing.Additive.type U V                          *)
-(*                                                                            *)
 (* * RMorphism (semiring or ring morphisms):                                  *)
 (*      monoid_morphism f <-> f of type R -> S is a multiplicative monoid     *)
 (*                           morphism, i.e., f maps 1 and * in R to 1 and *   *)
@@ -719,32 +690,19 @@ Declare Scope term_scope.
 Delimit Scope term_scope with T.
 Local Open Scope ring_scope.
 
+Module Export Dummy.
+Module GRing := Algebra.
+End Dummy.
+
 Module Import GRing.
 
+Export Algebra.
+
 Import Monoid.Theory.
-
-HB.mixin Record isNmodule V := {
-  zero : V;
-  add : V -> V -> V;
-  addrA : associative add;
-  addrC : commutative add;
-  add0r : left_id zero add;
-}.
-
-#[short(type="nmodType")]
-HB.structure Definition Nmodule := {V of isNmodule V & Choice V}.
-
-Module NmodExports.
-Bind Scope ring_scope with Nmodule.sort.
-End NmodExports.
-HB.export NmodExports.
 
 Local Notation "0" := (@zero _) : ring_scope.
 Local Notation "+%R" := (@add _) : function_scope.
 Local Notation "x + y" := (add x y) : ring_scope.
-
-Definition natmul V x n := iterop n +%R x (@zero V).
-Arguments natmul : simpl never.
 
 Local Notation "x *+ n" := (natmul x n) : ring_scope.
 
@@ -760,106 +718,68 @@ Section NmoduleTheory.
 Variable V : nmodType.
 Implicit Types x y : V.
 
-Lemma addr0 : @right_id V V 0 +%R.
-Proof. by move=> x; rewrite addrC add0r. Qed.
+Lemma addrA : associative (@add V).
+Proof. exact: addrA. Qed.
 
-#[export]
-HB.instance Definition _ := Monoid.isComLaw.Build V 0 +%R addrA addrC add0r.
+Lemma addrC : commutative (@add V).
+Proof. exact: addrC. Qed.
 
-Lemma addrCA : @left_commutative V V +%R. Proof. exact: mulmCA. Qed.
-Lemma addrAC : @right_commutative V V +%R. Proof. exact: mulmAC. Qed.
-Lemma addrACA : @interchange V +%R +%R. Proof. exact: mulmACA. Qed.
+Lemma add0r : left_id (@zero V) add.
+Proof. exact: add0r. Qed.
 
-Lemma mulr0n x : x *+ 0 = 0. Proof. by []. Qed.
-Lemma mulr1n x : x *+ 1 = x. Proof. by []. Qed.
-Lemma mulr2n x : x *+ 2 = x + x. Proof. by []. Qed.
+Lemma addr0 : right_id (@zero V) add.
+Proof. exact: addr0. Qed.
 
-Lemma mulrS x n : x *+ n.+1 = x + x *+ n.
-Proof. by case: n => //=; rewrite addr0. Qed.
+Lemma addrCA : @left_commutative V V +%R. Proof. exact: addrCA. Qed.
+Lemma addrAC : @right_commutative V V +%R. Proof. exact: addrAC. Qed.
+Lemma addrACA : @interchange V +%R +%R. Proof. exact: addrACA. Qed.
 
-Lemma mulrSr x n : x *+ n.+1 = x *+ n + x.
-Proof. by rewrite addrC mulrS. Qed.
+Lemma mulr0n x : x *+ 0 = 0. Proof. exact: mulr0n. Qed.
+Lemma mulr1n x : x *+ 1 = x. Proof. exact: mulr1n. Qed.
+Lemma mulr2n x : x *+ 2 = x + x. Proof. exact: mulr2n. Qed.
+Lemma mulrS x n : x *+ n.+1 = x + (x *+ n). Proof. exact: mulrS. Qed.
+Lemma mulrSr x n : x *+ n.+1 = x *+ n + x. Proof. exact: mulrSr. Qed.
 
 Lemma mulrb x (b : bool) : x *+ b = (if b then x else 0).
-Proof. by case: b. Qed.
+Proof. exact: mulrb. Qed.
 
-Lemma mul0rn n : 0 *+ n = 0 :> V.
-Proof. by elim: n => // n IHn; rewrite mulrS add0r. Qed.
+Lemma mul0rn n : 0 *+ n = 0 :> V. Proof. exact: mul0rn. Qed.
 
 Lemma mulrnDl n : {morph (fun x => x *+ n) : x y / x + y}.
-Proof.
-move=> x y; elim: n => [|n IHn]; rewrite ?addr0 // !mulrS.
-by rewrite addrCA -!addrA -IHn -addrCA.
-Qed.
+Proof. exact: mulrnDl. Qed.
 
 Lemma mulrnDr x m n : x *+ (m + n) = x *+ m + x *+ n.
-Proof.
-elim: m => [|m IHm]; first by rewrite add0r.
-by rewrite !mulrS IHm addrA.
-Qed.
+Proof. exact: mulrnDr. Qed.
 
-Lemma mulrnA x m n : x *+ (m * n) = x *+ m *+ n.
-Proof.
-by rewrite mulnC; elim: n => //= n IHn; rewrite mulrS mulrnDr IHn.
-Qed.
+Lemma mulrnA x m n : x *+ (m * n) = x *+ m *+ n. Proof. exact: mulrnA. Qed.
 
-Lemma mulrnAC x m n : x *+ m *+ n = x *+ n *+ m.
-Proof. by rewrite -!mulrnA mulnC. Qed.
+Lemma mulrnAC x m n : x *+ m *+ n = x *+ n *+ m. Proof. exact: mulrnAC. Qed.
 
 Lemma iter_addr n x y : iter n (+%R x) y = x *+ n + y.
-Proof. by elim: n => [|n ih]; rewrite ?add0r //= ih mulrS addrA. Qed.
+Proof. exact: iter_addr. Qed.
 
 Lemma iter_addr_0 n x : iter n (+%R x) 0 = x *+ n.
-Proof. by rewrite iter_addr addr0. Qed.
+Proof. exact: iter_addr_0. Qed.
 
 Lemma sumrMnl I r P (F : I -> V) n :
   \sum_(i <- r | P i) F i *+ n = (\sum_(i <- r | P i) F i) *+ n.
-Proof. by rewrite (big_morph _ (mulrnDl n) (mul0rn _)). Qed.
+Proof. exact: sumrMnl. Qed.
 
 Lemma sumrMnr x I r P (F : I -> nat) :
   \sum_(i <- r | P i) x *+ F i = x *+ (\sum_(i <- r | P i) F i).
-Proof. by rewrite (big_morph _ (mulrnDr x) (erefl _)). Qed.
+Proof. exact: sumrMnr. Qed.
 
 Lemma sumr_const (I : finType) (A : pred I) x : \sum_(i in A) x = x *+ #|A|.
-Proof. by rewrite big_const -iteropE. Qed.
+Proof. exact: sumr_const. Qed.
 
 Lemma sumr_const_nat m n x : \sum_(n <= i < m) x = x *+ (m - n).
-Proof. by rewrite big_const_nat iter_addr_0. Qed.
+Proof. exact: sumr_const_nat. Qed.
 
-Definition addr_closed (S : {pred V}) :=
-  0 \in S /\ {in S &, forall u v, u + v \in S}.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use Algebra.nmod_closed instead.")]
+Definition addr_closed := nmod_closed.
 
 End NmoduleTheory.
-
-HB.mixin Record Nmodule_isZmodule V of Nmodule V := {
-  opp : V -> V;
-  addNr : left_inverse zero opp add
-}.
-
-#[short(type="zmodType")]
-HB.structure Definition Zmodule := {V of Nmodule_isZmodule V & Nmodule V}.
-
-HB.factory Record isZmodule V of Choice V := {
-  zero : V;
-  opp : V -> V;
-  add : V -> V -> V;
-  addrA : associative add;
-  addrC : commutative add;
-  add0r : left_id zero add;
-  addNr : left_inverse zero opp add
-}.
-
-HB.builders Context V of isZmodule V.
-
-HB.instance Definition _ := isNmodule.Build V addrA addrC add0r.
-HB.instance Definition _ := Nmodule_isZmodule.Build V addNr.
-
-HB.end.
-
-Module ZmodExports.
-Bind Scope ring_scope with Zmodule.sort.
-End ZmodExports.
-HB.export ZmodExports.
 
 Local Notation "-%R" := (@opp _) : ring_scope.
 Local Notation "- x" := (opp x) : ring_scope.
@@ -872,127 +792,78 @@ Section ZmoduleTheory.
 Variable V : zmodType.
 Implicit Types x y : V.
 
-Lemma addrN : @right_inverse V V V 0 -%R +%R.
-Proof. by move=> x; rewrite addrC addNr. Qed.
+Lemma addNr : @left_inverse V V V 0 -%R +%R. Proof. exact: addNr. Qed.
+Lemma addrN : @right_inverse V V V 0 -%R +%R. Proof. exact: addrN. Qed.
 Definition subrr := addrN.
 
-Lemma addKr : @left_loop V V -%R +%R.
-Proof. by move=> x y; rewrite addrA addNr add0r. Qed.
-Lemma addNKr : @rev_left_loop V V -%R +%R.
-Proof. by move=> x y; rewrite addrA addrN add0r. Qed.
-Lemma addrK : @right_loop V V -%R +%R.
-Proof. by move=> x y; rewrite -addrA addrN addr0. Qed.
-Lemma addrNK : @rev_right_loop V V -%R +%R.
-Proof. by move=> x y; rewrite -addrA addNr addr0. Qed.
+Lemma addKr : @left_loop V V -%R +%R. Proof. exact: addKr. Qed.
+Lemma addNKr : @rev_left_loop V V -%R +%R. Proof. exact: addNKr. Qed.
+Lemma addrK : @right_loop V V -%R +%R. Proof. exact: addrK. Qed.
+Lemma addrNK : @rev_right_loop V V -%R +%R. Proof. exact: addrNK. Qed.
 Definition subrK := addrNK.
-Lemma subKr x : involutive (fun y => x - y).
-Proof. by move=> y; apply: (canLR (addrK _)); rewrite addrC subrK. Qed.
-Lemma addrI : @right_injective V V V +%R.
-Proof. by move=> x; apply: can_inj (addKr x). Qed.
-Lemma addIr : @left_injective V V V +%R.
-Proof. by move=> y; apply: can_inj (addrK y). Qed.
-Lemma subrI : right_injective (fun x y => x - y).
-Proof. by move=> x; apply: can_inj (subKr x). Qed.
-Lemma subIr : left_injective (fun x y => x - y).
-Proof. by move=> y; apply: addIr. Qed.
-Lemma opprK : @involutive V -%R.
-Proof. by move=> x; apply: (@subIr x); rewrite addNr addrN. Qed.
-Lemma oppr_inj : @injective V V -%R.
-Proof. exact: inv_inj opprK. Qed.
-Lemma oppr0 : -0 = 0 :> V.
-Proof. by rewrite -[-0]add0r subrr. Qed.
-Lemma oppr_eq0 x : (- x == 0) = (x == 0).
-Proof. by rewrite (inv_eq opprK) oppr0. Qed.
+Lemma subKr x : involutive (fun y => x - y). Proof. exact: subKr. Qed.
+Lemma addrI : @right_injective V V V +%R. Proof. exact: addrI. Qed.
+Lemma addIr : @left_injective V V V +%R. Proof. exact: addIr. Qed.
+Lemma subrI : right_injective (fun x y => x - y). Proof. exact: subrI. Qed.
+Lemma subIr : left_injective (fun x y => x - y). Proof. exact: subIr. Qed.
+Lemma opprK : @involutive V -%R. Proof. exact: opprK. Qed.
+Lemma oppr_inj : @injective V V -%R. Proof. exact: oppr_inj. Qed.
+Lemma oppr0 : -0 = 0 :> V. Proof. exact: oppr0. Qed.
+Lemma oppr_eq0 x : (- x == 0) = (x == 0). Proof. exact: oppr_eq0. Qed.
 
-Lemma subr0 x : x - 0 = x. Proof. by rewrite oppr0 addr0. Qed.
-Lemma sub0r x : 0 - x = - x. Proof. by rewrite add0r. Qed.
+Lemma subr0 x : x - 0 = x. Proof. exact: subr0. Qed.
+Lemma sub0r x : 0 - x = - x. Proof. exact: sub0r. Qed.
 
-Lemma opprB x y : - (x - y) = y - x.
-Proof. by apply: (canRL (addrK x)); rewrite addrC subKr. Qed.
-
-Lemma opprD : {morph -%R: x y / x + y : V}.
-Proof. by move=> x y; rewrite -[y in LHS]opprK opprB addrC. Qed.
-
-Lemma addrKA z x y : (x + z) - (z + y) = x - y.
-Proof. by rewrite opprD addrA addrK. Qed.
-
-Lemma subrKA z x y : (x - z) + (z + y) = x + y.
-Proof. by rewrite addrA addrNK. Qed.
-
-Lemma addr0_eq x y : x + y = 0 -> - x = y.
-Proof. by rewrite -[-x]addr0 => <-; rewrite addKr. Qed.
-
-Lemma subr0_eq x y : x - y = 0 -> x = y. Proof. by move/addr0_eq/oppr_inj. Qed.
-
-Lemma subr_eq x y z : (x - z == y) = (x == y + z).
-Proof. exact: can2_eq (subrK z) (addrK z) x y. Qed.
-
-Lemma subr_eq0 x y : (x - y == 0) = (x == y).
-Proof. by rewrite subr_eq add0r. Qed.
-
-Lemma addr_eq0 x y : (x + y == 0) = (x == - y).
-Proof. by rewrite -[y in LHS]opprK subr_eq0. Qed.
-
-Lemma eqr_opp x y : (- x == - y) = (x == y).
-Proof. exact: can_eq opprK x y. Qed.
-
-Lemma eqr_oppLR x y : (- x == y) = (x == - y).
-Proof. exact: inv_eq opprK x y. Qed.
-
-Lemma mulNrn x n : (- x) *+ n = x *- n.
-Proof. by elim: n => [|n IHn]; rewrite ?oppr0 // !mulrS opprD IHn. Qed.
+Lemma opprB x y : - (x - y) = y - x. Proof. exact: opprB. Qed.
+Lemma opprD : {morph -%R: x y / x + y : V}. Proof. exact: opprD. Qed.
+Lemma addrKA z x y : (x + z) - (z + y) = x - y. Proof. exact: addrKA. Qed.
+Lemma subrKA z x y : (x - z) + (z + y) = x + y. Proof. exact: subrKA. Qed.
+Lemma addr0_eq x y : x + y = 0 -> - x = y. Proof. exact: addr0_eq. Qed.
+Lemma subr0_eq x y : x - y = 0 -> x = y. Proof. exact: subr0_eq. Qed.
+Lemma subr_eq x y z : (x - z == y) = (x == y + z). Proof. exact: subr_eq. Qed.
+Lemma subr_eq0 x y : (x - y == 0) = (x == y). Proof. exact: subr_eq0. Qed.
+Lemma addr_eq0 x y : (x + y == 0) = (x == - y). Proof. exact: addr_eq0. Qed.
+Lemma eqr_opp x y : (- x == - y) = (x == y). Proof. exact: eqr_opp. Qed.
+Lemma eqr_oppLR x y : (- x == y) = (x == - y). Proof. exact: eqr_oppLR. Qed.
+Lemma mulNrn x n : (- x) *+ n = x *- n. Proof. exact: mulNrn. Qed.
 
 Lemma mulrnBl n : {morph (fun x => x *+ n) : x y / x - y}.
-Proof.
-move=> x y; elim: n => [|n IHn]; rewrite ?subr0 // !mulrS -!addrA; congr(_ + _).
-by rewrite addrC IHn -!addrA opprD [_ - y]addrC.
-Qed.
+Proof. exact: mulrnBl. Qed.
 
 Lemma mulrnBr x m n : n <= m -> x *+ (m - n) = x *+ m - x *+ n.
-Proof.
-elim: m n => [|m IHm] [|n le_n_m]; rewrite ?subr0 // {}IHm //.
-by rewrite mulrSr mulrS opprD addrA addrK.
-Qed.
+Proof. exact: mulrnBr. Qed.
 
 Lemma sumrN I r P (F : I -> V) :
   (\sum_(i <- r | P i) - F i = - (\sum_(i <- r | P i) F i)).
-Proof. by rewrite (big_morph _ opprD oppr0). Qed.
+Proof. exact: sumrN. Qed.
 
 Lemma sumrB I r (P : pred I) (F1 F2 : I -> V) :
   \sum_(i <- r | P i) (F1 i - F2 i)
      = \sum_(i <- r | P i) F1 i - \sum_(i <- r | P i) F2 i.
-Proof. by rewrite -sumrN -big_split /=. Qed.
+Proof. exact: sumrB. Qed.
 
 Lemma telescope_sumr n m (f : nat -> V) : n <= m ->
   \sum_(n <= k < m) (f k.+1 - f k) = f m - f n.
-Proof.
-move=> nm; rewrite (telescope_big (fun i j => f j - f i)).
-  by case: ltngtP nm => // ->; rewrite subrr.
-by move=> k /andP[nk km]/=; rewrite addrC subrKA.
-Qed.
+Proof. exact: telescope_sumr. Qed.
 
 Lemma telescope_sumr_eq n m (f u : nat -> V) : n <= m ->
     (forall k, (n <= k < m)%N -> u k = f k.+1 - f k) ->
   \sum_(n <= k < m) u k = f m - f n.
-Proof.
-by move=> ? uE; under eq_big_nat do rewrite uE //=; exact: telescope_sumr.
-Qed.
+Proof. exact: telescope_sumr_eq. Qed.
 
 Section ClosedPredicates.
 
 Variable S : {pred V}.
 
-Definition oppr_closed := {in S, forall u, - u \in S}.
-Definition subr_2closed := {in S &, forall u v, u - v \in S}.
-Definition zmod_closed := 0 \in S /\ subr_2closed.
-
+Definition oppr_closed := oppr_closed S.
+Definition subr_2closed := subr_closed S.
+Definition zmod_closed := zmod_closed S.
+ 
 Lemma zmod_closedN : zmod_closed -> oppr_closed.
-Proof. by case=> S0 SB y Sy; rewrite -sub0r !SB. Qed.
+Proof. exact: zmod_closedN. Qed.
 
-Lemma zmod_closedD : zmod_closed -> addr_closed S.
-Proof.
-by case=> S0 SB; split=> // y z Sy Sz; rewrite -[z]opprK -[- z]sub0r !SB.
-Qed.
+Lemma zmod_closedD : zmod_closed -> nmod_closed S.
+Proof. by move=> z; split; [case: z|apply/zmod_closedD]. Qed.
 
 End ClosedPredicates.
 
@@ -1210,11 +1081,8 @@ Proof. by rewrite mulrnAl mul1r. Qed.
 Lemma mulr_natr x n : x * n%:R = x *+ n.
 Proof. by rewrite mulrnAr mulr1. Qed.
 
-Lemma natrD m n : (m + n)%:R = m%:R + n%:R :> R.
-Proof. exact: mulrnDr. Qed.
-
+Lemma natrD m n : (m + n)%:R = m%:R + n%:R :> R. Proof. exact: mulrnDr. Qed.
 Lemma natr1 n : n%:R + 1 = n.+1%:R :> R. Proof. by rewrite mulrSr. Qed.
-
 Lemma nat1r n : 1 + n%:R = n.+1%:R :> R. Proof. by rewrite mulrS. Qed.
 
 Definition natr_sum := big_morph (natmul 1) natrD (mulr0n 1).
@@ -1277,8 +1145,7 @@ Lemma commr_prod (I : Type) (s : seq I) (P : pred I) (F : I -> R) x :
   (forall i, P i -> comm x (F i)) -> comm x (\prod_(i <- s | P i) F i).
 Proof. exact: (big_ind _ (commr1 x) (@commrM x)). Qed.
 
-Lemma commr_nat x n : comm x n%:R.
-Proof. exact/commrMn/commr1. Qed.
+Lemma commr_nat x n : comm x n%:R. Proof. exact/commrMn/commr1. Qed.
 
 Lemma commrX x y n : comm x y -> comm x (y ^+ n).
 Proof.
@@ -1295,8 +1162,7 @@ Qed.
 Lemma exprMn_n x m n : (x *+ m) ^+ n = x ^+ n *+ (m ^ n) :> R.
 Proof.
 elim: n => [|n IHn]; first by rewrite mulr1n.
-rewrite exprS IHn -mulr_natr -mulrA -commr_nat mulr_natr -mulrnA -expnSr.
-by rewrite -mulr_natr mulrA -exprS mulr_natr.
+by rewrite exprS IHn mulrnAl mulrnAr -mulrnA exprS -expnSr.
 Qed.
 
 Lemma exprM x m n : x ^+ (m * n) = x ^+ m ^+ n.
@@ -1422,9 +1288,9 @@ Variable S : {pred R}.
 
 Definition mulr_2closed := {in S &, forall u v, u * v \in S}.
 Definition mulr_closed := 1 \in S /\ mulr_2closed.
-Definition semiring_closed := addr_closed S /\ mulr_closed.
+Definition semiring_closed := nmod_closed S /\ mulr_closed.
 
-Lemma semiring_closedD : semiring_closed -> addr_closed S. Proof. by case. Qed.
+Lemma semiring_closedD : semiring_closed -> nmod_closed S. Proof. by case. Qed.
 
 Lemma semiring_closedM : semiring_closed -> mulr_closed. Proof. by case. Qed.
 
@@ -1733,8 +1599,7 @@ Proof. exact: mulrnBr. Qed.
 Lemma commrN x y : comm x y -> comm x (- y).
 Proof. by move=> com_xy; rewrite /comm mulrN com_xy mulNr. Qed.
 
-Lemma commrN1 x : comm x (-1).
-Proof. exact/commrN/commr1. Qed.
+Lemma commrN1 x : comm x (-1). Proof. exact/commrN/commr1. Qed.
 
 Lemma commrB x y z : comm x y -> comm x z -> comm x (y - z).
 Proof. by move=> com_xy com_xz; apply: commrD => //; apply: commrN. Qed.
@@ -1769,8 +1634,7 @@ Qed.
 Lemma exprNn x n : (- x) ^+ n = (-1) ^+ n * x ^+ n :> R.
 Proof. by rewrite -mulN1r exprMn_comm // /comm mulN1r mulrN mulr1. Qed.
 
-Lemma sqrrN x : (- x) ^+ 2 = x ^+ 2.
-Proof. exact: mulrNN. Qed.
+Lemma sqrrN x : (- x) ^+ 2 = x ^+ 2. Proof. exact: mulrNN. Qed.
 
 Lemma sqrr_sign n : ((-1) ^+ n) ^+ 2 = 1 :> R.
 Proof. by rewrite exprAC sqrrN !expr1n. Qed.
@@ -1996,8 +1860,7 @@ Implicit Types x y : R.
 Lemma mulIr0_rreg x : (forall y, y * x = 0 -> y = 0) -> rreg x.
 Proof. exact: (@mulrI0_lreg R^c). Qed.
 
-Lemma rregN x : rreg x -> rreg (- x).
-Proof. exact: (@lregN R^c). Qed.
+Lemma rregN x : rreg x -> rreg (- x). Proof. exact: (@lregN R^c). Qed.
 
 End RightRegular.
 
@@ -2107,9 +1970,9 @@ Section ClosedPredicates.
 Variable S : {pred V}.
 
 Definition scaler_closed := forall a, {in S, forall v, a *: v \in S}.
-Definition subsemimod_closed := addr_closed S /\ scaler_closed.
+Definition subsemimod_closed := nmod_closed S /\ scaler_closed.
 
-Lemma subsemimod_closedD : subsemimod_closed -> addr_closed S.
+Lemma subsemimod_closedD : subsemimod_closed -> nmod_closed S.
 Proof. by case. Qed.
 
 Lemma subsemimod_closedZ : subsemimod_closed -> scaler_closed.
@@ -2261,72 +2124,6 @@ End LalgebraTheory.
 
 (* Morphism hierarchy. *)
 
-Definition nmod_morphism (U V : nmodType) (f : U -> V) : Prop :=
-  (f 0 = 0) * {morph f : x y / x + y}.
-#[deprecated(since="mathcomp 2.5.0", note="use `nmod_morphism` instead")]
-Definition semi_additive := nmod_morphism.
-
-HB.mixin Record isNmodMorphism (U V : nmodType) (apply : U -> V) := {
-  nmod_morphism_subproof : nmod_morphism apply;
-}.
-
-#[mathcomp(axiom="nmod_morphism")]
-HB.structure Definition Additive (U V : nmodType) :=
-  {f of isNmodMorphism U V f}.
-
-Definition zmod_morphism (U V : zmodType) (f : U -> V) := {morph f : x y / x - y}.
-
-HB.factory Record isZmodMorphism (U V : zmodType) (apply : U -> V) := {
-  zmod_morphism_subproof : zmod_morphism apply;
-}.
-
-HB.builders Context U V apply of isZmodMorphism U V apply.
-
-Local Lemma raddf0 : apply 0 = 0.
-Proof. by rewrite -[0]subr0 zmod_morphism_subproof subrr. Qed.
-
-Local Lemma raddfD : {morph apply : x y / x + y}.
-Proof.
-move=> x y; rewrite -[y in LHS]opprK -[- y]add0r.
-by rewrite !zmod_morphism_subproof raddf0 sub0r opprK.
-Qed.
-
-HB.instance Definition _ := isNmodMorphism.Build U V apply (conj raddf0 raddfD).
-
-HB.end.
-
-#[deprecated(since="mathcomp 2.5.0", note="use `zmod_morphism` instead")]
-Definition additive := zmod_morphism.
-
-Module isSemiAdditive.
-#[deprecated(since="mathcomp 2.5.0",
-             note="Use isNmodMorphism.Build instead.")]
-Notation Build U V apply := (isNmodMorphism.Build U V apply) (only parsing).
-End isSemiAdditive.
-
-Module isAdditive.
-#[deprecated(since="mathcomp 2.5.0",
-             note="Use isZmodMorphism.Build instead.")]
-Notation Build U V apply := (isZmodMorphism.Build U V apply) (only parsing).
-End isAdditive.
-
-Module AdditiveExports.
-Notation "{ 'additive' U -> V }" := (Additive.type U%type V%type) : type_scope.
-End AdditiveExports.
-HB.export AdditiveExports.
-
-(* Lifted additive operations. *)
-Section LiftedNmod.
-Variables (U : Type) (V : nmodType).
-Definition null_fun of U : V := 0.
-Definition add_fun (f g : U -> V) x := f x + g x.
-End LiftedNmod.
-Section LiftedZmod.
-Variables (U : Type) (V : zmodType).
-Definition sub_fun (f g : U -> V) x := f x - g x.
-Definition opp_fun (f : U -> V) x := - f x.
-End LiftedZmod.
-
 (* Lifted multiplication. *)
 Section LiftedSemiRing.
 Variables (R : pzSemiRingType) (T : Type).
@@ -2353,47 +2150,13 @@ Local Notation "x \*o f" := (mull_fun x f) : function_scope.
 Local Notation "x \o* f" := (mulr_fun x f) : function_scope.
 Local Notation "f \* g" := (mul_fun f g) : function_scope.
 
-Arguments null_fun {_} V _ /.
-Arguments in_alg {_} A _ /.
-Arguments add_fun {_ _} f g _ /.
-Arguments sub_fun {_ _} f g _ /.
-Arguments opp_fun {_ _} f _ /.
+Arguments in_alg  {_} A _ /.
 Arguments mull_fun {_ _}  a f _ /.
 Arguments mulr_fun {_ _} a f _ /.
 Arguments scale_fun {_ _ _} a f _ /.
 Arguments mul_fun {_ _} f g _ /.
 
 Section AdditiveTheory.
-
-Section Properties.
-
-Variables (U V : nmodType) (f : {additive U -> V}).
-
-Lemma raddf0 : f 0 = 0.
-Proof. exact: nmod_morphism_subproof.1. Qed.
-
-Lemma raddf_eq0 x : injective f -> (f x == 0) = (x == 0).
-Proof. by move=> /inj_eq <-; rewrite raddf0. Qed.
-
-Lemma raddfD : {morph f : x y / x + y}.
-Proof. exact: nmod_morphism_subproof.2. Qed.
-
-Lemma raddfMn n : {morph f : x / x *+ n}.
-Proof. by elim: n => [|n IHn] x /=; rewrite ?raddf0 // !mulrS raddfD IHn. Qed.
-
-Lemma raddf_sum I r (P : pred I) E :
-  f (\sum_(i <- r | P i) E i) = \sum_(i <- r | P i) f (E i).
-Proof. exact: (big_morph f raddfD raddf0). Qed.
-
-Lemma can2_nmod_morphism f' : cancel f f' -> cancel f' f -> nmod_morphism f'.
-Proof.
-move=> fK f'K.
-by split=> [|x y]; apply: (canLR fK); rewrite ?raddf0// raddfD !f'K.
-Qed.
-#[deprecated(since="mathcomp 2.5.0", note="use `can2_nmod_morphism` instead")]
-Definition can2_semi_additive := can2_nmod_morphism.
-
-End Properties.
 
 Section SemiRingProperties.
 
@@ -2408,39 +2171,6 @@ Lemma raddfZnat n u : h (n%:R *: u) = n%:R *: h u.
 Proof. by rewrite !scaler_nat raddfMn. Qed.
 
 End SemiRingProperties.
-
-Section AddFun.
-
-Variables (U V W : nmodType).
-Variables (f g : {additive V -> W}) (h : {additive U -> V}).
-
-Fact idfun_is_nmod_morphism : nmod_morphism (@idfun U).
-Proof. by []. Qed.
-#[export]
-HB.instance Definition _ := isNmodMorphism.Build U U idfun
-  idfun_is_nmod_morphism.
-
-Fact comp_is_nmod_morphism : nmod_morphism (f \o h).
-Proof. by split=> [|x y]; rewrite /= ?raddf0// !raddfD. Qed.
-#[export]
-HB.instance Definition _ := isNmodMorphism.Build U W (f \o h)
-  comp_is_nmod_morphism.
-
-Fact null_fun_is_nmod_morphism : nmod_morphism (\0 : U -> V).
-Proof. by split=> // x y /=; rewrite addr0. Qed.
-#[export]
-HB.instance Definition _ := isNmodMorphism.Build U V \0
-  null_fun_is_nmod_morphism.
-
-Fact add_fun_is_nmod_morphism : nmod_morphism (f \+ g).
-Proof.
-by split=> [|x y]; rewrite /= ?raddf0 ?addr0// !raddfD addrCA -!addrA addrCA.
-Qed.
-#[export]
-HB.instance Definition _ := isNmodMorphism.Build V W (f \+ g)
-  add_fun_is_nmod_morphism.
-
-End AddFun.
 
 Section MulFun.
 
@@ -2464,27 +2194,13 @@ Section Properties.
 
 Variables (U V : zmodType) (f : {additive U -> V}).
 
-Lemma raddfN : {morph f : x / - x}.
-Proof.
-move=> x.
-by rewrite -[LHS]addr0 -(subrr (f x)) addrA -raddfD addNr raddf0 sub0r.
-Qed.
-
-Lemma raddfB : {morph f : x y / x - y}.
-Proof. by move=> x y; rewrite raddfD -raddfN. Qed.
+Lemma raddfN : {morph f : x / - x}. Proof. exact: raddfN. Qed.
+Lemma raddfB : {morph f : x y / x - y}. Proof. exact: raddfB. Qed.
 
 Lemma raddf_inj : (forall x, f x = 0 -> x = 0) -> injective f.
-Proof. by move=> fI x y eqxy; apply/subr0_eq/fI; rewrite raddfB eqxy subrr. Qed.
+Proof. exact: raddf_inj. Qed.
 
-Lemma raddfMNn n : {morph f : x / x *- n}.
-Proof. by move=> x /=; rewrite raddfN raddfMn. Qed.
-
-Lemma can2_zmod_morphism f' : cancel f f' -> cancel f' f -> zmod_morphism f'.
-Proof. by move=> fK f'K x y /=; apply: (canLR fK); rewrite raddfB !f'K. Qed.
-
-#[warning="-deprecated-since-mathcomp-2.5.0",
-    deprecated(since="mathcomp 2.5.0", note="use `can2_zmod_morphism` instead")]
-Definition can2_additive := can2_zmod_morphism.
+Lemma raddfMNn n : {morph f : x / x *- n}. Proof. exact: raddfMNn. Qed.
 
 End Properties.
 
@@ -2501,30 +2217,6 @@ Lemma raddfZsign n u : h ((-1) ^+ n *: u) = (-1) ^+ n *: h u.
 Proof. by rewrite !(scaler_sign, =^~ signr_odd) (fun_if h) raddfN. Qed.
 
 End RingProperties.
-
-Section AddFun.
-
-Variables (U V W : zmodType) (f g : {additive V -> W}) (h : {additive U -> V}).
-
-Fact opp_is_zmod_morphism : zmod_morphism (-%R : U -> U).
-Proof. by move=> x y; rewrite /= opprD. Qed.
-#[export]
-HB.instance Definition _ := isZmodMorphism.Build U U -%R opp_is_zmod_morphism.
-
-Fact sub_fun_is_zmod_morphism : zmod_morphism (f \- g).
-Proof.
-by move=> x y /=; rewrite !raddfB addrAC -!addrA -!opprD addrAC addrA.
-Qed.
-#[export]
-HB.instance Definition _ :=
-  isZmodMorphism.Build V W (f \- g) sub_fun_is_zmod_morphism.
-
-Fact opp_fun_is_zmod_morphism : zmod_morphism (\- g).
-Proof. by move=> x y /=; rewrite !raddfB opprB addrC opprK. Qed.
-#[export]
-HB.instance Definition _ := isZmodMorphism.Build V W (\- g) opp_fun_is_zmod_morphism.
-
-End AddFun.
 
 Section ScaleFun.
 
@@ -2544,6 +2236,7 @@ End AdditiveTheory.
 #[deprecated(since="mathcomp 2.5.0", note="use `monoid_morphism` instead")]
 Definition multiplicative (R S : pzSemiRingType) (f : R -> S) : Prop :=
   {morph f : x y / x * y}%R * (f 1 = 1).
+(* FIXME: remove once PzSemiRing extends Monoid. *)
 Definition monoid_morphism (R S : pzSemiRingType) (f : R -> S) : Prop :=
    (f 1 = 1) * {morph f : x y / x * y}%R.
 
@@ -3042,9 +2735,10 @@ Variables (s : Scale.preLaw R V) (f g : {linear U -> V | s}).
 Lemma null_fun_is_scalable : scalable_for s (\0 : U -> V).
 Proof. by move=> a v /=; rewrite raddf0. Qed.
 #[export]
-HB.instance Definition _ := isScalable.Build R U V s \0 null_fun_is_scalable.
+HB.instance Definition _ :=
+  isScalable.Build R U V s \0 null_fun_is_scalable.
 
-Lemma add_fun_is_scalable : scalable_for s (f \+ g).
+Lemma add_fun_is_scalable : scalable_for s (add_fun f g).
 Proof. by move=> a u; rewrite /= !linearZ_LR raddfD. Qed.
 #[export]
 HB.instance Definition _ :=
@@ -3453,7 +3147,7 @@ Proof. by rewrite subrXX !big_ord_recr big_ord0 /= add0r mulr1 mul1r. Qed.
 Lemma subr_sqrDB x y : (x + y) ^+ 2 - (x - y) ^+ 2 = x * y *+ 4.
 Proof.
 rewrite sqrrD sqrrB -!(addrAC _ (y ^+ 2)) opprB.
-by rewrite addrC addrA subrK -mulrnDr.
+by rewrite [LHS]addrC addrA subrK -mulrnDr.
 Qed.
 
 End ComPzRingTheory.
@@ -3716,8 +3410,7 @@ rewrite -(mulrK Ux _^-1) -mulrA commrV ?mulKr //.
 by apply/unitrP; exists x; rewrite divrr ?mulVr.
 Qed.
 
-Lemma invr_inj : injective (@inv R).
-Proof. exact: inv_inj invrK. Qed.
+Lemma invr_inj : injective (@inv R). Proof. exact: inv_inj invrK. Qed.
 
 Lemma unitrV x : (x^-1 \in unit) = (x \in unit).
 Proof. by rewrite !unitrE invrK commrV. Qed.
@@ -4071,7 +3764,7 @@ End UnitAlgebraTheory.
 
 Module ClosedExports.
 
-Notation addr_closed := addr_closed.
+Notation addr_closed := nmod_closed.
 Notation oppr_closed := oppr_closed.
 Notation zmod_closed := zmod_closed.
 Notation mulr_closed := mulr_closed.
@@ -4090,8 +3783,8 @@ Notation sdivr_closed := sdivr_closed.
 Notation divring_closed := divring_closed.
 Notation divalg_closed := divalg_closed.
 
+Coercion zmod_closedD : zmod_closed >-> nmod_closed.
 Coercion zmod_closedN : zmod_closed >-> oppr_closed.
-Coercion zmod_closedD : zmod_closed >-> addr_closed.
 Coercion semiring_closedD : semiring_closed >-> addr_closed.
 Coercion semiring_closedM : semiring_closed >-> mulr_closed.
 Coercion smulr_closedM : smulr_closed >-> mulr_closed.
@@ -5386,14 +5079,6 @@ Qed.
 
 (* Mixins for stability properties *)
 
-HB.mixin Record isAddClosed (V : nmodType) (S : {pred V}) := {
-  rpred0D : addr_closed S
-}.
-
-HB.mixin Record isOppClosed (V : zmodType) (S : {pred V}) := {
-  rpredNr : oppr_closed S
-}.
-
 HB.mixin Record isMul2Closed (R : pzSemiRingType) (S : {pred R}) := {
   rpredM : mulr_2closed S
 }.
@@ -5413,15 +5098,8 @@ HB.mixin Record isScaleClosed (R : pzSemiRingType) (V : lSemiModType R)
 
 (* Structures for stability properties *)
 
-#[short(type="addrClosed")]
-HB.structure Definition AddClosed (V : nmodType) := {S of isAddClosed V S}.
-
-#[short(type="opprClosed")]
-HB.structure Definition OppClosed (V : zmodType) := {S of isOppClosed V S}.
-
-#[short(type="zmodClosed")]
-HB.structure Definition ZmodClosed (V : zmodType) :=
-  {S of OppClosed V S & AddClosed V S}.
+Local Notation addrClosed := addrClosed.
+Local Notation opprClosed := opprClosed.
 
 #[short(type="mulr2Closed")]
 HB.structure Definition Mul2Closed (R : pzSemiRingType) :=
@@ -5472,17 +5150,6 @@ HB.structure Definition DivalgClosed (R : pzRingType) (A : unitAlgType R) :=
   {S of DivringClosed A S & isScaleClosed R A S}.
 
 (* Factories for stability properties *)
-
-HB.factory Record isZmodClosed (V : zmodType) (S : V -> bool) := {
-  zmod_closed_subproof : zmod_closed S
-}.
-
-HB.builders Context V S of isZmodClosed V S.
-HB.instance Definition _ := isOppClosed.Build V S
-  (zmod_closedN zmod_closed_subproof).
-HB.instance Definition _ := isAddClosed.Build V S
-  (zmod_closedD zmod_closed_subproof).
-HB.end.
 
 HB.factory Record isMulClosed (R : pzSemiRingType) (S : {pred R}) := {
   rpred1M : mulr_closed S
@@ -5616,18 +5283,7 @@ Section Add.
 
 Variable S : addrClosed V.
 
-Lemma rpred0 : 0 \in S.
-Proof. by case: (@rpred0D _ S). Qed.
-
-Lemma rpredD : {in S &, forall u v, u + v \in S}.
-Proof. by case: (@rpred0D _ S). Qed.
-
-Lemma rpred_sum I r (P : pred I) F :
-  (forall i, P i -> F i \in S) -> \sum_(i <- r | P i) F i \in S.
-Proof. by move=> IH; elim/big_ind: _; [apply: rpred0 | apply: rpredD |]. Qed.
-
-Lemma rpredMn n : {in S, forall u, u *+ n \in S}.
-Proof. by move=> u Su; rewrite -(card_ord n) -sumr_const rpred_sum. Qed.
+Lemma rpred0D : nmod_closed S. Proof. exact: nmod_closed_subproof. Qed.
 
 End Add.
 
@@ -5641,41 +5297,14 @@ Section Opp.
 
 Variable S : opprClosed V.
 
-Lemma rpredN : {mono -%R: u / u \in S}.
-Proof. by move=> u; apply/idP/idP=> /rpredNr; rewrite ?opprK; apply. Qed.
-
 End Opp.
 
 Section Sub.
 
 Variable S : zmodClosed V.
 
-Lemma rpredB : {in S &, forall u v, u - v \in S}.
-Proof. by move=> u v Su Sv; rewrite /= rpredD ?rpredN. Qed.
-
-Lemma rpredBC u v : u - v \in S = (v - u \in S).
-Proof. by rewrite -rpredN opprB. Qed.
-
-Lemma rpredMNn n : {in S, forall u, u *- n \in S}.
-Proof. by move=> u Su; rewrite /= rpredN rpredMn. Qed.
-
-Lemma rpredDr x y : x \in S -> (y + x \in S) = (y \in S).
-Proof.
-move=> Sx; apply/idP/idP=> [Sxy | /rpredD-> //].
-by rewrite -(addrK x y) rpredB.
-Qed.
-
-Lemma rpredDl x y : x \in S -> (x + y \in S) = (y \in S).
-Proof. by rewrite addrC; apply: rpredDr. Qed.
-
-Lemma rpredBr x y : x \in S -> (y - x \in S) = (y \in S).
-Proof. by rewrite -rpredN; apply: rpredDr. Qed.
-
-Lemma rpredBl x y : x \in S -> (x - y \in S) = (y \in S).
-Proof. by rewrite -(rpredN _ y); apply: rpredDl. Qed.
-
 Lemma zmodClosedP : zmod_closed S.
-Proof. split; [ exact: rpred0D.1 | exact: rpredB ]. Qed.
+Proof. split; [ exact: (@rpred0D V S).1 | exact: rpredB ]. Qed.
 
 End Sub.
 
@@ -5737,7 +5366,7 @@ Lemma rpredZnat (S : addrClosed V) n : {in S, forall u, n%:R *: u \in S}.
 Proof. by move=> u Su; rewrite /= scaler_nat rpredMn. Qed.
 
 Lemma subsemimodClosedP (modS : submodClosed V) : subsemimod_closed modS.
-Proof. by split; [exact rpred0D | exact: rpredZ]. Qed.
+Proof. by split; [exact: rpred0D | exact: rpredZ]. Qed.
 
 End LmodPred.
 
@@ -5750,7 +5379,7 @@ Proof. by rewrite -signr_odd scaler_sign fun_if if_arg rpredN if_same. Qed.
 
 Lemma submodClosedP (modS : submodClosed V) : submod_closed modS.
 Proof.
-split; first exact rpred0D.1.
+split; first exact (@rpred0D V modS).1.
 by move=> a u v uS vS; apply: rpredD; first exact: rpredZ.
 Qed.
 
@@ -5877,104 +5506,6 @@ Proof. by rewrite -!unitfE; apply: rpred_divr. Qed.
 End Predicates.
 
 End FieldPred.
-
-HB.mixin Record isSubNmodule (V : nmodType) (S : pred V) U
-    of SubType V S U & Nmodule U := {
-  valD_subproof : nmod_morphism (val : U -> V);
-}.
-
-#[short(type="subNmodType")]
-HB.structure Definition SubNmodule (V : nmodType) S :=
-  { U of SubChoice V S U & Nmodule U & isSubNmodule V S U }.
-
-Section nmod_morphism.
-Context (V : nmodType) (S : pred V) (U : SubNmodule.type S).
-Notation val := (val : U -> V).
-#[export]
-HB.instance Definition _ := isNmodMorphism.Build U V val valD_subproof.
-Lemma valD : {morph val : x y / x + y}. Proof. exact: raddfD. Qed.
-Lemma val0 : val 0 = 0. Proof. exact: raddf0. Qed.
-End nmod_morphism.
-
-HB.factory Record SubChoice_isSubNmodule (V : nmodType) S U
-    of SubChoice V S U := {
-  addr_closed_subproof : addr_closed S
-}.
-
-HB.builders Context V S U of SubChoice_isSubNmodule V S U.
-
-HB.instance Definition _ := isAddClosed.Build V S addr_closed_subproof.
-
-Let inU v Sv : U := Sub v Sv.
-Let zeroU := inU (rpred0 (AddClosed.clone V S _)).
-Let addU (u1 u2 : U) := inU (rpredD (valP u1) (valP u2)).
-
-Lemma addUA : associative addU.
-Proof. by move=> x y z; apply/val_inj; rewrite !SubK addrA. Qed.
-
-Lemma addUC : commutative addU.
-Proof. by move=> x y; apply/val_inj; rewrite !SubK addrC. Qed.
-
-Lemma add0U : left_id zeroU addU.
-Proof. by move=> x; apply/val_inj; rewrite !SubK add0r. Qed.
-
-HB.instance Definition _ := @isNmodule.Build U zeroU addU addUA addUC add0U.
-
-Lemma val0 : (val : U -> V) 0 = 0. Proof. by rewrite !SubK. Qed.
-Lemma valD : nmod_morphism (val : U -> V).
-Proof. by split=> [|x y]; rewrite !SubK. Qed.
-HB.instance Definition _ := isSubNmodule.Build V S U valD.
-HB.end.
-
-Implicit Type V : zmodType.
-
-HB.mixin Record isSubZmodule V (S : pred V) U
-    of SubNmodule V S U & Zmodule U := {
-  valB_subproof : zmod_morphism (val : U -> V);
-}.
-
-#[short(type="subZmodType")]
-HB.structure Definition SubZmodule V S :=
-  { U of SubNmodule V S U & Zmodule U & isSubZmodule V S U }.
-
-Section zmod_morphism.
-Context V (S : pred V) (U : SubZmodule.type S).
-Notation val := (val : U -> V).
-#[export, warning="-HB.no-new-instance"]
-HB.instance Definition _ := isZmodMorphism.Build U V val valB_subproof.
-Lemma valB : {morph val : x y / x - y}. Proof. exact: raddfB. Qed.
-Lemma valN : {morph val : x / - x}. Proof. exact: raddfN. Qed.
-End zmod_morphism.
-
-HB.factory Record SubChoice_isSubZmodule V S U of SubChoice V S U := {
-  zmod_closed_subproof : zmod_closed S
-}.
-
-HB.builders Context V S U of SubChoice_isSubZmodule V S U.
-
-HB.instance Definition _ := isZmodClosed.Build V S zmod_closed_subproof.
-
-Let inU v Sv : U := Sub v Sv.
-Let zeroU := inU (rpred0 (AddClosed.clone V S _)).
-Let oppU (u : U) := inU (rpredNr _ (valP u)).
-Let addU (u1 u2 : U) := inU (rpredD (valP u1) (valP u2)).
-
-HB.instance Definition _ := SubChoice_isSubNmodule.Build V S U
-  (zmod_closedD zmod_closed_subproof).
-
-Lemma addNr : left_inverse zeroU oppU addU.
-Proof. by move=> x; apply: val_inj; rewrite !SubK addNr. Qed.
-HB.instance Definition _ := Nmodule_isZmodule.Build U addNr.
-
-Lemma valD : nmod_morphism (val : U -> V).
-Proof. by split=> [|x y]; rewrite !SubK. Qed.
-#[warning="-HB.no-new-instance"]
-HB.instance Definition _ := isSubNmodule.Build V S U valD.
-
-Lemma valB : zmod_morphism (val : U -> V).
-Proof. by move=> x y; rewrite !SubK. Qed.
-HB.instance Definition _ := isSubZmodule.Build V S U valB.
-HB.end.
 
 HB.mixin Record isSubPzSemiRing (R : pzSemiRingType) (S : pred R) U
     of SubNmodule R S U & PzSemiRing U := {
@@ -6165,7 +5696,7 @@ HB.end.
 
 #[short(type="subNzRingType")]
 HB.structure Definition SubNzRing (R : nzRingType) (S : pred R) :=
-  { U of SubNzSemiRing R S U & NzRing U & isSubZmodule R S U }.
+  { U of SubNzSemiRing R S U & NzRing U & isSubBaseAddUMagma R S U }.
 
 #[deprecated(since="mathcomp 2.4.0",
              note="Use SubNzRing instead.")]
@@ -7522,6 +7053,9 @@ Notation subRingType := (subNzRingType) (only parsing).
              note="Try subComPzRingType (the potentially-zero counterpart) first, or use subComNzRingType instead.")]
 Notation subComNzRingType := (subComNzRingType) (only parsing).
 
+Notation addrClosed := addrClosed.
+Notation opprClosed := opprClosed.
+
 Variant Ione := IOne : Ione.
 Inductive Inatmul :=
   | INatmul : Ione -> nat -> Inatmul
@@ -7550,7 +7084,7 @@ Definition print (x : Inatmul) : option Number.int :=
 Arguments GRing.one {_}.
 Set Warnings "-via-type-remapping,-via-type-mismatch".
 Number Notation Idummy_placeholder parse print (via Inatmul
-  mapping [[GRing.natmul] => INatmul, [GRing.opp] => IOpp, [GRing.one] => IOne])
+  mapping [[natmul] => INatmul, [opp] => IOpp, [one] => IOne])
   : ring_scope.
 Set Warnings "via-type-remapping,via-type-mismatch".
 Arguments GRing.one : clear implicits.
@@ -7601,11 +7135,6 @@ Notation "x \*o f" := (mull_fun x f) : ring_scope.
 Notation "x \o* f" := (mulr_fun x f) : ring_scope.
 Notation "f \* g" := (mul_fun f g) : ring_scope.
 
-Arguments null_fun {_} V _ /.
-Arguments in_alg {_} A _ /.
-Arguments add_fun {_ _} f g _ /.
-Arguments sub_fun {_ _} f g _ /.
-Arguments opp_fun {_ _} f _ /.
 Arguments mull_fun {_ _}  a f _ /.
 Arguments mulr_fun {_ _} a f _ /.
 Arguments scale_fun {_ _ _} a f _ /.
@@ -7690,27 +7219,10 @@ Notation "''exists' ''X_' i , f" := (Exists i f) : term_scope.
 Notation "''forall' ''X_' i , f" := (Forall i f) : term_scope.
 
 (* Lifting Structure from the codomain of finfuns. *)
-Section FinFunNmod.
-
-Variable (aT : finType) (rT : nmodType).
-Implicit Types f g : {ffun aT -> rT}.
-
-Definition ffun_zero := [ffun a : aT => (0 : rT)].
-Definition ffun_add f g := [ffun a => f a + g a].
-
-Fact ffun_addA : associative ffun_add.
-Proof. by move=> f1 f2 f3; apply/ffunP=> a; rewrite !ffunE addrA. Qed.
-Fact ffun_addC : commutative ffun_add.
-Proof. by move=> f1 f2; apply/ffunP=> a; rewrite !ffunE addrC. Qed.
-Fact ffun_add0 : left_id ffun_zero ffun_add.
-Proof. by move=> f; apply/ffunP=> a; rewrite !ffunE add0r. Qed.
-
-#[export]
-HB.instance Definition _ := isNmodule.Build {ffun aT -> rT}
-  ffun_addA ffun_addC ffun_add0.
 
 Section Sum.
 
+Variables (aT : finType) (rT : nmodType).
 Variables (I : Type) (r : seq I) (P : pred I) (F : I -> {ffun aT -> rT}).
 
 Lemma sum_ffunE x : (\sum_(i <- r | P i) F i) x = \sum_(i <- r | P i) F i x.
@@ -7721,27 +7233,6 @@ Lemma sum_ffun :
 Proof. by apply/ffunP=> i; rewrite sum_ffunE ffunE. Qed.
 
 End Sum.
-
-Lemma ffunMnE f n x : (f *+ n) x = f x *+ n.
-Proof. by rewrite -[n]card_ord -!sumr_const sum_ffunE. Qed.
-
-End FinFunNmod.
-
-Section FinFunZmod.
-
-Variable (aT : finType) (rT : zmodType).
-Implicit Types f g : {ffun aT -> rT}.
-
-Definition ffun_opp f := [ffun a => - f a].
-
-Fact ffun_addN : left_inverse (@ffun_zero _ _) ffun_opp (@ffun_add _ _).
-Proof. by move=> f; apply/ffunP=> a; rewrite !ffunE addNr. Qed.
-
-#[export]
-HB.instance Definition _ := Nmodule_isZmodule.Build {ffun aT -> rT}
-  ffun_addN.
-
-End FinFunZmod.
 
 Section FinFunSemiRing.
 
@@ -7857,50 +7348,6 @@ HB.instance Definition _ (R : pzRingType) (aT : finType) (rT : lmodType R) :=
   LSemiModule.on {ffun aT -> rT}.
 
 (* External direct product. *)
-Section PairNmod.
-
-Variables U V : nmodType.
-
-Definition add_pair (x y : U * V) := (x.1 + y.1, x.2 + y.2).
-
-Fact pair_addA : associative add_pair.
-Proof. by move=> x y z; congr (_, _); apply: addrA. Qed.
-
-Fact pair_addC : commutative add_pair.
-Proof. by move=> x y; congr (_, _); apply: addrC. Qed.
-
-Fact pair_add0 : left_id (0, 0) add_pair.
-Proof. by case=> x1 x2; congr (_, _); apply: add0r. Qed.
-
-#[export]
-HB.instance Definition _ := isNmodule.Build (U * V)%type
-  pair_addA pair_addC pair_add0.
-
-Fact fst_is_nmod_morphism : nmod_morphism fst. Proof. by []. Qed.
-#[export]
-HB.instance Definition _ := isNmodMorphism.Build (U * V)%type U fst
-  fst_is_nmod_morphism.
-
-Fact snd_is_nmod_morphism : nmod_morphism snd. Proof. by []. Qed.
-#[export]
-HB.instance Definition _ := isNmodMorphism.Build (U * V)%type V snd
-  snd_is_nmod_morphism.
-
-End PairNmod.
-
-Section PairZmod.
-
-Variables U V : zmodType.
-
-Definition opp_pair (x : U * V) := (- x.1, - x.2).
-
-Fact pair_addN : left_inverse (0, 0) opp_pair (@add_pair U V).
-Proof. by move=> x; congr (_, _); apply: addNr. Qed.
-
-#[export]
-HB.instance Definition _ := Nmodule_isZmodule.Build (U * V)%type pair_addN.
-
-End PairZmod.
 
 Section PairSemiRing.
 
@@ -8169,7 +7616,6 @@ End Test3.
 
 (* Algebraic structure of bool *)
 
-HB.instance Definition _ := isZmodule.Build bool addbA addbC addFb addbb.
 HB.instance Definition _ := Zmodule_isComNzRing.Build bool
   andbA andbC andTb andb_addl isT.
 
@@ -8188,12 +7634,8 @@ HB.instance Definition _ := ComUnitRing_isField.Build bool bool_fieldP.
 
 (* Algebraic structure of nat *)
 
-HB.instance Definition _ := isNmodule.Build nat addnA addnC add0n.
 HB.instance Definition _ := Nmodule_isComNzSemiRing.Build nat
   mulnA mulnC mul1n mulnDl mul0n erefl.
-
-HB.instance Definition _ (V : nmodType) (x : V) :=
-  isNmodMorphism.Build nat V (natmul x) (mulr0n x, mulrnDr x).
 
 HB.instance Definition _ (R : pzSemiRingType) :=
   isMonoidMorphism.Build nat R (natmul 1) (mulr1n 1, natrM R).

--- a/algebra/ssrnum.v
+++ b/algebra/ssrnum.v
@@ -93,6 +93,7 @@ Reserved Notation "'Re z" (at level 10, z at level 8).
 Reserved Notation "'Im z" (at level 10, z at level 8).
 
 Local Open Scope order_scope.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 Import Order.TTheory GRing.Theory.
 
@@ -2832,8 +2833,6 @@ End NumDomainMonotonyTheoryForReals.
 
 Section FinGroup.
 
-Import GroupScope.
-
 Variables (R : numDomainType) (gT : finGroupType).
 Implicit Types G : {group gT}.
 
@@ -3002,7 +3001,7 @@ Lemma sgrV x : sgr x^-1 = sgr x.
 Proof. by rewrite /sgr invr_eq0 invr_lt0. Qed.
 
 Lemma splitr x : x = x / 2%:R + x / 2%:R.
-Proof. by rewrite -mulr2n -mulr_natr mulfVK //= pnatr_eq0. Qed.
+Proof. by rewrite -mulr2n -[RHS]mulr_natr mulfVK //= pnatr_eq0. Qed.
 
 (* lteif *)
 
@@ -4325,7 +4324,7 @@ have [->|nz_x] := eqVneq x 0; first by exists (u y); rewrite uE ?normr0 ?mul0r.
 exists (u x); rewrite uE // /u (negPf nz_x); congr (_ , _).
 have{lin_xy} def2xy: `|x| * `|y| *+ 2 = x * y ^* + y * x ^*.
   apply/(addrI (x * x^* ))/(addIr (y * y^* )); rewrite -2!{1}normCK -sqrrD.
-  by rewrite addrA -addrA -!mulrDr -mulrDl -rmorphD -normCK lin_xy.
+  by rewrite addrA -[RHS]addrA -!mulrDr -mulrDl -rmorphD -normCK lin_xy.
 have def_xy: x * y^* = y * x^*.
   apply/eqP; rewrite -subr_eq0 -[_ == 0](@expf_eq0 _ _ 2).
   rewrite (canRL (subrK _) (subr_sqrDB _ _)) opprK -def2xy exprMn_n exprMn.

--- a/algebra/vector.v
+++ b/algebra/vector.v
@@ -864,7 +864,7 @@ Lemma directv_sum_independent {Us : I -> {vspace vT}} :
 Proof.
 apply: (iffP directv_sumP) => [dxU us Uu u_0 i Pi | dxU i Pi].
   apply/eqP; rewrite -memv0 -(dxU i Pi) memv_cap Uu //= -memvN -sub0r -{1}u_0.
-  by rewrite (bigD1 i) //= addrC addKr memv_sumr // => j /andP[/Uu].
+  by rewrite (bigD1 i) //= [_ - us i]addrC addKr memv_sumr // => j /andP[/Uu].
 apply/eqP; rewrite -subv0; apply/subvP=> v.
 rewrite memv_cap memv0 => /andP[Uiv /memv_sumP[us Uu Dv]].
 have: \sum_(j | P j) [eta us with i |-> - v] j = 0.

--- a/algebra/zmodp.v
+++ b/algebra/zmodp.v
@@ -1,8 +1,8 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrfun ssrbool choice eqtype ssrnat seq div.
-From mathcomp Require Import fintype bigop finset prime fingroup perm.
+From mathcomp Require Import ssreflect ssrfun ssrbool choice eqtype ssrnat seq.
+From mathcomp Require Import div fintype bigop finset prime fingroup perm.
 From mathcomp Require Import ssralg finalg countalg.
 
 (******************************************************************************)

--- a/character/character.v
+++ b/character/character.v
@@ -2558,7 +2558,7 @@ have GHx: coset H x \in (G / H)%g by apply: mem_quotient.
 move: (second_orthogonality_relation (coset H x) GHx).
 rewrite mulrb class_refl => <-.
 rewrite -2!(eq_bigr _ (fun _ _ => normCK _)) sum_norm_irr_quo // -subr_ge0.
-rewrite (bigID (fun i => H \subset cfker 'chi[G]_i)) //= addrC addKr.
+rewrite (bigID (fun i => H \subset cfker 'chi[G]_i)) //= addrC addrK.
 by apply: sumr_ge0 => i _; rewrite normCK mul_conjC_ge0.
 Qed.
 

--- a/character/classfun.v
+++ b/character/classfun.v
@@ -4,10 +4,9 @@ From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq path.
 From mathcomp Require Import div choice fintype tuple finfun bigop prime order.
 From mathcomp Require Import ssralg poly finset fingroup morphism perm.
-From mathcomp Require Import automorphism quotient finalg action gproduct.
-From mathcomp Require Import zmodp commutator cyclic center pgroup sylow.
-From mathcomp Require Import matrix vector falgebra ssrnum algC algnum.
-From mathcomp Require Import archimedean.
+From mathcomp Require Import automorphism quotient finalg action gproduct zmodp.
+From mathcomp Require Import commutator cyclic center pgroup sylow matrix.
+From mathcomp Require Import vector falgebra ssrnum algC algnum archimedean.
 
 (******************************************************************************)
 (* This file contains the basic theory of class functions:                    *)

--- a/character/integral_char.v
+++ b/character/integral_char.v
@@ -6,10 +6,10 @@ From mathcomp Require Import div choice fintype tuple finfun bigop prime order.
 From mathcomp Require Import ssralg poly finset fingroup morphism perm.
 From mathcomp Require Import automorphism quotient action countalg finalg zmodp.
 From mathcomp Require Import commutator cyclic center pgroup sylow gseries.
-From mathcomp Require Import nilpotent abelian ssrnum ssrint archimedean polydiv.
-From mathcomp Require Import rat matrix mxalgebra intdiv mxpoly vector falgebra.
-From mathcomp Require Import fieldext separable galois algC cyclotomic algnum.
-From mathcomp Require Import mxrepresentation classfun character.
+From mathcomp Require Import nilpotent abelian ssrnum ssrint archimedean.
+From mathcomp Require Import polydiv rat matrix mxalgebra intdiv mxpoly vector.
+From mathcomp Require Import falgebra fieldext separable galois algC cyclotomic.
+From mathcomp Require Import algnum mxrepresentation classfun character.
 
 (******************************************************************************)
 (* This file provides some standard results based on integrality properties   *)

--- a/character/mxrepresentation.v
+++ b/character/mxrepresentation.v
@@ -6,7 +6,7 @@ From mathcomp Require Import div choice fintype tuple finfun bigop prime.
 From mathcomp Require Import ssralg poly polydiv finset fingroup morphism.
 From mathcomp Require Import perm automorphism quotient finalg action zmodp.
 From mathcomp Require Import commutator cyclic center pgroup matrix mxalgebra.
-From mathcomp Require Import mxpoly.
+From mathcomp Require Import mxalgebra mxpoly.
 
 (******************************************************************************)
 (*  This file provides linkage between classic Group Theory and commutative   *)

--- a/doc/changelog/01-added/1256-algebra.md
+++ b/doc/changelog/01-added/1256-algebra.md
@@ -1,0 +1,168 @@
+- file `monoid.v`
+	+ mixin `hasMul`
+	+ structures `magmaType`, `ChoiceMagma.type`
+	+ definition `commute`
+	+ lemmas `commute_refl`, `commute_sym`
+	+ definition `mulg_closed`
+	+ mixin `Magma_isSemigroup`
+	+ structure `semigroupType`
+	+ factory `isSemigroup`
+	+ lemma `commuteM`
+	+ mixin `hasOne`
+	+ structures `baseUMagmaType`, `ChoiceBaseUMagma.type`
+	+ definition `natexp`
+	+ lemmas `expg0`, `expg1`, `expg2`, `expgSS`, `expgb`
+	+ definition `umagma_closed`
+	+ mixin `BaseUMagma_isUMagma`
+	+ factory `Magma_isUMagma`
+	+ structure `umagmaType`
+	+ lemmas `expgS`, `expg1n`, `commute1`
+	+ structure `monoidType`
+	+ factories `Semigroup_isMonoid`, `UMagma_isMonoid`, `isMonoid`
+	+ lemmas `expgSr`, `expgnDr`, `expgnA`, `expgnAC`, `iter_mulg`, `iter_mulg_1`,
+		`prodg_const`, `prodg_const_nat`, `prodgXr`, `commute_prod`,
+		`prodgM_commute`, `prodgMl_commute`, `prodgMr_commute`, `commuteX`,
+		`comuteX2`, `expgMn`.
+	+ notation `monoid_closed`
+	+ mixin `hasInv`
+	+ structure `baseGroupType`
+	+ mixin `Monoid_isGroup`
+	+ structure `groupType`
+	+ factory `isGroup`
+	+ definitions `conjg`, `commg`
+	+ lemmas `divgg`, `mulKg`, `mulVKg`, `mulgK`, `mulgVK`, `mulgI`, `mulIg`,
+		`invgK`, `invg_inj`, `divgI`, `divIg`, `invg1`, `invg_eq1`, `divg1`,
+		`div1g`, `invgF`, `invgM`, `prodgV`, `divKg`, `mulgKA`, `divgKA`,
+		`mulg1_eq`, `divg1_eq`, `divg_eq`, `divg_eq1`, `mulg_eq1`, `eqg_inv`,
+		`iqg_invLR`, `commuteV`, `expVgn`, `expgnFr`, `expgnFl`, `conjgE`, `conjgC`,
+		`conjgCV`, `conjg1`, `conj1g`, `conjMg`, `conjgM`, `conjVg`, `conjJg`,
+		`conjXg`, `conjgK`, conjgKV`, `conjg_inj`, `conjg_eq1`, `commgEl`,
+		`commgEr`, `commgC`, `commgCV`, `conjRg`, `invgR`, `commgP`, `conjg_fix`,
+		`conjg_fixP`, `commg1_sym`, `commg1`, `comm1g`, `commgg`, `commgXg`,
+		`commgVg`, `commgXVg`
+	+ definitions `invg_closed`, `divg_closed`, `group_closed`
+	+ lemmas `group_closedV`, `group_closedM`
+	+ mixin `isMultiplicative`
+	+ structure `Multiplicative.type`
+	+ mixin `isUMagmaMorphism`
+	+ structure `UMagmaMorphism.type`
+	+ factory `isGroupMorphism`
+	+ notation `{multiplicative _ -> _}`
+	+ definitions `mul_fun`, `one_fun`
+	+ lemmas `can2_gmulfM`, `gmulf_commute`, `gmulf_eq1`, `can2_gmulf1`,
+		`gmulfXn`, `gmulf_prod`, `gumlfV`, `gmulfF`, `gmulf_inj`, `gmulfXVn`,
+		`gmulfJ`, `gmulfR`, `idfun_gmulfM`, `comp_gmulfM`, `idfun_gmulf1`,
+		`one_fun_gmulf1`, `comp_gmulf1`, `one_fun_gmulf1`, `mul_fun_gmulf1`
+	+ mixins `isMulClosed`, `isMul1Closed`, `isInvClosed`
+	+ structures `mulgClosed`, `umagmaClosed`, `invgClosed`, `groupClosed`
+	+ lemmas `gpred_prod`, `gpredXn`, `gpredV`, `gpredF`, `gpredFC`, `gpredXNn`,
+		`gpredMr`, `gpredMl`, `gpredFr`, `gpredFl`, `gpredJ`, `gpredR`
+	+ mixin `isSubMagma`
+	+ structure `subMagmaType`
+	+ factory `SubChoice_isSubMagma`
+	+ structure `subSemigroupType`
+	+ factory `SubChoice_isSubSemigroup`
+	+ mixin `isSubBaseUMagma`
+	+ structures `subBaseUMagmaType`, `subUMagmaType`
+	+ factory `SubChoice_isSubUMagma`
+	+ structure `subMonoidType`
+	+ factory `SubChoice_isSubMonoid`
+	+ structure `subGroupType`
+	+ factory `SubChoice_isSubGroup`
+	+ definition `ffun_mul`
+	+ lemma `ffun_mulgA`
+	+ definition `ffun_one`
+	+ lemmas `ffun_mul1g`, `ffun_mulg1`
+	+ definition `ffun_inv`
+	+ lemmas `ffun_mulVg`, `ffun_mulgV`
+	+ definition `mul_pair`
+	+ lemmas `fst_is_multiplicative`, `snd_is_multiplicative`, `pair_mulgA`
+	+ definition `one_pair`
+	+ lemmas `first_is_umagma_morphism`, `snd_is_umagma_morphism`, `pair_mul1g`,
+		`pair_mulg1`
+	+ definition `inv_pair`
+	+ lemmas `pair_mulVg`, `pair_mulgV`
+
+- file nmodule.v
+	+ mixin `hasAdd`
+	+ structures `baseAddMagmaType`, `ChoiceBaseAddMagma.type`
+	+ definition `to_multiplicative`, `addr_closed`
+	+ mixin `BaseAddMagma_isAddMagma`
+	+ structure `addMagmaType`
+	+ factory `isAddMagma`
+	+ lemma `commuteT`
+	+ mixin `AddMagma_isAddSemigroup`
+	+ structure `addSemigroupType`
+	+ factory `isAddSemigroup`
+	+ lemmas `addrCA`, `addrAC`, `addrACA`
+	+ mixin `hasZero`
+	+ structure `baseAddUMagmaType`, `ChoiceBaseAddUMagma.type`
+	+ definition `natmul`
+	+ lemmas `mulr0n`, `mulr1n`, `mulr2n`, `mulrb`, `mulrSS`
+	+ definition `addumagma_closed`
+	+ mixin `BaseAddUMagma_isAddUMagma`
+	+ factory `isAddUMagma`
+	+ structure `addUMagmaType`
+	+ lemma `addr0`
+	+ factory `isNmodule`
+	+ structure `nmodType`
+	+ lemmas `mulrS`, `mulrSr`, `mul0rn`, `mulrnDl`, `mulrnDr`, `mulrnA`,
+		`mulrnAC`, `iter_addr`, `iter_addr_0`, `sumrMnl`, `sumrMnr`, `sumr_const`,
+		`sumr_const_nat`
+	+ definition `nmod_closed`
+	+ mixin `hasOpp`
+	+ structure `baseZmodType`
+	+ definitions `oppr_closed`, `subr_closed`, `zmod_closed`
+	+ mixin `BaseZmoduleNmodule_isZmodule`
+	+ structure `zmodType`
+	+ factories `Nmodule_isZmodule`, `isZmodule`, `Group_isZmodule`
+	+ lemmas `addrN`, `subrr`, `addKr`, `addNKr`, `addrK`, `addrNK`, `subrK`,
+		`subKr`, `addrI`, `subrI`, `subIr`, `opprK`, `oppr_inj`, `oppr0`,
+		`oppr_eq0`, `subr0`, `opprB`, `opprD`, `addrKA`, `subrKA`, `addr0_eq`,
+		`subr0_eq`, `subr_eq`, `subr_eq0`, `addr_eq0`, `eqr_opp`, `eqr_oppLR`,
+		`mulNrn`, `mulrnBl`, `mulrnBr`, `sumrN`, `sumrB`, `telescope_sumr`,
+		`telescope_sumr_eq`, `zmod_closedN`, `zmod_closedD`, `zmod_closed0D`
+	+ definition `semi_additive`
+	+ mixin `isSemiAdditive`
+	+ structure `Additive.type`
+	+ definition `additive`
+	+ factory `isAdditive`
+	+ notation `{additive _ -> _}`
+	+ lemmas `raddf0`, `raddfD`, `raddf_sum`
+	+ definitions `to_fmultiplicative`, `add_fun`, `null_fun`, `opp_fun`,
+		`sub_fun`
+	+ lemmas `raddf_eq0`, `raddfMn`, `can2_semi_additive`, `raddfN`, `raddfB`,
+		`raddf_inj`, `raddfMNn`, `can2_additive`, `add_fun_semi_additiveè,
+		`idfun_is_semi_additive`, `comp_is_semi_additive`,
+		`null_fun_is_semi_additive`, `opp_is_semi_additive`, `opp_fun_is_additive`,
+		`sub_fun_is_additive`
+	+ mixins `isAddClosed`, `isOppClosed`
+	+ structures `addrClosed`, `opprClosed`, `zmodClosed`
+	+ factory `isZmodClosed`
+	+ definition `to_pmultiplicative`
+	+ lemmas `rpred0`, `rpredD`, `rpred0D`, `rpredMn`, `rpredNr`, `rpredN`,
+		`rpredB`, `rpredBC`, `rpredMNn`, `rpredDr`, `rpredDl`, `rpredBr`, `rpredBl`
+		`zmodClosedP`
+	+ mixin `isSubBaseAddUMagma`
+	+ structures `subBaseAddUMagma`, `subAddUMagma`, `subNmodType`
+	+ lemmas `valD`, `val0`
+	+ factories `SubChoice_isSubAddUMagma`, `SubChoice_isSubNmodule`
+	+ structure `subZmodType` 
+	+ lemmas `valB`, `valN`
+	+ factories `isSubZmodule`, `SubChoice_isSubZmodule`
+	+ notations `0`, `-%R`, `- x`, `+%R`, `x + y`, `x - y`, `x *+ n`, `x *- n`,
+		`\sum_<range> e`, ``s `_ i`` `support` `1` `- 1` `n %:R`
+	+ definition `ffun_add`
+	+ lemmas `ffun_addrC`, `ffun_addrA`
+	+ definition `ffun_zero`
+	+ lemmas `ffun_add0r`, `ffunMnE`, `sum_ffunE`, `sum_ffun`
+	+ definition `ffun_opp`
+	+ lemma `ffun_addNr`
+	+ definition `pair_add`
+	+ lemmas `pair_addrC`, `pair_addrA`
+	+ definition `pair_zero`
+	+ lemmas `fst_is_additive`, `snd_is_additive`, `pair_add0r`
+	+ definition `pair_opp`
+	+ lemmas `pair_addNr`, `natr0E`, `natrDE`, `natrE`
+    (`#1256 <https://github.com/coq/stdlib/pull/1256>`_,
+    by Tragicus).

--- a/field/algC.v
+++ b/field/algC.v
@@ -246,7 +246,7 @@ Proof.
   rewrite addrA addrC !addrA -(addrC (y * conj y)) !addrA.
   move: (y * _ + _) => u; rewrite -!addrA leB opprD addrACA {u}subrr add0r -leB.
   rewrite {}le_sqr ?posD //.
-    by rewrite rmorphD !rmorphM /= !conjK addrC mulrC (mulrC y).
+    by rewrite rmorphD !rmorphM /= !conjK addrC mulrC (mulrC x).
   rewrite -mulr2n -mulr_natr exprMn normK -natrX mulr_natr sqrrD mulrACA.
   rewrite -rmorphM (mulrC y x) addrAC leB mulrnA mulr2n opprD addrACA.
   rewrite subrr addr0 {2}(mulrC x) rmorphM mulrACA -opprB addrAC -sqrrB -sqrMi.

--- a/field/algebraics_fundamentals.v
+++ b/field/algebraics_fundamentals.v
@@ -321,12 +321,11 @@ have ofQ_K z: cancel (ofQ z) (inQ z).
 have sQring z: divring_closed (sQ z).
   have sQ_1: 1 \in sQ z by rewrite -(rmorph1 (ofQ z)) sQof.
   by split=> // x y /inQ_K<- /inQ_K<- /=; rewrite -(rmorphB, fmorph_div) sQof.
-pose sQoM z := GRing.isOppClosed.Build _ _ (sQring z).
-pose sQaM z := GRing.isAddClosed.Build _ _ (sQring z).
+pose sQzM z := GRing.isZmodClosed.Build _ _ (sQring z : zmod_closed _).
 pose sQmM z := GRing.isMulClosed.Build _ _ (sQring z).
 pose sQiM z := GRing.isInvClosed.Build _ _ (sQring z).
 pose sQC z : divringClosed _ := HB.pack (sQ z)
-  (sQaM z) (sQoM z) (sQmM z) (sQiM z).
+  (sQzM z) (sQmM z) (sQiM z).
 pose morph_ofQ x z Qxz := forall u, ofQ z (Qxz u) = ofQ x u.
 have QtoQ z x: x \in sQ z -> {Qxz : 'AHom(Q x, Q z) | morph_ofQ x z Qxz}.
   move=> z_x; pose Qxz u := inQ z (ofQ x u).

--- a/field/closed_field.v
+++ b/field/closed_field.v
@@ -701,12 +701,10 @@ have I_ideal : idealr_closed I.
   apply/memI; exists (maxn (pickle q1).+1 (pickle q2).+1); apply: dvdp_add.
     by apply: dvdp_mull; apply: dvdp_trans Iq1; apply/dv_d/leq_maxl.
   by apply: dvdp_trans Iq2; apply/dv_d/leq_maxr.
-pose IaM := GRing.isAddClosed.Build _ I (idealr_closedB I_ideal).
-pose IoM := GRing.isOppClosed.Build _ I (idealr_closedB I_ideal).
+pose IaM := GRing.isZmodClosed.Build _ I (idealr_closedB I_ideal).
 pose IpM := isProperIdeal.Build _ I (idealr_closed_nontrivial I_ideal).
-pose Iid : idealr _ := HB.pack I IaM IoM IpM.
-pose EMixin := GRing.PzRing_hasCommutativeMul.Build _ (@Quotient.mulqC _ Iid).
-pose E : comNzRingType := (HB.pack _ EMixin : comPzRingType).
+pose Iid : idealr _ := HB.pack I IaM IpM.
+pose E : comNzRingType := {ideal_quot Iid}.
 pose PtoE : {rmorphism {poly F} -> E} := \pi_E%qT.
 have PtoEd i: PtoE (d i) = 0.
   by apply/eqP; rewrite piE Quotient.equivE subr0; apply/memI; exists i.

--- a/field/qfpoly.v
+++ b/field/qfpoly.v
@@ -1,13 +1,9 @@
 From HB Require Import structures.
-From mathcomp
-Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice fintype tuple.
-From mathcomp
-Require Import div bigop binomial finset finfun ssralg countalg finalg.
-From mathcomp
-Require Import poly polydiv qpoly perm fingroup falgebra fieldext finfield
-               galois.
-From mathcomp
-Require Import finalg zmodp matrix vector.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype tuple div bigop binomial finset finfun.
+From mathcomp Require Import ssralg countalg finalg poly polydiv qpoly perm.
+From mathcomp Require Import fingroup falgebra fieldext finfield galois.
+From mathcomp Require Import finalg zmodp matrix vector.
 
 (******************************************************************************)
 (* This file extends the algebras R[X]/<p> defined in qpoly with the field    *)

--- a/fingroup/fingroup.v
+++ b/fingroup/fingroup.v
@@ -3,6 +3,7 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq choice.
 From mathcomp Require Import fintype div path tuple bigop prime finset.
+From mathcomp Require Export monoid.
 
 (******************************************************************************)
 (*                               Finite groups                                *)
@@ -134,10 +135,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Declare Scope group_scope.
 Declare Scope Group_scope.
 
-Delimit Scope group_scope with g.
 Delimit Scope Group_scope with G.
 
 (* This module can be imported to open the scope for group element *)

--- a/solvable/abelian.v
+++ b/solvable/abelian.v
@@ -1,10 +1,10 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq path choice.
-From mathcomp Require Import div fintype finfun bigop finset prime binomial.
-From mathcomp Require Import fingroup morphism perm automorphism action.
-From mathcomp Require Import quotient gfunctor gproduct ssralg countalg finalg zmodp.
-From mathcomp Require Import cyclic pgroup gseries nilpotent sylow.
+From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq path.
+From mathcomp Require Import choice div fintype finfun bigop finset prime.
+From mathcomp Require Import binomial fingroup morphism perm automorphism.
+From mathcomp Require Import action quotient gfunctor gproduct ssralg countalg.
+From mathcomp Require Import finalg zmodp cyclic pgroup gseries nilpotent sylow.
 
 (******************************************************************************)
 (* Constructions based on abelian groups and their structure, with some       *)

--- a/solvable/cyclic.v
+++ b/solvable/cyclic.v
@@ -1,8 +1,8 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq choice div.
-From mathcomp Require Import fintype bigop prime finset fingroup morphism.
+From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq choice.
+From mathcomp Require Import div fintype bigop prime finset fingroup morphism.
 From mathcomp Require Import perm automorphism quotient gproduct ssralg.
 From mathcomp Require Import finalg zmodp poly.
 

--- a/solvable/finmodule.v
+++ b/solvable/finmodule.v
@@ -3,7 +3,7 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq path.
 From mathcomp Require Import div choice fintype bigop ssralg finset fingroup.
-From mathcomp Require Import morphism perm finalg action gproduct commutator.
+From mathcomp Require Import morphism perm finalg action gproduct commutator .
 From mathcomp Require Import cyclic.
 
 (******************************************************************************)
@@ -298,7 +298,7 @@ have cocycle_mu: {in G & &, forall x y z,
   mu (x * y)%g z + mu x y ^@ z = mu y z + mu x (y * z)%g}%R.
 - move=> x y z Gx Gy Gz; apply: val_inj.
   apply: (mulgI (rH x * rH y * rH z)).
-  rewrite -(actrH _ _ Gz) addrC fmvalA fmvalJ ?nHG ?GrH //.
+  rewrite -(actrH _ _ Gz) addrC [in LHS]fmvalA fmvalJ ?nHG ?GrH //.
   rewrite mulgA -(mulgA _ (rH z)) -conjgC mulgA -!rHmul ?groupM //.
   by rewrite mulgA -mulgA -2!(mulgA (rH x)) -!rHmul ?groupM.
 move: mu => mu in rHmul mu_Pmul cocycle_mu nu nu_Hmul.

--- a/solvable/maximal.v
+++ b/solvable/maximal.v
@@ -3,7 +3,7 @@
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq choice.
 From mathcomp Require Import div fintype finfun bigop finset prime binomial.
 From mathcomp Require Import fingroup morphism perm automorphism quotient.
-From mathcomp Require Import action commutator gproduct gfunctor ssralg.
+From mathcomp Require Import action commutator gproduct gfunctor ssralg .
 From mathcomp Require Import countalg finalg zmodp cyclic pgroup center gseries.
 From mathcomp Require Import nilpotent sylow abelian finmodule.
 

--- a/solvable/sylow.v
+++ b/solvable/sylow.v
@@ -2,7 +2,7 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq div.
 From mathcomp Require Import fintype prime bigop finset fingroup morphism.
-From mathcomp Require Import automorphism quotient action cyclic gproduct.
+From mathcomp Require Import automorphism quotient action cyclic gproduct .
 From mathcomp Require Import gfunctor commutator pgroup center nilpotent.
 
 (******************************************************************************)

--- a/ssreflect/Make
+++ b/ssreflect/Make
@@ -15,6 +15,8 @@ fingraph.v
 finset.v
 fintype.v
 generic_quotient.v
+monoid.v
+nmodule.v
 path.v
 prime.v
 tuple.v

--- a/ssreflect/all_ssreflect.v
+++ b/ssreflect/all_ssreflect.v
@@ -5,6 +5,8 @@ Require Export eqtype.
 Require Export ssrnat.
 Require Export seq.
 Require Export choice.
+Require Export monoid.
+Require Export nmodule.
 Require Export path.
 Require Export div.
 Require Export fintype.

--- a/ssreflect/monoid.v
+++ b/ssreflect/monoid.v
@@ -1,0 +1,1315 @@
+From HB Require Import structures.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype choice ssrnat seq.
+From mathcomp Require Import bigop fintype finfun.
+
+(******************************************************************************)
+(*                          Group-like structures                             *)
+(*                                                                            *)
+(* NB: See CONTRIBUTING.md for an introduction to HB concepts and commands.   *)
+(*                                                                            *)
+(* This file defines the following algebraic structures:                      *)
+(*                                                                            *)
+(*             magmaType == magma                                             *)
+(*                          The HB class is called Magma.                     *)
+(*      ChoiceMagma.type == join of magmaType and choiceType                  *)
+(*                          The HB class is called ChoiceMagma.               *)
+(*         semigroupType == associative magma                                 *)
+(*                          The HB class is called Semigroup.                 *)
+(*        baseUMagmaType == pointed magma                                     *)
+(*                          The HB class is called BaseUMagma.                *)
+(* ChoiceBaseUMagma.type == join of baseUMagmaType and choiceType             *)
+(*                          The HB class is called ChoiceBaseUMagma.          *)
+(*            umagmaType == unitary magma                                     *)
+(*                          The HB class is called UMagma.                    *)
+(*            monoidType == monoid                                            *)
+(*                          The HB class is called Monoid.                    *)
+(*         baseGroupType == pointed magma with an inversion operator          *)
+(*                          The HB class is called BaseGroup.                 *)
+(*             groupType == group                                             *)
+(*                          The HB class is called Group.                     *)
+(*                                                                            *)
+(* and their joins with subType:                                              *)
+(*                                                                            *)
+(*        subMagmaType V P == join of magmaType and subType (P : pred V) such *)
+(*                            that val is multiplicative                      *)
+(*                            The HB class is called SubMagma.                *)
+(*    subSemigroupType V P == join of semigroupType and subType (P : pred V)  *)
+(*                            such that val is multiplicative                 *)
+(*                            The HB class is called SubSemigroup.            *)
+(*   subBaseUMagmaType V P == join of baseUMagmaType and subType (P : pred V) *)
+(*                            such that val is multiplicative and preserves 1 *)
+(*                            The HB class is called SubBaseUMagma.           *)
+(*      subUMagmaType V P == join of UMagmaType and subType (P : pred V)      *)
+(*                            such that val is multiplicative and preserves 1 *)
+(*                            The HB class is called SubUMagma.               *)
+(*      subMonoidType V P == join of monoidType and subType (P : pred V)      *)
+(*                            such that val is multiplicative and preserves 1 *)
+(*                            The HB class is called SubMonoid.               *)
+(*       subGroupType V P == join of groupType and subType (P : pred V)       *)
+(*                            such that val is multiplicative and preserves 1 *)
+(*                            The HB class is called SubGroup.                *)
+(*                                                                            *)
+(* Morphisms between the above structures:                                    *)
+(*                                                                            *)
+(*  Multiplicative.type G H == multiplicative functions between magmaType     *)
+(*                             instances G and H                              *)
+(*  UMagmaMorphism.type G H == multiplicative functions preserving 1 between  *)
+(*                             baseUMagmaType instances G and H               *)
+(*                                                                            *)
+(* Closedness predicates for the algebraic structures:                        *)
+(*                                                                            *)
+(*    mulgClosed V == predicate closed under multiplication on G : magmaType  *)
+(*                    The HB class is called MulClosed.                       *)
+(*  umagmaClosed V == predicate closed under multiplication and containing 1  *)
+(*                    on G : baseUMagmaType                                   *)
+(*                    The HB class is called UMagmaClosed.                    *)
+(*    invgClosed V == predicate closed under inversion on G : baseGroupType   *)
+(*                    The HB class is called InvClosed.                       *)
+(*   groupClosed V == predicate closed under multiplication and inversion and *)
+(*                    containing 1 on G : baseGroupType                       *)
+(*                    The HB class is called InvClosed.                       *)
+(*                                                                            *)
+(* Canonical properties of the algebraic structures:                          *)
+(*  * magmaType (magmas):                                                     *)
+(*                 x * y == the product of x and y                            *)
+(*           commute x y <-> x and y commute (i.e. x * y = y * x)             *)
+(*         mulg_closed S <-> collective predicate S is closed under           *)
+(*                          multiplication                                    *)
+(*                                                                            *)
+(*  * baseUMagmaType (pointed magmas):                                        *)
+(*                     1 == the unit of a unitary magma                       *)
+(*                x ^+ n == x to the power n, with n in nat (non-negative),   *)
+(*                          i.e. x * (x * .. (x * x)..) (n terms); x ^+ 1 is  *)
+(*                          thus convertible to x, and x ^+ 2 to x * x        *)
+(*        \prod<range> e == iterated product for a baseUMagmaType (cf bigop.v)*)
+(*       umagma_closed S <-> collective predicate S is closed under           *)
+(*                          multiplication and contains 1                     *)
+(*                                                                            *)
+(*  * monoidType (monoids):                                                   *)
+(*       monoid_closed S := umagma_closed S                                   *)
+(*                                                                            *)
+(*  * baseGroupType (pointed magmas with an inversion operator):              *)
+(*                 x ^-1 == the inverse of x                                  *)
+(*                 x / y == x * (y ^- 1)                                      *)
+(*                x ^- n == (x ^+ n)^-1                                       *)
+(*                 x ^ y := y^-1 * (x * y)                                    *)
+(*                       == the conjugate of x by y                           *)
+(*              [~ x, y] := x^-1 * (y^-1 * (x * y)                            *)
+(*                       == the commutator of x and y                         *)
+(*         invg_closed S <-> collective predicate S is closed under inversion *)
+(*         divg_closed S <-> collective predicate S is closed under division  *)
+(*        group_closed S <-> collective predicate S is closed under division  *)
+(*                           and contains 1                                   *)
+(*                                                                            *)
+(*   In addition to this structure hierarchy, we also develop a separate,     *)
+(*                                                                            *)
+(* * Multiplicative (magma morphisms):                                        *)
+(* {multiplicative U -> V} == the interface type for magma morphisms, i.e.    *)
+(*                            functions from U to V which maps * in U to * in *)
+(*                            V; both U and V must have magmaType instances   *)
+(*                         := GRing.RMorphism.type R S                        *)
+(*                                                                            *)
+(* * UMagmaMorphism (unitary magma morphisms):                                *)
+(*         monoid_morphism f <-> f of type U -> V is a multiplicative monoid  *)
+(*                               morphism, i.e., f maps 1 and * in U to 1 and *)
+(*                               * in V, respectively. U and V must have      *)
+(*                               canonical baseUMagmaType instances.          *)
+(*Algebra.UMagmaMorphism.type == the interface type for unitary magma         *)
+(*                               morphisms; both U and V must have magmaType  *)
+(*                               instances                                    *)
+(*                                                                            *)
+(*   Notations are defined in scope group_scope (delimiter %g)                *)
+(*   This library also extends the conventional suffixes described in library *)
+(* ssrbool.v with the following:                                              *)
+(*   1 -- unitary magma 1, as in mulg1 : x * 1 = x                            *)
+(*   M -- magma multiplication, as in conjgM : x ^ (y * z) = (x ^ y) ^ z      *)
+(*  Mn -- ring by nat multiplication, as in expgMn :                          *)
+(*        (x * y) ^+ n = x ^+ n * y ^+ n                                      *)
+(*   V -- group inverse, as in expVgn : (x^-1) ^+ n = x ^- n                  *)
+(*   F -- group division, as in invgF : (x / y)^-1 = y / x                    *)
+(*   X -- unitary magma exponentiation, as in conjXg :                        *)
+(*        (x ^+ n) ^ y = (x ^ y) ^+ n                                         *)
+(*   J -- group conjugation, as in conjJg : (x ^ y) ^ z = (x ^ z) ^ y ^ z     *)
+(*   R -- group commutator, as in conjRg : [~ x, y] ^ z = [~ x ^ z, y ^ z]    *)
+(* The operator suffixes D, B, M and X are also used for the corresponding    *)
+(* operations on nat, as in expgnDr : x ^+ (m + n) = x ^+ m * x ^+ n. For the *)
+(* binary power operator, a trailing "n" suffix is used to indicate the       *)
+(* operator suffix applies to the left-hand group argument, as in             *)
+(*   expg1n : 1 ^+ n = 1 vs. expg1 : x ^+ 1 = x.                              *)
+(******************************************************************************)
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Reserved Notation "*%g" (at level 0).
+Reserved Notation "\1" (at level 0).
+Reserved Notation "f \* g" (at level 40, left associativity).
+
+Reserved Notation "'{' 'multiplicative' G '->' H '}'"
+  (at level 0, G at level 98, H at level 99,
+   format "{ 'multiplicative'  G  ->  H }").
+
+Declare Scope group_scope.
+Delimit Scope group_scope with g.
+Local Open Scope group_scope.
+
+HB.mixin Record hasMul G := {
+  mul : G -> G -> G
+}.
+
+#[short(type="magmaType")]
+HB.structure Definition Magma := {G of hasMul G}.
+
+Bind Scope group_scope with Magma.sort.
+
+HB.structure Definition ChoiceMagma := {G of Magma G & Choice G}.
+
+Bind Scope group_scope with ChoiceMagma.sort.
+
+Local Notation "*%g" := (@mul _) : function_scope.
+Local Notation "x * y" := (mul x y) : group_scope.
+
+Section MagmaTheory.
+
+Variable G : magmaType.
+Implicit Types x y : G.
+
+Definition commute x y := x * y = y * x.
+
+Lemma commute_refl x : commute x x.
+Proof. by []. Qed.
+
+Lemma commute_sym x y : commute x y -> commute y x.
+Proof. by []. Qed.
+
+Section ClosedPredicates.
+
+Variable S : {pred G}.
+
+Definition mulg_closed := {in S &, forall u v, u * v \in S}.
+
+End ClosedPredicates.
+
+End MagmaTheory.
+
+HB.mixin Record Magma_isSemigroup G of Magma G := {
+  mulgA : associative (@mul G)
+}.
+
+#[short(type="semigroupType")]
+HB.structure Definition Semigroup := {G of Magma_isSemigroup G & ChoiceMagma G}.
+
+HB.factory Record isSemigroup G of Choice G := {
+  mul : G -> G -> G;
+  mulgA : associative mul
+}.
+
+HB.builders Context G of isSemigroup G.
+
+HB.instance Definition _ := hasMul.Build G mul.
+HB.instance Definition _ := Magma_isSemigroup.Build G mulgA.
+
+HB.end.
+
+Bind Scope group_scope with Semigroup.sort.
+
+Section SemigroupTheory.
+Variable G : semigroupType.
+Implicit Types x y : G.
+
+Lemma commuteM x y z : commute x y -> commute x z -> commute x (y * z).
+Proof. by move=> cxy cxz; rewrite /commute -mulgA -cxz !mulgA cxy. Qed.
+
+End SemigroupTheory.
+
+HB.mixin Record hasOne G := {
+  one : G
+}.
+
+#[short(type="baseUMagmaType")]
+HB.structure Definition BaseUMagma := {G of hasOne G & Magma G}.
+
+Bind Scope group_scope with BaseUMagma.sort.
+
+HB.structure Definition ChoiceBaseUMagma := {G of BaseUMagma G & Choice G}.
+
+Bind Scope group_scope with ChoiceBaseUMagma.sort.
+
+Local Notation "1" := (@one _) : group_scope.
+Local Notation "s `_ i" := (nth 1 s i) : group_scope.
+Local Notation "\prod_ ( i <- r | P ) F" := (\big[*%g/1]_(i <- r | P) F).
+Local Notation "\prod_ ( i | P ) F" := (\big[*%g/1]_(i | P) F).
+Local Notation "\prod_ ( i 'in' A ) F" := (\big[*%g/1]_(i in A) F).
+Local Notation "\prod_ ( m <= i < n ) F" := (\big[*%g/1%g]_(m <= i < n) F%g).
+
+Definition natexp (G : baseUMagmaType) (x : G) n : G := iterop n *%g x 1.
+Arguments natexp : simpl never.
+
+Local Notation "x ^+ n" := (natexp x n) : group_scope.
+
+Section baseUMagmaTheory.
+
+Variable G : baseUMagmaType.
+Implicit Types x : G.
+Lemma expg0 x : x ^+ 0 = 1. Proof. by []. Qed.
+Lemma expg1 x : x ^+ 1 = x. Proof. by []. Qed.
+Lemma expg2 x : x ^+ 2 = x * x. Proof. by []. Qed.
+
+Lemma expgSS x n : x ^+ n.+2 = x * x ^+ n.+1.
+Proof. by []. Qed.
+
+Lemma expgb x (b : bool) : x ^+ b = (if b then x else 1).
+Proof. by case: b. Qed.
+
+Section ClosedPredicates.
+
+Variable S : {pred G}.
+
+Definition umagma_closed := 1 \in S /\ mulg_closed S.
+
+End ClosedPredicates.
+
+End baseUMagmaTheory.
+
+HB.mixin Record BaseUMagma_isUMagma G of BaseUMagma G := {
+  mul1g : left_id one (@mul G);
+  mulg1 : right_id one (@mul G)
+}.
+
+HB.factory Record Magma_isUMagma G of Magma G := {
+  one : G;
+  mul1g : left_id one (@mul G);
+  mulg1 : right_id one (@mul G)
+}.
+
+HB.builders Context G of Magma_isUMagma G.
+HB.instance Definition _ := hasOne.Build G one.
+#[warning="-HB.no-new-instance"]
+HB.instance Definition _ := BaseUMagma_isUMagma.Build G mul1g mulg1.
+HB.end.
+
+#[short(type="umagmaType")]
+HB.structure Definition UMagma := {G of Magma_isUMagma G & ChoiceMagma G}.
+
+Bind Scope group_scope with UMagma.sort.
+
+Section UMagmaTheory.
+
+Variable G : umagmaType.
+Implicit Types x y : G.
+
+Lemma expgS x n : x ^+ n.+1 = x * x ^+ n.
+Proof. by case: n => //=; rewrite mulg1. Qed.
+
+Lemma expg1n n : 1 ^+ n = 1 :> G.
+Proof. by elim: n => // n IHn; rewrite expgS mul1g. Qed.
+
+Lemma commute1 x : commute x 1.
+Proof. by rewrite /commute mulg1 mul1g. Qed.
+
+End UMagmaTheory.
+
+#[short(type="monoidType")]
+HB.structure Definition Monoid := {G of Magma_isUMagma G & Semigroup G}.
+
+HB.factory Record Semigroup_isMonoid G of Semigroup G := {
+  one : G;
+  mul1g : left_id one mul;
+  mulg1 : right_id one mul
+}.
+
+HB.builders Context G of Semigroup_isMonoid G.
+
+HB.instance Definition _ := Magma_isUMagma.Build G mul1g mulg1.
+
+HB.end.
+
+HB.factory Record UMagma_isMonoid G of UMagma G := {
+  mulgA : associative (@mul G)
+}.
+
+HB.builders Context G of UMagma_isMonoid G.
+
+HB.instance Definition _ := Magma_isSemigroup.Build G mulgA.
+
+HB.end.
+
+HB.factory Record isMonoid G of Choice G := {
+  mul : G -> G -> G;
+  one : G;
+  mulgA : associative mul;
+  mul1g : left_id one mul;
+  mulg1 : right_id one mul
+}.
+
+HB.builders Context G of isMonoid G.
+
+HB.instance Definition _ := hasMul.Build G mul.
+HB.instance Definition _ := Magma_isSemigroup.Build G mulgA.
+HB.instance Definition _ := Magma_isUMagma.Build G mul1g mulg1.
+
+HB.end.
+
+#[export]
+HB.instance Definition _ (G : monoidType) := Monoid.isLaw.Build G 1 *%g mulgA mul1g mulg1.
+
+Bind Scope group_scope with Monoid.sort.
+
+Section MonoidTheory.
+
+Variable G : monoidType.
+Implicit Types x y : G.
+
+Lemma expgSr x n : x ^+ n.+1 = x ^+ n * x.
+Proof.
+elim: n => [|n IHn]; first by rewrite mul1g.
+by rewrite expgS [in LHS]IHn expgS mulgA.
+Qed.
+
+Lemma expgnDr x m n : x ^+ (m + n) = x ^+ m * x ^+ n.
+Proof.
+elim: m => [|m IHm]; first by rewrite mul1g.
+by rewrite 2!expgS IHm mulgA.
+Qed.
+
+Lemma expgnA x m n : x ^+ (m * n) = x ^+ m ^+ n.
+Proof. by rewrite mulnC; elim: n => //= n IHn; rewrite expgS expgnDr IHn. Qed.
+
+Lemma expgnAC x m n : x ^+ m ^+ n = x ^+ n ^+ m.
+Proof. by rewrite -2!expgnA mulnC. Qed.
+
+Lemma iter_mulg n x y : iter n ( *%g x) y = x ^+ n * y.
+Proof. by elim: n => [|n IHn]; rewrite ?mul1g //= IHn expgS mulgA. Qed.
+
+Lemma iter_mulg_1 n x : iter n ( *%g x) 1 = x ^+ n.
+Proof. by rewrite iter_mulg mulg1. Qed.
+
+Lemma prodg_const (I : finType) (A : pred I) x : \prod_(i in A) x = x ^+ #|A|.
+Proof. by rewrite big_const -Monoid.iteropE. Qed.
+
+Lemma prodg_const_nat n m x : \prod_(n <= i < m) x = x ^+ (m - n).
+Proof. by rewrite big_const_nat -Monoid.iteropE. Qed.
+
+Lemma prodgXr x I r P (F : I -> nat) :
+  \prod_(i <- r | P i) x ^+ F i = x ^+ (\sum_(i <- r | P i) F i).
+Proof. by rewrite (big_morph _ (expgnDr _) (erefl _)). Qed.
+
+Lemma commute_prod (I : Type) (s : seq I) (P : pred I) (F : I -> G) x :
+  (forall i, P i -> commute x (F i)) -> commute x (\prod_(i <- s | P i) F i).
+Proof. exact: (big_ind _ (commute1 x) (@commuteM _ x)). Qed.
+
+Lemma prodgM_commute {I : eqType} r (P : pred I) (F H : I -> G) :
+    (forall i j, P i -> P j -> commute (F i) (H j)) ->
+  \prod_(i <- r | P i) (F i * H i) =
+    \prod_(i <- r | P i) F i * \prod_(i <- r | P i) H i.
+Proof.
+move=> FH; elim: r => [|i r IHr]; rewrite !(big_nil, big_cons) ?mulg1//.
+case: ifPn => // Pi; rewrite IHr !mulgA; congr (_ * _); rewrite -!mulgA.
+by rewrite commute_prod // => j Pj; apply/commute_sym/FH.
+Qed.
+
+Lemma prodgMl_commute {I : finType} (A : pred I) (x : G) F :
+    (forall i, A i -> commute x (F i)) ->
+  \prod_(i in A) (x * F i) = x ^+ #|A| * \prod_(i in A) F i.
+Proof. by move=> xF; rewrite prodgM_commute ?prodg_const// => i j _ /xF. Qed.
+
+Lemma prodgMr_commute {I : finType} (A : pred I) (x : G) F :
+    (forall i, A i -> commute x (F i)) ->
+  \prod_(i in A) (F i * x) = \prod_(i in A) F i * x ^+ #|A|.
+Proof. by move=> xF; rewrite prodgM_commute ?prodg_const// => i j /xF. Qed.
+
+Lemma commuteX x y n : commute x y -> commute x (y ^+ n).
+Proof.
+by move=> cxy; case: n; [apply: commute1 | elim=> // n; apply: commuteM].
+Qed.
+
+Lemma commuteX2 x y m n : commute x y -> commute (x ^+ m) (y ^+ n).
+Proof. by move=> cxy; apply/commuteX/commute_sym/commuteX. Qed.
+
+Lemma expgMn x y n : commute x y -> (x * y) ^+ n = x ^+ n * y ^+ n.
+Proof.
+move=> cxy; elim: n => [|n IHn]; first by rewrite mulg1.
+by rewrite !expgS IHn -mulgA (mulgA y) (commuteX _ (commute_sym cxy)) !mulgA.
+Qed.
+
+End MonoidTheory.
+
+Notation monoid_closed := umagma_closed.
+
+HB.mixin Record hasInv G := {
+  inv : G -> G
+}.
+
+#[short(type="baseGroupType")]
+HB.structure Definition BaseGroup := {G of hasInv G & BaseUMagma G}.
+
+Bind Scope group_scope with BaseGroup.sort.
+
+HB.mixin Record Monoid_isGroup G of BaseGroup G := {
+  mulVg : left_inverse one inv (@mul G);
+  mulgV : right_inverse one inv (@mul G)
+}.
+
+#[short(type="groupType")]
+HB.structure Definition Group :=
+  {G of Monoid_isGroup G & BaseGroup G & Monoid G}.
+
+HB.factory Record isGroup G of Choice G := {
+  one : G;
+  inv : G -> G;
+  mul : G -> G -> G;
+  mulgA : associative mul;
+  mul1g : left_id one mul;
+  mulg1 : right_id one mul;
+  mulVg : left_inverse one inv mul;
+  mulgV : right_inverse one inv mul
+}.
+
+HB.builders Context G of isGroup G.
+
+HB.instance Definition _ := hasMul.Build G mul.
+HB.instance Definition _ := Magma_isSemigroup.Build G mulgA.
+HB.instance Definition _ := Magma_isUMagma.Build G mul1g mulg1.
+HB.instance Definition _ := hasInv.Build G inv.
+HB.instance Definition _ := Monoid_isGroup.Build G mulVg mulgV.
+
+HB.end.
+
+Bind Scope group_scope with Group.sort.
+
+Local Notation "x ^-1" := (inv x) : group_scope.
+Local Notation "x / y" := (x * y^-1) : group_scope.
+Local Notation "x ^- n" := ((x ^+ n)^-1) : group_scope.
+
+Definition conjg (G : groupType) (x y : G) := y^-1 * (x * y).
+Local Notation "x ^ y" := (conjg x y) : group_scope.
+
+Definition commg (G : groupType) (x y : G) := x^-1 * (conjg x y).
+Local Notation "[~ x , y ]" := (commg x y) : group_scope.
+
+Section GroupTheory.
+Variable G : groupType.
+Implicit Types x y : G.
+
+Definition divgg := @mulgV G.
+
+Lemma mulKg : @left_loop G G (@inv G) *%g.
+Proof. by move=> x y; rewrite mulgA mulVg mul1g. Qed.
+
+Lemma mulVKg : @rev_left_loop G G (@inv G) *%g.
+Proof. by move=> x y ; rewrite mulgA mulgV mul1g. Qed.
+
+Lemma mulgK : @right_loop G G (@inv G) *%g.
+Proof. by move=> x y; rewrite -mulgA mulgV mulg1. Qed.
+
+Lemma mulgVK : @rev_right_loop G G (@inv G) *%g.
+Proof. by move=> x y ; rewrite -mulgA mulVg mulg1. Qed.
+Definition divgK := mulgVK.
+
+Lemma mulgI : @right_injective G G G *%g.
+Proof. by move=> x; apply: can_inj (mulKg x). Qed.
+
+Lemma mulIg : @left_injective G G G *%g.
+Proof. by move=> x; apply: can_inj (mulgK x). Qed.
+
+Lemma invgK : @involutive G (@inv G).
+Proof. by move=> x; rewrite -[LHS](mulVKg x) divgg mulg1. Qed.
+
+Lemma invg_inj : @injective G G (@inv G).
+Proof. exact: inv_inj invgK. Qed.
+
+Lemma divgI : @right_injective G G G (fun x y => x / y).
+Proof. by move=> x y z /mulgI/invg_inj. Qed.
+
+Lemma divIg : @left_injective G G G (fun x y => x / y).
+Proof. by move=> x y z /mulIg. Qed.
+
+Lemma invg1 : 1 ^-1 = 1 :> G.
+Proof. by rewrite -[LHS]mul1g divgg. Qed.
+
+Lemma invg_eq1 x : (x ^-1 == 1) = (x == 1).
+Proof. by rewrite (inv_eq invgK) invg1. Qed.
+
+Lemma divg1 x : x / 1 = x. Proof. by rewrite invg1 mulg1. Qed.
+
+Lemma div1g x : 1 / x = x^-1. Proof. by rewrite mul1g. Qed.
+
+Lemma invgF x y : (x / y)^-1 = y / x.
+Proof. by apply/(canRL (mulgK x))/(@divIg y); rewrite -mulgA mulVg divgg. Qed.
+
+Lemma invgM : {morph (@inv G): x y / x * y >-> y * x : G}.
+Proof. by move=> x y; rewrite -[y in LHS]invgK invgF. Qed.
+
+Lemma prodgV I r (P : pred I) (E : I -> G) :
+  \prod_(i <- r | P i) (E i)^-1 = (\prod_(i <- rev r | P i) E i)^-1.
+Proof.
+elim: r => [|x r IHr]; first by rewrite !big_nil invg1.
+rewrite big_cons rev_cons big_rcons/= IHr.
+by case: ifP => _; rewrite ?mulg1// invgM.
+Qed.
+
+Lemma divKg x y : commute x y -> x / (x / y) = y.
+Proof. by move=> xyC; rewrite invgF mulgA xyC mulgK. Qed.
+
+(* TOTHINK : This does not have the same form as addrKA in ssralg.v *)
+Lemma mulgKA z x y : (x * z) / (y * z) = x / y.
+Proof. by rewrite invgM mulgA mulgK. Qed.
+
+Lemma divgKA z x y : (x / z) * (z * y) = x * y.
+Proof. by rewrite mulgA mulgVK. Qed.
+
+Lemma mulg1_eq x y : x * y = 1 -> x^-1 = y.
+Proof. by rewrite -[x^-1]mulg1 => <-; rewrite mulKg. Qed.
+
+Lemma divg1_eq x y : x / y = 1 -> x = y.
+Proof. by move/mulg1_eq/invg_inj. Qed.
+
+Lemma divg_eq x y z : (x / z == y) = (x == y * z).
+Proof. exact: can2_eq (divgK z) (mulgK z) x y. Qed.
+
+Lemma divg_eq1 x y : (x / y == 1) = (x == y).
+Proof. by rewrite divg_eq mul1g. Qed.
+
+Lemma mulg_eq1 x y : (x * y == 1) = (x == y^-1).
+Proof. by rewrite -[y in LHS]invgK divg_eq1. Qed.
+
+Lemma eqg_inv x y : (x^-1 == y^-1) = (x == y).
+Proof. exact: can_eq invgK x y. Qed.
+
+Lemma eqg_invLR x y : (x^-1 == y) = (x == y^-1).
+Proof. exact: inv_eq invgK x y. Qed.
+
+Lemma commuteV x y : commute x y -> commute x y^-1.
+Proof. by move=> cxy; apply: (@mulIg y); rewrite mulgVK -mulgA cxy mulKg. Qed.
+
+Lemma expVgn x n : (x^-1) ^+ n = x ^- n.
+Proof.
+apply/esym/mulg1_eq; rewrite -expgMn; first by rewrite divgg expg1n.
+exact/commuteV.
+Qed.
+
+Lemma expgnFr x m n : n <= m -> x ^+ (m - n) = x ^+ m / x ^+ n.
+Proof. by move=> lenm; rewrite -[in RHS](subnK lenm) expgnDr mulgK. Qed.
+
+Lemma expgnFl x y n : commute x y -> (x / y) ^+ n = x ^+ n / y ^+ n.
+Proof. by move=> xyC; rewrite expgMn 1?expVgn; last exact/commuteV. Qed.
+
+Lemma conjgE x y : x ^ y = y^-1 * (x * y). Proof. by []. Qed.
+
+Lemma conjgC x y : x * y = y * x ^ y.
+Proof. by rewrite mulVKg. Qed.
+
+Lemma conjgCV x y : x * y = y ^ x^-1 * x.
+Proof. by rewrite -mulgA mulgVK invgK. Qed.
+
+Lemma conjg1 x : x ^ 1 = x.
+Proof. by rewrite conjgE commute1 mulKg. Qed.
+
+Lemma conj1g x : 1 ^ x = 1.
+Proof. by rewrite conjgE mul1g mulVg. Qed.
+
+Lemma conjMg x y z : (x * y) ^ z = x ^ z * y ^ z.
+Proof. by rewrite !conjgE !mulgA mulgK. Qed.
+
+Lemma conjgM x y z : x ^ (y * z) = (x ^ y) ^ z.
+Proof. by rewrite !conjgE invgM !mulgA. Qed.
+
+Lemma conjVg x y : x^-1 ^ y = (x ^ y)^-1.
+Proof. by rewrite !conjgE !invgM invgK mulgA. Qed.
+
+Lemma conjJg x y z : (x ^ y) ^ z = (x ^ z) ^ y ^ z.
+Proof. by rewrite 2!conjMg conjVg. Qed.
+
+Lemma conjXg x y n : (x ^+ n) ^ y = (x ^ y) ^+ n.
+Proof. by elim: n => [|n IHn]; rewrite ?conj1g // !expgS conjMg IHn. Qed.
+
+Lemma conjgK : @right_loop G G (@inv G) (@conjg G).
+Proof. by move=> y x; rewrite -conjgM mulgV conjg1. Qed.
+
+Lemma conjgKV : @rev_right_loop G G (@inv G) (@conjg G).
+Proof. by move=> y x; rewrite -conjgM mulVg conjg1. Qed.
+
+Lemma conjg_inj : @left_injective G G G (@conjg G).
+Proof. by move=> y; apply: can_inj (conjgK y). Qed.
+
+Lemma conjg_eq1 x y : (x ^ y == 1) = (x == 1).
+Proof. by rewrite (can2_eq (conjgK _) (conjgKV _)) conj1g. Qed.
+
+Lemma commgEl x y : [~ x, y] = x^-1 * x ^ y. Proof. by []. Qed.
+
+Lemma commgEr x y : [~ x, y] = y^-1 ^ x * y.
+Proof. by rewrite -!mulgA. Qed.
+
+Lemma commgC x y : x * y = y * x * [~ x, y].
+Proof. by rewrite -mulgA !mulVKg. Qed.
+
+Lemma commgCV x y : x * y = [~ x^-1, y^-1] * (y * x).
+Proof. by rewrite commgEl !mulgA !invgK !mulgVK. Qed.
+
+Lemma conjRg x y z : [~ x, y] ^ z = [~ x ^ z, y ^ z].
+Proof. by rewrite !conjMg !conjVg. Qed.
+
+Lemma invgR x y : [~ x, y]^-1 = [~ y, x].
+Proof. by rewrite commgEr conjVg invgM invgK. Qed.
+
+Lemma commgP x y : reflect (commute x y) ([~ x, y] == 1).
+Proof. rewrite [[~ x, y]]mulgA -invgM mulg_eq1 eqg_inv eq_sym; apply: eqP. Qed.
+
+Lemma conjg_fix x y : x ^ y == x = ([~ x, y] == 1).
+Proof. by rewrite mulg_eq1 eqg_inv. Qed.
+
+Lemma conjg_fixP x y : reflect (x ^ y = x) ([~ x, y] == 1).
+Proof. by rewrite -conjg_fix; apply: eqP. Qed.
+
+Lemma commg1_sym x y : ([~ x, y] == 1) = ([~ y, x] == 1).
+Proof. by rewrite -invgR (inv_eq invgK) invg1. Qed.
+
+Lemma commg1 x : [~ x, 1] = 1.
+Proof. exact/eqP/commgP/commute1. Qed.
+
+Lemma comm1g x : [~ 1, x] = 1.
+Proof. by rewrite -invgR commg1 invg1. Qed.
+
+Lemma commgg x : [~ x, x] = 1.
+Proof. exact/eqP/commgP. Qed.
+
+Lemma commgXg x n : [~ x, x ^+ n] = 1.
+Proof. exact/eqP/commgP/commuteX. Qed.
+
+Lemma commgVg x : [~ x, x^-1] = 1.
+Proof. exact/eqP/commgP/commuteV. Qed.
+
+Lemma commgXVg x n : [~ x, x ^- n] = 1.
+Proof. exact/eqP/commgP/commuteV/commuteX. Qed.
+
+Section ClosedPredicates.
+
+Variable S : {pred G}.
+
+Definition invg_closed := {in S, forall u, u^-1 \in S}.
+Definition divg_closed := {in S &, forall u v, u / v \in S}.
+Definition group_closed := 1 \in S /\ divg_closed.
+
+Lemma group_closedV : group_closed -> invg_closed.
+Proof. by move=> [S1 SB] x /(SB 1)-/(_ S1); rewrite div1g. Qed.
+
+Lemma group_closedM : group_closed -> mulg_closed S.
+Proof.
+move=> /[dup]-[S1 SB] /group_closedV SV x y xS /SV yS.
+rewrite -[y]invgK; exact: SB.
+Qed.
+
+End ClosedPredicates.
+
+End GroupTheory.
+
+(* Morphism hierarchy. *)
+
+HB.mixin Record isMultiplicative (G H : magmaType) (apply : G -> H) := {
+  gmulfM : {morph apply : x y / x * y}
+}.
+
+HB.structure Definition Multiplicative (G H : magmaType) :=
+  {f of isMultiplicative G H f}.
+
+(* TODO: define pointedTypes and generalize this to pointedTypes. *)
+HB.mixin Record Multiplicative_isUMagmaMorphism (G H : baseUMagmaType)
+  (f : G -> H) := {
+  gmulf1 : f 1 = 1
+}.
+
+HB.structure Definition UMagmaMorphism (G H : baseUMagmaType) :=
+  {f of Multiplicative_isUMagmaMorphism G H f & isMultiplicative G H f}.
+
+Definition monoid_morphism (G H : baseUMagmaType) (f : G -> H) : Prop :=
+   (f 1 = 1) * {morph f : x y / x * y}.
+
+HB.factory Record isUMagmaMorphism (G H : baseUMagmaType) (f : G -> H) := {
+  monoid_morphism_subproof : monoid_morphism f
+}.
+
+HB.builders Context G H apply of isUMagmaMorphism G H apply.
+HB.instance Definition _ :=
+  isMultiplicative.Build G H apply monoid_morphism_subproof.2.
+HB.instance Definition _ :=
+  Multiplicative_isUMagmaMorphism.Build G H apply monoid_morphism_subproof.1.
+HB.end.
+
+HB.factory Record isGroupMorphism (G H : groupType) (f : G -> H) := {
+  gmulfF : {morph f : x y / x / y}
+}.
+
+HB.builders Context G H apply of isGroupMorphism G H apply.
+
+Local Lemma gmulf1 : apply 1 = 1.
+Proof. by rewrite -[1]divg1 gmulfF divgg. Qed.
+
+Local Lemma gmulfM : {morph apply : x y / x * y}.
+Proof.
+move=> x y; rewrite -[y in LHS] invgK -[y^-1]mul1g.
+by rewrite !gmulfF gmulf1 div1g invgK.
+Qed.
+
+HB.instance Definition _ := isMultiplicative.Build G H apply gmulfM.
+HB.instance Definition _ :=
+  Multiplicative_isUMagmaMorphism.Build G H apply gmulf1.
+
+HB.end.
+
+Module MultiplicativeExports.
+Notation "{ 'multiplicative' U -> V }" :=
+  (Multiplicative.type U%type V%type) : type_scope.
+End MultiplicativeExports.
+HB.export MultiplicativeExports.
+
+(* FIXME: The instance below makes sure that the join instance between        *)
+(* Multiplicative.type and UMagmaMorphism.type is declared in both directions.*)
+(* HB should do this automatically.                                           *)
+#[non_forgetful_inheritance]
+HB.instance Definition _ G H (f : UMagmaMorphism.type G H) :=
+  UMagmaMorphism.on (Multiplicative.sort f).
+
+Section LiftedMagma.
+Variables (T : Type) (G : magmaType).
+Definition mul_fun (f g : T -> G) x := f x * g x.
+
+End LiftedMagma.
+Section LiftedBaseUMagma.
+Variables (T : Type) (G : baseUMagmaType).
+Definition one_fun : T -> G := fun=> 1.
+
+End LiftedBaseUMagma.
+
+Local Notation "\1" := (one_fun _) : function_scope.
+Local Notation "f \* g" := (mul_fun f g) : function_scope.
+Arguments one_fun {_} G _ /.
+Arguments mul_fun {_ _} f g _ /.
+
+Section MorphismTheory.
+
+Section Magma.
+Variables (G H : magmaType) (f : {multiplicative G -> H}).
+
+Lemma can2_gmulfM f' : cancel f f' -> cancel f' f -> {morph f' : x y / x * y}.
+Proof. by move=> fK f'K x y; apply: (canLR fK); rewrite gmulfM !f'K. Qed.
+
+Lemma gmulf_commute x y : commute x y -> commute (f x) (f y).
+Proof. by move=> xy; rewrite /commute -!gmulfM xy. Qed.
+
+End Magma.
+
+Section UMagma.
+Variables (G H : umagmaType) (f : UMagmaMorphism.type G H).
+
+Lemma gmulf_eq1 x : injective f -> (f x == 1) = (x == 1).
+Proof. by move=> /inj_eq <-; rewrite gmulf1. Qed.
+
+Lemma can2_gmulf1 f' : cancel f f' -> cancel f' f -> f' 1 = 1.
+Proof. by move=> fK f'K; apply: (canLR fK); rewrite gmulf1. Qed.
+
+Lemma gmulfXn n : {morph f : x / x ^+ n}.
+Proof. by elim: n => [|[|n] IHn] x /=; rewrite ?(gmulf1, gmulfM) // IHn. Qed.
+
+Lemma gmulf_prod I r (P : pred I) E :
+  f (\prod_(i <- r | P i) E i) = \prod_(i <- r | P i) f (E i).
+Proof. exact: (big_morph f gmulfM gmulf1). Qed.
+
+End UMagma.
+
+Section Group.
+Variables (G H : groupType) (f : UMagmaMorphism.type G H).
+
+Lemma gmulfV : {morph f : x / x^-1}.
+Proof. by move=> x; apply/divg1_eq; rewrite invgK -gmulfM mulVg gmulf1. Qed.
+
+Lemma gmulfF : {morph f : x y / x / y}.
+Proof. by move=> x y; rewrite gmulfM gmulfV. Qed.
+
+Lemma gmulf_inj : (forall x, f x = 1 -> x = 1) -> injective f.
+Proof. by move=> fI x y xy; apply/divg1_eq/fI; rewrite gmulfF xy divgg. Qed.
+
+Lemma gmulfXVn n : {morph f : x / x ^- n}.
+Proof. by move=> x /=; rewrite gmulfV gmulfXn. Qed.
+
+Lemma gmulfJ : {morph f : x y / x ^ y}.
+Proof. by move=> x y; rewrite !gmulfM/= gmulfV. Qed.
+
+Lemma gmulfR : {morph f : x y / [~ x, y]}.
+Proof. by move=> x y; rewrite !gmulfM/= !gmulfV. Qed.
+End Group.
+
+Section MulFun.
+Variables (G H K : magmaType).
+Variables (f g : {multiplicative H -> K}) (h : {multiplicative G -> H}).
+
+Fact idfun_gmulfM : {morph @idfun G : x y / x * y}.
+Proof. by []. Qed.
+HB.instance Definition _ := isMultiplicative.Build G G idfun idfun_gmulfM.
+
+Fact comp_gmulfM : {morph f \o h : x y / x * y}.
+Proof. by move=> x y /=; rewrite !gmulfM. Qed.
+HB.instance Definition _ := isMultiplicative.Build G K (f \o h) comp_gmulfM.
+End MulFun.
+
+Section Mul1Fun.
+Variables (G : magmaType) (H : umagmaType).
+
+Fact idfun_gmulf1 : idfun 1 = 1 :> H.
+Proof. by []. Qed.
+HB.instance Definition _ :=
+  Multiplicative_isUMagmaMorphism.Build H H idfun idfun_gmulf1.
+
+Fact one_fun_gmulfM : {morph @one_fun G H : x y / x * y}.
+Proof. by move=> x y; rewrite mulg1. Qed.
+HB.instance Definition _ :=
+  isMultiplicative.Build G H (@one_fun G H) one_fun_gmulfM.
+End Mul1Fun.
+
+Section Mul11Fun.
+Variables (G H K : umagmaType).
+Variables (f g : UMagmaMorphism.type H K) (h : UMagmaMorphism.type G H).
+
+Fact comp_gmulf1 : (f \o h) 1 = 1.
+Proof. by rewrite /= !gmulf1. Qed.
+#[warning="-HB.no-new-instance"]
+HB.instance Definition _ :=
+  Multiplicative_isUMagmaMorphism.Build G K (f \o h) comp_gmulf1.
+
+Fact one_fun_gmulf1 : @one_fun G H 1 = 1.
+Proof. by []. Qed.
+HB.instance Definition _ :=
+  Multiplicative_isUMagmaMorphism.Build G H (@one_fun G H) one_fun_gmulf1.
+
+Fact mul_fun_gmulf1 : (f \* g) 1 = 1.
+Proof. by rewrite /= !gmulf1 mulg1. Qed.
+
+End Mul11Fun.
+End MorphismTheory.
+
+(* Mixins for stability properties *)
+
+HB.mixin Record isMulClosed (G : magmaType) (S : {pred G}) := {
+  gpredM : mulg_closed S
+}.
+
+HB.mixin Record isMul1Closed (G : baseUMagmaType) (S : {pred G}) := {
+  gpred1 : 1 \in S
+}.
+
+HB.mixin Record isInvClosed (G : groupType) (S : {pred G}) := {
+  gpredVr : invg_closed S
+}.
+
+(* Structures for stability properties *)
+
+#[short(type="mulgClosed")]
+HB.structure Definition MulClosed G := {S of isMulClosed G S}.
+
+#[short(type="umagmaClosed")]
+HB.structure Definition UMagmaClosed G :=
+  {S of isMul1Closed G S & isMulClosed G S}.
+
+#[short(type="invgClosed")]
+HB.structure Definition InvClosed G := {S of isInvClosed G S}.
+
+#[short(type="groupClosed")]
+HB.structure Definition GroupClosed G :=
+  {S of isInvClosed G S & isMul1Closed G S & isMulClosed G S}.
+
+Section UMagmaPred.
+Variables (G : baseUMagmaType).
+
+Section UMagma.
+Variables S : umagmaClosed G.
+
+Lemma gpred_prod I r (P : pred I) F :
+  (forall i, P i -> F i \in S) -> \prod_(i <- r | P i) F i \in S.
+Proof. by move=> IH; elim/big_ind: _; [apply: gpred1 | apply: gpredM |]. Qed.
+
+Lemma gpredXn n : {in S, forall u, u ^+ n \in S}.
+Proof.
+by move=> x xS; elim: n => [|[//|n] IHn]; [exact: gpred1 | exact: gpredM].
+Qed.
+
+End UMagma.
+End UMagmaPred.
+
+Section GroupPred.
+Variables (G : groupType).
+
+Lemma gpredV (S : invgClosed G) : {mono (@inv G): u / u \in S}.
+Proof. by move=> u; apply/idP/idP=> /gpredVr; rewrite ?invgK; apply. Qed.
+
+Section Group.
+Variables S : groupClosed G.
+
+Lemma gpredF : {in S &, forall u v, u / v \in S}.
+Proof. by move=> x y xS yS; rewrite gpredM// gpredV. Qed.
+
+Lemma gpredFC u v : u / v \in S = (v / u \in S).
+Proof. by rewrite -gpredV invgF. Qed.
+
+Lemma gpredXNn n: {in S, forall u, u ^- n \in S}.
+Proof. by move=> x xS; apply/gpredVr/gpredXn. Qed.
+
+Lemma gpredMr x y : x \in S -> (y * x \in S) = (y \in S).
+Proof.
+move=> Sx; apply/idP/idP => [Sxy|/gpredM-> //].
+by rewrite -(mulgK x y) gpredF.
+Qed.
+
+Lemma gpredMl x y : x \in S -> (x * y \in S) = (y \in S).
+Proof.
+move=> Sx; apply/idP/idP => [Sxy|/(gpredM x y Sx)//].
+by rewrite -(mulKg x y) gpredM// gpredV.
+Qed.
+
+Lemma gpredFr x y : x \in S -> (y / x \in S) = (y \in S).
+Proof. by rewrite -gpredV; apply: gpredMr. Qed.
+
+Lemma gpredFl x y : x \in S -> (x / y \in S) = (y \in S).
+Proof. by rewrite -(gpredV S y); apply: gpredMl. Qed.
+
+Lemma gpredJ x y : x \in S -> y \in S -> x ^ y \in S.
+Proof. by move=> xS yS; apply/gpredM; [apply/gpredVr|apply/gpredM]. Qed.
+
+Lemma gpredR x y : x \in S -> y \in S -> [~ x, y] \in S.
+Proof. by move=> xS yS; apply/gpredM; [apply/gpredVr|apply/gpredJ]. Qed.
+
+End Group.
+End GroupPred. 
+
+HB.mixin Record isSubMagma (G : magmaType) (S : pred G) H
+    of SubType G S H & Magma H := {
+  valM_subproof : {morph (val : H -> G) : x y / x * y}
+}.
+
+#[short(type="subMagmaType")]
+HB.structure Definition SubMagma (G : magmaType) S :=
+  { H of SubChoice G S H & Magma H & isSubMagma G S H }.
+
+Section subMagma.
+Context (G : magmaType) (S : pred G) (H : subMagmaType S).
+Notation val := (val : H -> G).
+HB.instance Definition _ := isMultiplicative.Build H G val valM_subproof.
+Lemma valM : {morph val : x y / x * y}. Proof. exact: gmulfM. Qed.
+End subMagma.
+
+HB.factory Record SubChoice_isSubMagma (G : magmaType) S H
+    of SubChoice G S H := {
+  mulg_closed_subproof : mulg_closed S
+}.
+
+HB.builders Context G S H of SubChoice_isSubMagma G S H.
+
+HB.instance Definition _ := isMulClosed.Build G S mulg_closed_subproof.
+
+Let inH v Sv : H := Sub v Sv.
+Let mulH (u1 u2 : H) := inH (gpredM _ _ (valP u1) (valP u2)).
+
+HB.instance Definition _ := hasMul.Build H mulH.
+
+Lemma valM : {morph (val : H -> G) : x y / x * y}.
+Proof. by move=> x y; rewrite SubK. Qed.
+
+HB.instance Definition _ := isSubMagma.Build G S H valM.
+
+HB.end.
+
+#[short(type="subSemigroupType")]
+HB.structure Definition SubSemigroup (G : semigroupType) S :=
+  { H of SubMagma G S H & Semigroup H}.
+
+HB.factory Record SubChoice_isSubSemigroup (G : semigroupType) S H
+    of SubChoice G S H := {
+  mulg_closed_subproof : mulg_closed S
+}.
+
+HB.builders Context G S H of SubChoice_isSubSemigroup G S H.
+
+HB.instance Definition _ :=
+  SubChoice_isSubMagma.Build G S H mulg_closed_subproof.
+
+Lemma mulgA : associative (@mul H).
+Proof. by move=> x y z; apply/val_inj; rewrite !valM mulgA. Qed.
+
+HB.instance Definition _ := isSemigroup.Build H mulgA.
+
+HB.end.
+
+HB.mixin Record isSubBaseUMagma (G : baseUMagmaType) (S : pred G) H
+    of SubMagma G S H & BaseUMagma H := {
+  val1_subproof : (val : H -> G) 1 = 1
+}.
+
+#[short(type="subBaseUMagmaType")]
+HB.structure Definition SubBaseUMagma (G : umagmaType) S :=
+  { H of SubMagma G S H & BaseUMagma H & isSubBaseUMagma G S H}.
+
+#[short(type="subUMagmaType")]
+HB.structure Definition SubUMagma (G : umagmaType) S :=
+  { H of SubMagma G S H & UMagma H & isSubBaseUMagma G S H}.
+
+Section subUMagma.
+Context (G : umagmaType) (S : pred G) (H : subUMagmaType S).
+Notation val := (val : H -> G).
+HB.instance Definition _ :=
+  Multiplicative_isUMagmaMorphism.Build H G val val1_subproof.
+Lemma val1 : val 1 = 1. Proof. exact: gmulf1. Qed.
+End subUMagma.
+
+HB.factory Record SubChoice_isSubUMagma (G : umagmaType) S H
+    of SubChoice G S H := {
+  umagma_closed_subproof : umagma_closed S
+}.
+
+HB.builders Context G S H of SubChoice_isSubUMagma G S H.
+
+HB.instance Definition _ :=
+  SubChoice_isSubMagma.Build G S H (snd umagma_closed_subproof).
+
+Let inH v Sv : H := Sub v Sv.
+Let oneH := inH (fst umagma_closed_subproof).
+
+HB.instance Definition _ := hasOne.Build H oneH.
+
+Lemma val1 : (val : H -> G) 1 = 1. 
+Proof. exact/SubK. Qed.
+
+HB.instance Definition _ := isSubBaseUMagma.Build G S H val1.
+
+Lemma mul1g : left_id 1 (@mul H).
+Proof. by move=> x; apply/val_inj; rewrite valM val1 mul1g. Qed.
+Lemma mulg1 : right_id 1 (@mul H).
+Proof. by move=> x; apply/val_inj; rewrite valM val1 mulg1. Qed.
+
+HB.instance Definition _ := BaseUMagma_isUMagma.Build H mul1g mulg1.
+
+HB.end.
+
+#[short(type="subMonoidType")]
+HB.structure Definition SubMonoid (G : monoidType) S :=
+  { H of SubUMagma G S H & Monoid H}.
+
+HB.factory Record SubChoice_isSubMonoid (G : monoidType) S H
+    of SubChoice G S H := {
+  monoid_closed_subproof : monoid_closed S
+}.
+
+HB.builders Context G S H of SubChoice_isSubMonoid G S H.
+
+HB.instance Definition _ :=
+  SubChoice_isSubUMagma.Build G S H monoid_closed_subproof.
+HB.instance Definition _ :=
+  SubChoice_isSubSemigroup.Build G S H (snd monoid_closed_subproof).
+
+HB.end.
+
+#[short(type="subGroupType")]
+HB.structure Definition SubGroup (G : groupType) S :=
+  { H of SubUMagma G S H & Group H}.
+
+HB.factory Record SubChoice_isSubGroup (G : groupType) S H
+    of SubChoice G S H := {
+  group_closed_subproof : group_closed S
+}.
+
+HB.builders Context G S H of SubChoice_isSubGroup G S H.
+
+Lemma umagma_closed : umagma_closed S.
+Proof.
+split; first exact/(fst group_closed_subproof).
+exact/group_closedM/group_closed_subproof.
+Qed.
+HB.instance Definition _ := SubChoice_isSubMonoid.Build G S H umagma_closed.
+HB.instance Definition _ :=
+  isInvClosed.Build G S (group_closedV group_closed_subproof).
+
+Let inH v Sv : H := Sub v Sv.
+Let invH (u : H) := inH (gpredVr _ (valP u)).
+
+HB.instance Definition _ := hasInv.Build H invH.
+
+Lemma mulVg : left_inverse 1%g invH *%g.
+Proof. by move=> x; apply/val_inj; rewrite valM SubK mulVg val1. Qed.
+Lemma mulgV : right_inverse 1%g invH *%g.
+Proof. by move=> x; apply/val_inj; rewrite valM SubK mulgV val1. Qed. 
+
+HB.instance Definition _ := Monoid_isGroup.Build H mulVg mulgV.
+
+HB.end.
+
+(* Lifting Structure from the codomain of finfuns. *)
+Section FinFunMagma.
+Variable (aT : finType) (rT : magmaType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Definition ffun_mul f g := [ffun a => f a * g a].
+
+HB.instance Definition _ := hasMul.Build {ffun aT -> rT} ffun_mul.
+
+End FinFunMagma.
+
+(* FIXME: HB.saturate *)
+HB.instance Definition _ (aT : finType) (rT : ChoiceMagma.type) :=
+  Magma.on {ffun aT -> rT}.
+
+Section FinFunSemigroup.
+Variable (aT : finType) (rT : semigroupType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Fact ffun_mulgA : associative (@ffun_mul aT rT).
+Proof. by move=> f1 f2 f3; apply/ffunP=> a; rewrite !ffunE mulgA. Qed.
+
+HB.instance Definition _ := isSemigroup.Build {ffun aT -> rT} ffun_mulgA.
+
+End FinFunSemigroup.
+
+Section FinFunBaseUMagma.
+Variable (aT : finType) (rT : baseUMagmaType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Definition ffun_one := [ffun a : aT => (1 : rT)].
+
+HB.instance Definition _ :=
+  hasOne.Build {ffun aT -> rT} ffun_one.
+
+End FinFunBaseUMagma.
+
+(* FIXME: HB.saturate *)
+HB.instance Definition _ (aT : finType) (rT : ChoiceBaseUMagma.type) :=
+  BaseUMagma.on {ffun aT -> rT}.
+
+Section FinFunUMagma.
+Variable (aT : finType) (rT : umagmaType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Fact ffun_mul1g : left_id (@ffun_one aT rT) *%g.
+Proof. by move=> f; apply/ffunP => a; rewrite !ffunE mul1g. Qed.
+Fact ffun_mulg1 : right_id (@ffun_one aT rT) *%g.
+Proof. by move=> f; apply/ffunP => a; rewrite !ffunE mulg1. Qed.
+
+HB.instance Definition _ :=
+  Magma_isUMagma.Build {ffun aT -> rT} ffun_mul1g ffun_mulg1.
+
+End FinFunUMagma.
+
+(* FIXME: HB.saturate *)
+HB.instance Definition _ (aT : finType) (rT : monoidType) :=
+  UMagma.on {ffun aT -> rT}.
+
+Section FinFunBaseGroup.
+
+Variable (aT : finType) (rT : baseGroupType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Definition ffun_inv f := [ffun a => (f a)^-1].
+
+HB.instance Definition _ := hasInv.Build {ffun aT -> rT} ffun_inv.
+
+End FinFunBaseGroup.
+
+Section FinFunGroup.
+
+Variable (aT : finType) (rT : groupType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Fact ffun_mulVg :
+  left_inverse (@ffun_one aT rT) (@ffun_inv _ _) (@ffun_mul _ _).
+Proof. by move=> f; apply/ffunP=> a; rewrite !ffunE mulVg. Qed.
+Fact ffun_mulgV :
+  right_inverse (@ffun_one aT rT) (@ffun_inv _ _) (@ffun_mul _ _).
+Proof. by move=> f; apply/ffunP=> a; rewrite !ffunE mulgV. Qed.
+
+HB.instance Definition _ := Monoid_isGroup.Build {ffun aT -> rT}
+  ffun_mulVg ffun_mulgV.
+
+End FinFunGroup.
+
+(* External direct product *)
+Section PairMagma.
+Variables G H : magmaType.
+
+Definition mul_pair (x y : G * H) := (x.1 * y.1, x.2 * y.2).
+
+HB.instance Definition _ := hasMul.Build (G * H)%type mul_pair.
+
+Fact fst_is_multiplicative : {morph fst : x y / x * y}. Proof. by []. Qed.
+HB.instance Definition _ :=
+  isMultiplicative.Build _ _ fst fst_is_multiplicative.
+
+Fact snd_is_multiplicative : {morph snd : x y / x * y}. Proof. by []. Qed.
+HB.instance Definition _ :=
+  isMultiplicative.Build _ _ snd snd_is_multiplicative.
+
+End PairMagma.
+
+Section PairSemigroup.
+Variables G H : semigroupType.
+
+Lemma pair_mulgA : associative (@mul (G * H)%type).
+Proof. by move=> x y z; congr (_, _); apply/mulgA. Qed.
+
+HB.instance Definition _ := Magma_isSemigroup.Build (G * H)%type pair_mulgA.
+
+End PairSemigroup.
+
+Section PairBaseUMagma.
+Variables G H : baseUMagmaType.
+
+Definition one_pair : G * H := (1, 1).
+
+HB.instance Definition _ := hasOne.Build (G * H)%type one_pair.
+
+Fact fst_is_umagma_morphism : fst (1 : G * H) = 1. Proof. by []. Qed.
+HB.instance Definition _ :=
+  Multiplicative_isUMagmaMorphism.Build _ _ fst fst_is_umagma_morphism.
+
+Fact snd_is_umagma_morphism : snd (1 : G * H) = 1. Proof. by []. Qed.
+HB.instance Definition _ :=
+  Multiplicative_isUMagmaMorphism.Build _ _ snd snd_is_umagma_morphism.
+
+End PairBaseUMagma.
+
+Section PairUMagma.
+Variables G H : umagmaType.
+
+Lemma pair_mul1g : left_id (@one_pair G H) *%g.
+Proof. by move=> [x y]; congr (_, _); rewrite mul1g. Qed.
+Lemma pair_mulg1 : right_id (@one_pair G H) *%g.
+Proof. by move=> [x y]; congr (_, _); rewrite mulg1. Qed.
+
+HB.instance Definition _ :=
+  BaseUMagma_isUMagma.Build (G * H)%type pair_mul1g pair_mulg1.
+
+End PairUMagma.
+
+(* FIXME: HB.saturate *)
+HB.instance Definition _ (G H : ChoiceMagma.type) := Magma.on (G * H)%type.
+HB.instance Definition _ (G H : ChoiceBaseUMagma.type) :=
+  BaseUMagma.on (G * H)%type.
+HB.instance Definition _ (G H : monoidType) := Semigroup.on (G * H)%type.
+(* /FIXME *)
+
+Section PairBaseGroup.
+Variables G H : baseGroupType.
+
+Definition inv_pair (u : G * H) := (u.1 ^-1, u.2 ^-1).
+
+HB.instance Definition _ := hasInv.Build (G * H)%type inv_pair.
+
+End PairBaseGroup.
+
+Section PairGroup.
+Variables G H : groupType.
+
+Lemma pair_mulVg : left_inverse one (@inv_pair G H) mul.
+Proof. by move=> x; congr (_, _); apply/mulVg. Qed.
+Lemma pair_mulgV : right_inverse one (@inv_pair G H) mul.
+Proof. by move=> x; congr (_, _); apply/mulgV. Qed.
+
+HB.instance Definition _ :=
+  Monoid_isGroup.Build (G * H)%type pair_mulVg pair_mulgV.
+
+End PairGroup.

--- a/ssreflect/nmodule.v
+++ b/ssreflect/nmodule.v
@@ -1,0 +1,1395 @@
+From HB Require Import structures.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype choice ssrnat seq.
+From mathcomp Require Import bigop fintype finfun monoid.
+
+(******************************************************************************)
+(*                       Additive group-like structures                       *)
+(*                                                                            *)
+(* NB: See CONTRIBUTING.md for an introduction to HB concepts and commands.   *)
+(*                                                                            *)
+(* This file defines the following algebraic structures:                      *)
+(*                                                                            *)
+(*         baseAddMagmaType == type with an addition operator                 *)
+(*                             The HB class is called BaseAddMagma.           *)
+(*  ChoiceBaseAddMagma.type == join of baseAddMagmaType and choiceType        *)
+(*                             The HB class is called ChoiceBaseAddMagma.     *)
+(*             addMagmaType == additive magma                                 *)
+(*                             The HB class is called AddMagma.               *)
+(*         addSemigroupType == additive semigroup                             *)
+(*                             The HB class is called AddSemigroup.           *)
+(*        baseAddUMagmaType == pointed additive magma                         *)
+(*                             The HB class is called BaseAddUMagma.          *)
+(* ChoiceBaseAddUMagma.type == join of baseAddUMagmaType and choiceType       *)
+(*                             The HB class is called ChoiceBaseUMagma.       *)
+(*            addUmagmaType == additive unitary magma                         *)
+(*                             The HB class is called AddUMagma.              *)
+(*                 nmodType == additive monoid                                *)
+(*                             The HB class is called Nmodule.                *)
+(*             baseZmodType == pointed additive magma with an opposite        *)
+(*                             operator                                       *)
+(*                             The HB class is called BaseZmodule.            *)
+(*                 zmodType == abelian group                                  *)
+(*                             The HB class is called Group.                  *)
+(*                                                                            *)
+(* and their joins with subType:                                              *)
+(*                                                                            *)
+(*  subBaseAddUMagmaType V P == join of baseAddUMagmaType and subType         *)
+(*                              (P : pred V) such that val is additive        *)
+(*                              The HB class is called SubBaseAddUMagma.      *)
+(*      subAddUMagmaType V P == join of addUMagmaType and subType (P : pred V)*)
+(*                              such that val is additive                     *)
+(*                              The HB class is called SubAddUMagma.          *)
+(*           subNmodType V P == join of nmodType and subType (P : pred V)     *)
+(*                              such that val is additive                     *)
+(*                              The HB class is called SubNmodule.            *)
+(*           subZmodType V P == join of zmodType and subType (P : pred V)     *)
+(*                              such that val is additive                     *)
+(*                              The HB class is called SubZmodule.            *)
+(*                                                                            *)
+(* Morphisms between the above structures (see below for details):            *)
+(*                                                                            *)
+(*       {additive U -> V} == nmod (resp. zmod) morphism between nmodType     *)
+(*                            (resp. zmodType) instances U and V.             *)
+(*                            The HB class is called Additive.                *)
+(*                                                                            *)
+(* Closedness predicates for the algebraic structures:                        *)
+(*                                                                            *)
+(*    mulgClosed V == predicate closed under multiplication on G : magmaType  *)
+(*                    The HB class is called MulClosed.                       *)
+(*  umagmaClosed V == predicate closed under multiplication and containing 1  *)
+(*                    on G : baseUMagmaType                                   *)
+(*                    The HB class is called UMagmaClosed.                    *)
+(*    invgClosed V == predicate closed under inversion on G : baseGroupType   *)
+(*                    The HB class is called InvClosed.                       *)
+(*   groupClosed V == predicate closed under multiplication and inversion and *)
+(*                    containing 1 on G : baseGroupType                       *)
+(*                    The HB class is called InvClosed.                       *)
+(*                                                                            *)
+(* Canonical properties of the algebraic structures:                          *)
+(*  * addMagmaType (additive magmas):                                         *)
+(*                 x + y == the addition of x and y                           *)
+(*         addr_closed S <-> collective predicate S is closed under addition  *)
+(*                                                                            *)
+(*  * baseAddUMagmaType (pointed additive magmas):                            *)
+(*                     0 == the zero of a unitary additive magma              *)
+(*                x *+ n == n times x, with n in nat (non-negative),          *)
+(*                          i.e. x + (x + .. (x + x)..) (n terms); x *+ 1 is  *)
+(*                          thus convertible to x, and x *+ 2 to x + x        *)
+(*        \sum_<range> e == iterated sum for a baseAddUMagmaType (cf bigop.v)*)
+(*                  e`_i == nth 0 e i, when e : seq M and M has an            *)
+(*                          addUMagmaType structure                           *)
+(*             support f == 0.-support f, i.e., [pred x | f x != 0]           *)
+(*    addumagma_closed S <-> collective predicate S is closed under           *)
+(*                          addition and contains 0                           *)
+(*                                                                            *)
+(*  * nmodType (abelian monoids):                                             *)
+(*         nmod_closed S := addumagma_closed S                                *)
+(*                                                                            *)
+(*  * baseZmodType (pointed additive magmas with an opposite operator):       *)
+(*                   - x == the opposite of x                                 *)
+(*                 x - y == x + (- y)                                         *)
+(*                x *- n == - (x *+ n)                                        *)
+(*         oppr_closed S <-> collective predicate S is closed under opposite  *)
+(*         subr_closed S <-> collective predicate S is closed under           *)
+(*                           subtraction                                      *)
+(*         zmod_closed S <-> collective predicate S is closed under           *)
+(*                           subtraction and contains 1                       *)
+(*                                                                            *)
+(*   In addition to this structure hierarchy, we also develop a separate,     *)
+(* parallel hierarchy for morphisms linking these structures:                 *)
+(*                                                                            *)
+(* * Additive (nmod or zmod morphisms):                                       *)
+(*        nmod_morphism f <-> f of type U -> V is an nmod morphism, i.e., f   *)
+(*                           maps the Nmodule structure of U to that of V, 0  *)
+(*                           to 0 and + to +                                  *)
+(*                        := (f 0 = 0) * {morph f : x y / x + y}              *)
+(*       zmod_morphisme f <-> f of type U -> V is a zmod morphism, i.e., f    *)
+(*                           maps the Zmodule structure of U to that of V, 0  *)
+(*                           to 0, - to - and + to + (equivalently, binary -  *)
+(*                           to -)                                            *)
+(*                        := {morph f : u v / u - v}                          *)
+(*      {additive U -> V} == the interface type for a Structure (keyed on     *)
+(*                           a function f : U -> V) that encapsulates the     *)
+(*                           nmod_morphism property; both U and V must have   *)
+(*                           canonical baseAddUMagmaType instances            *)
+(*                           When both U and V have zmodType instances, it is *)
+(*                           a zmod morphism.                                 *)
+(*                        := Algebra.Additive.type U V                        *)
+(*                                                                            *)
+(*   Notations are defined in scope ring_scope (delimiter %R)                 *)
+(*   This library also extends the conventional suffixes described in library *)
+(* ssrbool.v with the following:                                              *)
+(*   0 -- unitary additive magma 0, as in addr0 : x + 0 = x                   *)
+(*   D -- additive magma addition, as in mulrnDr :                            *)
+(*        x *+ (m + n) = x *+ m + x *+ n                                      *)
+(*   B -- z-module subtraction, as in opprB : - (x - y) = y - x               *)
+(*  Mn -- ring by nat multiplication, as in raddfMn : f (x *+ n) = f x *+ n   *)
+(*   N -- z-module opposite, as in mulNr : (- x) * y = - (x * y)              *)
+(* The operator suffixes D, B are also used for the corresponding operations  *)
+(* on nat, as in mulrDr : x *+ (m + n) = x *+ m + x *+ n.                     *)
+(******************************************************************************)
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Declare Scope ring_scope.
+Delimit Scope ring_scope with R.
+Local Open Scope ring_scope.
+
+Reserved Notation "+%R" (at level 0).
+Reserved Notation "-%R" (at level 0).
+Reserved Notation "n %:R" (at level 1, left associativity, format "n %:R").
+Reserved Notation "\0" (at level 0).
+Reserved Notation "f \+ g" (at level 50, left associativity).
+Reserved Notation "f \- g" (at level 50, left associativity).
+Reserved Notation "\- f" (at level 35, f at level 35).
+
+Reserved Notation "'{' 'additive' U '->' V '}'"
+  (at level 0, U at level 98, V at level 99,
+   format "{ 'additive'  U  ->  V }").
+
+Module Import Algebra.
+
+HB.mixin Record hasAdd V := {
+  add : V -> V -> V
+}.
+
+#[short(type="baseAddMagmaType")]
+HB.structure Definition BaseAddMagma := {V of hasAdd V}.
+
+Module BaseAddMagmaExports.
+Bind Scope ring_scope with BaseAddMagma.sort.
+End BaseAddMagmaExports.
+HB.export BaseAddMagmaExports. 
+
+HB.structure Definition ChoiceBaseAddMagma := {V of BaseAddMagma V & Choice V}.
+
+Module ChoiceBaseAddMagmaExports.
+Bind Scope ring_scope with ChoiceBaseAddMagma.sort.
+End ChoiceBaseAddMagmaExports.
+HB.export ChoiceBaseAddMagmaExports. 
+
+Local Notation "+%R" := (@add _) : function_scope.
+Local Notation "x + y" := (add x y) : ring_scope.
+
+Definition to_multiplicative := @id Type.
+
+#[export]
+HB.instance Definition _ (V : choiceType) := Choice.on (to_multiplicative V).
+#[export]
+HB.instance Definition _ (V : baseAddMagmaType) :=
+  hasMul.Build (to_multiplicative V) (@add V).
+(* FIXME: HB.saturate *)
+#[export]
+HB.instance Definition _ (V : ChoiceBaseAddMagma.type) :=
+  Magma.on (to_multiplicative V).
+
+Section BaseAddMagmaTheory.
+Variables V : baseAddMagmaType.
+
+Section ClosedPredicates.
+
+Variable S : {pred V}.
+
+Definition addr_closed := {in S &, forall u v, u + v \in S}.
+
+End ClosedPredicates.
+End BaseAddMagmaTheory.
+
+HB.mixin Record BaseAddMagma_isAddMagma V of BaseAddMagma V := {
+  addrC : commutative (@add V)
+}.
+
+#[short(type="addMagmaType")]
+HB.structure Definition AddMagma :=
+  {V of BaseAddMagma_isAddMagma V & ChoiceBaseAddMagma V}.
+
+HB.factory Record isAddMagma V of Choice V := {
+  add : V -> V -> V;
+  addrC : commutative add
+}.
+
+HB.builders Context V of isAddMagma V.
+HB.instance Definition _ := hasAdd.Build V add.
+HB.instance Definition _ := BaseAddMagma_isAddMagma.Build V addrC.
+HB.end.
+
+Module AddMagmaExports.
+Bind Scope ring_scope with AddMagma.sort.
+End AddMagmaExports.
+HB.export AddMagmaExports.
+
+Section AddMagmaTheory.
+Variables V : addMagmaType.
+
+Lemma commuteT x y : @commute (to_multiplicative V) x y.
+Proof. exact/addrC. Qed.
+
+End AddMagmaTheory.
+
+HB.mixin Record AddMagma_isAddSemigroup V of AddMagma V := {
+  addrA : associative (@add V)
+}.
+
+#[short(type="addSemigroupType")]
+HB.structure Definition AddSemigroup :=
+  {V of AddMagma_isAddSemigroup V & AddMagma V}.
+
+HB.factory Record isAddSemigroup V of Choice V := {
+  add : V -> V -> V;
+  addrC : commutative add;
+  addrA : associative add
+}.
+
+HB.builders Context V of isAddSemigroup V.
+HB.instance Definition _ := isAddMagma.Build V addrC.
+HB.instance Definition _ := AddMagma_isAddSemigroup.Build V addrA.
+HB.end.
+
+Module AddSemigroupExports.
+Bind Scope ring_scope with AddSemigroup.sort.
+End AddSemigroupExports.
+HB.export AddSemigroupExports.
+
+#[export]
+HB.instance Definition _ (V : addSemigroupType) :=
+  Magma_isSemigroup.Build (to_multiplicative V) addrA.
+
+Section AddSemigroupTheory.
+Variables V : addSemigroupType.
+
+Lemma addrCA : @left_commutative V V +%R.
+Proof. by move=> x y z; rewrite !addrA [x + _]addrC. Qed.
+
+Lemma addrAC : @right_commutative V V +%R.
+Proof. by move=> x y z; rewrite -!addrA [y + _]addrC. Qed.
+
+Lemma addrACA : @interchange V +%R +%R.
+Proof. by move=> x y z t; rewrite -!addrA [y + (z + t)]addrCA. Qed.
+
+End AddSemigroupTheory.
+
+HB.mixin Record hasZero V := {
+  zero : V
+}.
+
+#[short(type="baseAddUMagmaType")]
+HB.structure Definition BaseAddUMagma :=
+  {V of hasZero V & BaseAddMagma V}.
+
+Module BaseAddUMagmaExports.
+Bind Scope ring_scope with BaseAddUMagma.sort.
+End BaseAddUMagmaExports.
+HB.export BaseAddUMagmaExports.
+
+HB.structure Definition ChoiceBaseAddUMagma :=
+  {V of BaseAddUMagma V & Choice V}.
+
+Module ChoiceBaseAddUMagmaExports.
+Bind Scope ring_scope with ChoiceBaseAddUMagma.sort.
+End ChoiceBaseAddUMagmaExports.
+HB.export ChoiceBaseAddUMagmaExports.
+
+Local Notation "0" := (@zero _) : ring_scope.
+
+Definition natmul (V : baseAddUMagmaType) (x : V) n : V := iterop n +%R x 0.
+Arguments natmul : simpl never.
+
+Local Notation "x *+ n" := (natmul x n) : ring_scope.
+
+#[export]
+HB.instance Definition _ (V : baseAddUMagmaType) :=
+  hasOne.Build (to_multiplicative V) (@zero V).
+
+(* FIXME: HB.saturate *)
+#[export]
+HB.instance Definition _ (V : ChoiceBaseAddUMagma.type) :=
+  BaseUMagma.on (to_multiplicative V).
+
+Section BaseAddUMagmaTheory.
+Variable V : baseAddUMagmaType.
+Implicit Types x : V.
+
+Lemma mulr0n x : x *+ 0 = 0. Proof. by []. Qed.
+Lemma mulr1n x : x *+ 1 = x. Proof. by []. Qed.
+Lemma mulr2n x : x *+ 2 = x + x. Proof. by []. Qed.
+Lemma mulrb x (b : bool) : x *+ b = (if b then x else 0).
+Proof. exact: (@expgb (to_multiplicative V)). Qed.
+Lemma mulrSS x n : x *+ n.+2 = x + x *+ n.+1. Proof. by []. Qed.
+
+Section ClosedPredicates.
+
+Variable S : {pred V}.
+
+Definition addumagma_closed := 0 \in S /\ addr_closed S.
+
+End ClosedPredicates.
+
+End BaseAddUMagmaTheory.
+
+HB.mixin Record BaseAddUMagma_isAddUMagma V of BaseAddUMagma V := {
+  add0r : left_id zero (@add V)
+}.
+
+HB.factory Record isAddUMagma V of Choice V := {
+  add : V -> V -> V;
+  zero : V;
+  addrC : commutative add;
+  add0r : left_id zero add
+}.
+
+HB.builders Context V of isAddUMagma V.
+HB.instance Definition _ := isAddMagma.Build V addrC.
+HB.instance Definition _ := hasZero.Build V zero.
+#[warning="-HB.no-new-instance"]
+HB.instance Definition _ := BaseAddUMagma_isAddUMagma.Build V add0r.
+HB.end.
+
+#[short(type="addUMagmaType")]
+HB.structure Definition AddUMagma := {V of isAddUMagma V & Choice V}.
+
+Lemma addr0 (V : addUMagmaType) : right_id (@zero V) add.
+Proof. by move=> x; rewrite addrC add0r. Qed.
+
+Local Notation "\sum_ ( i <- r | P ) F" := (\big[+%R/0]_(i <- r | P) F).
+Local Notation "\sum_ ( m <= i < n ) F" := (\big[+%R/0]_(m <= i < n) F).
+Local Notation "\sum_ ( i < n ) F" := (\big[+%R/0]_(i < n) F).
+Local Notation "\sum_ ( i 'in' A ) F" := (\big[+%R/0]_(i in A) F).
+
+Import Monoid.Theory.
+
+#[export]
+HB.instance Definition _ (V : addUMagmaType) :=
+  Magma_isUMagma.Build (to_multiplicative V) add0r (@addr0 V).
+
+HB.factory Record isNmodule V of Choice V := {
+  zero : V;
+  add : V -> V -> V;
+  addrA : associative add;
+  addrC : commutative add;
+  add0r : left_id zero add
+}.
+
+HB.builders Context V of isNmodule V.
+HB.instance Definition _ := isAddUMagma.Build V addrC add0r.
+HB.instance Definition _ := AddMagma_isAddSemigroup.Build V addrA.
+HB.end.
+
+Module AddUMagmaExports.
+Bind Scope ring_scope with AddUMagma.sort.
+End AddUMagmaExports.
+HB.export AddUMagmaExports.
+
+#[short(type="nmodType")]
+HB.structure Definition Nmodule := {V of isNmodule V & Choice V}.
+
+Module NmoduleExports.
+Bind Scope ring_scope with Nmodule.sort.
+End NmoduleExports.
+HB.export NmoduleExports.
+
+#[export]
+HB.instance Definition _ (V : nmodType) :=
+  UMagma_isMonoid.Build (to_multiplicative V) addrA.
+
+#[export]
+HB.instance Definition _ (V : nmodType) :=
+  Monoid.isComLaw.Build V 0%R +%R addrA addrC add0r.
+
+Section NmoduleTheory.
+
+Variable V : nmodType.
+Implicit Types x y : V.
+
+Let G := to_multiplicative V.
+
+(* addrA, addrC and add0r in the structure *)
+(* addr0 proved above *)
+
+Lemma mulrS x n : x *+ n.+1 = x + (x *+ n).
+Proof. exact: (@expgS G). Qed.
+
+Lemma mulrSr x n : x *+ n.+1 = x *+ n + x.
+Proof. exact: (@expgSr G). Qed.
+
+Lemma mul0rn n : 0 *+ n = 0 :> V.
+Proof. exact: (@expg1n G). Qed.
+
+Lemma mulrnDl n : {morph (fun x => x *+ n) : x y / x + y}.
+Proof. by move=> x y; apply/(@expgMn G)/commuteT. Qed.
+
+Lemma mulrnDr x m n : x *+ (m + n) = x *+ m + x *+ n.
+Proof. exact: (@expgnDr G). Qed.
+
+Lemma mulrnA x m n : x *+ (m * n) = x *+ m *+ n.
+Proof. exact: (@expgnA G). Qed.
+
+Lemma mulrnAC x m n : x *+ m *+ n = x *+ n *+ m.
+Proof. exact: (@expgnAC G). Qed.
+
+Lemma iter_addr n x y : iter n (+%R x) y = x *+ n + y.
+Proof. exact: (@iter_mulg G). Qed.
+
+Lemma iter_addr_0 n x : iter n (+%R x) 0 = x *+ n.
+Proof. exact: (@iter_mulg_1 G). Qed.
+
+Lemma sumrMnl I r P (F : I -> V) n :
+  \sum_(i <- r | P i) F i *+ n = (\sum_(i <- r | P i) F i) *+ n.
+Proof. by rewrite (big_morph _ (mulrnDl n) (mul0rn _)). Qed.
+
+Lemma sumrMnr x I r P (F : I -> nat) :
+  \sum_(i <- r | P i) x *+ F i = x *+ (\sum_(i <- r | P i) F i).
+Proof. by rewrite (big_morph _ (mulrnDr x) (erefl _)). Qed.
+
+Lemma sumr_const (I : finType) (A : pred I) x : \sum_(i in A) x = x *+ #|A|.
+Proof. by rewrite big_const -iteropE. Qed.
+
+Lemma sumr_const_nat m n x : \sum_(n <= i < m) x = x *+ (m - n).
+Proof. by rewrite big_const_nat iter_addr_0. Qed.
+
+End NmoduleTheory.
+Notation nmod_closed := addumagma_closed.
+
+HB.mixin Record hasOpp V := {
+  opp : V -> V
+}.
+
+#[short(type="baseZmodType")]
+HB.structure Definition BaseZmodule := {V of hasOpp V & BaseAddUMagma V}.
+
+Module BaseZmodExports.
+Bind Scope ring_scope with BaseZmodule.sort.
+End BaseZmodExports.
+HB.export BaseZmodExports.
+
+Local Notation "-%R" := (@opp _) : ring_scope.
+Local Notation "- x" := (opp x) : ring_scope.
+Local Notation "x - y" := (x + - y) : ring_scope.
+Local Notation "x *- n" := (- (x *+ n)) : ring_scope.
+
+Section ClosedPredicates.
+
+Variable (U : baseZmodType) (S : {pred U}).
+
+Definition oppr_closed := {in S, forall u, - u \in S}.
+Definition subr_closed := {in S &, forall u v, u - v \in S}.
+Definition zmod_closed := 0 \in S /\ subr_closed.
+
+End ClosedPredicates.
+
+HB.mixin Record BaseZmoduleNmodule_isZmodule V of BaseZmodule V := {
+  addNr : left_inverse zero opp (@add V)
+}.
+
+#[short(type="zmodType")]
+HB.structure Definition Zmodule :=
+  {V of BaseZmoduleNmodule_isZmodule V & BaseZmodule V & Nmodule V}.
+
+HB.factory Record Nmodule_isZmodule V of Nmodule V := {
+  opp : V -> V;
+  addNr : left_inverse zero opp add
+}.
+
+HB.builders Context V of Nmodule_isZmodule V.
+HB.instance Definition _ := hasOpp.Build V opp.
+HB.instance Definition _ := BaseZmoduleNmodule_isZmodule.Build V addNr.
+HB.end.
+
+HB.factory Record isZmodule V of Choice V := {
+  zero : V;
+  opp : V -> V;
+  add : V -> V -> V;
+  addrA : associative add;
+  addrC : commutative add;
+  add0r : left_id zero add;
+  addNr : left_inverse zero opp add
+}.
+
+HB.builders Context V of isZmodule V.
+
+HB.instance Definition _ := isNmodule.Build V addrA addrC add0r.
+HB.instance Definition _ := Nmodule_isZmodule.Build V addNr.
+
+HB.end.
+
+Module ZmoduleExports.
+Bind Scope ring_scope with Zmodule.sort.
+End ZmoduleExports.
+HB.export ZmoduleExports.
+
+Lemma addrN (V : zmodType) : @right_inverse V V V 0 -%R +%R.
+Proof. by move=> x; rewrite addrC addNr. Qed.
+
+#[export]
+HB.instance Definition _ (V : baseZmodType) :=
+  hasInv.Build (to_multiplicative V) (@opp V).
+#[export]
+HB.instance Definition _ (V : zmodType) :=
+  Monoid_isGroup.Build (to_multiplicative V) addNr (@addrN V).
+
+Section ZmoduleTheory.
+
+Variable V : zmodType.
+Implicit Types x y : V.
+
+Let G := to_multiplicative V.
+
+Definition subrr := addrN.
+
+Lemma addKr : @left_loop V V -%R +%R.
+Proof. exact: (@mulKg G). Qed.
+Lemma addNKr : @rev_left_loop V V -%R +%R.
+Proof. exact: (@mulVKg G). Qed.
+Lemma addrK : @right_loop V V -%R +%R.
+Proof. exact: (@mulgK G). Qed.
+Lemma addrNK : @rev_right_loop V V -%R +%R.
+Proof. exact: (@mulgVK G). Qed.
+Definition subrK := addrNK.
+Lemma subKr x : involutive (fun y => x - y).
+Proof. by move=> y; exact/(@divKg G)/commuteT. Qed.
+Lemma addrI : @right_injective V V V +%R.
+Proof. exact: (@mulgI G). Qed.
+Lemma addIr : @left_injective V V V +%R.
+Proof. exact: (@mulIg G). Qed.
+Lemma subrI : right_injective (fun x y => x - y).
+Proof. exact: (@divgI G). Qed.
+Lemma subIr : left_injective (fun x y => x - y).
+Proof. exact: (@divIg G). Qed.
+Lemma opprK : @involutive V -%R.
+Proof. exact: (@invgK G). Qed.
+Lemma oppr_inj : @injective V V -%R.
+Proof. exact: (@invg_inj G). Qed.
+Lemma oppr0 : -0 = 0 :> V.
+Proof. exact: (@invg1 G). Qed.
+Lemma oppr_eq0 x : (- x == 0) = (x == 0).
+Proof. exact: (@invg_eq1 G). Qed.
+
+Lemma subr0 x : x - 0 = x. Proof. exact: (@divg1 G). Qed.
+Lemma sub0r x : 0 - x = - x. Proof. exact: (@div1g G). Qed.
+
+Lemma opprB x y : - (x - y) = y - x.
+Proof. exact: (@invgF G). Qed.
+
+Lemma opprD : {morph -%R: x y / x + y : V}.
+Proof. by move=> x y; rewrite -[y in LHS]opprK opprB addrC. Qed.
+
+Lemma addrKA z x y : (x + z) - (z + y) = x - y.
+Proof. by rewrite opprD addrA addrK. Qed.
+
+Lemma subrKA z x y : (x - z) + (z + y) = x + y.
+Proof. exact: (@divgKA G). Qed.
+
+Lemma addr0_eq x y : x + y = 0 -> - x = y.
+Proof. exact: (@mulg1_eq G). Qed.
+
+Lemma subr0_eq x y : x - y = 0 -> x = y.
+Proof. exact: (@divg1_eq G). Qed.
+
+Lemma subr_eq x y z : (x - z == y) = (x == y + z).
+Proof. exact: (@divg_eq G). Qed.
+
+Lemma subr_eq0 x y : (x - y == 0) = (x == y).
+Proof. exact: (@divg_eq1 G). Qed.
+
+Lemma addr_eq0 x y : (x + y == 0) = (x == - y).
+Proof. exact: (@mulg_eq1 G). Qed.
+
+Lemma eqr_opp x y : (- x == - y) = (x == y).
+Proof. exact: (@eqg_inv G). Qed.
+
+Lemma eqr_oppLR x y : (- x == y) = (x == - y).
+Proof. exact: (@eqg_invLR G). Qed.
+
+Lemma mulNrn x n : (- x) *+ n = x *- n.
+Proof. exact: (@expVgn G). Qed.
+
+Lemma mulrnBl n : {morph (fun x => x *+ n) : x y / x - y}.
+Proof. by move=> x y; exact/(@expgnFl G)/commuteT. Qed.
+
+Lemma mulrnBr x m n : n <= m -> x *+ (m - n) = x *+ m - x *+ n.
+Proof. exact: (@expgnFr G). Qed.
+
+Lemma sumrN I r P (F : I -> V) :
+  (\sum_(i <- r | P i) - F i = - (\sum_(i <- r | P i) F i)).
+Proof. by rewrite (big_morph _ opprD oppr0). Qed.
+
+Lemma sumrB I r (P : pred I) (F1 F2 : I -> V) :
+  \sum_(i <- r | P i) (F1 i - F2 i)
+     = \sum_(i <- r | P i) F1 i - \sum_(i <- r | P i) F2 i.
+Proof. by rewrite -sumrN -big_split /=. Qed.
+
+Lemma telescope_sumr n m (f : nat -> V) : n <= m ->
+  \sum_(n <= k < m) (f k.+1 - f k) = f m - f n.
+Proof.
+move=> nm; rewrite (telescope_big (fun i j => f j - f i)).
+  by case: ltngtP nm => // ->; rewrite subrr.
+by move=> k /andP[nk km]/=; rewrite addrC subrKA.
+Qed.
+
+Lemma telescope_sumr_eq n m (f u : nat -> V) : n <= m ->
+    (forall k, (n <= k < m)%N -> u k = f k.+1 - f k) ->
+  \sum_(n <= k < m) u k = f m - f n.
+Proof.
+by move=> ? uE; under eq_big_nat do rewrite uE //=; exact: telescope_sumr.
+Qed.
+
+Section ClosedPredicates.
+
+Variable (S : {pred V}).
+
+Lemma zmod_closedN : zmod_closed S -> oppr_closed S.
+Proof. exact: (@group_closedV G). Qed.
+
+Lemma zmod_closedD : zmod_closed S -> addr_closed S.
+Proof. exact: (@group_closedM G). Qed.
+
+Lemma zmod_closed0D : zmod_closed S -> nmod_closed S.
+Proof. by move=> z; split; [case: z|apply: zmod_closedD]. Qed.
+
+End ClosedPredicates.
+
+End ZmoduleTheory.
+
+Arguments addrI {V} y [x1 x2].
+Arguments addIr {V} x [x1 x2].
+Arguments opprK {V}.
+Arguments oppr_inj {V} [x1 x2].
+
+Definition nmod_morphism (U V : baseAddUMagmaType) (f : U -> V) : Prop :=
+  (f 0 = 0) * {morph f : x y / x + y}.
+#[deprecated(since="mathcomp 2.5.0", note="use `nmod_morphism` instead")]
+Definition semi_additive := nmod_morphism.
+
+HB.mixin Record isNmodMorphism (U V : baseAddUMagmaType) (apply : U -> V) := {
+  nmod_morphism_subproof : nmod_morphism apply;
+}.
+
+Module isSemiAdditive.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use isNmodMorphism.Build instead.")]
+Notation Build U V apply := (isNmodMorphism.Build U V apply) (only parsing).
+End isSemiAdditive.
+
+#[mathcomp(axiom="nmod_morphism")]
+HB.structure Definition Additive (U V : baseAddUMagmaType) :=
+  {f of isNmodMorphism U V f}.
+
+Definition zmod_morphism (U V : zmodType) (f : U -> V) :=
+  {morph f : x y / x - y}.
+
+#[deprecated(since="mathcomp 2.5.0", note="use `zmod_morphism` instead")]
+Definition additive := zmod_morphism.
+
+HB.factory Record isZmodMorphism (U V : zmodType) (apply : U -> V) := {
+  zmod_morphism_subproof : zmod_morphism apply;
+}.
+
+Module isAdditive.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use isZmodMorphism.Build instead.")]
+Notation Build U V apply := (isZmodMorphism.Build U V apply) (only parsing).
+End isAdditive.
+
+HB.builders Context U V apply of isZmodMorphism U V apply.
+Local Lemma raddf0 : apply 0 = 0.
+Proof. by rewrite -[0]subr0 zmod_morphism_subproof subrr. Qed.
+
+Local Lemma raddfD : {morph apply : x y / x + y}.
+Proof.
+move=> x y; rewrite -[y in LHS]opprK -[- y]add0r.
+by rewrite !zmod_morphism_subproof raddf0 sub0r opprK.
+Qed.
+
+HB.instance Definition _ := isNmodMorphism.Build U V apply (conj raddf0 raddfD).
+
+HB.end.
+
+Module AdditiveExports.
+Notation "{ 'additive' U -> V }" := (Additive.type U%type V%type) : type_scope.
+End AdditiveExports.
+HB.export AdditiveExports.
+
+Section AdditiveTheory.
+Variables (U V : baseAddUMagmaType) (f : {additive U -> V}).
+
+Lemma raddf0 : f 0 = 0.
+Proof. exact: nmod_morphism_subproof.1. Qed.
+
+Lemma raddfD :
+  {morph f : x y / x + y}.
+Proof. exact: nmod_morphism_subproof.2. Qed.
+
+End AdditiveTheory.
+
+Definition to_fmultiplicative U V :=
+  @id (to_multiplicative U -> to_multiplicative V).
+
+#[export]
+HB.instance Definition _ U V (f : {additive U -> V}) :=
+  isMultiplicative.Build (to_multiplicative U) (to_multiplicative V)
+    (to_fmultiplicative f) (@raddfD _ _ f).
+#[export]
+HB.instance Definition _ (U V : baseAddUMagmaType) (f : {additive U -> V}) :=
+  Multiplicative_isUMagmaMorphism.Build
+    (to_multiplicative U) (to_multiplicative V) (to_fmultiplicative f)
+    (@raddf0 _ _ f).
+
+Section LiftedAddMagma.
+Variables (U : Type) (V : baseAddMagmaType).
+Definition add_fun (f g : U -> V) x := f x + g x.
+End LiftedAddMagma.
+Section LiftedNmod.
+Variables (U : Type) (V : baseAddUMagmaType).
+Definition null_fun of U : V := 0.
+End LiftedNmod.
+Section LiftedZmod.
+Variables (U : Type) (V : baseZmodType).
+Definition opp_fun (f : U -> V) x := - f x.
+Definition sub_fun (f g : U -> V) x := f x - g x.
+End LiftedZmod.
+
+Arguments null_fun {_} V _ /.
+Arguments add_fun {_ _} f g _ /.
+Arguments opp_fun {_ _} f _ /.
+Arguments sub_fun {_ _} f g _ /.
+
+Local Notation "\0" := (null_fun _) : function_scope.
+Local Notation "f \+ g" := (add_fun f g) : function_scope.
+Local Notation "\- f" := (opp_fun f) : function_scope.
+Local Notation "f \- g" := (sub_fun f g) : function_scope.
+
+Section Nmod.
+Variables (U V : addUMagmaType) (f : {additive U -> V}).
+Let g := to_fmultiplicative f.
+
+Lemma raddf_eq0 x : injective f -> (f x == 0) = (x == 0).
+Proof. exact: (@gmulf_eq1 _ _ g). Qed.
+
+Lemma raddfMn n : {morph f : x / x *+ n}.
+Proof. exact: (@gmulfXn _ _ g). Qed.
+
+Lemma raddf_sum I r (P : pred I) E :
+  f (\sum_(i <- r | P i) E i) = \sum_(i <- r | P i) f (E i).
+Proof. exact: (@gmulf_prod _ _ g). Qed.
+
+Lemma can2_nmod_morphism f' : cancel f f' -> cancel f' f -> nmod_morphism f'.
+Proof.
+split; first exact/(@can2_gmulf1 _ _ g).
+exact/(@can2_gmulfM _ _ g).
+Qed.
+
+#[deprecated(since="mathcomp 2.5.0", note="use `can2_nmod_morphism` instead")]
+Definition can2_semi_additive := can2_nmod_morphism.
+
+End Nmod.
+
+Section Zmod.
+Variables (U V : zmodType) (f : {additive U -> V}).
+Let g := to_fmultiplicative f.
+
+Lemma raddfN : {morph f : x / - x}.
+Proof. exact: (@gmulfV _ _ g). Qed.
+
+Lemma raddfB : {morph f : x y / x - y}.
+Proof. exact: (@gmulfF _ _ g). Qed.
+
+Lemma raddf_inj : (forall x, f x = 0 -> x = 0) -> injective f.
+Proof. exact: (@gmulf_inj _ _ g). Qed.
+
+Lemma raddfMNn n : {morph f : x / x *- n}.
+Proof. exact: (@gmulfXVn _ _ g). Qed.
+
+Lemma can2_zmod_morphism f' : cancel f f' -> cancel f' f -> zmod_morphism f'.
+Proof. by move=> fK f'K x y /=; apply: (canLR fK); rewrite raddfB !f'K. Qed.
+
+#[warning="-deprecated-since-mathcomp-2.5.0",
+    deprecated(since="mathcomp 2.5.0", note="use `can2_zmod_morphism` instead")]
+Definition can2_additive := can2_zmod_morphism.
+End Zmod.
+
+Section AdditiveTheory.
+Section AddCFun.
+Variables (U : baseAddUMagmaType) (V : nmodType).
+Implicit Types (f g : {additive U -> V}).
+
+Fact add_fun_nmod_morphism f g : nmod_morphism (add_fun f g).
+Proof.
+by split=> [|x y]; rewrite /= ?raddf0 ?addr0// !raddfD addrCA -!addrA addrCA.
+Qed.
+#[export]
+HB.instance Definition _ f g :=
+  isNmodMorphism.Build U V (add_fun f g) (add_fun_nmod_morphism f g).
+
+End AddCFun.
+
+Section AddFun.
+Variables (U V W : baseAddUMagmaType).
+Variables (f : {additive V -> W}) (g : {additive U -> V}).
+
+Fact idfun_is_nmod_morphism : nmod_morphism (@idfun U).
+Proof. by []. Qed.
+#[export]
+HB.instance Definition _ := isNmodMorphism.Build U U idfun
+  idfun_is_nmod_morphism.
+
+Fact comp_is_nmod_morphism : nmod_morphism (f \o g).
+Proof. by split=> [|x y]; rewrite /= ?raddf0// !raddfD. Qed.
+#[export]
+HB.instance Definition _ := isNmodMorphism.Build U W (f \o g)
+  comp_is_nmod_morphism.
+
+End AddFun.
+Section AddFun.
+Variables (U : baseAddUMagmaType) (V : addUMagmaType) (W : nmodType).
+Variables (f g : {additive U -> W}).
+
+Fact null_fun_is_nmod_morphism : nmod_morphism (\0 : U -> V).
+Proof. by split=> // x y /=; rewrite addr0. Qed.
+#[export]
+HB.instance Definition _ :=
+  isNmodMorphism.Build U V (\0 : U -> V)
+    null_fun_is_nmod_morphism.
+
+End AddFun.
+
+Section AddVFun.
+Variables (U : baseAddUMagmaType) (V : zmodType).
+Variables (f g : {additive U -> V}).
+
+Fact opp_is_zmod_morphism : zmod_morphism (-%R : V -> V).
+Proof. by move=> x y; rewrite /= opprD. Qed.
+#[export]
+HB.instance Definition _ :=
+  isZmodMorphism.Build V V -%R opp_is_zmod_morphism.
+
+Fact opp_fun_is_zmod_morphism : nmod_morphism (\- f).
+Proof.
+split=> [|x y]; first by rewrite -[LHS]/(- (f 0)) raddf0 oppr0.
+by rewrite -[LHS]/(- (f (x + y))) !raddfD/=.
+Qed.
+#[export]
+HB.instance Definition _ :=
+  isNmodMorphism.Build U V (opp_fun f) opp_fun_is_zmod_morphism.
+
+Fact sub_fun_is_zmod_morphism :
+  nmod_morphism (f \- g).
+Proof.
+split=> [|x y]/=; first by rewrite !raddf0 addr0.
+by rewrite !raddfD/= addrACA.
+Qed.
+#[export]
+HB.instance Definition _ :=
+  isNmodMorphism.Build U V (f \- g) sub_fun_is_zmod_morphism.
+
+End AddVFun.
+End AdditiveTheory.
+
+(* Mixins for stability properties *)
+
+HB.mixin Record isAddClosed (V : baseAddUMagmaType) (S : {pred V}) := {
+  nmod_closed_subproof : addumagma_closed S
+}.
+
+HB.mixin Record isOppClosed (V : zmodType) (S : {pred V}) := {
+  oppr_closed_subproof : oppr_closed S
+}.
+
+(* Structures for stability properties *)
+
+#[short(type="addrClosed")]
+HB.structure Definition AddClosed V := {S of isAddClosed V S}.
+
+#[short(type="opprClosed")]
+HB.structure Definition OppClosed V := {S of isOppClosed V S}.
+
+#[short(type="zmodClosed")]
+HB.structure Definition ZmodClosed V := {S of OppClosed V S & AddClosed V S}.
+
+(* Factories for stability properties *)
+
+HB.factory Record isZmodClosed (V : zmodType) (S : V -> bool) := {
+  zmod_closed_subproof : zmod_closed S
+}.
+
+HB.builders Context V S of isZmodClosed V S.
+HB.instance Definition _ := isOppClosed.Build V S
+  (zmod_closedN zmod_closed_subproof).
+HB.instance Definition _ := isAddClosed.Build V S
+  (zmod_closed0D zmod_closed_subproof).
+HB.end.
+
+Definition to_pmultiplicative (T : Type) := @id {pred to_multiplicative T}.
+
+#[export]
+HB.instance Definition _ (U : baseAddUMagmaType) (S : addrClosed U) :=
+  isMulClosed.Build (to_multiplicative U) (to_pmultiplicative S)
+    (snd nmod_closed_subproof).
+#[export]
+HB.instance Definition _ (U : baseAddUMagmaType) (S : addrClosed U) :=
+  isMul1Closed.Build (to_multiplicative U) (to_pmultiplicative S)
+    (fst nmod_closed_subproof).
+#[export]
+HB.instance Definition _ (U : zmodType) (S : opprClosed U) :=
+  isInvClosed.Build (to_multiplicative U) (to_pmultiplicative S)
+    oppr_closed_subproof.
+
+(* FIXME: HB.saturate *)
+#[export]
+HB.instance Definition _ (U : zmodType) (S : zmodClosed U) :=
+  InvClosed.on (to_pmultiplicative S).
+
+Section BaseAddUMagmaPred.
+Variables (V : baseAddUMagmaType).
+
+Section BaseAddUMagmaPred.
+Variables S : addrClosed V.
+
+Lemma rpred0 : 0 \in S.
+Proof. by case: (@nmod_closed_subproof V S). Qed.
+Lemma rpredD : {in S &, forall u v, u + v \in S}.
+Proof. by case: (@nmod_closed_subproof V S). Qed.
+
+Lemma rpred0D : addumagma_closed S.
+Proof. exact: nmod_closed_subproof. Qed.
+
+Lemma rpredMn n : {in S, forall u, u *+ n \in S}.
+Proof. exact: (@gpredXn _ (to_pmultiplicative S)). Qed.
+
+Lemma rpred_sum I r (P : pred I) F :
+  (forall i, P i -> F i \in S) -> \sum_(i <- r | P i) F i \in S.
+Proof. by move=> IH; elim/big_ind: _; [apply: rpred0 | apply: rpredD |]. Qed.
+
+End BaseAddUMagmaPred.
+End BaseAddUMagmaPred.
+
+Section ZmodPred.
+Variables (V : zmodType).
+
+Section Opp.
+
+Variable S : opprClosed V.
+
+Lemma rpredNr : {in S, forall u, - u \in S}.
+Proof. exact: oppr_closed_subproof. Qed.
+
+Lemma rpredN : {mono -%R: u / u \in S}.
+Proof. exact: (gpredV (to_pmultiplicative S)). Qed.
+
+End Opp.
+
+Section Zmod.
+Variables S : zmodClosed V.
+Let T := to_pmultiplicative S.
+
+Lemma rpredB : {in S &, forall u v, u - v \in S}.
+Proof. exact: (@gpredF _ T). Qed.
+
+Lemma rpredBC u v : u - v \in S = (v - u \in S).
+Proof. exact: (@gpredFC _ T). Qed.
+
+Lemma rpredMNn n: {in S, forall u, u *- n \in S}.
+Proof. exact: (@gpredXNn _ T). Qed.
+
+Lemma rpredDr x y : x \in S -> (y + x \in S) = (y \in S).
+Proof. exact: (@gpredMr _ T). Qed.
+
+Lemma rpredDl x y : x \in S -> (x + y \in S) = (y \in S).
+Proof. exact: (@gpredMl _ T). Qed.
+
+Lemma rpredBr x y : x \in S -> (y - x \in S) = (y \in S).
+Proof. exact: (@gpredFr _ T). Qed.
+
+Lemma rpredBl x y : x \in S -> (x - y \in S) = (y \in S).
+Proof. exact: (@gpredFl _ T). Qed.
+
+Lemma zmodClosedP : zmod_closed S.
+Proof. split; [ exact: (@rpred0D V S).1 | exact: rpredB ]. Qed.
+End Zmod.
+End ZmodPred. 
+
+HB.mixin Record isSubBaseAddUMagma (V : baseAddUMagmaType) (S : pred V) U
+    of SubType V S U & BaseAddUMagma U := {
+  valD0_subproof : nmod_morphism (val : U -> V)
+}.
+
+#[short(type="subBaseAddUMagma")]
+HB.structure Definition SubBaseAddUMagma (V : baseAddUMagmaType) S :=
+  { U of SubChoice V S U & BaseAddUMagma U & isSubBaseAddUMagma V S U }.
+
+#[short(type="subAddUMagma")]
+HB.structure Definition SubAddUMagma (V : addUMagmaType) S :=
+  { U of SubChoice V S U & AddUMagma U & isSubBaseAddUMagma V S U }.
+
+#[short(type="subNmodType")]
+HB.structure Definition SubNmodule (V : nmodType) S :=
+  { U of SubChoice V S U & Nmodule U & isSubBaseAddUMagma V S U}.
+
+Section subBaseAddUMagma.
+Context (V : baseAddUMagmaType) (S : pred V) (U : subBaseAddUMagma S).
+Notation val := (val : U -> V).
+#[export]
+HB.instance Definition _ := isNmodMorphism.Build U V val valD0_subproof.
+Lemma valD : {morph val : x y / x + y}. Proof. exact: raddfD. Qed.
+Lemma val0 : val 0 = 0. Proof. exact: raddf0. Qed.
+End subBaseAddUMagma.
+
+HB.factory Record SubChoice_isSubAddUMagma (V : addUMagmaType) S U
+    of SubChoice V S U := {
+  addumagma_closed_subproof : addumagma_closed S
+}.
+
+HB.builders Context V S U of SubChoice_isSubAddUMagma V S U.
+
+HB.instance Definition _ := isAddClosed.Build V S addumagma_closed_subproof.
+
+Let inU v Sv : U := Sub v Sv.
+Let addU (u1 u2 : U) := inU (rpredD (valP u1) (valP u2)).
+Let oneU := inU (fst addumagma_closed_subproof).
+
+Lemma addrC : commutative addU.
+Proof. by move=> x y; apply/val_inj; rewrite !SubK addrC. Qed.
+
+Lemma add0r : left_id oneU addU.
+Proof. by move=> x; apply/val_inj; rewrite !SubK add0r. Qed.
+
+HB.instance Definition _ := isAddUMagma.Build U addrC add0r.
+
+Lemma valD0 : nmod_morphism (val : U -> V).
+Proof. by split=> [|x y]; rewrite !SubK. Qed.
+
+HB.instance Definition _ := isSubBaseAddUMagma.Build V S U valD0.
+
+HB.end.
+
+HB.factory Record SubChoice_isSubNmodule (V : nmodType) S U
+    of SubChoice V S U := {
+  nmod_closed_subproof : nmod_closed S
+}.
+
+HB.builders Context V S U of SubChoice_isSubNmodule V S U.
+
+HB.instance Definition _ :=
+  SubChoice_isSubAddUMagma.Build V S U nmod_closed_subproof.
+
+Lemma addrA : associative (@add U).
+Proof. by move=> x y z; apply/val_inj; rewrite !SubK addrA. Qed.
+
+HB.instance Definition _ := AddMagma_isAddSemigroup.Build U addrA.
+
+HB.end.
+
+#[short(type="subZmodType")]
+HB.structure Definition SubZmodule (V : zmodType) S :=
+  { U of SubChoice V S U & Zmodule U & isSubBaseAddUMagma V S U}.
+
+Section zmod_morphism.
+Context (V : zmodType) (S : pred V) (U : SubZmodule.type S).
+Notation val := (val : U -> V).
+Lemma valB : {morph val : x y / x - y}. Proof. exact: raddfB. Qed.
+Lemma valN : {morph val : x / - x}. Proof. exact: raddfN. Qed.
+End zmod_morphism.
+
+HB.factory Record isSubZmodule (V : zmodType) S U
+    of SubChoice V S U & Zmodule U := {
+  valB_subproof : zmod_morphism (val : U -> V)
+}.
+
+HB.builders Context V S U of isSubZmodule V S U.
+
+Fact valD0 : nmod_morphism (val : U -> V).
+Proof.
+have val0: (val : U -> V) 0 = 0.
+  by rewrite -[X in val X](subr0 0) valB_subproof subrr.
+split=> // x y; apply/(@subIr _ (val y)).
+by rewrite -valB_subproof -!addrA !subrr !addr0.
+Qed.
+
+HB.instance Definition _ := isSubBaseAddUMagma.Build V S U valD0.
+
+HB.end.
+
+HB.factory Record SubChoice_isSubZmodule (V : zmodType) S U
+    of SubChoice V S U := {
+  zmod_closed_subproof : zmod_closed S
+}.
+
+HB.builders Context V S U of SubChoice_isSubZmodule V S U.
+
+HB.instance Definition _ := isZmodClosed.Build V S zmod_closed_subproof.
+HB.instance Definition _ :=
+  SubChoice_isSubNmodule.Build V S U nmod_closed_subproof.
+
+Let inU v Sv : U := Sub v Sv.
+Let oppU (u : U) := inU (rpredNr (valP u)).
+
+HB.instance Definition _ := hasOpp.Build U oppU.
+
+Lemma addNr : left_inverse 0 oppU (@add U).
+Proof. by move=> x; apply/val_inj; rewrite !SubK addNr. Qed.
+
+HB.instance Definition _ := Nmodule_isZmodule.Build U addNr.
+
+HB.end.
+
+Module SubExports.
+
+Notation "[ 'SubChoice_isSubNmodule' 'of' U 'by' <: ]" :=
+  (SubChoice_isSubNmodule.Build _ _ U rpred0D)
+  (at level 0, format "[ 'SubChoice_isSubNmodule'  'of'  U  'by'  <: ]")
+  : form_scope.
+Notation "[ 'SubChoice_isSubZmodule' 'of' U 'by' <: ]" :=
+  (SubChoice_isSubZmodule.Build _ _ U (zmodClosedP _))
+  (at level 0, format "[ 'SubChoice_isSubZmodule'  'of'  U  'by'  <: ]")
+  : form_scope.
+
+End SubExports.
+HB.export SubExports.
+
+Module AllExports. HB.reexport. End AllExports.
+
+End Algebra.
+
+Export AllExports.
+
+Notation "0" := (@zero _) : ring_scope.
+Notation "-%R" := (@opp _) : ring_scope.
+Notation "- x" := (opp x) : ring_scope.
+Notation "+%R" := (@add _) : function_scope.
+Notation "x + y" := (add x y) : ring_scope.
+Notation "x - y" := (add x (- y)) : ring_scope.
+Arguments natmul : simpl never.
+Notation "x *+ n" := (natmul x n) : ring_scope.
+Notation "x *- n" := (opp (x *+ n)) : ring_scope.
+Notation "s `_ i" := (seq.nth 0%R s%R i) : ring_scope.
+Notation support := 0.-support.
+
+Notation "1" := (@one _) : ring_scope.
+Notation "- 1" := (opp 1) : ring_scope.
+
+Notation "n %:R" := (natmul 1 n) : ring_scope.
+
+Notation "\sum_ ( i <- r | P ) F" :=
+  (\big[+%R/0%R]_(i <- r | P%B) F%R) : ring_scope.
+Notation "\sum_ ( i <- r ) F" :=
+  (\big[+%R/0%R]_(i <- r) F%R) : ring_scope.
+Notation "\sum_ ( m <= i < n | P ) F" :=
+  (\big[+%R/0%R]_(m <= i < n | P%B) F%R) : ring_scope.
+Notation "\sum_ ( m <= i < n ) F" :=
+  (\big[+%R/0%R]_(m <= i < n) F%R) : ring_scope.
+Notation "\sum_ ( i | P ) F" :=
+  (\big[+%R/0%R]_(i | P%B) F%R) : ring_scope.
+Notation "\sum_ i F" :=
+  (\big[+%R/0%R]_i F%R) : ring_scope.
+Notation "\sum_ ( i : t | P ) F" :=
+  (\big[+%R/0%R]_(i : t | P%B) F%R) (only parsing) : ring_scope.
+Notation "\sum_ ( i : t ) F" :=
+  (\big[+%R/0%R]_(i : t) F%R) (only parsing) : ring_scope.
+Notation "\sum_ ( i < n | P ) F" :=
+  (\big[+%R/0%R]_(i < n | P%B) F%R) : ring_scope.
+Notation "\sum_ ( i < n ) F" :=
+  (\big[+%R/0%R]_(i < n) F%R) : ring_scope.
+Notation "\sum_ ( i 'in' A | P ) F" :=
+  (\big[+%R/0%R]_(i in A | P%B) F%R) : ring_scope.
+Notation "\sum_ ( i 'in' A ) F" :=
+  (\big[+%R/0%R]_(i in A) F%R) : ring_scope.
+
+Section FinFunBaseAddMagma.
+Variable (aT : finType) (rT : baseAddMagmaType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Definition ffun_add f g := [ffun a => f a + g a].
+
+HB.instance Definition _ := hasAdd.Build {ffun aT -> rT} ffun_add.
+
+End FinFunBaseAddMagma.
+
+Section FinFunAddMagma.
+Variable (aT : finType) (rT : addMagmaType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Fact ffun_addrC : commutative (@ffun_add aT rT).
+Proof. by move=> f1 f2; apply/ffunP => a; rewrite !ffunE addrC. Qed.
+
+HB.instance Definition _ :=
+  BaseAddMagma_isAddMagma.Build {ffun aT -> rT} ffun_addrC.
+
+End FinFunAddMagma.
+
+Section FinFunAddSemigroup.
+Variable (aT : finType) (rT : addSemigroupType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Fact ffun_addrA : associative (@ffun_add aT rT).
+Proof. by move=> f g h; apply/ffunP => a; rewrite !ffunE addrA. Qed.
+
+HB.instance Definition _ :=
+  AddMagma_isAddSemigroup.Build {ffun aT -> rT} ffun_addrA.
+
+End FinFunAddSemigroup.
+
+Section FinFunBaseAddUMagma.
+Variable (aT : finType) (rT : baseAddUMagmaType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Definition ffun_zero := [ffun a : aT => (0 : rT)].
+
+HB.instance Definition _ := hasZero.Build {ffun aT -> rT} ffun_zero.
+
+End FinFunBaseAddUMagma.
+
+Section FinFunAddUMagma.
+Variable (aT : finType) (rT : addUMagmaType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Fact ffun_add0r : left_id (@ffun_zero aT rT) (@ffun_add aT rT).
+Proof. by move=> f; apply/ffunP => a; rewrite !ffunE add0r. Qed.
+
+HB.instance Definition _ :=
+  BaseAddUMagma_isAddUMagma.Build {ffun aT -> rT} ffun_add0r.
+
+End FinFunAddUMagma.
+
+(* FIXME: HB.saturate *)
+HB.instance Definition _ (aT : finType) (rT : ChoiceBaseAddMagma.type) :=
+  BaseAddMagma.on {ffun aT -> rT}.
+HB.instance Definition _ (aT : finType) (rT : ChoiceBaseAddUMagma.type) :=
+  BaseAddMagma.on {ffun aT -> rT}.
+
+Section FinFunNmod.
+Variable (aT : finType) (rT : nmodType).
+Implicit Types f g : {ffun aT -> rT}.
+
+(* FIXME: HB.saturate *)
+HB.instance Definition _ := AddSemigroup.on {ffun aT -> rT}.
+
+Lemma ffunMnE f n x : (f *+ n) x = f x *+ n.
+Proof.
+elim: n => [|n IHn]; first by rewrite ffunE.
+by rewrite !mulrS ffunE IHn.
+Qed.
+
+Section Sum.
+
+Variables (I : Type) (r : seq I) (P : pred I) (F : I -> {ffun aT -> rT}).
+
+Lemma sum_ffunE x : (\sum_(i <- r | P i) F i) x = \sum_(i <- r | P i) F i x.
+Proof. by elim/big_rec2: _ => // [|i _ y _ <-]; rewrite !ffunE. Qed.
+
+Lemma sum_ffun :
+  \sum_(i <- r | P i) F i = [ffun x => \sum_(i <- r | P i) F i x].
+Proof. by apply/ffunP=> i; rewrite sum_ffunE ffunE. Qed.
+
+End Sum.
+
+End FinFunNmod.
+
+Section FinFunZmod.
+
+Variable (aT : finType) (rT : zmodType).
+Implicit Types f g : {ffun aT -> rT}.
+
+Definition ffun_opp f := [ffun a => - f a].
+
+HB.instance Definition _ := hasOpp.Build {ffun aT -> rT} ffun_opp.
+
+Fact ffun_addNr : left_inverse 0 ffun_opp +%R.
+Proof. by move=> f; apply/ffunP => a; rewrite !ffunE addNr. Qed.
+
+HB.instance Definition _ := Nmodule_isZmodule.Build {ffun aT -> rT} ffun_addNr.
+
+End FinFunZmod.
+
+Section PairBaseAddMagma.
+Variables U V : baseAddMagmaType.
+
+Definition add_pair (a b : U * V) := (a.1 + b.1, a.2 + b.2).
+
+HB.instance Definition _ := hasAdd.Build (U * V)%type add_pair.
+
+End PairBaseAddMagma.
+
+Section PairAddMagma.
+Variables U V : addMagmaType.
+
+Fact pair_addrC : commutative (@add_pair U V).
+Proof. by move=> a b; congr pair; exact: addrC. Qed.
+
+HB.instance Definition _ :=
+  BaseAddMagma_isAddMagma.Build (U * V)%type pair_addrC.
+
+End PairAddMagma.
+
+Section PairAddSemigroup.
+Variables U V : addSemigroupType.
+
+Fact pair_addrA : associative (@add_pair U V).
+Proof. by move=> [] al ar [] bl br [] cl cr; rewrite /add_pair !addrA. Qed.
+
+HB.instance Definition _ :=
+  AddMagma_isAddSemigroup.Build (U * V)%type pair_addrA.
+
+End PairAddSemigroup.
+
+Section PairBaseAddUMagma.
+Variables U V : baseAddUMagmaType.
+
+Definition pair_zero : U * V := (0, 0).
+
+HB.instance Definition _ := hasZero.Build (U * V)%type pair_zero.
+
+Fact fst_is_zmod_morphism : nmod_morphism (@fst U V). Proof. by []. Qed.
+Fact snd_is_zmod_morphism : nmod_morphism (@snd U V). Proof. by []. Qed.
+
+HB.instance Definition _ :=
+  isNmodMorphism.Build _ _ (@fst U V) fst_is_zmod_morphism.
+HB.instance Definition _ :=
+  isNmodMorphism.Build _ _ (@snd U V) snd_is_zmod_morphism.
+
+End PairBaseAddUMagma.
+
+Section PairAddUMagma.
+Variables U V : addUMagmaType.
+
+Fact pair_add0r : left_id (@pair_zero U V) (@add_pair U V).
+Proof. by move=> [] al ar; rewrite /add_pair !add0r. Qed.
+
+HB.instance Definition _ :=
+  BaseAddUMagma_isAddUMagma.Build (U * V)%type pair_add0r.
+
+End PairAddUMagma.
+
+(* FIXME: HB.saturate *)
+HB.instance Definition _ (U V : ChoiceBaseAddMagma.type) :=
+  BaseAddMagma.on (U * V)%type.
+HB.instance Definition _ (U V : ChoiceBaseAddUMagma.type) :=
+  BaseAddMagma.on (U * V)%type.
+HB.instance Definition _ (U V : nmodType) := AddSemigroup.on (U * V)%type.
+(* /FIXME *)
+
+Section PairZmodule.
+Variables U V : zmodType.
+
+Definition pair_opp (a : U * V) := (- a.1, - a.2).
+
+HB.instance Definition _ := hasOpp.Build (U * V)%type pair_opp.
+
+Fact pair_addNr : left_inverse 0 pair_opp +%R.
+Proof. by move=> [] al ar; rewrite /pair_opp; congr pair; apply/addNr. Qed.
+
+HB.instance Definition _ := Nmodule_isZmodule.Build (U * V)%type pair_addNr.
+
+End PairZmodule.
+
+(* zmodType structure on bool *)
+HB.instance Definition _ := isZmodule.Build bool addbA addbC addFb addbb.
+
+(* nmodType structure on nat *)
+HB.instance Definition _ := isNmodule.Build nat addnA addnC add0n.
+
+HB.instance Definition _ (V : nmodType) (x : V) :=
+  isNmodMorphism.Build nat V (natmul x) (mulr0n x, mulrnDr x).
+
+Lemma natr0E : 0 = 0%N. Proof. by []. Qed.
+Lemma natrDE n m : n + m = (n + m)%N. Proof. by []. Qed.
+Definition natrE := (natr0E, natrDE).


### PR DESCRIPTION
##### Motivation for this change

Adds the main structures with one operation, i.e. magmas, unitary magmas, semigroups, monoids and groups and refactors N-modules and Z-modules with them.
TODO:
- [x] finish duplicating the multiplicative hierarchy into the additive one
- [x] make sure that this behaves well with `fingroup.v` (without yet making the latter depend on the former).
- [x] make it backwards compatible
- [x] Wait for https://github.com/math-comp/math-comp/pull/1296 to be merged and copy the `multiplicative` and `additive` definitions and deprecations.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Dependencies (Edit by Cyril)

- https://github.com/coq/coq/pull/19611

##### Overlays

- https://github.com/jasmin-lang/jasmin/pull/1093

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
