### PR TITLE
Inverse of products + related lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `bigop.v`
   + lemma `big_ord1`, `big_ord1_cond`, `big_rcons_op`, `big_change_idx`,
     `big_rcons`, `big_only1`, `big_mknat`
+  + lemmas `big_rev`, `rev_big_rev` and `big_morph_in`
 
 - in `eqtype.v`
   + definition `dfwith`
@@ -160,6 +161,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemma `irreducible_rat_int`
 
 ### Changed
+
+- in `seq.v`
+  + fix incorrectly exported notations `'all_view` and `'has_view`
 
 - in `bigop.v`
   + weaken hypothesis of lemma `telescope_sumn_in`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - in `ssrnum.v`
   + lemma `invf_pgt`, `invf_pge`, `invf_ngt`, `invf_nge`
   + lemma `invf_plt`, `invf_ple`, `invf_nlt`, `invf_nle`
+
 - in `bigop.v`
   + lemma `big_ord1`, `big_ord1_cond`, `big_rcons_op`, `big_change_idx`,
     `big_rcons`, `big_only1`, `big_mknat`
@@ -57,6 +58,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - in `ssralg.v`
   + lemmas `prodM_comm`, `prodMl_comm`, `prodMr_comm`, `prodrMl`, `prodrMr`
+    `rev_prodr`, `unitr_prod`, `unitr_prod_in`, `rev_prodrV`,
+    `unitr_prodP`, `prodrV`
 
 - in `ssrbool.v`
   + lemmas `classic_sigW`, `classic_ex`

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -1554,16 +1554,10 @@ HB.instance Definition _ (R : semiRingType) :=
 HB.instance Definition _ (R : ringType) := SemiRing.on R^c.
 End ConverseRing.
 
-
 Lemma rev_prodr (R : semiRingType)
   (I : Type) (r : seq I) (P : pred I) (E : I -> R) :
   \prod_(i <- r | P i) (E i : R^c) = \prod_(i <- rev r | P i) E i.
-Proof.
-elim: r => [|x r IHr]; first by rewrite !big_nil.
-rewrite big_cons rev_cons big_rcons /= {}IHr.
-by case: (P x); rewrite ?mulr1.
-Qed.
-
+Proof. by rewrite rev_big_rev. Qed.
 
 Section SemiRightRegular.
 
@@ -2949,18 +2943,15 @@ Arguments invrK {R}.
 Arguments invr_inj {R} [x1 x2].
 Arguments telescope_prodr_eq {R n m} f u.
 
-
 Lemma rev_prodrV (R : unitRingType)
   (I : Type) (r : seq I) (P : pred I) (E : I -> R) :
   (forall i, P i -> E i \is a GRing.unit) ->
   \prod_(i <- r | P i) (E i)^-1 = ((\prod_(i <- r | P i) (E i : R^c))^-1).
 Proof.
-move=> Eunit.
-have := unitr_prod r (Eunit : forall i, P i -> (E i : R^c) \is a GRing.unit).
-elim/big_rec2: _ => [|i x y Pi]; first by rewrite invr1.
-by rewrite unitrMr ?Eunit// => + yunit => ->//; rewrite invrM// ?Eunit.
+move=> Eunit; symmetry.
+apply: (big_morph_in GRing.unit _ _ (unitr1 R^c) (@invrM _) (invr1 _)) Eunit.
+by move=> x y xunit; rewrite unitrMr.
 Qed.
-
 
 Section UnitRingClosedPredicates.
 
@@ -3096,20 +3087,15 @@ Lemma unitr_prodP (I : eqType) (r : seq I) (P : pred I) (E : I -> R) :
   reflect {in r, forall i, P i -> E i \is a GRing.unit}
     (\prod_(i <- r | P i) E i \is a GRing.unit).
 Proof.
