### PR TITLE
fixes #1287 (`idempotent`)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -281,6 +281,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + lemma `orthomx_spectral_subproof`, definitions `spectralmx`, `spectral_diag
   + lemmas `spectral_unitarymx`, `spectral_unit`, `orthomx_spectralP`, `hermitian_spectral_diag_real`
 
+- in `ssrfun.v`:
+  + definitions `idempotent_op`, `idempotent_fun`
+
 ### Changed
 
 - in `seq.v`
@@ -744,6 +747,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     (use `archiRealDomainType` and `Num.ArchiRealDomain` instead, respectively)
   + structure `archiFieldType` and its HB class `Num.ArchiField`
     (use `archiRealFieldType` and `Num.ArchiRealField` instead, respectively)
+
+- in `ssrfun.v`:
+  + definition `idempotent` (is now `idempotent_op`)
 
 ### Infrastructure
 

--- a/mathcomp/algebra/polydiv.v
+++ b/mathcomp/algebra/polydiv.v
@@ -1666,7 +1666,7 @@ rewrite gcdpE size_polyC oner_eq0 /= modp1 ltnS; case: leqP.
 by rewrite gcd0p size_polyC oner_eq0.
 Qed.
 
-Lemma gcdpp : idempotent gcdp.
+Lemma gcdpp : idempotent_op gcdp.
 Proof. by move=> p; rewrite gcdpE ltnn modpp gcd0p. Qed.
 
 Lemma dvdp_gcdlr p q : (gcdp p q %| p) && (gcdp p q %| q).

--- a/mathcomp/algebra/vector.v
+++ b/mathcomp/algebra/vector.v
@@ -499,7 +499,7 @@ Proof. by rewrite /subV (sameP addsmx_idPl eqmxP) -vs2mxD; apply: vs2mxP. Qed.
 Lemma addv_idPr {U V} : reflect (U + V = V)%VS (U <= V)%VS.
 Proof. by rewrite addvC; apply: addv_idPl. Qed.
 
-Lemma addvv : idempotent addV.
+Lemma addvv : idempotent_op addV.
 Proof. by move=> U; apply/addv_idPl. Qed.
 
 Lemma add0v : left_id 0%VS addV.
@@ -591,7 +591,7 @@ Proof. by rewrite /subV(sameP capmx_idPl eqmxP) -vs2mxI; apply: vs2mxP. Qed.
 Lemma capv_idPr {U V} : reflect (U :&: V = V)%VS (V <= U)%VS.
 Proof. by rewrite capvC; apply: capv_idPl. Qed.
 
-Lemma capvv : idempotent capV.
+Lemma capvv : idempotent_op capV.
 Proof. by move=> U; apply/capv_idPl. Qed.
 
 Lemma cap0v : left_zero 0%VS capV.

