### PR TITLE
Cherry-pick from #1125, and cleanup algnum.v

### DIFF
--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -341,9 +341,8 @@ Definition powers_mx d := \matrix_(i < d) mxvec (A ^+ i).
 Lemma horner_rVpoly m (u : 'rV_m) :
   horner_mx (rVpoly u) = vec_mx (u *m powers_mx m).
 Proof.
-rewrite mulmx_sum_row linear_sum [rVpoly u]poly_def rmorph_sum.
-apply: eq_bigr => i _.
-by rewrite valK /= !linearZ rmorphXn /= horner_mx_X rowK mxvecK.
+rewrite mulmx_sum_row [rVpoly u]poly_def 2!linear_sum; apply: eq_bigr => i _.
+by rewrite valK /= 2!linearZ rmorphXn/= horner_mx_X rowK mxvecK.
 Qed.
 
 End OneMatrix.
@@ -354,8 +353,8 @@ Proof.
 apply/matrixP => i j; rewrite !mxE.
 elim/poly_ind: p => [|p c ihp]; first by rewrite rmorph0 horner0 mxE mul0rn.
 rewrite !hornerE mulrnDl rmorphD rmorphM /= horner_mx_X horner_mx_C !mxE.
-rewrite (bigD1 j)//= ihp mxE ?eqxx mulr1n -mulrnAl big1 ?addr0//.
-  by case: (altP (i =P j)) => [->|]; rewrite /= !(mulr1n, addr0, mul0r).
+rewrite (bigD1 j)//= ihp mxE eqxx mulr1n -mulrnAl big1 ?addr0.
+  by have [->|_] := eqVneq; rewrite /= !(mulr1n, addr0, mul0r).
 by move=> k /negPf nkF; rewrite mxE nkF mulr0.
 Qed.
 

--- a/mathcomp/algebra/vector.v
+++ b/mathcomp/algebra/vector.v
@@ -402,7 +402,7 @@ Qed.
 
 Fact memv_submod_closed U : submod_closed U.
 Proof.
-split=> [|a u v]; rewrite !memvK ?linear0 ?sub0mx // => Uu Uv.
+split=> [|a u v]; rewrite !memvK 1?linear0 1?sub0mx // => Uu Uv.
 by rewrite linearP addmx_sub ?scalemx_sub.
 Qed.
 HB.instance Definition _ (U : {vspace vT}) :=
@@ -1011,7 +1011,7 @@ Qed.
 Lemma coord_sum_free n (X : n.-tuple vT) k j :
   free X -> coord X j (\sum_(i < n) k i *: X`_i) = k j.
 Proof.
-move=> Xfree; rewrite linear_sum (bigD1 j) ?linearZ //= coord_free // eqxx.
+move=> Xfree; rewrite linear_sum (bigD1 j) 1?linearZ //= coord_free // eqxx.
 rewrite mulr1 big1 ?addr0 // => i /negPf j'i.
 by rewrite linearZ /= coord_free // j'i mulr0.
 Qed.

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -126,7 +126,7 @@ HB.instance Definition _ n1 m2 n2 A :=
   GRing.isLinear.Build _ _ _ _ (@trow n1 A m2 n2)
     (@trow_is_linear n1 m2 n2 A).
 
-Fixpoint tprod  (m1 : nat) :
+Fixpoint tprod (m1 : nat) :
   forall n1 (A : 'M[F]_(m1,n1)) m2 n2 (B : 'M[F]_(m2,n2)),
         'M[F]_(m1 * m2,n1 * n2) :=
   if m1 is m'1.+1
@@ -496,7 +496,7 @@ Definition xcfun (chi : 'CF(G)) A :=
   (gring_row A *m (\col_(i < #|G|) chi (enum_val i))) 0 0.
 
 Lemma xcfun_is_additive phi : additive (xcfun phi).
-Proof. by move=> A B; rewrite /xcfun linearB mulmxBl !mxE. Qed.
+Proof. by move=> A B; rewrite /xcfun [gring_row _]linearB mulmxBl !mxE. Qed.
 HB.instance Definition _ phi :=
   GRing.isAdditive.Build 'M_(gcard G) _ (xcfun phi) (xcfun_is_additive phi).
 

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -4352,8 +4352,7 @@ Qed.
 
 Lemma rank_irr_comp : \rank 'R_iG = \rank E_G.
 Proof.
-symmetry; rewrite -{1}irr_comp_envelop; apply/mxrank_injP.
-by rewrite ker_irr_comp_op.
+by rewrite -irr_comp_envelop; apply/esym/mxrank_injP; rewrite ker_irr_comp_op.
 Qed.
 
 End IrrComponent.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -545,8 +545,7 @@ move=> a p; rewrite -mul_polyC rmorphM /= fieldExt_hornerC.
 by rewrite -scalerAl mul1r.
 Qed.
 HB.instance Definition _ :=
-  GRing.isScalable.Build F0 {poly F0} L *:%R fieldExt_horner
-    fieldExt_hornerZ.
+  GRing.isScalable.Build F0 {poly F0} L *:%R fieldExt_horner fieldExt_hornerZ.
 
 End Horner.
 

--- a/mathcomp/field/galois.v
+++ b/mathcomp/field/galois.v
@@ -193,7 +193,7 @@ Variables (K E : {subfield L}) (f : 'End(L)) (x y : L).
 Let kHomf z := (map_poly f (Fadjoin_poly E x z)).[y].
 
 Fact kHomExtend_additive_subproof : additive kHomf.
-Proof. by move=> a b; rewrite /kHomf !raddfB hornerD hornerN. Qed.
+Proof. by move=> a b; rewrite /kHomf 2!raddfB hornerD hornerN. Qed.
 
 Fact kHomExtend_scalable_subproof : scalable kHomf.
 Proof.


### PR DESCRIPTION
##### Motivation for this change

The main motivation is to reduce the size of the diff of #1125. While at it, I found that `algnum.v` repeats similar proofs several times.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
