### PR TITLE
feat: Use OCaml 4.14 (not 4.13) by default for mathcomp/mathcomp-dev

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,10 @@ stages:
   - deploy
   - test
 
+variables:
+  # cf. https://hub.docker.com/r/coqorg/coq#supported-tags
+  OCAML_VERSION: "4.14-flambda"
+
 ################
 #### build stage
 ################
@@ -48,7 +52,7 @@ stages:
     - echo "${OPAM_SWITCH}"
     - echo "${COQ_VERSION}"
   script:
-    - docker build -f Dockerfile.make --pull --build-arg=coq_image="coqorg/coq:${COQ_VERSION}" -t "${IMAGE}" .
+    - docker build -f Dockerfile.make --pull --build-arg=coq_image="coqorg/coq:${COQ_VERSION}-ocaml-${OCAML_VERSION}" -t "${IMAGE}" .
   except:
     refs:
       # - /^pr-.*$/
@@ -76,7 +80,7 @@ make-coq-latest:
     - echo "${OPAM_SWITCH}"
     - echo "${CI_JOB_TOKEN}" | docker login -u "${CI_REGISTRY_USER}" --password-stdin "${CI_REGISTRY}"
   script:
-    - docker build --pull --build-arg=coq_image="coqorg/${CI_JOB_NAME//-/:}" --build-arg=compiler="${OPAM_SWITCH}" -t "${IMAGE}" .
+    - docker build --pull --build-arg=coq_image="coqorg/${CI_JOB_NAME//-/:}-ocaml-${OCAML_VERSION}" --build-arg=compiler="${OPAM_SWITCH}" -t "${IMAGE}" .
     - docker push "${IMAGE}"
     - docker logout "${CI_REGISTRY}"
   except:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG coq_image="coqorg/coq:dev"
+ARG coq_image="coqorg/coq:dev-ocaml-4.14"
 # hadolint ignore=DL3006
 FROM ${coq_image} as builder
 


### PR DESCRIPTION
##### Motivation for this change

Related: https://github.com/math-comp/docker-mathcomp/commit/779977ea94e2b62dba07ab3585cdf0cdaacd44d9

& Zulip discussion: https://coq.zulipchat.com/#narrow/channel/237662-VsCoq-devs-.26-users/topic/Installing.20vscoq-language-server.20on.20top.20of.20mathcomp.20docker/near/478113341

Cc @CohenCyril @gares FYI

After the PR merge and deployment,
we'll be able to see the metadata of https://explore.ggcr.dev/?repo=mathcomp%2Fmathcomp-dev updated (with 4.14)

##### Minimal TODO list

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