-apply (iffP idP); last exact: unitr_prod_in.
-elim: r => [|r0 r IHr] //; rewrite big_cons.
-case: (boolP (P r0)) => [Pr0 | /negbTE nPr0].
-  rewrite unitrM => /andP[unitEr0 {}/IHr unitr].
-  by move=> i /[!inE]/orP[/eqP->{i} // | ]; last exact: unitr.
-by move=> {}/IHr unitr i /[!inE]/orP[/eqP->{i} // /[!nPr0]|]; last exact: unitr.
+rewrite (big_morph [in unit] unitrM (@unitr1 _) ) big_all_cond.
+exact: 'all_implyP.
 Qed.
 
 Lemma prodrV (I : eqType) (r : seq I) (P : pred I) (E : I -> R) :
   (forall i, P i -> E i \is a GRing.unit) ->
   \prod_(i <- r | P i) (E i)^-1 = (\prod_(i <- r | P i) E i)^-1.
 Proof.
-move/rev_prodrV => ->; rewrite rev_prodr; congr _^-1 => /=.
-by apply: perm_big; rewrite perm_rev.
+by move=> /rev_prodrV->; rewrite rev_prodr (perm_big r)// perm_rev.
 Qed.
 
 (* TODO: HB.saturate *)

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -841,6 +841,22 @@ Arguments big_ind [R] K [idx op] _ _ [I r P F].
 Arguments eq_big_op [R] K [idx op] op' _ _ _ [I].
 Arguments big_endo [R] f [idx op] _ _ [I].
 
+Lemma big_morph_in (R1 R2 : Type) (Q : {pred R2}) (f : R2 -> R1)
+    (id1 : R1) (op1 : R1 -> R1 -> R1)
+    (id2 : R2) (op2 : R2 -> R2 -> R2) :
+    {in Q &, forall x y, op2 x y \in Q} ->
+    id2 \in Q ->
+    {in Q &, {morph f : x y / op2 x y >-> op1 x y}} ->
+    f id2 = id1 ->
+    forall [I : Type] (r : seq I) (P : pred I) (F : I -> R2),
+      (forall i, P i -> F i \in Q) ->
+  f (\big[op2/id2]_(i <- r | P i) F i) = \big[op1/id1]_(i <- r | P i) f (F i).
+Proof.
+move=> Qop Qid fop fid I r P F QF; elim/(big_load Q): _.
+by elim/big_rec2: _ => // j x y Pj [Qx <-]; rewrite [Q _]Qop ?fop ?QF.
+Qed.
+Arguments big_morph_in [R1 R2] Q f [id1 op1 id2 op2].
+
 Section oAC.
 
 Variables (T : Type) (op : T -> T -> T).
@@ -1826,6 +1842,14 @@ Lemma big_allpairs I1 I2 (r1 : seq I1) (r2 : seq I2) F :
     \big[*%M/1]_(i1 <- r1) \big[op/idx]_(i2 <- r2) F (i1, i2).
 Proof. exact: big_allpairs_dep. Qed.
 
+Lemma rev_big_rev I (r : seq I) P F :
+  \big[*%M/1]_(i <- rev r | P i) F i =
+  \big[(fun x y => y * x)/1]_(i <- r | P i) F i.
+Proof.
+elim: r => [|i r IHr]; rewrite ?big_nil// big_cons rev_cons big_rcons IHr.
+by case: (P i); rewrite ?mulm1.
+Qed.
+
 Lemma big_only1 (I : finType) (i : I) (P : pred I) (F : I -> R) : P i ->
     (forall j, j != i -> P j -> F j = idx) ->
   \big[op/idx]_(j | P j) F j = F i.
@@ -1991,6 +2015,12 @@ Lemma big_rem (I : eqType) r x (P : pred I) F :
     = (if P x then F x else 1) * \big[*%M/1]_(y <- rem x r | P y) F y.
 Proof.
 by move/perm_to_rem/(perm_big _)->; rewrite !(big_mkcond _ _ P) big_cons.
+Qed.
+
+Lemma big_rev I (r : seq I) P F :
+  \big[*%M/1]_(i <- rev r | P i) F i = \big[*%M/1]_(i <- r | P i) F i.
+Proof.
+by rewrite rev_big_rev; apply: eq_big_op => //= x y _ _; apply: mulmC.
 Qed.
 
 Lemma eq_big_idem (I : eqType) (r1 r2 : seq I) (P : pred I) F :

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -2020,7 +2020,7 @@ Qed.
 Lemma big_rev I (r : seq I) P F :
   \big[*%M/1]_(i <- rev r | P i) F i = \big[*%M/1]_(i <- r | P i) F i.
 Proof.
-by rewrite rev_big_rev; apply: eq_big_op => //= x y _ _; apply: mulmC.
+by rewrite rev_big_rev; apply: (eq_big_op (fun=> True)) => // *; apply: mulmC.
 Qed.
 
 Lemma eq_big_idem (I : eqType) (r1 r2 : seq I) (P : pred I) F :

--- a/mathcomp/ssreflect/seq.v
+++ b/mathcomp/ssreflect/seq.v
@@ -1196,11 +1196,6 @@ Proof. by apply: (iffP allP) => a_s x /a_s/aP. Qed.
 
 End Filters.
 
-Notation "'has_ view" := (hasPP _ (fun _ => view))
-  (at level 4, right associativity, format "''has_' view").
-Notation "'all_ view" := (allPP _ (fun _ => view))
-  (at level 4, right associativity, format "''all_' view").
-
 Section EqIn.
 
 Variables a1 a2 : pred T.
@@ -1522,6 +1517,11 @@ Proof. by move=> ?; rewrite eq_sym uniq_eqseq_pivotl//; case: eqVneq => /=. Qed.
 
 End EqSeq.
 Arguments eqseq : simpl nomatch.
+
+Notation "'has_ view" := (hasPP _ (fun _ => view))
+  (at level 4, right associativity, format "''has_' view").
+Notation "'all_ view" := (allPP _ (fun _ => view))
+  (at level 4, right associativity, format "''all_' view").
 
 Section RotIndex.
 Variables (T : eqType).


### PR DESCRIPTION
##### Add lemmas expressing the inverse of a product

This PR add a few missing lemma about products (commutative or not) in unitary ring.
The most important one is
```
Lemma prodrV (I : eqType) (r : seq I) (P : pred I) (E : I -> R) :
  (forall i, P i -> E i \is a GRing.unit) ->
  \prod_(i <- r | P i) (E i)^-1 = (\prod_(i <- r | P i) E i)^-1.
```

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

- [ ] ~added corresponding documentation in the headers~
- [x ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