--- a/mathcomp/ssreflect/bigop.v
+++ b/mathcomp/ssreflect/bigop.v
@@ -1355,7 +1355,7 @@ by case: eqP => [-> //|]; rewrite ih// big_cons; case: ifPn; case: ifPn.
 Qed.
 
 Lemma big_undup (I : eqType) (r : seq I) (P : pred I) F :
-    idempotent op ->
+    idempotent_op op ->
   \big[op/x]_(i <- undup r | P i) F i = \big[op/x]_(i <- r | P i) F i.
 Proof.
 move=> opxx; rewrite -!(big_filter _ _ _ P) filter_undup.
@@ -2024,7 +2024,7 @@ by rewrite rev_big_rev; apply: (eq_big_op (fun=> True)) => // *; apply: mulmC.
 Qed.
 
 Lemma eq_big_idem (I : eqType) (r1 r2 : seq I) (P : pred I) F :
-    idempotent *%M -> r1 =i r2 ->
+    idempotent_op *%M -> r1 =i r2 ->
   \big[*%M/1]_(i <- r1 | P i) F i = \big[*%M/1]_(i <- r2 | P i) F i.
 Proof.
 move=> idM eq_r; rewrite -big_undup // -(big_undup r2) //; apply/perm_big.
@@ -2267,7 +2267,7 @@ Proof. by move=> u v /(uniq_sub_le_big xpredT F u v); rewrite !big_filter. Qed.
 
 Section Id.
 
-Hypothesis opK : idempotent op.
+Hypothesis opK : idempotent_op op.
 
 Lemma idem_sub_le_big (I : eqType) s s' P (F : I -> R) :
     {subset s <= s'} ->

--- a/mathcomp/ssreflect/div.v
+++ b/mathcomp/ssreflect/div.v
@@ -588,7 +588,7 @@ rewrite {}IHm // subn_if_gt ltnW //=; congr gcdn.
 by rewrite -(subnK (ltnW lt_pm)) modnDr.
 Qed.
 
-Lemma gcdnn : idempotent gcdn.
+Lemma gcdnn : idempotent_op gcdn.
 Proof. by case=> // n; rewrite gcdnE modnn. Qed.
 
 Lemma gcdnC : commutative gcdn.

--- a/mathcomp/ssreflect/finset.v
+++ b/mathcomp/ssreflect/finset.v
@@ -1477,7 +1477,7 @@ by move=> /subsetP AP; apply: sub_le_big => // i; have /[!inE] := AP i.
 Qed.
 
 Lemma big_imset_idem [I J : finType] (h : I -> J) (A : pred I) F :
-    idempotent op ->
+    idempotent_op op ->
   \big[op/x]_(j in h @: A) F j = \big[op/x]_(i in A) F (h i).
 Proof.
 rewrite -!big_image => op_idem; rewrite -big_undup// -[RHS]big_undup//.
@@ -1529,7 +1529,7 @@ Lemma big_setU1 a A F : a \notin A ->
 Proof. by move=> notAa; rewrite (@big_setD1 a) ?setU11 //= setU1K. Qed.
 
 Lemma big_subset_idem_cond A B P F :
-    idempotent aop ->
+    idempotent_op aop ->
     A \subset B ->
   aop (\big[aop/idx]_(i in A | P i) F i) (\big[aop/idx]_(i in B | P i) F i)
     = \big[aop/idx]_(i in B | P i) F i.
@@ -1538,14 +1538,14 @@ by move=> idaop /setIidPr <-; rewrite (big_setIDcond B A) Monoid.mulmA /= idaop.
 Qed.
 
 Lemma big_subset_idem A B F :
-    idempotent aop ->
+    idempotent_op aop ->
     A \subset B ->
   aop (\big[aop/idx]_(i in A) F i) (\big[aop/idx]_(i in B) F i)
     = \big[aop/idx]_(i in B) F i.
 Proof. by rewrite -2!big_condT; apply: big_subset_idem_cond. Qed.
 
 Lemma big_setU_cond A B P F :
-    idempotent aop ->
+    idempotent_op aop ->
   \big[aop/idx]_(i in A :|: B | P i) F i
     = aop (\big[aop/idx]_(i in A | P i) F i) (\big[aop/idx]_(i in B | P i) F i).
 Proof.
@@ -1555,7 +1555,7 @@ by rewrite (@big_subset_idem_cond (B :&: A)) // subsetIr.
 Qed.
 
 Lemma big_setU A B F :
-    idempotent aop ->
+    idempotent_op aop ->
   \big[aop/idx]_(i in A :|: B) F i
     = aop (\big[aop/idx]_(i in A) F i) (\big[aop/idx]_(i in B) F i).
 Proof. by rewrite -3!big_condT; apply: big_setU_cond. Qed.

--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -2578,10 +2578,10 @@ Lemma min_r x y : y <= x -> min x y = y. Proof. by case: comparableP. Qed.
 Lemma max_l x y : y <= x -> max x y = x. Proof. by case: comparableP. Qed.
 Lemma max_r x y : x <= y -> max x y = y. Proof. by case: comparableP. Qed.
 
-Lemma minxx : idempotent (min : T -> T -> T).
+Lemma minxx : idempotent_op (min : T -> T -> T).
 Proof. by rewrite /min => x; rewrite ltxx. Qed.
 
-Lemma maxxx : idempotent (max : T -> T -> T).
+Lemma maxxx : idempotent_op (max : T -> T -> T).
 Proof. by rewrite /max => x; rewrite ltxx. Qed.
 
 Lemma eq_minl x y : (min x y == x) = (x <= y).
@@ -3197,7 +3197,7 @@ rewrite ![_ `&` (_ `&` _) <= _]leIxr ?(leIr, leIl) //=.
 by rewrite leIxl ?leIl // leIxl // leIr.
 Qed.
 
-Lemma meetxx : idempotent (@meet _ L).
+Lemma meetxx : idempotent_op (@meet _ L).
 Proof. by move=> x; apply/eqP; rewrite -leEmeet. Qed.
 Lemma meetAC : right_commutative (@meet _ L).
 Proof. by move=> x y z; rewrite -!meetA [X in _ `&` X]meetC. Qed.
@@ -3360,7 +3360,7 @@ Proof. exact: (@leI2 _ L^d). Qed.
 Lemma joinC : commutative (@join _ L). Proof. exact: (@meetC _ L^d). Qed.
 Lemma joinA : associative (@join _ L). Proof. exact: (@meetA _ L^d). Qed.
 
-Lemma joinxx : idempotent (@join _ L).
+Lemma joinxx : idempotent_op (@join _ L).
 Proof. exact: (@meetxx _ L^d). Qed.
 Lemma joinAC : right_commutative (@join _ L).
 Proof. exact: (@meetAC _ L^d). Qed.
@@ -4771,7 +4771,7 @@ HB.factory Record POrder_Meet_isSemilattice d T of POrder d T := {
 
 HB.builders Context d T of POrder_Meet_isSemilattice d T.
 
-Fact meetxx : idempotent meet.
+Fact meetxx : idempotent_op meet.
 Proof. by move=> x; apply/eqP; rewrite -leEmeet. Qed.
 
 Fact lexI x y z : (x <= meet y z) = (x <= y) && (x <= z).
@@ -4795,7 +4795,7 @@ HB.factory Record POrder_Join_isSemilattice d T of POrder d T := {
 
 HB.builders Context d T of POrder_Join_isSemilattice d T.
 
-Fact joinxx : idempotent join.
+Fact joinxx : idempotent_op join.
 Proof. by move=> x; apply/eqP; rewrite -leEjoin. Qed.
 
 Fact leUx x y z : (join x y <= z) = (x <= z) && (y <= z).
@@ -4844,7 +4844,7 @@ rewrite leEmeet; apply/eqP/eqP => <-.
 by rewrite joinC joinKI.
 Qed.
 
-Fact meetxx : idempotent meet.
+Fact meetxx : idempotent_op meet.
 Proof. by move=> x; apply/eqP; rewrite -leEmeet. Qed.
 
 Fact lexI x y z : (x <= meet y z) = (x <= y) && (x <= z).
@@ -4855,7 +4855,7 @@ rewrite !leEmeet; apply/eqP/andP => [<-|[/eqP<- /eqP<-]].
 by rewrite -!meetA (meetC z) -meetA (meetA y) !meetxx.
 Qed.
 
-Fact joinxx : idempotent join.
+Fact joinxx : idempotent_op join.
 Proof. by move=> x; apply/eqP; rewrite -leEjoin. Qed.
 
 Fact leUx x y z : (join x y <= z) = (x <= z) && (y <= z).
@@ -4924,7 +4924,7 @@ HB.factory Record isMeetJoinDistrLattice (d : disp_t) T of Choice T := {
   joinKI : forall y x : T, meet x (join x y) = x;
   meetKU : forall y x : T, join x (meet x y) = x;
   meetUl : left_distributive meet join;
-  meetxx : idempotent meet;
+  meetxx : idempotent_op meet;
 }.
 
 HB.builders Context d T of isMeetJoinDistrLattice d T.
@@ -5230,7 +5230,7 @@ Fact meetKU y x : join x (meet x y) = x.
 Proof. by rewrite meetE joinE meetKU. Qed.
 Fact meetUl : left_distributive meet join.
 Proof. by move=> *; rewrite !meetE !joinE meetUl. Qed.
-Fact meetxx : idempotent meet.
+Fact meetxx : idempotent_op meet.
 Proof. by move=> *; rewrite meetE meetxx. Qed.
 Fact le_def x y : x <= y = (meet x y == x).
 Proof. by rewrite meetE (eq_meetl x y). Qed.

--- a/mathcomp/ssreflect/ssrfun.v
+++ b/mathcomp/ssreflect/ssrfun.v
@@ -80,3 +80,10 @@ Proof. by move=> Ef [?|] //=; rewrite Ef. Qed.
 Lemma omapK {aT rT : Type} (f : aT -> rT) (g : rT -> aT) :
   cancel f g -> cancel (omap f) (omap g).
 Proof. by move=> fK [?|] //=; rewrite fK. Qed.
+
+Definition idempotent_op (S : Type) (op : S -> S -> S) := forall x, op x x = x.
+
+#[deprecated(since="mathcomp 2.3.0", note="use `idempotent_op` instead")]
+Notation idempotent:= idempotent_op (only parsing).
+
+Definition idempotent_fun (U : Type) (f : U -> U) := f \o f =1 f.

--- a/mathcomp/ssreflect/ssrnat.v
+++ b/mathcomp/ssreflect/ssrnat.v
@@ -746,7 +746,7 @@ Proof. by rewrite -subn_eq0 -(eqn_add2l m) addn0 -maxnE; apply: eqP. Qed.
 Lemma maxn_idPr {m n} : reflect (maxn m n = n) (m <= n).
 Proof. by rewrite maxnC; apply: maxn_idPl. Qed.
 
-Lemma maxnn : idempotent maxn.
+Lemma maxnn : idempotent_op maxn.
 Proof. by move=> n; apply/maxn_idPl. Qed.
 
 Lemma leq_max m n1 n2 : (m <= maxn n1 n2) = (m <= n1) || (m <= n2).
@@ -815,7 +815,7 @@ Qed.
 Lemma minn_idPr {m n} : reflect (minn m n = n) (m >= n).
 Proof. by rewrite minnC; apply: minn_idPl. Qed.
 
-Lemma minnn : idempotent minn.
+Lemma minnn : idempotent_op minn.
 Proof. by move=> n; apply/minn_idPl. Qed.
 
 Lemma leq_min m n1 n2 : (m <= minn n1 n2) = (m <= n1) && (m <= n2).


### PR DESCRIPTION
##### Motivation for this change

fixes #1287

We added the definition `idempotent_fun` to MathComp-Analysis
(https://github.com/math-comp/analysis/blob/b74a117092059a3ffb9be9b5e56b6013fb03e477/classical/mathcomp_extra.v#L122)
that we use in `topology_structure.v` and realize on this
occasion that `idempotent` should maybe be renamed to
`idempotent_op` for clarity, hence this PR.

Is it possible to merge for MathComp 2.3.0?

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
