### PR TITLE
change the implicit arguments of big cat nat

### DIFF
--- a/doc/changelog/02-changed/1261-changeImplicits.md
+++ b/doc/changelog/02-changed/1261-changeImplicits.md
@@ -1,0 +1,5 @@
+- in `bigop.v`
+  + change the implicit arguments of lemmas `big_cat_nat_idem` and
+    `big_cat_nat`
+    ([#1261](https://github.com/math-comp/math-comp/pull/1261),
+    by Kimaya Bedarkar).

--- a/ssreflect/bigop.v
+++ b/ssreflect/bigop.v
@@ -2211,6 +2211,8 @@ Arguments big_ord_recl [R idx op].
 Arguments big_ord_recr [R idx op].
 Arguments big_nat_recl [R idx op].
 Arguments big_nat_recr [R idx op].
+Arguments big_cat_nat_idem [R op x] opxx [n m p P F].
+Arguments big_cat_nat [R idx op n m p P F].
 Arguments big_pmap [R idx op J I] h [r].
 Arguments telescope_big [R idx op] f [n m].
 


### PR DESCRIPTION
##### Motivation for this change
The current way arguments for the lemma `big_cat_nat` are declared makes it hard to use the lemma in developments. This MR changes the arguments that are considered implicit and explicit for the lemma. 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

<!--##### Minimal TODO list -->

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~- [ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

<!--See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details. -->

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
<!--##### Automatic note to reviewers -->

<!--Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).-->

#### Overlays (to be merged before the current PR)

* https://github.com/rocq-community/gaia/pull/26
* https://github.com/rocq-community/apery/pull/32