### PR TITLE
Adding Index_nth in seq.v

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemmas `dfwith_in`, `dfwith_out`, `dfwithP`
 
 - in `seq.v`
-  + lemmas `has_undup`, `all_undup`, `zip_uniql`, `zip_uniqr`
+  + lemmas `has_undup`, `all_undup`, `zip_uniql`, `zip_uniqr`, `index_nth`
 
 - in `finset.v`
   + definition `setXn`

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1422,6 +1422,12 @@ Proof. by rewrite -?has_pred1; apply: has_take. Qed.
 Lemma in_take_leq x s i : i <= size s -> (x \in take i s) = (index x s < i).
 Proof. by rewrite -?has_pred1; apply: has_take_leq. Qed.
 
+Lemma index_nth i s : i < size s -> index (nth s i) s <= i.
+Proof.
+move=> lti; rewrite -ltnS index_ltn// -(@nth_take i.+1)// mem_nth // size_take.
+by case: ifP.
+Qed.
+
 Lemma nthK s: uniq s -> {in gtn (size s), cancel (nth s) (index^~ s)}.
 Proof.
 elim: s => //= x s IHs /andP[s'x Us] i; rewrite inE ltnS eq_sym -if_neg.


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

All other `index` of `nth` lemmas deal with `uniq` sequences.

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
-  added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
