### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -957,7 +957,7 @@ split => * //; rat_to_ring;
 by rewrite ?(add0r, addrA, mul1r, mulrA, mulrDl, subrr) // (addrC, mulrC).
 Qed.
 
-Require setoid_ring.Field_theory setoid_ring.Field_tac.
+From Coq.setoid_ring Require Field_theory Field_tac.
 
 Lemma rat_field_theory :
   Field_theory.field_theory 0%Q 1%Q addq mulq subq oppq divq invq eq.


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.