### PR TITLE
Adding gtn_sorted_uniq_geq

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -43,7 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemmas `tnth_lshift`, `tnth_rshift`
 
 - in `path.v`
-  + lemmas `count_sort`, `sorted_cat_cons`
+  + lemmas `count_sort`, `sorted_cat_cons`, `gtn_sorted_uniq_geq`
 
 - in `poly.v`
   + lemmas `coef0M`, `coef0_prod`, `polyseqXaddC`, `lead_coefXaddC`,

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -1177,9 +1177,7 @@ by rewrite -pairwise_relI; apply/eq_pairwise => ? ?; rewrite ltn_neqAle.
 Qed.
 
 Lemma gtn_sorted_uniq_geq s : sorted gtn s = uniq s && sorted geq s.
-Proof. 
-by rewrite -rev_sorted -[in RHS]rev_sorted -rev_uniq ltn_sorted_uniq_leq.
-Qed.
+Proof. by rewrite -rev_sorted ltn_sorted_uniq_leq rev_sorted rev_uniq. Qed.
 
 Lemma iota_sorted i n : sorted leq (iota i n).
 Proof. by elim: n i => // [[|n] //= IHn] i; rewrite IHn leqW. Qed.

--- a/mathcomp/ssreflect/path.v
+++ b/mathcomp/ssreflect/path.v
@@ -1176,6 +1176,11 @@ rewrite (sorted_pairwise leq_trans) (sorted_pairwise ltn_trans) uniq_pairwise.
 by rewrite -pairwise_relI; apply/eq_pairwise => ? ?; rewrite ltn_neqAle.
 Qed.
 
+Lemma gtn_sorted_uniq_geq s : sorted gtn s = uniq s && sorted geq s.
+Proof. 
+by rewrite -rev_sorted -[in RHS]rev_sorted -rev_uniq ltn_sorted_uniq_leq.
+Qed.
+
 Lemma iota_sorted i n : sorted leq (iota i n).
 Proof. by elim: n i => // [[|n] //= IHn] i; rewrite IHn leqW. Qed.
 


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

This PR adds `gtn_sorted_uniq_geq` to `path.v for` completeness (only the ltn/leq version exists as of now).

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
