### PR TITLE
feat: Deploy mathcomp/mathcomp-dev:coq-8.20 (Coq 8.20+rc1)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,8 +102,12 @@ coq-8.18:
 coq-8.19:
   extends: .opam-build-once
 
-# coq-8.20: # to uncomment when 8.20+rc1 available
-#   # to be replaced with .opam-build-once when 8.20.0 available
+coq-8.20: # to uncomment when 8.20+rc1 available
+  # to be replaced with .opam-build-once when 8.20.0 available
+  extends: .opam-build
+
+# coq-8.21: # to uncomment when 8.21+rc1 available
+#   # to be replaced with .opam-build-once when 8.21.0 available
 #   extends: .opam-build
 
 coq-dev:
@@ -162,11 +166,17 @@ test-coq-8.19:
   variables:
     COQ_VERSION: "8.19"
 
-# test-coq-8.20: # to uncomment when 8.20+rc1 available
-#   # to be replaced with .test-once when 8.20.0 available
+test-coq-8.20: # to uncomment when 8.20+rc1 available
+  # to be replaced with .test-once when 8.20.0 available
+  extends: .test
+  variables:
+    COQ_VERSION: "8.20"
+
+# test-coq-8.21: # to uncomment when 8.21+rc1 available
+#   # to be replaced with .test-once when 8.21.0 available
 #   extends: .test
 #   variables:
-#     COQ_VERSION: "8.20"
+#     COQ_VERSION: "8.21"
 
 test-coq-dev:
   extends: .test
@@ -402,8 +412,12 @@ mathcomp-dev_coq-8.18:
 mathcomp-dev_coq-8.19:
   extends: .docker-deploy-once
 
-# mathcomp-dev_coq-8.20: # to uncomment when 8.20+rc1 available
-#   # to be replaced with .docker-deploy-once when 8.20.0 available
+mathcomp-dev_coq-8.20: # to uncomment when 8.20+rc1 available
+  # to be replaced with .docker-deploy-once when 8.20.0 available
+  extends: .docker-deploy
+
+# mathcomp-dev_coq-8.21: # to uncomment when 8.21+rc1 available
+#   # to be replaced with .docker-deploy-once when 8.21.0 available
 #   extends: .docker-deploy
 
 mathcomp-dev_coq-dev:

--- a/coq-mathcomp-ssreflect.opam
+++ b/coq-mathcomp-ssreflect.opam
@@ -10,7 +10,7 @@ license: "CECILL-B"
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [
-  "coq" {(>= "8.18" & < "8.20~") | (= "dev")}
+  "coq" {(>= "8.18" & < "8.21~") | (= "dev")}
   # Please keep the "dev" above as it is required for the coq-dev Docker images
   "elpi" {>= "1.17.0"}
   "coq-hierarchy-builder" { >= "1.5.0"}


### PR DESCRIPTION
##### Motivation for this change

The Docker image `coqorg/coq:8.20-rc1` is now available with Coq 8.20+rc1 + coq-serapi 8.20+rc1+0.20.0.

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).