### PR TITLE
Swap the order of the axioms for multiplicative

### DIFF
--- a/algebra/fraction.v
+++ b/algebra/fraction.v
@@ -292,24 +292,30 @@ Proof. exact: FracField.Ratio_numden. Qed.
 Local Notation tofrac := (@FracField.tofrac R).
 Local Notation "x %:F" := (tofrac x).
 
-Lemma tofrac_is_additive: additive tofrac.
+Lemma tofrac_is_zmod_morphism: zmod_morphism tofrac.
 Proof.
 move=> p q /=; unlock tofrac.
 rewrite -[X in _ = _ + X]pi_opp -[RHS]pi_add.
 by rewrite /addf /oppf /= !numden_Ratio ?(oner_neq0, mul1r, mulr1).
 Qed.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `tofrac_is_zmod_morphism` instead")]
+Definition tofrac_is_additive := tofrac_is_zmod_morphism.
 
-HB.instance Definition _ := GRing.isAdditive.Build R {fraction R} tofrac
-  tofrac_is_additive.
+HB.instance Definition _ := GRing.isZmodMorphism.Build R {fraction R} tofrac
+  tofrac_is_zmod_morphism.
 
-Lemma tofrac_is_multiplicative: multiplicative tofrac.
+Lemma tofrac_is_monoid_morphism: monoid_morphism tofrac.
 Proof.
-split=> [p q|//]; unlock tofrac; rewrite -[RHS]pi_mul.
+split=> [//|p q]; unlock tofrac; rewrite -[RHS]pi_mul.
 by rewrite /mulf /= !numden_Ratio ?(oner_neq0, mul1r, mulr1).
 Qed.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `tofrac_is_monoid_morphism` instead")]
+Definition tofrac_is_multiplicative := tofrac_is_monoid_morphism.
 
-HB.instance Definition _ := GRing.isMultiplicative.Build R {fraction R} tofrac
-  tofrac_is_multiplicative.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build R {fraction R} tofrac
+  tofrac_is_monoid_morphism.
 
 (* tests *)
 Lemma tofrac0 : 0%:F = 0. Proof. exact: rmorph0. Qed.

--- a/algebra/matrix.v
+++ b/algebra/matrix.v
@@ -1638,10 +1638,13 @@ Lemma summxE I r (P : pred I) (E : I -> 'M_(m, n)) i j :
   (\sum_(k <- r | P k) E k) i j = \sum_(k <- r | P k) E k i j.
 Proof. by apply: (big_morph (fun A => A i j)) => [A B|]; rewrite mxE. Qed.
 
-Lemma const_mx_is_semi_additive : semi_additive const_mx.
+Lemma const_mx_is_nmod_morphism : nmod_morphism const_mx.
 Proof. by split=> [|a b]; apply/matrixP => // i j; rewrite !mxE. Qed.
-HB.instance Definition _ := GRing.isSemiAdditive.Build V 'M[V]_(m, n) const_mx
-  const_mx_is_semi_additive.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `const_mx_is_nmod_morphism` instead")]
+Definition const_mx_is_semi_additive := const_mx_is_nmod_morphism.
+HB.instance Definition _ := GRing.isNmodMorphism.Build V 'M[V]_(m, n) const_mx
+  const_mx_is_nmod_morphism.
 
 End FixedDim.
 
@@ -1652,10 +1655,13 @@ Variables (m n p q : nat) (f : 'I_p -> 'I_q -> 'I_m) (g : 'I_p -> 'I_q -> 'I_n).
 Definition swizzle_mx k (A : 'M[V]_(m, n)) :=
   \matrix[k]_(i, j) A (f i j) (g i j).
 
-Lemma swizzle_mx_is_semi_additive k : semi_additive (swizzle_mx k).
+Lemma swizzle_mx_is_nmod_morphism k : nmod_morphism (swizzle_mx k).
 Proof. by split=> [|A B]; apply/matrixP => i j; rewrite !mxE. Qed.
-HB.instance Definition _ k := GRing.isSemiAdditive.Build 'M_(m, n) 'M_(p, q)
-  (swizzle_mx k) (swizzle_mx_is_semi_additive k).
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `swizzle_mx_is_nmod_morphism` instead")]
+Definition swizzle_mx_is_semi_additive := swizzle_mx_is_nmod_morphism.
+HB.instance Definition _ k := GRing.isNmodMorphism.Build 'M_(m, n) 'M_(p, q)
+  (swizzle_mx k) (swizzle_mx_is_nmod_morphism k).
 
 End SemiAdditive.
 
@@ -1676,8 +1682,8 @@ HB.instance Definition _ m n1 n2 := SwizzleAdd (@rsubmx V m n1 n2).
 HB.instance Definition _ m1 m2 n := SwizzleAdd (@usubmx V m1 m2 n).
 HB.instance Definition _ m1 m2 n := SwizzleAdd (@dsubmx V m1 m2 n).
 HB.instance Definition _ m n := SwizzleAdd (@vec_mx V m n).
-HB.instance Definition _ m n := GRing.isSemiAdditive.Build 'M_(m, n) 'rV_(m * n)
-  mxvec (can2_semi_additive (@vec_mxK V m n) mxvecK).
+HB.instance Definition _ m n := GRing.isNmodMorphism.Build 'M_(m, n) 'rV_(m * n)
+  mxvec (can2_nmod_morphism (@vec_mxK V m n) mxvecK).
 
 Lemma flatmx0 n : all_equal_to (0 : 'M_(0, n)).
 Proof. by move=> A; apply/matrixP=> [] []. Qed.
@@ -1952,12 +1958,15 @@ Definition diag_mx n (d : 'rV[V]_n) :=
 Lemma tr_diag_mx n (d : 'rV_n) : (diag_mx d)^T = diag_mx d.
 Proof. by apply/matrixP=> i j /[!mxE]; case: eqVneq => // ->. Qed.
 
-Lemma diag_mx_is_semi_additive n : semi_additive (@diag_mx n).
+Lemma diag_mx_is_nmod_morphism n : nmod_morphism (@diag_mx n).
 Proof.
 by split=> [|A B]; apply/matrixP => i j; rewrite !mxE ?mul0rn// mulrnDl.
 Qed.
-HB.instance Definition _ n := GRing.isSemiAdditive.Build 'rV_n 'M_n (@diag_mx n)
-  (@diag_mx_is_semi_additive n).
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `diag_mx_is_nmod_morphism` instead")]
+Definition diag_mx_is_semi_additive := diag_mx_is_nmod_morphism.
+HB.instance Definition _ n := GRing.isNmodMorphism.Build 'rV_n 'M_n (@diag_mx n)
+  (@diag_mx_is_nmod_morphism n).
 
 Lemma diag_mx_row m n (l : 'rV_n) (r : 'rV_m) :
   diag_mx (row_mx l r) = block_mx (diag_mx l) 0 0 (diag_mx r).
@@ -1997,10 +2006,13 @@ Proof. by apply/matrixP=> i j; rewrite !mxE. Qed.
 Lemma tr_scalar_mx a : (a%:M)^T = a%:M.
 Proof. by apply/matrixP=> i j; rewrite !mxE eq_sym. Qed.
 
-Lemma scalar_mx_is_semi_additive : semi_additive scalar_mx.
+Lemma scalar_mx_is_nmod_morphism : nmod_morphism scalar_mx.
 Proof. by split=> [|a b]; rewrite -!diag_const_mx ?raddf0// !raddfD. Qed.
-HB.instance Definition _ := GRing.isSemiAdditive.Build V 'M_n scalar_mx
-  scalar_mx_is_semi_additive.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `scalar_mx_is_nmod_morphism` instead")]
+Definition scalar_mx_is_semi_additive := scalar_mx_is_nmod_morphism.
+HB.instance Definition _ := GRing.isNmodMorphism.Build V 'M_n scalar_mx
+  scalar_mx_is_nmod_morphism.
 
 Definition is_scalar_mx (A : 'M[V]_n) :=
   if insub 0 is Some i then A == (A i i)%:M else true.
@@ -2055,15 +2067,18 @@ Local Notation "'\tr' A" := (mxtrace A) : ring_scope.
 Lemma mxtrace_tr A : \tr A^T = \tr A.
 Proof. by apply: eq_bigr=> i _; rewrite mxE. Qed.
 
-Lemma mxtrace_is_semi_additive : semi_additive mxtrace.
+Lemma mxtrace_is_nmod_morphism : nmod_morphism mxtrace.
 Proof.
 split=> [|A B].
 - rewrite /mxtrace; under eq_bigr => i _ do rewrite mxE.
   by rewrite big_const_idem //= addr0.
 - by rewrite -big_split /=; apply: eq_bigr => i _; rewrite mxE.
 Qed.
-HB.instance Definition _ := GRing.isSemiAdditive.Build 'M_n V mxtrace
-  mxtrace_is_semi_additive.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `mxtrace_is_nmod_morphism` instead")]
+Definition mxtrace_is_semi_additive := mxtrace_is_nmod_morphism.
+HB.instance Definition _ := GRing.isNmodMorphism.Build 'M_n V mxtrace
+  mxtrace_is_nmod_morphism.
 
 Lemma mxtrace0 : \tr 0 = 0. Proof. exact: raddf0. Qed.
 Lemma mxtraceD A B : \tr (A + B) = \tr A + \tr B. Proof. exact: raddfD. Qed.
@@ -2115,7 +2130,7 @@ Proof. by apply/matrixP=> i j; rewrite !mxE raddfD. Qed.
 Definition map_mx_sum := big_morph _ map_mxD map_mx0.
 
 HB.instance Definition _ :=
-  GRing.isSemiAdditive.Build 'M[aR]_(m, n) 'M[rR]_(m, n) (map_mx f)
+  GRing.isNmodMorphism.Build 'M[aR]_(m, n) 'M[rR]_(m, n) (map_mx f)
     (map_mx0, map_mxD).
 
 End MapNmodMatrix.
@@ -2138,11 +2153,14 @@ Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE addNr. Qed.
 HB.instance Definition _ := GRing.Nmodule_isZmodule.Build 'M[V]_(m, n)
   addNmx.
 
-Lemma const_mx_is_additive : additive const_mx.
+Lemma const_mx_is_zmod_morphism : zmod_morphism const_mx.
 Proof. by move=> a b; apply/matrixP=> i j; rewrite !mxE. Qed.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `const_mx_is_zmod_morphism` instead")]
+Definition const_mx_is_additive := const_mx_is_zmod_morphism.
 #[warning="-HB.no-new-instance"]
-HB.instance Definition _ := GRing.isAdditive.Build V 'M[V]_(m, n) const_mx
-  const_mx_is_additive.
+HB.instance Definition _ := GRing.isZmodMorphism.Build V 'M[V]_(m, n) const_mx
+  const_mx_is_zmod_morphism.
 
 End FixedDim.
 
@@ -2150,11 +2168,14 @@ Section Additive.
 
 Variables (m n p q : nat) (f : 'I_p -> 'I_q -> 'I_m) (g : 'I_p -> 'I_q -> 'I_n).
 
-Lemma swizzle_mx_is_additive k : additive (swizzle_mx f g k).
+Lemma swizzle_mx_is_zmod_morphism k : zmod_morphism (swizzle_mx f g k).
 Proof. by move=> A B; apply/matrixP=> i j; rewrite !mxE. Qed.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `swizzle_mx_is_zmod_morphism` instead")]
+Definition swizzle_mx_is_additive := swizzle_mx_is_zmod_morphism.
 #[warning="-HB.no-new-instance"]
-HB.instance Definition _ k := GRing.isAdditive.Build 'M_(m, n) 'M_(p, q)
-  (swizzle_mx f g k) (swizzle_mx_is_additive k).
+HB.instance Definition _ k := GRing.isZmodMorphism.Build 'M_(m, n) 'M_(p, q)
+  (swizzle_mx f g k) (swizzle_mx_is_zmod_morphism k).
 
 End Additive.
 
@@ -2191,8 +2212,8 @@ HB.instance Definition _ m1 m2 n := SwizzleAdd (@dsubmx V m1 m2 n).
 #[warning="-HB.no-new-instance"]
 HB.instance Definition _ m n := SwizzleAdd (@vec_mx V m n).
 #[warning="-HB.no-new-instance"]
-HB.instance Definition _ m n := GRing.isAdditive.Build 'M_(m, n) 'rV_(m * n)
-  mxvec (can2_additive (@vec_mxK V m n) mxvecK).
+HB.instance Definition _ m n := GRing.isZmodMorphism.Build 'M_(m, n) 'rV_(m * n)
+  mxvec (can2_zmod_morphism (@vec_mxK V m n) mxvecK).
 
 Ltac split_mxE := apply/matrixP=> i j; do ![rewrite mxE | case: split => ?].
 
@@ -2210,24 +2231,30 @@ Proof. by rewrite opp_col_mx !opp_row_mx. Qed.
 
 (* Diagonal matrices *)
 
-Lemma diag_mx_is_additive n : additive (@diag_mx V n).
+Lemma diag_mx_is_zmod_morphism n : zmod_morphism (@diag_mx V n).
 Proof.
 by move=>A B; apply/matrixP=>i j; rewrite !mxE mulrnBl.
 Qed.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `diag_mx_is_zmod_morphism` instead")]
+Definition diag_mx_is_additive := diag_mx_is_zmod_morphism.
 #[warning="-HB.no-new-instance"]
-HB.instance Definition _ n := GRing.isAdditive.Build 'rV_n 'M_n (@diag_mx V n)
-  (@diag_mx_is_additive n).
+HB.instance Definition _ n := GRing.isZmodMorphism.Build 'rV_n 'M_n (@diag_mx V n)
+  (@diag_mx_is_zmod_morphism n).
 
 (* Scalar matrix : a diagonal matrix with a constant on the diagonal *)
 Section ScalarMx.
 
 Variable n : nat.
 
-Lemma scalar_mx_is_additive : additive (@scalar_mx V n).
+Lemma scalar_mx_is_zmod_morphism : zmod_morphism (@scalar_mx V n).
 Proof. by move=> a b; rewrite -!diag_const_mx !raddfB. Qed.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `scalar_mx_is_zmod_morphism` instead")]
+Definition scalar_mx_is_additive := scalar_mx_is_zmod_morphism.
 #[warning="-HB.no-new-instance"]
-HB.instance Definition _ := GRing.isAdditive.Build V 'M_n scalar_mx
-  scalar_mx_is_additive.
+HB.instance Definition _ := GRing.isZmodMorphism.Build V 'M_n scalar_mx
+  scalar_mx_is_zmod_morphism.
 
 End ScalarMx.
 
@@ -2236,14 +2263,17 @@ Section Trace.
 
 Variable n : nat.
 
-Lemma mxtrace_is_additive : additive (@mxtrace V n).
+Lemma mxtrace_is_zmod_morphism : zmod_morphism (@mxtrace V n).
 Proof.
 move=>A B; rewrite -sumrN -big_split /=.
 by apply: eq_bigr=> i _; rewrite !mxE.
 Qed.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `mxtrace_is_zmod_morphism` instead")]
+Definition mxtrace_is_additive := mxtrace_is_zmod_morphism.
 #[warning="-HB.no-new-instance"]
-HB.instance Definition _ := GRing.isAdditive.Build 'M_n V (@mxtrace V n)
-  mxtrace_is_additive.
+HB.instance Definition _ := GRing.isZmodMorphism.Build 'M_n V (@mxtrace V n)
+  mxtrace_is_zmod_morphism.
 
 End Trace.
 
@@ -2264,7 +2294,7 @@ Proof. by rewrite map_mxD map_mxN. Qed.
 
 #[warning="-HB.no-new-instance"]
 HB.instance Definition _ :=
-  GRing.isAdditive.Build 'M[aR]_(m, n) 'M[rR]_(m, n) (map_mx f) map_mxB.
+  GRing.isZmodMorphism.Build 'M[aR]_(m, n) 'M[rR]_(m, n) (map_mx f) map_mxB.
 
 End MapZmodMatrix.
 
@@ -2745,10 +2775,13 @@ HB.instance Definition _ := GRing.Nmodule_isPzSemiRing.Build 'M[R]_n
 Lemma mulmxE : mulmx = *%R. Proof. by []. Qed.
 Lemma idmxE : 1%:M = 1 :> 'M_n. Proof. by []. Qed.
 
-Lemma scalar_mx_is_multiplicative : multiplicative (@scalar_mx R n).
+Lemma scalar_mx_is_monoid_morphism : monoid_morphism (@scalar_mx R n).
 Proof. by split=> //; apply: scalar_mxM. Qed.
-HB.instance Definition _ := GRing.isMultiplicative.Build R 'M_n (@scalar_mx _ n)
-  scalar_mx_is_multiplicative.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `scalar_mx_is_monoid_morphism` instead")]
+Definition scalar_mx_is_multiplicative := scalar_mx_is_monoid_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build R 'M_n (@scalar_mx _ n)
+  scalar_mx_is_monoid_morphism.
 
 End MatrixSemiRing.
 
@@ -2908,12 +2941,14 @@ Proof. by rewrite rmorph_sum; apply: eq_bigr => i _; rewrite mxE. Qed.
 
 End FixedSize.
 
-Lemma map_mx_is_multiplicative n : multiplicative (map_mx f : 'M_n -> 'M_n).
-Proof. by split; [apply: map_mxM | apply: map_mx1]. Qed.
-
+Lemma map_mx_is_monoid_morphism n : monoid_morphism (map_mx f : 'M_n -> 'M_n).
+Proof. by split; [apply: map_mx1 | apply: map_mxM]. Qed.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `map_mx_is_monoid_morphism` instead")]
+Definition map_mx_is_multiplicative := map_mx_is_monoid_morphism.
 HB.instance Definition _ n :=
-  GRing.isMultiplicative.Build 'M[aR]_n 'M[rR]_n (map_mx f)
-    (map_mx_is_multiplicative n).
+  GRing.isMonoidMorphism.Build 'M[aR]_n 'M[rR]_n (map_mx f)
+    (map_mx_is_monoid_morphism n).
 
 End MapNzSemiRingMatrix.
 
@@ -3259,7 +3294,7 @@ Proof. by rewrite mul_rV_lin !mxvecK. Qed.
 
 End LinMatrix.
 HB.instance Definition _ m n p A :=
-  GRing.isAdditive.Build 'M_(n, p) 'M_(m, p) (mulmx A) (mulmxBr A).
+  GRing.isZmodMorphism.Build 'M_(n, p) 'M_(m, p) (mulmx A) (mulmxBr A).
 
 Section Mulmxr.
 

--- a/algebra/mxpoly.v
+++ b/algebra/mxpoly.v
@@ -473,11 +473,11 @@ pose phi (A : M_RX) := \poly_(k < Msize A) \matrix_(i, j) (A i j)`_k.
 have coef_phi A i j k: (phi A)`_k i j = (A i j)`_k.
   rewrite coef_poly; case: (ltnP k _) => le_m_k; rewrite mxE // nth_default //.
   by apply: leq_trans (leq_trans (leq_bigmax i) le_m_k); apply: (leq_bigmax j).
-have phi_is_additive : additive phi.
+have phi_is_zmod_morphism : zmod_morphism phi.
   move=> A B; apply/polyP => k; apply/matrixP => i j.
   by rewrite !(coef_phi, mxE, coefD, coefN).
-have phi_is_multiplicative : multiplicative phi.
-  split=> [A B|]; apply/polyP => k; apply/matrixP => i j; last first.
+have phi_is_monoid_morphism : monoid_morphism phi.
+  split=> [|A B]; apply/polyP => k; apply/matrixP => i j.
     by rewrite coef_phi mxE coefMn !coefC; case: (k == _); rewrite ?mxE ?mul0rn.
   rewrite !coef_phi !mxE !coefM summxE coef_sum.
   pose F k1 k2 := (A i k1)`_k2 * (B k1 j)`_(k - k2).
@@ -492,8 +492,8 @@ have bij_phi: bijective phi.
     by case: leqP => // P_le_k; rewrite nth_default ?mxE.
   apply/polyP=> k; apply/matrixP=> i j; rewrite coef_phi mxE coef_poly.
   by case: leqP => // P_le_k; rewrite nth_default ?mxE.
-pose phiaM := GRing.isAdditive.Build _ _ phi phi_is_additive.
-pose phimM := GRing.isMultiplicative.Build _ _ phi phi_is_multiplicative.
+pose phiaM := GRing.isZmodMorphism.Build _ _ phi phi_is_zmod_morphism.
+pose phimM := GRing.isMonoidMorphism.Build _ _ phi phi_is_monoid_morphism.
 pose phiRM : {rmorphism _ -> _} := HB.pack phi phiaM phimM.
 exists phiRM; split=> // [p | A]; apply/polyP=> k; apply/matrixP=> i j.
   by rewrite coef_phi coef_map !mxE coefMn.

--- a/algebra/poly.v
+++ b/algebra/poly.v
@@ -636,7 +636,7 @@ Proof. exact: coef_opp_poly. Qed.
 Lemma coefB p q i : (p - q)`_i = p`_i - q`_i.
 Proof. by rewrite coefD coefN. Qed.
 
-HB.instance Definition _ i := GRing.isAdditive.Build {poly R} R (coefp i)
+HB.instance Definition _ i := GRing.isZmodMorphism.Build {poly R} R (coefp i)
   (fun p => (coefB p)^~ i).
 
 Lemma coefMn p n i : (p *+ n)`_i = p`_i *+ n.
@@ -655,7 +655,7 @@ Proof. by move=> c; apply/polyP=> [[|i]]; rewrite coefN !coefC ?oppr0. Qed.
 Lemma polyCB : {morph (@polyC R) : a b / a - b}.
 Proof. by move=> a b; rewrite polyCD polyCN. Qed.
 
-HB.instance Definition _ := GRing.isAdditive.Build R {poly R} (@polyC _) polyCB.
+HB.instance Definition _ := GRing.isZmodMorphism.Build R {poly R} (@polyC _) polyCB.
 
 Lemma polyCMn n : {morph (@polyC R) : c / c *+ n}. Proof. exact: raddfMn. Qed.
 
@@ -669,10 +669,14 @@ Proof. by rewrite /lead_coef size_polyN coefN. Qed.
 
 (* Polynomial ring structure. *)
 
-Fact polyC_multiplicative : multiplicative (@polyC R).
-Proof. by split; first apply: polyCM. Qed.
-HB.instance Definition _ := GRing.isMultiplicative.Build R {poly R} (@polyC R)
-  polyC_multiplicative.
+Fact polyC_is_monoid_morphism : monoid_morphism (@polyC R).
+Proof. by split; last apply: polyCM. Qed.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `polyC_is_monoid_morphism` instead")]
+Definition polyC_multiplicative :=
+  (fun g => (g.2, g.1)) polyC_is_monoid_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build R {poly R} (@polyC R)
+  polyC_is_monoid_morphism.
 
 Lemma polyC_exp n : {morph (@polyC R) : c / c ^+ n}. Proof. exact: rmorphXn. Qed.
 
@@ -691,14 +695,17 @@ Proof.
 by rewrite -signr_odd; case: (odd n); rewrite ?mul1r// mulN1r size_polyN.
 Qed.
 
-Fact coefp0_multiplicative : multiplicative (coefp 0 : {poly R} -> R).
+Fact coefp0_is_monoid_morphism : monoid_morphism (coefp 0 : {poly R} -> R).
 Proof.
-split=> [p q|]; last by rewrite polyCK.
+split=> [|p q]; first by rewrite polyCK.
 by rewrite [coefp 0 _]coefM big_ord_recl big_ord0 addr0.
 Qed.
-
-HB.instance Definition _ := GRing.isMultiplicative.Build {poly R} R (coefp 0)
-  coefp0_multiplicative.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `coefp0_is_monoid_morphism` instead")]
+Definition coefp0_multiplicative :=
+  (fun g => (g.2, g.1)) coefp0_is_monoid_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build {poly R} R (coefp 0)
+  coefp0_is_monoid_morphism.
 
 (* Algebra structure of polynomials. *)
 Definition scale_poly_def a (p : {poly R}) := \poly_(i < size p) (a * p`_i).
@@ -2015,10 +2022,14 @@ Lemma map_poly_comp (g : iR -> aR) p :
   map_poly (f \o g) p = map_poly f (map_poly g p).
 Proof. exact: map_poly_comp_id0 (raddf0 f). Qed.
 
-Fact map_poly_is_additive : additive (map_poly f).
+Fact map_poly_is_zmod_morphism : zmod_morphism (map_poly f).
 Proof. by move=> p q; apply/polyP=> i; rewrite !(coef_map, coefB) raddfB. Qed.
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `map_poly_is_zmod_morphism` instead")]
+Definition map_poly_is_additive := map_poly_is_zmod_morphism.
 HB.instance Definition _ :=
-  GRing.isAdditive.Build {poly aR} {poly rR} (map_poly f) map_poly_is_additive.
+  GRing.isZmodMorphism.Build {poly aR} {poly rR} (map_poly f)
+    map_poly_is_zmod_morphism.
 
 Lemma map_polyC a : (a%:P)^f = (f a)%:P.
 Proof. by apply/polyP=> i; rewrite !(coef_map, coefC) -!mulrb raddfMn. Qed.
@@ -2034,17 +2045,20 @@ Implicit Types p : {poly aR}.
 
 Local Notation "p ^f" := (map_poly (GRing.RMorphism.sort f) p) : ring_scope.
 
-Fact map_poly_is_multiplicative : multiplicative (map_poly f).
+Fact map_poly_is_monoid_morphism : monoid_morphism (map_poly f).
 Proof.
-split=> [p q|]; apply/polyP=> i; last first.
+split=> [|p q]; apply/polyP=> i.
   by rewrite !(coef_map, coef1) /= rmorph_nat.
 rewrite coef_map /= !coefM /= !rmorph_sum; apply: eq_bigr => j _.
 by rewrite !coef_map rmorphM.
 Qed.
-
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `map_poly_is_monoid_morphism` instead")]
+Definition map_poly_is_multiplicative :=
+  (fun g => (g.2, g.1)) map_poly_is_monoid_morphism.
 HB.instance Definition _ :=
-  GRing.isMultiplicative.Build {poly aR} {poly rR} (map_poly f)
-    map_poly_is_multiplicative.
+  GRing.isMonoidMorphism.Build {poly aR} {poly rR} (map_poly f)
+    map_poly_is_monoid_morphism.
 
 Lemma map_polyZ c p : (c *: p)^f = f c *: p^f.
 Proof. by apply/polyP=> i; rewrite !(coef_map, coefZ) /= rmorphM. Qed.
@@ -2118,20 +2132,23 @@ Proof. by rewrite /horner_morph map_polyX hornerX. Qed.
 Fact horner_is_linear : linear_for (f \; *%R) (horner_morph cfu).
 Proof. by move=> c p q; rewrite /horner_morph linearP /= hornerD hornerZ. Qed.
 
-Fact horner_is_multiplicative : multiplicative (horner_morph cfu).
+Fact horner_is_monoid_morphism : monoid_morphism (horner_morph cfu).
 Proof.
-split=> [p q|]; last by rewrite /horner_morph rmorph1 hornerC.
+split=> [|p q]; first by rewrite /horner_morph rmorph1 hornerC.
 rewrite /horner_morph rmorphM /= hornerM_comm //.
 by apply: comm_coef_poly => i; rewrite coef_map cfu.
 Qed.
-
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `horner_is_monoid_morphism` instead")]
+Definition horner_is_multiplicative :=
+  (fun g => (g.2, g.1)) horner_is_monoid_morphism.
 HB.instance Definition _ :=
   GRing.isSemilinear.Build aR {poly aR} rR _ (horner_morph cfu)
     (GRing.semilinear_linear horner_is_linear).
 
 HB.instance Definition _ :=
-  GRing.isMultiplicative.Build {poly aR} rR (horner_morph cfu)
-    horner_is_multiplicative.
+  GRing.isMonoidMorphism.Build {poly aR} rR (horner_morph cfu)
+    horner_is_monoid_morphism.
 
 End HornerMorph.
 
@@ -2656,21 +2673,24 @@ have evalE : horner_eval x =1 horner_morph cxid.
 by move=> c p q; rewrite !evalE linearP.
 Qed.
 
-Fact horner_eval_is_multiplicative x : multiplicative (horner_eval x).
+Fact horner_eval_is_monoid_morphism x : monoid_morphism (horner_eval x).
 Proof.
 have cxid: commr_rmorph idfun x by apply: mulrC.
 have evalE : horner_eval x =1 horner_morph cxid.
   by move=> p; congr _.[x]; rewrite map_poly_id.
-by split=> [p q|]; rewrite !evalE ?rmorph1// rmorphM.
+by split=> [|p q]; rewrite !evalE ?rmorph1// rmorphM.
 Qed.
-
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `horner_eval_is_monoid_morphism` instead")]
+Definition horner_eval_is_multiplicative x :=
+  (fun g => (g.2, g.1)) (horner_eval_is_monoid_morphism x).
 HB.instance Definition _ x :=
   GRing.isSemilinear.Build R {poly R} R _ (horner_eval x)
     (GRing.semilinear_linear (horner_eval_is_linear x)).
 
 HB.instance Definition _ x :=
-  GRing.isMultiplicative.Build {poly R} R (horner_eval x)
-    (horner_eval_is_multiplicative x).
+  GRing.isMonoidMorphism.Build {poly R} R (horner_eval x)
+    (horner_eval_is_monoid_morphism x).
 
 Section HornerAlg.
 
@@ -2706,13 +2726,17 @@ Qed.
 
 End HornerAlg.
 
-Fact comp_poly_multiplicative q : multiplicative (comp_poly q).
+Fact comp_poly_is_monoid_morphism q : monoid_morphism (comp_poly q).
 Proof.
-split=> [p1 p2|]; last by rewrite comp_polyC.
+split=> [|p1 p2]; first by rewrite comp_polyC.
 by rewrite /comp_poly rmorphM hornerM_comm //; apply: mulrC.
 Qed.
-HB.instance Definition _ q := GRing.isMultiplicative.Build _ _ (comp_poly q)
-  (comp_poly_multiplicative q).
+#[deprecated(since="mathcomp 2.5.0",
+      note="use `comp_poly_is_monoid_morphism` instead")]
+Definition comp_poly_multiplicative q :=
+  (fun g => (g.2, g.1)) (comp_poly_is_monoid_morphism q).
+HB.instance Definition _ q := GRing.isMonoidMorphism.Build _ _ (comp_poly q)
+  (comp_poly_is_monoid_morphism q).
 
 Lemma comp_polyM p q r : (p * q) \Po r = (p \Po r) * (q \Po r).
 Proof. exact: rmorphM. Qed.

--- a/algebra/polyXY.v
+++ b/algebra/polyXY.v
@@ -76,11 +76,14 @@ Proof. by rewrite unlock map_polyX hornerX. Qed.
 Lemma swapXY_Y : swapXY 'Y = 'X.
 Proof. by rewrite swapXY_polyC map_polyX. Qed.
 
-Lemma swapXY_is_additive : additive swapXY.
+Lemma swapXY_is_zmod_morphism : zmod_morphism swapXY.
 Proof. by move=> u v; rewrite unlock rmorphB !hornerE. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `swapXY_is_zmod_morphism` instead")]
+Definition swapXY_is_additive := swapXY_is_zmod_morphism.
 HB.instance Definition _ :=
-  GRing.isAdditive.Build {poly {poly R}} {poly {poly R}} swapXY
-    swapXY_is_additive.
+  GRing.isZmodMorphism.Build {poly {poly R}} {poly {poly R}} swapXY
+    swapXY_is_zmod_morphism.
 
 Lemma coef_swapXY u i j : (swapXY u)`_i`_j = u`_j`_i.
 Proof.
@@ -99,17 +102,21 @@ Proof. by rewrite -swapXY_polyC swapXYK. Qed.
 Lemma swapXY_eq0 u : (swapXY u == 0) = (u == 0).
 Proof. by rewrite (inv_eq swapXYK) raddf0. Qed.
 
-Lemma swapXY_is_multiplicative : multiplicative swapXY.
+Lemma swapXY_is_monoid_morphism : monoid_morphism swapXY.
 Proof.
-split=> [u v|]; last by rewrite swapXY_polyC map_polyC.
+split=> [|u v]; first by rewrite swapXY_polyC map_polyC.
 apply/polyP=> i; apply/polyP=> j; rewrite coef_swapXY !coefM !coef_sum.
 rewrite (eq_bigr _ (fun _ _ => coefM _ _ _)) exchange_big /=.
 apply: eq_bigr => j1 _; rewrite coefM; apply: eq_bigr=> i1 _.
 by rewrite !coef_swapXY.
 Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `swapXY_is_monoid_morphism` instead")]
+Definition swapXY_is_multiplicative :=
+  (fun g => (g.2,g.1)) swapXY_is_monoid_morphism.
 HB.instance Definition _ :=
-  GRing.isMultiplicative.Build {poly {poly R}} {poly {poly R}} swapXY
-    swapXY_is_multiplicative.
+  GRing.isMonoidMorphism.Build {poly {poly R}} {poly {poly R}} swapXY
+    swapXY_is_monoid_morphism.
 
 Lemma swapXY_is_scalable : scalable_for (map_poly polyC \; *%R) swapXY.
 Proof. by move=> p u /=; rewrite -mul_polyC rmorphM /= swapXY_polyC. Qed.

--- a/algebra/qpoly.v
+++ b/algebra/qpoly.v
@@ -582,12 +582,15 @@ apply/val_eqP => /=.
 by rewrite rmodp_mulml ?rmodp_mulmr // monic_mk_monic.
 Qed.
 
-Fact in_qpoly_multiplicative : multiplicative (in_qpoly h).
-Proof. by split; [ apply: in_qpolyM | apply: in_qpoly1]. Qed.
-
+Fact in_qpoly_monoid_morphism : monoid_morphism (in_qpoly h).
+Proof. by split; [ apply: in_qpoly1 | apply: in_qpolyM]. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `in_qpoly_is_monoid_morphism` instead")]
+Definition in_qpoly_is_multiplicative :=
+  (fun g => (g.2,g.1)) in_qpoly_monoid_morphism.
 HB.instance Definition _ :=
-  GRing.isMultiplicative.Build {poly A} {poly %/ h} (in_qpoly h)
-    in_qpoly_multiplicative.
+  GRing.isMonoidMorphism.Build {poly A} {poly %/ h} (in_qpoly h)
+    in_qpoly_monoid_morphism.
 
 Lemma poly_of_qpoly_sum I (r : seq I) (P1 : pred I) (F : I -> {poly %/ h}) :
   ((\sum_(i <- r | P1 i) F i) =
@@ -637,17 +640,24 @@ have := qpolyC_proof h (a * b).
 by rewrite qualifE/= -ltnS prednK // size_mk_monic_gt0.
 Qed.
 
-Lemma qpolyC_is_additive : additive (qpolyC h).
+Lemma qpolyC_is_zmod_morphism : zmod_morphism (qpolyC h).
 Proof. by move=> x y; rewrite qpolyCD qpolyCN. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `qpolyC_is_zmod_morphism` instead")]
+Definition qpolyC_is_additive := qpolyC_is_zmod_morphism.
 
-Lemma qpolyC_is_multiplicative : multiplicative (qpolyC h).
+Lemma qpolyC_is_monoid_morphism : monoid_morphism (qpolyC h).
 Proof. by split=> // x y; rewrite qpolyCM. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `qpolyC_is_monoid_morphism` instead")]
+Definition qpolyC_is_multiplicative :=
+  (fun g => (g.2,g.1)) qpolyC_is_monoid_morphism.
 
-HB.instance Definition _ := GRing.isAdditive.Build A {poly %/ h} (qpolyC h)
-  qpolyC_is_additive.
+HB.instance Definition _ := GRing.isZmodMorphism.Build A {poly %/ h} (qpolyC h)
+  qpolyC_is_zmod_morphism.
 HB.instance Definition _ :=
-  GRing.isMultiplicative.Build A {poly %/ h} (qpolyC h)
-    qpolyC_is_multiplicative.
+  GRing.isMonoidMorphism.Build A {poly %/ h} (qpolyC h)
+    qpolyC_is_monoid_morphism.
 
 Definition qpoly_scale k (p : {poly %/ h}) : {poly %/ h} := (k *: p)%R.
 

--- a/algebra/rat.v
+++ b/algebra/rat.v
@@ -865,10 +865,10 @@ Section Linear.
 
 Implicit Types (U V : lmodType rat) (A B : lalgType rat).
 
-Lemma rat_linear U V (f : U -> V) : additive f -> scalable f.
+Lemma rat_linear U V (f : U -> V) : zmod_morphism f -> scalable f.
 Proof.
 move=> fB a u.
-pose aM := GRing.isAdditive.Build U V f fB.
+pose aM := GRing.isZmodMorphism.Build U V f fB.
 pose phi : {additive U -> V} := HB.pack f aM.
 rewrite -[f]/(phi : _ -> _) -{2}[a]divq_num_den mulrC -scalerA.
 apply: canRL (scalerK _) _; first by rewrite intr_eq0 denq_neq0.
@@ -882,7 +882,7 @@ Section InPrealField.
 
 Variable F : numFieldType.
 
-Fact ratr_is_additive : additive (@ratr F).
+Fact ratr_is_zmod_morphism : zmod_morphism (@ratr F).
 Proof.
 have injZtoQ: @injective rat int intr by apply: intr_inj.
 have nz_den x: (denq x)%:~R != 0 :> F by rewrite intr_eq0 denq_eq0.
@@ -894,22 +894,29 @@ rewrite -!(rmorphM, rmorphB); congr _%:~R; apply: injZtoQ.
 rewrite !(rmorphM, rmorphB) /= [_ - _]lock /= -lock !numqE.
 by rewrite (mulrAC y) -!mulrBl -mulrA mulrAC !mulrA.
 Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `ratr_is_additive` instead")]
+Definition ratr_is_additive := ratr_is_zmod_morphism.
 
-Fact ratr_is_multiplicative : multiplicative (@ratr F).
+Fact ratr_is_monoid_morphism : monoid_morphism (@ratr F).
 Proof.
 have injZtoQ: @injective rat int intr by apply: intr_inj.
 have nz_den x: (denq x)%:~R != 0 :> F by rewrite intr_eq0 denq_eq0.
-split=> [x y|]; last by rewrite /ratr divr1.
+split=> [|x y]; first by rewrite /ratr divr1.
 rewrite /ratr mulrC mulrAC; apply: canLR (mulKf (nz_den _)) _; rewrite !mulrA.
 do 2!apply: canRL (mulfK (nz_den _)) _; rewrite -!rmorphM; congr _%:~R.
 apply: injZtoQ; rewrite !rmorphM [x * y]lock /= !numqE -lock.
 by rewrite -!mulrA mulrA mulrCA -!mulrA (mulrCA y).
 Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `ratr_is_monoid_morphism` instead")]
+Definition ratr_is_multiplicative :=
+  (fun g => (g.2,g.1)) ratr_is_monoid_morphism.
 
-HB.instance Definition _ := GRing.isAdditive.Build rat F (@ratr F)
-  ratr_is_additive.
-HB.instance Definition _ := GRing.isMultiplicative.Build rat F (@ratr F)
-  ratr_is_multiplicative.
+HB.instance Definition _ := GRing.isZmodMorphism.Build rat F (@ratr F)
+  ratr_is_zmod_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build rat F (@ratr F)
+  ratr_is_monoid_morphism.
 
 Lemma ler_rat : {mono (@ratr F) : x y / x <= y}.
 Proof.

--- a/algebra/ring_quotient.v
+++ b/algebra/ring_quotient.v
@@ -121,10 +121,13 @@ Section PiAdditive.
 Variables (V : zmodType) (equivV : rel V) (zeroV : V).
 Variable Q : @zmodQuotType V equivV zeroV -%R +%R.
 
-Lemma pi_is_additive : additive \pi_Q.
+Lemma pi_is_zmod_morphism : zmod_morphism \pi_Q.
 Proof. by move=> x y /=; rewrite !piE. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `pi_is_monoid_morphism` instead")]
+Definition pi_is_additive := pi_is_zmod_morphism.
 
-HB.instance Definition _ := GRing.isAdditive.Build V Q \pi_Q pi_is_additive.
+HB.instance Definition _ := GRing.isZmodMorphism.Build V Q \pi_Q pi_is_zmod_morphism.
 
 End PiAdditive.
 
@@ -181,11 +184,14 @@ Variables (R : nzRingType) (equivR : rel R) (zeroR : R).
 
 Variable Q : @nzRingQuotType R equivR zeroR -%R +%R 1 *%R.
 
-Lemma pi_is_multiplicative : multiplicative \pi_Q.
+Lemma pi_is_monoid_morphism : monoid_morphism \pi_Q.
 Proof. by split; do ?move=> x y /=; rewrite !piE. Qed.
-
-HB.instance Definition _ := GRing.isMultiplicative.Build R Q \pi_Q
-  pi_is_multiplicative.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `pi_is_monoid_morphism` instead")]
+Definition pi_is_multiplicative :=
+  (fun g => (g.2,g.1)) pi_is_monoid_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build R Q \pi_Q
+  pi_is_monoid_morphism.
 
 End PiRMorphism.
 

--- a/algebra/sesquilinear.v
+++ b/algebra/sesquilinear.v
@@ -182,8 +182,8 @@ Notation "[ 'revop' revop 'of' op ]" :=
 
 HB.mixin Record isBilinear (R : nzRingType) (U U' : lmodType R) (V : zmodType)
     (s : R -> V -> V) (s' : R -> V -> V) (f : U -> U' -> V) := {
-  additivel_subproof : forall u', additive (f ^~ u') ;
-  additiver_subproof : forall u, additive (f u) ;
+  zmod_morphisml_subproof : forall u', zmod_morphism (f ^~ u') ;
+  zmod_morphismr_subproof : forall u, zmod_morphism (f u) ;
   linearl_subproof : forall u', scalable_for s (f ^~ u') ;
   linearr_subproof : forall u, scalable_for s' (f u)
 }.
@@ -206,8 +206,8 @@ HB.factory Record bilinear_isBilinear (R : nzRingType) (U U' : lmodType R)
 
 HB.builders Context R U U' V s s' f of bilinear_isBilinear R U U' V s s' f.
 HB.instance Definition _ := isBilinear.Build R U U' V s s' f
-    (fun u' => additive_linear (bilinear_subproof.1 u'))
-    (fun u => additive_linear (bilinear_subproof.2 u))
+    (fun u' => zmod_morphism_linear (bilinear_subproof.1 u'))
+    (fun u => zmod_morphism_linear (bilinear_subproof.2 u))
     (fun u' => scalable_linear (bilinear_subproof.1 u'))
     (fun u => scalable_linear (bilinear_subproof.2 u)).
 HB.end.
@@ -266,7 +266,7 @@ Export BilinearExports.
 HB.instance Definition _ (R : nzRingType) (U U' : lmodType R) (V : zmodType)
     (s : R -> V -> V) (s' : R -> V -> V)
   (f : {bilinear U -> U' -> V | s & s'}) (u : U)
-  := @GRing.isAdditive.Build U' V (f u) (@additiver_subproof _ _ _ _ _ _ f u).
+  := @GRing.isZmodMorphism.Build U' V (f u) (@zmod_morphismr_subproof _ _ _ _ _ _ f u).
 
 #[non_forgetful_inheritance]
 HB.instance Definition _ (R : nzRingType) (U U' : lmodType R) (V : zmodType)
@@ -308,7 +308,7 @@ Variable z : U.
 
 #[local, non_forgetful_inheritance, warning="-HB.no-new-instance"]
 HB.instance Definition _ :=
-  GRing.isAdditive.Build _ _ (f z) (@additiver_subproof _ _ _ _ _ _ f z).
+  GRing.isZmodMorphism.Build _ _ (f z) (@zmod_morphismr_subproof _ _ _ _ _ _ f z).
 #[local, non_forgetful_inheritance]
 HB.instance Definition _ :=
   GRing.isScalable.Build _ _ _ _ (f z) (@linearr_subproof _ _ _ _ _ _ f z).
@@ -335,7 +335,7 @@ Section GenericPropertiesl.
 Variable z : U'.
 
 HB.instance Definition _ :=
-  GRing.isAdditive.Build _ _ (applyr f z) (@additivel_subproof _ _ _ _ _ _ f z).
+  GRing.isZmodMorphism.Build _ _ (applyr f z) (@zmod_morphisml_subproof _ _ _ _ _ _ f z).
 HB.instance Definition _ :=
   GRing.isScalable.Build _ _ _ _ (applyr f z) (@linearl_subproof _ _ _ _ _ _ f z).
 
@@ -473,7 +473,7 @@ Notation "{ 'hermitian' U 'for' eps & theta }" := (@Hermitian.type _ U eps theta
 #[non_forgetful_inheritance]
 HB.instance Definition _ (R : nzRingType) (U : lmodType R)
     (eps : bool) (theta : R -> R) (f : {hermitian U for eps & theta}) (u : U) :=
-  @GRing.isAdditive.Build _ _ (f u) (@additiver_subproof _ _ _ _ _ _ f u).
+  @GRing.isZmodMorphism.Build _ _ (f u) (@zmod_morphismr_subproof _ _ _ _ _ _ f u).
 
 #[non_forgetful_inheritance]
 HB.instance Definition _ (R : nzRingType) (U : lmodType R)
@@ -731,7 +731,7 @@ Notation "{ 'dot' U 'for' theta }" := (@Dot.type _ U theta)
 #[non_forgetful_inheritance]
 HB.instance Definition _ (R : numDomainType) (U : lmodType R)
     (theta : R -> R) (f : {dot U for theta}) (u : U) :=
-  @GRing.isAdditive.Build _ _ (f u) (@additiver_subproof _ _ _ _ _ _ f u).
+  @GRing.isZmodMorphism.Build _ _ (f u) (@zmod_morphismr_subproof _ _ _ _ _ _ f u).
 
 #[non_forgetful_inheritance]
 HB.instance Definition _ (R : numDomainType) (U : lmodType R)

--- a/algebra/ssrint.v
+++ b/algebra/ssrint.v
@@ -223,7 +223,7 @@ End intZmod.
 
 HB.instance Definition _ := intZmod.Mixin.
 
-HB.instance Definition _ := GRing.isSemiAdditive.Build nat int Posz
+HB.instance Definition _ := GRing.isNmodMorphism.Build nat int Posz
   (erefl, intZmod.PoszD).
 
 Local Open Scope ring_scope.
@@ -348,8 +348,8 @@ Proof. exact: intZmod.predn_int. Qed.
 
 End intRingTheory.
 
-HB.instance Definition _ := GRing.isMultiplicative.Build nat int Posz
-  (PoszM, erefl).
+HB.instance Definition _ := GRing.isMonoidMorphism.Build nat int Posz
+  (erefl, PoszM).
 
 Module intUnitRing.
 Section intUnitRing.
@@ -607,7 +607,7 @@ Lemma mulrz_suml : forall n I r (P : pred I) (F : I -> M),
   (\sum_(i <- r | P i) F i) *~ n= \sum_(i <- r | P i) F i *~ n.
 Proof. by rewrite -/M^z; apply: scaler_sumr. Qed.
 
-HB.instance Definition _ (x : M) := GRing.isAdditive.Build int M ( *~%R x)
+HB.instance Definition _ (x : M) := GRing.isZmodMorphism.Build int M ( *~%R x)
   (@mulrzBr x).
 
 End ZintLmod.
@@ -660,10 +660,14 @@ Lemma intrB m n : (m - n)%:~R = m%:~R - n%:~R :> R. Proof. exact: mulrzBr. Qed.
 Lemma intrM m n : (m * n)%:~R = m%:~R * n%:~R :> R.
 Proof. by rewrite mulrzA -mulrzr. Qed.
 
-Lemma intmul1_is_multiplicative : multiplicative ( *~%R (1 : R)).
+Lemma intmul1_is_monoid_morphism : monoid_morphism ( *~%R (1 : R)).
 Proof. by split; move=> // x y /=; rewrite ?intrD ?mulrNz ?intrM. Qed.
-HB.instance Definition _ := GRing.isMultiplicative.Build int R ( *~%R 1)
-  intmul1_is_multiplicative.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `intmul1_is_monoid_morphism` instead")]
+Definition intmul1_is_multiplicative :=
+  (fun g => (g.2,g.1)) intmul1_is_monoid_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build int R ( *~%R 1)
+  intmul1_is_monoid_morphism.
 
 Lemma mulr2z n : n *~ 2 = n + n. Proof. exact: mulr2n. Qed.
 

--- a/algebra/ssrnum.v
+++ b/algebra/ssrnum.v
@@ -3844,17 +3844,23 @@ by rewrite conjCi -opprB mulrNN.
 Qed.
 Hint Resolve Creal_Re Creal_Im : core.
 
-Fact Re_is_additive : additive Re.
+Fact Re_is_zmod_morphism : zmod_morphism Re.
 Proof. by move=> x y; rewrite !ReE rmorphB addrACA -opprD mulrBl. Qed.
 #[export]
-HB.instance Definition _ := GRing.isAdditive.Build C C Re Re_is_additive.
+HB.instance Definition _ := GRing.isZmodMorphism.Build C C Re Re_is_zmod_morphism.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `Re_is_zmod_morphism` instead")]
+Definition Re_is_additive := Re_is_zmod_morphism.
 
-Fact Im_is_additive : additive Im.
+Fact Im_is_zmod_morphism : zmod_morphism Im.
 Proof.
 by move=> x y; rewrite !ImE rmorphB opprD addrACA -opprD mulrBr mulrBl.
 Qed.
 #[export]
-HB.instance Definition _ := GRing.isAdditive.Build C C Im Im_is_additive.
+HB.instance Definition _ := GRing.isZmodMorphism.Build C C Im Im_is_zmod_morphism.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `Im_is_zmod_morphism` instead")]
+Definition Im_is_additive := Im_is_zmod_morphism.
 
 Lemma Creal_ImP z : reflect ('Im z = 0) (z \is real).
 Proof.

--- a/character/character.v
+++ b/character/character.v
@@ -498,10 +498,13 @@ Qed.
 Definition xcfun (chi : 'CF(G)) A :=
   (gring_row A *m (\col_(i < #|G|) chi (enum_val i))) 0 0.
 
-Lemma xcfun_is_additive phi : additive (xcfun phi).
+Lemma xcfun_is_zmod_morphism phi : zmod_morphism (xcfun phi).
 Proof. by move=> A B; rewrite /xcfun [gring_row _]linearB mulmxBl !mxE. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `xcfun_is_zmod_morphism` instead")]
+Definition xcfun_is_additive := xcfun_is_zmod_morphism.
 HB.instance Definition _ phi :=
-  GRing.isAdditive.Build 'M_(gcard G) _ (xcfun phi) (xcfun_is_additive phi).
+  GRing.isZmodMorphism.Build 'M_(gcard G) _ (xcfun phi) (xcfun_is_zmod_morphism phi).
 
 Lemma xcfunZr a phi A : xcfun phi (a *: A) = a * xcfun phi A.
 Proof. by rewrite /xcfun linearZ -scalemxAl mxE. Qed.
@@ -512,13 +515,16 @@ Arguments xcfun_r A phi /.
 
 Lemma xcfun_rE A chi : xcfun_r A chi = xcfun chi A. Proof. by []. Qed.
 
-Fact xcfun_r_is_additive A : additive (xcfun_r A).
+Fact xcfun_r_is_zmod_morphism A : zmod_morphism (xcfun_r A).
 Proof.
 move=> phi psi; rewrite /= /xcfun !mxE -sumrB; apply: eq_bigr => i _.
 by rewrite !mxE !cfunE mulrBr.
 Qed.
-HB.instance Definition _ A := GRing.isAdditive.Build _ _ (xcfun_r A)
-  (xcfun_r_is_additive A).
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `xcfun_r_is_zmod_morphism` instead")]
+Definition xcfun_r_is_additive := xcfun_r_is_zmod_morphism.
+HB.instance Definition _ A := GRing.isZmodMorphism.Build _ _ (xcfun_r A)
+  (xcfun_r_is_zmod_morphism A).
 
 Lemma xcfunZl a phi A : xcfun (a *: phi) A = a * xcfun phi A.
 Proof.

--- a/character/classfun.v
+++ b/character/classfun.v
@@ -337,20 +337,27 @@ Proof. by apply/cfunP=> x; rewrite !cfunElock rmorph_nat. Qed.
 Lemma cfAutZ a phi : cfAut (a *: phi) = u a *: cfAut phi.
 Proof. by apply/cfunP=> x; rewrite !cfunE rmorphM. Qed.
 
-Lemma cfAut_is_additive : additive cfAut.
+Lemma cfAut_is_zmod_morphism : zmod_morphism cfAut.
 Proof.
 by move=> phi psi; apply/cfunP=> x; rewrite ?cfAut_cfun1i // !cfunE /= rmorphB.
 Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `cfAut_is_zmod_morphism` instead")]
+Definition cfAut_is_additive := cfAut_is_zmod_morphism.
 
-Lemma cfAut_is_multiplicative : multiplicative cfAut.
+Lemma cfAut_is_monoid_morphism : monoid_morphism cfAut.
 Proof.
-by split=> [phi psi|]; apply/cfunP=> x; rewrite ?cfAut_cfun1i // !cfunE rmorphM.
+by split=> [|phi psi]; apply/cfunP=> x; rewrite ?cfAut_cfun1i // !cfunE rmorphM.
 Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `cfAut_is_monoid_morphism` instead")]
+Definition cfAut_is_multiplicative :=
+  (fun g => (g.2,g.1)) cfAut_is_monoid_morphism.
 
-HB.instance Definition _ := GRing.isAdditive.Build classfun classfun cfAut
-  cfAut_is_additive.
-HB.instance Definition _ := GRing.isMultiplicative.Build classfun classfun cfAut
-  cfAut_is_multiplicative.
+HB.instance Definition _ := GRing.isZmodMorphism.Build classfun classfun cfAut
+  cfAut_is_zmod_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build classfun classfun cfAut
+  cfAut_is_monoid_morphism.
 
 Lemma cfAut_cfun1 : cfAut 1 = 1. Proof. exact: rmorph1. Qed.
 
@@ -882,7 +889,7 @@ Proof. by move=> Aphi /eq_cfdotl eq_dot; rewrite cfdotC eq_dot // -cfdotC. Qed.
 Lemma cfdotBr xi phi psi : '[xi, phi - psi] = '[xi, phi] - '[xi, psi].
 Proof. by rewrite !(cfdotC xi) -rmorphB cfdotBl. Qed.
 HB.instance Definition _ xi :=
-  GRing.isAdditive.Build _ _ (cfdot xi) (cfdotBr xi).
+  GRing.isZmodMorphism.Build _ _ (cfdot xi) (cfdotBr xi).
 
 Lemma cfdot0r xi : '[xi, 0] = 0. Proof. exact: raddf0. Qed.
 Lemma cfdotNr xi phi : '[xi, - phi] = - '[xi, phi].
@@ -1406,13 +1413,17 @@ apply: cfun_in_genP => x Hx; rewrite cfunElock Hx !cfun1Egen Hx.
 by case: subsetP => [-> // | _]; rewrite group1.
 Qed.
 
-Lemma cfRes_is_multiplicative : multiplicative cfRes.
+Lemma cfRes_is_monoid_morphism : monoid_morphism cfRes.
 Proof.
-split=> [phi psi|]; [apply/cfunP=> x | exact: cfRes_cfun1].
+split=> [|phi psi]; [exact: cfRes_cfun1 | apply/cfunP=> x].
 by rewrite !cfunElock mulrnAr mulrnAl -mulrnA mulnb andbb.
 Qed.
-HB.instance Definition _ := GRing.isMultiplicative.Build _ _ cfRes
-  cfRes_is_multiplicative.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `cfRes_is_monoid_morphism` instead")]
+Definition cfRes_is_multiplicative :=
+  (fun g => (g.2,g.1)) cfRes_is_monoid_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build _ _ cfRes
+  cfRes_is_monoid_morphism.
 
 End Restrict.
 
@@ -1509,13 +1520,13 @@ Qed.
 HB.instance Definition _ := GRing.isSemilinear.Build algC _ _ _ cfMorph
   (GRing.semilinear_linear cfMorph_is_linear).
 
-Fact cfMorph_is_multiplicative : multiplicative cfMorph.
+Fact cfMorph_is_monoid_morphism : monoid_morphism cfMorph.
 Proof.
-split=> [phi psi|]; [apply/cfunP=> x | exact: cfMorph_cfun1].
+split=> [|phi psi]; [exact: cfMorph_cfun1 | apply/cfunP=> x].
 by rewrite !cfunElock mulrnAr mulrnAl -mulrnA mulnb andbb.
 Qed.
-HB.instance Definition _ := GRing.isMultiplicative.Build _ _ cfMorph
-  cfMorph_is_multiplicative.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build _ _ cfMorph
+  cfMorph_is_monoid_morphism.
 
 Hypothesis sGD : G \subset D.
 
@@ -1596,18 +1607,25 @@ Qed.
 Lemma cfIsom1 phi : cfIsom phi 1%g = phi 1%g.
 Proof. by rewrite -(morph1 f) cfIsomE. Qed.
 
-Lemma cfIsom_is_additive : additive cfIsom.
+Lemma cfIsom_is_zmod_morphism : zmod_morphism cfIsom.
 Proof. rewrite unlock; exact: raddfB. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `cfIsom_is_zmod_morphism` instead")]
+Definition cfIsom_is_additive := cfIsom_is_zmod_morphism.
 
-Lemma cfIsom_is_multiplicative : multiplicative cfIsom.
-Proof. rewrite unlock; exact: (rmorphM _, rmorph1 _). Qed.
+Lemma cfIsom_is_monoid_morphism : monoid_morphism cfIsom.
+Proof. rewrite unlock; exact: (rmorph1 _, rmorphM _). Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `cfIsom_is_monoid_morphism` instead")]
+Definition cfIsom_is_multiplicative :=
+  (fun g => (g.2,g.1)) cfIsom_is_monoid_morphism.
 
 Lemma cfIsom_is_scalable : scalable cfIsom.
 Proof. rewrite unlock; exact: linearZ_LR. Qed.
 
-HB.instance Definition _ := GRing.isAdditive.Build _ _ cfIsom cfIsom_is_additive.
-HB.instance Definition _ := GRing.isMultiplicative.Build _ _ cfIsom
-  cfIsom_is_multiplicative.
+HB.instance Definition _ := GRing.isZmodMorphism.Build _ _ cfIsom cfIsom_is_zmod_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build _ _ cfIsom
+  cfIsom_is_monoid_morphism.
 HB.instance Definition _ := GRing.isScalable.Build _ _ _ _ cfIsom
   cfIsom_is_scalable.
 
@@ -1852,18 +1870,25 @@ Definition cfSdprod :=
    (cfMorph \o cfIsom (tagged (sdprod_isom defG)) : 'CF(H) -> 'CF(G)).
 Canonical cfSdprod_unlockable := [unlockable of cfSdprod].
 
-Lemma cfSdprod_is_additive : additive cfSdprod.
+Lemma cfSdprod_is_zmod_morphism : zmod_morphism cfSdprod.
 Proof. rewrite unlock; exact: raddfB. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `cfSdprod_is_zmod_morphism` instead")]
+Definition cfSdprod_is_additive := cfSdprod_is_zmod_morphism.
 
-Lemma cfSdprod_is_multiplicative : multiplicative cfSdprod.
-Proof. rewrite unlock; exact: (rmorphM _, rmorph1 _). Qed.
+Lemma cfSdprod_is_monoid_morphism : monoid_morphism cfSdprod.
+Proof. rewrite unlock; exact: (rmorph1 _, rmorphM _). Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `cfSdprod_is_monoid_morphism` instead")]
+Definition cfSdprod_is_multiplicative :=
+  (fun g => (g.2,g.1)) cfSdprod_is_monoid_morphism.
 
 Lemma cfSdprod_is_scalable : scalable cfSdprod.
 Proof. rewrite unlock; exact: linearZ_LR. Qed.
 
-HB.instance Definition _ := GRing.isAdditive.Build _ _ cfSdprod cfSdprod_is_additive.
-HB.instance Definition _ := GRing.isMultiplicative.Build _ _ cfSdprod
-  cfSdprod_is_multiplicative.
+HB.instance Definition _ := GRing.isZmodMorphism.Build _ _ cfSdprod cfSdprod_is_zmod_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build _ _ cfSdprod
+  cfSdprod_is_monoid_morphism.
 HB.instance Definition _ := GRing.isScalable.Build _ _ _ _ cfSdprod
   cfSdprod_is_scalable.
 

--- a/character/inertia.v
+++ b/character/inertia.v
@@ -137,13 +137,17 @@ Proof.
 by rewrite -cfuniG; have [/cfConjg_cfuni|/cfConjgEout] := boolP (y \in 'N(G)).
 Qed.
 
-Fact cfConjg_is_multiplicative y : multiplicative (cfConjg y : _ -> 'CF(G)).
+Fact cfConjg_is_monoid_morphism y : monoid_morphism (cfConjg y : _ -> 'CF(G)).
 Proof.
-split=> [phi psi|]; last exact: cfConjg_cfun1.
+split=> [|phi psi]; first exact: cfConjg_cfun1.
 by apply/cfunP=> x; rewrite !cfunElock.
 Qed.
-HB.instance Definition _ y := GRing.isMultiplicative.Build _ _ (cfConjg y)
-  (cfConjg_is_multiplicative y).
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `cfConjg_is_monoid_morphism` instead")]
+Definition cfConjg_is_multiplicative y :=
+  (fun g => (g.2,g.1)) (cfConjg_is_monoid_morphism y).
+HB.instance Definition _ y := GRing.isMonoidMorphism.Build _ _ (cfConjg y)
+  (cfConjg_is_monoid_morphism y).
 
 Lemma cfConjg_eq1 phi y : ((phi ^ y)%CF == 1) = (phi == 1).
 Proof. by apply: rmorph_eq1; apply: can_inj (cfConjgK y). Qed.

--- a/character/mxrepresentation.v
+++ b/character/mxrepresentation.v
@@ -5256,15 +5256,24 @@ Lemma mxval1 : mxval 1 = 1%:M. Proof. exact: mxval_gen1. Qed.
 Lemma mxvalM : {morph mxval : x y / x * y >-> x *m y}.
 Proof. exact: mxval_genM. Qed.
 
-Lemma mxval_sub : additive mxval.
+Lemma mxval_is_zmod_morphism : zmod_morphism mxval.
 Proof. by move=> x y; rewrite mxvalD mxvalN. Qed.
-#[export] HB.instance Definition _ :=
-  GRing.isAdditive.Build FA 'M[F]_n mxval mxval_sub.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `mxval_is_zmod_morphism` instead")]
+Definition mxval_sub := mxval_is_zmod_morphism.
 
-Lemma mxval_is_multiplicative : multiplicative mxval.
-Proof. by split; [apply: mxvalM | apply: mxval1]. Qed.
 #[export] HB.instance Definition _ :=
-  GRing.isMultiplicative.Build FA 'M[F]_n mxval mxval_is_multiplicative.
+  GRing.isZmodMorphism.Build FA 'M[F]_n mxval mxval_is_zmod_morphism.
+
+Lemma mxval_is_monoid_morphism : monoid_morphism mxval.
+Proof. by split; [apply: mxval1 | apply: mxvalM]. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `mxval_is_monoid_morphism` instead")]
+Definition mxval_is_multiplicative :=
+  (fun g => (g.2,g.1)) mxval_is_monoid_morphism.
+
+#[export] HB.instance Definition _ :=
+  GRing.isMonoidMorphism.Build FA 'M[F]_n mxval mxval_is_monoid_morphism.
 
 Lemma mxval_centg x : centgmx rG (mxval x).
 Proof.
@@ -5289,16 +5298,23 @@ Proof. by apply: mxval_inj; rewrite mxval_genV !mxval0 -{2}invr0. Qed.
 Lemma mxvalV : {morph mxval : x / x^-1 >-> invmx x}.
 Proof. exact: mxval_genV. Qed.
 
-Lemma gen_is_additive : additive gen.
+Lemma gen_is_zmod_morphism : zmod_morphism gen.
 Proof. by move=> x y; apply: mxval_inj; rewrite genK !rmorphB /= !genK. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `gen_is_zmod_morphism` instead")]
+Definition gen_is_additive := gen_is_zmod_morphism.
 
-Lemma gen_is_multiplicative : multiplicative gen.
+Lemma gen_is_monoid_morphism : monoid_morphism gen.
 Proof. by split=> // x y; apply: mxval_inj; rewrite genK !rmorphM /= !genK. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `gen_is_monoid_morphism` instead")]
+Definition gen_is_multiplicative :=
+  (fun g => (g.2,g.1)) gen_is_monoid_morphism.
 
-#[export] HB.instance Definition _ := GRing.isAdditive.Build F FA gen
-  gen_is_additive.
-#[export] HB.instance Definition _ := GRing.isMultiplicative.Build F FA gen
-  gen_is_multiplicative.
+#[export] HB.instance Definition _ := GRing.isZmodMorphism.Build F FA gen
+  gen_is_zmod_morphism.
+#[export] HB.instance Definition _ := GRing.isMonoidMorphism.Build F FA gen
+  gen_is_monoid_morphism.
 
 (* The generated field contains a root of the minimal polynomial (in some  *)
 (* cases we want to use the construction solely for that purpose).         *)

--- a/doc/changelog/03-renamed/1296-1first.md
+++ b/doc/changelog/03-renamed/1296-1first.md
@@ -1,0 +1,150 @@
+- in `ssralg.v`
+  + `semi_additive` -> `nmod_morphism`
+  + `isSemiAdditive` -> `isNmodMorphism`
+  + `additive` -> `zmod_morphism`
+  + `isAdditive` -> `isZmodMorphism`
+  + `multiplicative` -> `monoid_morphism`
+  + `isMultiplicative` -> `isMonoidMorphism`
+  + `can2_semi_additive` -> `can2_nmod_morphism`.
+  + `can2_additive` -> `can2_zmod_morphism`.
+  + `additive_semilinear` -> `nmod_morphism_semilinear`.
+  + `additive_linear` -> `zmod_morphism_linear`.
+  + `rmorphismMP` -> `rmorphism_monoidP`.
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `ring_quotient.v`
+  + `isRingQuotient` -> `isNzRingQuotient`
+  + `ringQuotType` -> `nzRingQuotType`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `finalg.v`
+  + `isRing` -> `isNzRing`
+  + `finSemiRingType`-> `finNzSemiRingType`
+  + `finRingType` -> `finNzRingType`
+  + `finComSemiRingType` -> `finComNzSemiRingType`
+  + `finComRingType` -> `finComNzRingType`
+  + `card_finRing_gt1` -> `card_finNzRing_gt1`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `countalg.v`
+  + `countSemiRingType`-> `countNzSemiRingType`
+  + `countRingType` -> `countNzRingType`
+  + `countComSemiRingType` -> `countComNzSemiRingType`
+  + `countComRingType` -> `countComNzRingType`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `fraction.v`
+  + `tofrac_is_additive` -> `tofrac_is_zmod_morphism`
+  + `tofrac_is_multiplicative` -> `tofrac_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `matrix.v`
+  + `const_mx_is_semi_additive` -> `const_mx_is_nmod_morphism`
+  + `swizzle_mx_is_semi_additive` -> `swizzle_mx_is_nmod_morphism`
+  + `diag_mx_is_semi_additive` -> `diag_mx_is_nmod_morphism`
+  + `scalar_mx_is_semi_additive` -> `scalar_mx_is_nmod_morphism`
+  + `mxtrace_is_semi_additive` -> `mxtrace_is_nmod_morphism`
+  + `const_mx_is_additive` -> `const_mx_is_zmod_morphism`
+  + `swizzle_mx_is_additive` -> `swizzle_mx_is_zmod_morphism`
+  + `diag_mx_is_additive` -> `diag_mx_is_zmod_morphism`
+  + `scalar_mx_is_additive` -> `scalar_mx_is_zmod_morphism`
+  + `mxtrace_is_additive` -> `mxtrace_is_zmod_morphism`
+  + `scalar_mx_is_multiplicative` -> `scalar_mx_is_monoid_morphism`
+  + `map_mx_is_multiplicative` -> `map_mx_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `poly.v`
+  + `polyC_multiplicative` -> `polyC_is_monoid_morphism`
+  + `coefp0_multiplicative` -> `coefp0_is_monoid_morphism`
+  + `map_poly_is_additive` -> `map_poly_is_zmod_morphism`
+  + `map_poly_is_multiplicative` -> `map_poly_is_monoid_morphism`
+  + `horner_is_multiplicative` -> `horner_is_monoid_morphism`
+  + `horner_eval_is_multiplicative` -> `horner_eval_is_monoid_morphism`
+  + `comp_poly_multiplicative` -> `comp_poly_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `galois.v`
+  + `kHomP` -> `kHomP_tmp`
+  + `kHom_is_additive` -> `kHom_is_zmod_morphism`
+  + `kHom_is_multiplicative` -> `kHom_is_monoid_morphism`
+  + `kHom_kHom_lrmorphism` -> `kHom_monoid_morphism`
+  + `galTrace_is_additive` -> `galTrace_is_zmod_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `falgebra.v`
+  + `amulr_is_multiplicative` -> `amulr_is_monoid_morphism`
+  + `ahomP` -> `ahomP_tmp`
+  + `hom_is_multiplicative f` -> `ahom_is_monoid_morphism f`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `polyXY.v`
+  + `swapXY_is_additive` -> `swapXY_is_zmod_morphism`
+  + `swapXY_is_multiplicative` -> `swapXY_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `qpoly.v`
+  + `in_qpoly_is_multiplicative` -> `in_qpoly_monoid_morphism`
+  + `qpolyC_is_additive` -> `qpolyC_is_zmod_morphism`
+  + `qpolyC_is_multiplicative` -> `qpolyC_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `rat.v`
+  + `ratr_is_additive` -> `ratr_is_zmod_morphism`
+  + `ratr_is_multiplicative` -> `ratr_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `ring_quotient.v`
+  + `pi_is_additive` -> `pi_is_zmod_morphism`
+  + `pi_is_multiplicative` -> `pi_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `ssrint.v`
+  + `intmul1_is_multiplicative` -> `intmul1_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `ssrnum.v`
+  + `Re_is_additive` -> `Re_is_zmod_morphism`
+  + `Im_is_additive` -> `Im_is_zmod_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `fieldext.v`
+  + `vsval_is_multiplicative K` -> `vsval_monoid_morphism`
+  + `subfx_inj_is_zmod_additive` -> `subfx_inj_is_zmod_morphism`
+  + `subfx_eval_is_zmod_additive` -> `subfx_eval_is_zmod_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `algC.v`
+  + `CtoL_is_zmod_additive` -> `CtoL_is_zmod_morphism`
+  + `CtoL_is_multiplicative` -> `CtoL_is_monoid_morphism`
+  + `conj_is_semi_additive` -> `conj_is_nmod_morphism`
+  + `conj_is_additive` -> `conj_is_zmod_morphism`
+  + `conj_is_multiplicative` -> `conj_is_monoid_morphism`
+  + `algC_invaut_is_additive` -> `algC_invaut_is_zmod_morphism`
+  + `algC_invaut_is_multiplicative nu` -> `algC_invaut_is_monoid_morphism nu`
+  + `algRval_is_additive` -> `algRval_is_zmod_morphism`
+  + `algRval_is_multiplicative` -> `algRval_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `classfun.v`
+  + `cfAut_is_additive` -> `cfAut_is_zmod_morphism`
+  + `cfAut_is_multiplicative` -> `cfAut_is_monoid_morphism`
+  + `cfRes_is_multiplicative` -> `cfRes_is_monoid_morphism`
+  + `cfIsom_is_additive` -> `cfIsom_is_zmod_morphism`
+  + `cfIsom_is_multiplicative` -> `cfIsom_is_monoid_morphism`
+  + `cfSdprod_is_additive` -> `cfSdprod_is_zmod_morphism`
+  + `cfSdprod_is_multiplicative` -> `cfSdprod_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `character.v`
+  + `xcfun_is_additive` -> `xcfun_is_zmod_morphism`
+  + `xcfun_r_is_additive` -> `xcfun_r_is_zmod_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `mxrepresentation.v`
+  + `mxval_sub` -> `mxval_is_zmod_morphism`
+  + `mxval_is_multiplicative` -> `mxval_is_monoid_morphism`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).
+
+- in `inertia.v`
+  + `cfConjg_is_multiplicative y` -> `cfConjg_is_monoid_morphism y`
+    ([#1296](https://github.com/math-comp/math-comp/pull/1296)).

--- a/field/algC.v
+++ b/field/algC.v
@@ -13,7 +13,7 @@ From mathcomp Require Import algebraics_fundamentals.
 (* filed with an automorphism of order 2; this amounts to the purely          *)
 (* algebraic contents of the Fundamenta Theorem of Algebra.                   *)
 (*       algC == the closed, countable field of algebraic numbers.            *)
-(*  algCeq, algCnzRing, ..., algCnumField == structures for algC.               *)
+(*  algCeq, algCnzRing, ..., algCnumField == structures for algC.             *)
 (* The ssrnum interfaces are implemented for algC as follows:                 *)
 (*     x <= y <=> (y - x) is a nonnegative real                               *)
 (*      x < y <=> (y - x) is a (strictly) positive real                       *)
@@ -373,10 +373,13 @@ Proof. by move=> u; apply: CtoL_inj; rewrite !LtoC_K addNr. Qed.
 
 HB.instance Definition _ := GRing.isZmodule.Build type addA addC add0 addN.
 
-Fact CtoL_is_additive : additive CtoL.
+Fact CtoL_is_zmod_morphism : zmod_morphism CtoL.
 Proof. by move=> u v; rewrite !LtoC_K. Qed.
-HB.instance Definition _ := GRing.isAdditive.Build type L' CtoL
-  CtoL_is_additive.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `CtoL_inj_is_zmod_morphism` instead")]
+Definition CtoL_is_additive := CtoL_is_zmod_morphism.
+HB.instance Definition _ := GRing.isZmodMorphism.Build type L' CtoL
+  CtoL_is_zmod_morphism.
 
 Definition one := LtoC (integral1 _).
 Definition mul u v := LtoC (integral_mul (CtoL_P u) (CtoL_P v)).
@@ -400,10 +403,14 @@ Proof. by rewrite -(inj_eq CtoL_inj) !LtoC_K oner_eq0. Qed.
 HB.instance Definition _ :=
   GRing.Zmodule_isComNzRing.Build type mulA mulC mul1 mulD one_nz.
 
-Fact CtoL_is_multiplicative : multiplicative CtoL.
-Proof. by split=> [u v|]; rewrite !LtoC_K. Qed.
-HB.instance Definition _ := GRing.isMultiplicative.Build type L' CtoL
-  CtoL_is_multiplicative.
+Fact CtoL_is_monoid_morphism : monoid_morphism CtoL.
+Proof. by split=> [|u v]; rewrite !LtoC_K. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `CtoL_is_monoid_morphism` instead")]
+Definition CtoL_is_multiplicative :=
+  (fun g => (g.2,g.1)) CtoL_is_monoid_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build type L' CtoL
+  CtoL_is_monoid_morphism.
 
 Fact mulVf u :  u != 0 -> inv u * u = 1.
 Proof.
@@ -442,25 +449,34 @@ rewrite -(fmorph_root conjL) conjL_K map_poly_id // => _ /(nthP 0)[j _ <-].
 by rewrite coef_map fmorph_rat.
 Qed.
 
-Fact conj_is_semi_additive : semi_additive (fun u => LtoC (conj_subproof u)).
+Fact conj_is_nmod_morphism : nmod_morphism (fun u => LtoC (conj_subproof u)).
 Proof.
 by split=> [|u v]; apply: CtoL_inj; rewrite LtoC_K ?raddf0// !rmorphD/= !LtoC_K.
 Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `conj_is_nmod_morphism` instead")]
+Definition conj_is_semi_additive := conj_is_nmod_morphism.
 
-Fact conj_is_additive : {morph (fun u => LtoC (conj_subproof u)) : x / - x}.
+Fact conj_is_zmod_morphism : {morph (fun u => LtoC (conj_subproof u)) : x / - x}.
 Proof. by move=> u; apply: CtoL_inj; rewrite LtoC_K !raddfN /= LtoC_K. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `CtoL_inj_is_zmod_morphism` instead")]
+Definition conj_is_additive := conj_is_zmod_morphism.
 
-Fact conj_is_multiplicative : multiplicative (fun u => LtoC (conj_subproof u)).
+Fact conj_is_monoid_morphism : monoid_morphism (fun u => LtoC (conj_subproof u)).
 Proof.
-split=> [u v|]; apply: CtoL_inj; last by rewrite !LtoC_K rmorph1.
+split=> [|u v]; apply: CtoL_inj; first by rewrite !LtoC_K rmorph1.
 by rewrite LtoC_K 3!{1}rmorphM /= !LtoC_K.
 Qed.
-
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `conj_is_monoid_morphism` instead")]
+Definition conj_is_multiplicative :=
+  (fun g => (g.2,g.1)) conj_is_monoid_morphism.
 Definition conj : {rmorphism type -> type} :=
   GRing.RMorphism.Pack
     (GRing.RMorphism.Class
-       (GRing.isSemiAdditive.Build _ _ _ conj_is_semi_additive)
-       (GRing.isMultiplicative.Build _ _ _ conj_is_multiplicative)).
+       (GRing.isNmodMorphism.Build _ _ _ conj_is_nmod_morphism)
+       (GRing.isMonoidMorphism.Build _ _ _ conj_is_monoid_morphism)).
 
 Lemma conjK : involutive conj.
 Proof. by move=> u; apply: CtoL_inj; rewrite !LtoC_K conjL_K. Qed.
@@ -905,19 +921,25 @@ Proof. by move=> x; rewrite /algC_invaut; case: algC_invaut_subproof. Qed.
 Lemma algC_autK nu : cancel nu (algC_invaut nu).
 Proof. exact: inj_can_sym (algC_invautK nu) (fmorph_inj nu). Qed.
 
-Fact algC_invaut_is_additive nu : additive (algC_invaut nu).
-Proof. exact: can2_additive (algC_autK nu) (algC_invautK nu). Qed.
+Fact algC_invaut_is_zmod_morphism nu : zmod_morphism (algC_invaut nu).
+Proof. exact: can2_zmod_morphism (algC_autK nu) (algC_invautK nu). Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `algC_invaut_is_zmod_morphism` instead")]
+Definition algC_invaut_is_additive := algC_invaut_is_zmod_morphism.
 
-Fact algC_invaut_is_rmorphism nu : multiplicative (algC_invaut nu).
-Proof. exact: can2_rmorphism (algC_autK nu) (algC_invautK nu). Qed.
+Fact algC_invaut_is_monoid_morphism nu : monoid_morphism (algC_invaut nu).
+Proof. exact: can2_monoid_morphism (algC_autK nu) (algC_invautK nu). Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `algC_invaut_is_monoid_morphism` instead")]
+Definition algC_invaut_is_multiplicative nu :=
+  (fun g => (g.2,g.1)) (algC_invaut_is_monoid_morphism nu).
+HB.instance Definition _ (nu : {rmorphism algC -> algC}) :=
+  GRing.isZmodMorphism.Build algC algC (algC_invaut nu)
+    (algC_invaut_is_zmod_morphism nu).
 
 HB.instance Definition _ (nu : {rmorphism algC -> algC}) :=
-  GRing.isAdditive.Build algC algC (algC_invaut nu)
-    (algC_invaut_is_additive nu).
-
-HB.instance Definition _ (nu : {rmorphism algC -> algC}) :=
-  GRing.isMultiplicative.Build algC algC (algC_invaut nu)
-    (algC_invaut_is_rmorphism nu).
+  GRing.isMonoidMorphism.Build algC algC (algC_invaut nu)
+    (algC_invaut_is_monoid_morphism nu).
 
 Lemma minCpoly_aut nu x : minCpoly (nu x) = minCpoly x.
 Proof.
@@ -953,12 +975,19 @@ Lemma total_algR : total (<=%O : rel (algR : porderType _)).
 Proof. by move=> x y; apply/real_leVge/valP/valP. Qed.
 HB.instance Definition _ := Order.POrder_isTotal.Build _ algR total_algR.
 
-Lemma algRval_is_additive : additive algRval. Proof. by []. Qed.
-Lemma algRval_is_multiplicative : multiplicative algRval. Proof. by []. Qed.
-HB.instance Definition _ := GRing.isAdditive.Build algR algC algRval
-  algRval_is_additive.
-HB.instance Definition _ := GRing.isMultiplicative.Build algR algC algRval
-  algRval_is_multiplicative.
+Lemma algRval_is_zmod_morphism : zmod_morphism algRval. Proof. by []. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `algRval_is_zmod_morphism` instead")]
+Definition algRval_is_additive := algRval_is_zmod_morphism.
+Lemma algRval_is_monoid_morphism : monoid_morphism algRval. Proof. by []. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `algRval_is_monoid_morphism` instead")]
+Definition algRval_is_multiplicative :=
+  (fun g => (g.2,g.1)) algRval_is_monoid_morphism.
+HB.instance Definition _ := GRing.isZmodMorphism.Build algR algC algRval
+  algRval_is_zmod_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build algR algC algRval
+  algRval_is_monoid_morphism.
 
 Definition algR_norm (x : algR) : algR := in_algR (normr_real (val x)).
 Lemma algR_ler_normD x y : algR_norm (x + y) <= (algR_norm x + algR_norm y).

--- a/field/algebraics_fundamentals.v
+++ b/field/algebraics_fundamentals.v
@@ -331,13 +331,13 @@ pose morph_ofQ x z Qxz := forall u, ofQ z (Qxz u) = ofQ x u.
 have QtoQ z x: x \in sQ z -> {Qxz : 'AHom(Q x, Q z) | morph_ofQ x z Qxz}.
   move=> z_x; pose Qxz u := inQ z (ofQ x u).
   have QxzE u: ofQ z (Qxz u) = ofQ x u by apply/inQ_K/(sQtrans x).
-  have Qxza : additive Qxz.
+  have Qxza : zmod_morphism Qxz.
     by move=> u v; apply: (canLR (ofQ_K z)); rewrite !rmorphB !QxzE.
-  have Qxzm : multiplicative Qxz.
-    by split=> [u v|]; apply: (canLR (ofQ_K z));
+  have Qxzm : monoid_morphism Qxz.
+    by split=> [|u v]; apply: (canLR (ofQ_K z));
       rewrite ?rmorph1 ?rmorphM /= ?QxzE.
-  have QxzaM := GRing.isAdditive.Build _ _ _ Qxza.
-  have QxzmM := GRing.isMultiplicative.Build _ _ _ Qxzm.
+  have QxzaM := GRing.isZmodMorphism.Build _ _ _ Qxza.
+  have QxzmM := GRing.isMonoidMorphism.Build _ _ _ Qxzm.
   have QxzlM := GRing.isScalable.Build _ _ _ _ _ (rat_linear Qxza).
   pose QxzLRM : {lrmorphism _ -> _} := HB.pack Qxz QxzaM QxzmM QxzlM.
   by exists (linfun_ahom QxzLRM) => u; rewrite lfunE QxzE.
@@ -604,12 +604,12 @@ have add_Rroot xR p c: {yR | extendsR xR yR & has_Rroot xR p c -> root_in yR p}.
   exists (HB.pack_for archiRealFieldType _ QisArchi); apply: idfun.
 have some_realC: realC.
   suffices /all_sig[f QfK] x: {a | in_alg (Q 0) a = x}.
-    have fA : additive f.
-      exact: can2_additive (inj_can_sym QfK (fmorph_inj _)) QfK.
-    have fM : multiplicative f.
-      exact: can2_rmorphism (inj_can_sym QfK (fmorph_inj _)) QfK.
-    pose faM := GRing.isAdditive.Build _ _ _ fA.
-    pose fmM := GRing.isMultiplicative.Build _ _ _ fM.
+    have fA : zmod_morphism f.
+      exact: can2_zmod_morphism (inj_can_sym QfK (fmorph_inj _)) QfK.
+    have fM : monoid_morphism f.
+      exact: can2_monoid_morphism (inj_can_sym QfK (fmorph_inj _)) QfK.
+    pose faM := GRing.isZmodMorphism.Build _ _ _ fA.
+    pose fmM := GRing.isMonoidMorphism.Build _ _ _ fM.
     pose fRM : {rmorphism _ -> _} := HB.pack f faM fmM.
     by exists 0, rat; exact: fRM.
   have /Fadjoin1_polyP/sig_eqW[q]: x \in <<1; 0>>%VS by rewrite -sQof2 rmorph0.
@@ -875,17 +875,17 @@ have conjE n z: (n_ z <= n)%N -> conj z = conj_ n z.
   move/leq_trans=> le_zn; set x := conj z; set y := conj_ n z.
   have [m [le_xm le_ym le_nm]] := maxn3 (n_ x) (n_ y) n.
   by have /conjK/=/can_in_inj := leqnn m; apply; rewrite ?conjK // le_zn.
-  have conjA : additive conj.
+  have conjA : zmod_morphism conj.
   move=> x y.
   have [m [le_xm le_ym le_xym]] := maxn3 (n_ x) (n_ y) (n_ (x - y)).
   by rewrite !(conjE m) // (inFTA m x) // (inFTA m y) -?rmorphB /conj_ ?ofQ_K.
-have conjM : multiplicative conj.
-  split=> [x y|]; last pose n1 := n_ 1.
-    have [m [le_xm le_ym le_xym]] := maxn3 (n_ x) (n_ y) (n_ (x * y)).
-    by rewrite !(conjE m) // (inFTA m x) // (inFTA m y) -?rmorphM /conj_ ?ofQ_K.
-  by rewrite /conj -/n1 -(rmorph1 (ofQ (z_ n1))) /conj_ ofQ_K !rmorph1.
-have conjaM := GRing.isAdditive.Build _ _ _ conjA.
-have conjmM := GRing.isMultiplicative.Build _ _ _ conjM.
+have conjM : monoid_morphism conj.
+  split=> [|x y]; first pose n1 := n_ 1.
+    by rewrite /conj -/n1 -(rmorph1 (ofQ (z_ n1))) /conj_ ofQ_K !rmorph1.
+  have [m [le_xm le_ym le_xym]] := maxn3 (n_ x) (n_ y) (n_ (x * y)).
+  by rewrite !(conjE m) // (inFTA m x) // (inFTA m y) -?rmorphM /conj_ ?ofQ_K.
+have conjaM := GRing.isZmodMorphism.Build _ _ _ conjA.
+have conjmM := GRing.isMonoidMorphism.Build _ _ _ conjM.
 pose conjRM : {rmorphism _ -> _} := HB.pack conj conjaM conjmM.
 exists conjRM => [z | /(_ i)/eqP/idPn[]] /=.
   by have [n [/conjE-> /(conjK (n_ z))->]] := maxn3 (n_ (conj z)) (n_ z) 0.

--- a/field/algnum.v
+++ b/field/algnum.v
@@ -211,13 +211,13 @@ Proof.
 move=> Qn_nu; pose nu0 x := sval (sig_eqW (Qn_nu x)).
 have QnC_nu0: {morph QnC : x / nu0 x >-> nu x}.
   by rewrite /nu0 => x; case: (sig_eqW _).
-have nu0a : additive nu0.
+have nu0a : zmod_morphism nu0.
   by move=> x y; apply: (fmorph_inj QnC); rewrite !(QnC_nu0, rmorphB).
-have nu0m : multiplicative nu0.
-  split=> [x y|]; apply: (fmorph_inj QnC); rewrite ?QnC_nu0 ?rmorph1 //.
+have nu0m : monoid_morphism nu0.
+  split=> [|x y]; apply: (fmorph_inj QnC); rewrite ?QnC_nu0 ?rmorph1 //.
   by rewrite !rmorphM /= !QnC_nu0.
-pose nu0aM := GRing.isAdditive.Build Qn Qn nu0 nu0a.
-pose nu0mM := GRing.isMultiplicative.Build Qn Qn nu0 nu0m.
+pose nu0aM := GRing.isZmodMorphism.Build Qn Qn nu0 nu0a.
+pose nu0mM := GRing.isMonoidMorphism.Build Qn Qn nu0 nu0m.
 pose nu0RM : {rmorphism _ -> _} := HB.pack nu0 nu0aM nu0mM.
 pose nu0lM := GRing.isScalable.Build rat Qn Qn *:%R nu0 (fmorph_numZ nu0RM).
 pose nu0LRM : {lrmorphism _ -> _} := HB.pack nu0 nu0aM nu0mM nu0lM.
@@ -371,14 +371,14 @@ have ext1 mu0 x : {mu1 | exists y, x = Sinj mu1 y
     pose in01 y := sval (in01P y).
     have Din01 y: Sinj mu0 y = QrC (in01 y) by rewrite /in01; case: (in01P y).
     pose rwM := (=^~ Din01, rmorphZ_num, rmorph1, rmorphB, rmorphM).
-    have in01a : additive in01.
+    have in01a : zmod_morphism in01.
       by move=> ? ?; apply: (fmorph_inj QrC); rewrite !rwM.
-    have in01m : multiplicative in01.
+    have in01m : monoid_morphism in01.
       by split; try move=> ? ?; apply: (fmorph_inj QrC); rewrite !rwM /= ?rwM.
     have in01l : scalable in01.
       by try move=> ? ?; apply: (fmorph_inj QrC); rewrite !rwM.
-    pose in01aM := GRing.isAdditive.Build _ _ in01 in01a.
-    pose in01mM := GRing.isMultiplicative.Build _ _ in01 in01m.
+    pose in01aM := GRing.isZmodMorphism.Build _ _ in01 in01a.
+    pose in01mM := GRing.isMonoidMorphism.Build _ _ in01 in01m.
     pose in01lM := GRing.isScalable.Build _ _  _ _ in01 in01l.
     pose in01LRM : {lrmorphism _ -> _} := HB.pack in01
       in01aM in01mM in01lM.
@@ -402,9 +402,9 @@ have ext1 mu0 x : {mu1 | exists y, x = Sinj mu1 y
     transitivity (f (lin01 y)); first by rewrite !lfunE.
     by do 4!rewrite lfunE /=; rewrite lker0_lfunK.
   have hom_f: kHom 1 (ASpace algK) f.
-    apply/kHomP; split=> [_ _ /memK[y1 ->] /memK[y2 ->] |_ /vlineP[a ->]].
-      by rewrite -rmorphM !Df !rmorphM.
-    by rewrite -(rmorph_alg in01) Df /= !rmorph_alg.
+    apply/kHomP_tmp; split=> [_ /vlineP[a ->] | _ _ /memK[y1 ->] /memK[y2 ->]].
+      by rewrite -(rmorph_alg in01) Df /= !rmorph_alg.
+    by rewrite -rmorphM !Df !rmorphM.
   pose pr := map_poly (in_alg Qr) p.
   have Qpr: pr \is a polyOver 1%VS.
     by apply/polyOverP=> i; rewrite coef_map memvZ ?memv_line.
@@ -414,7 +414,7 @@ have ext1 mu0 x : {mu1 | exists y, x = Sinj mu1 y
     rewrite Sinj_poly Dr -Drr big_map rmorph_prod /=; apply: eq_bigr => zz _.
     by rewrite map_polyXsubC.
   have [f1 aut_f1 Df1]:= kHom_extends (sub1v (ASpace algK)) hom_f Qpr splitQr.
-  pose f1mM := GRing.isMultiplicative.Build _ _ f1 (kHom_lrmorphism aut_f1).
+  pose f1mM := GRing.isMonoidMorphism.Build _ _ f1 (kHom_monoid_morphism aut_f1).
   pose nu : {lrmorphism _ -> _} := HB.pack (fun_of_lfun f1) f1mM.
   exists (SubAut Qr QrC nu) => //; exists in01 => //= y.
   by rewrite -Df -Df1 //; apply/memK; exists y.
@@ -447,19 +447,19 @@ pose le_nu (x : algC) n := (pickle x < n)%N.
 have max3 x1 x2 x3: exists n, [/\ le_nu x1 n, le_nu x2 n & le_nu x3 n].
   exists (maxn (pickle x1) (maxn (pickle x2) (pickle x3))).+1.
   by apply/and3P; rewrite /le_nu !ltnS -!geq_max.
-have nua : additive nu.
+have nua : zmod_morphism nu.
   move=> x1 x2; have [n] := max3 (x1 - x2) x1 x2.
   case=> /mem_ext[y Dx] /mem_ext[y1 Dx1] /mem_ext[y2 Dx2].
   rewrite -Dx nu_inj; rewrite -Dx1 -Dx2 -rmorphB in Dx.
   by rewrite (fmorph_inj _ Dx) !rmorphB -!nu_inj Dx1 Dx2.
-have num : multiplicative nu.
-  split=> [x1 x2|]; last by rewrite -(rmorph1 QsC) (nu_inj 0) !rmorph1.
+have num : monoid_morphism nu.
+  split=> [|x1 x2]; first by rewrite -(rmorph1 QsC) (nu_inj 0) !rmorph1.
   have [n] := max3 (x1 * x2) x1 x2.
   case=> /mem_ext[y Dx] /mem_ext[y1 Dx1] /mem_ext[y2 Dx2].
   rewrite -Dx nu_inj; rewrite -Dx1 -Dx2 -rmorphM in Dx.
   by rewrite (fmorph_inj _ Dx) !rmorphM /= -!nu_inj Dx1 Dx2.
-pose nuaM := GRing.isAdditive.Build _ _ nu nua.
-pose numM := GRing.isMultiplicative.Build _ _ nu num.
+pose nuaM := GRing.isZmodMorphism.Build _ _ nu nua.
+pose numM := GRing.isMonoidMorphism.Build _ _ nu num.
 pose nuRM : {rmorphism _ -> _} := HB.pack nu nuaM numM.
 by exists nuRM => x; rewrite /= (nu_inj 0).
 Qed.
@@ -493,9 +493,9 @@ have pzn_zk0: root (map_poly \1%VF (minPoly 1 zn)) (zn ^+ k).
   rewrite (minCpoly_cyclotomic prim_z) /cyclotomic.
   rewrite (bigD1 (Ordinal (ltn_pmod k n_gt0))) ?coprime_modl //=.
   by rewrite rootM root_XsubC prim_expr_mod ?eqxx.
-have phim : multiplicative phi.
-  by apply/kHom_lrmorphism; rewrite -genQn span_seq1 /= kHomExtendP.
-pose phimM := GRing.isMultiplicative.Build _ _ phi phim.
+have phim : monoid_morphism phi.
+  by apply/kHom_monoid_morphism; rewrite -genQn span_seq1 /= kHomExtendP.
+pose phimM := GRing.isMonoidMorphism.Build _ _ phi phim.
 pose phiRM : {rmorphism _ -> _} := HB.pack (fun_of_lfun phi) phimM.
 have [nu Dnu] := extend_algC_subfield_aut QnC phiRM.
 exists nu => _ /(prim_rootP prim_z)[i ->].

--- a/field/closed_field.v
+++ b/field/closed_field.v
@@ -876,12 +876,12 @@ have KmulV: forall x : Kring, x != 0 -> (Kinv x : Kring) * x = 1.
 have Kinv0: Kinv (FtoK 0) = FtoK 0 by rewrite -EtoK_V invr0.
 pose KfieldMixin := GRing.ComNzRing_isField.Build _ KmulV Kinv0.
 pose Kfield : fieldType := HB.pack K Kring KfieldMixin.
-have EtoKAdd i : additive (EtoK i : E i -> Kfield).
+have EtoKAdd i : zmod_morphism (EtoK i : E i -> Kfield).
   by move=> x y; rewrite EtoK_D EtoK_N.
-have EtoKMul i : multiplicative (EtoK i : E i -> Kfield).
-  by split=> [x y|]; rewrite ?EtoK_M ?EtoK_1.
-pose EtoKMa i := GRing.isAdditive.Build _ _ _ (EtoKAdd i).
-pose EtoKMm i := GRing.isMultiplicative.Build _ _ _ (EtoKMul i).
+have EtoKMul i : monoid_morphism (EtoK i : E i -> Kfield).
+  by split=> [|x y]; rewrite ?EtoK_M ?EtoK_1.
+pose EtoKMa i := GRing.isZmodMorphism.Build _ _ _ (EtoKAdd i).
+pose EtoKMm i := GRing.isMonoidMorphism.Build _ _ _ (EtoKMul i).
 pose EtoKM i : {rmorphism _ -> _} :=
   HB.pack (EtoK i : E i -> Kfield) (EtoKMa i) (EtoKMm i).
 have EtoK_E: EtoK _ = EtoKM _ by [].

--- a/field/falgebra.v
+++ b/field/falgebra.v
@@ -252,18 +252,22 @@ move=> a u v; apply/lfunP => w.
 by rewrite !lfunE /= !lfunE /= lfunE mulrDr /= scalerAr.
 Qed.
 
-Lemma amulr_is_multiplicative : multiplicative amulr.
+Lemma amulr_is_monoid_morphism : monoid_morphism amulr.
 Proof.
-split=> [x y|]; last by apply/lfunP => w; rewrite id_lfunE !lfunE /= mulr1.
+split=> [|x y]; first by apply/lfunP => w; rewrite id_lfunE !lfunE /= mulr1.
 by apply/lfunP=> w; rewrite comp_lfunE !lfunE /= mulrA.
 Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `amulr_is_monoid_morphism` instead")]
+Definition amulr_is_multiplicative :=
+  (fun p => (p.2, p.1)) amulr_is_monoid_morphism.
 
 #[hnf]
 HB.instance Definition _ := GRing.isSemilinear.Build K aT (hom aT aT) _ amulr
   (GRing.semilinear_linear amulr_is_linear).
 #[hnf]
-HB.instance Definition _ := GRing.isMultiplicative.Build aT (hom aT aT) amulr
-  amulr_is_multiplicative.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build aT (hom aT aT) amulr
+  amulr_is_monoid_morphism.
 
 Lemma lker0_amull u : u \is a GRing.unit -> lker (amull u) == 0%VS.
 Proof. by move=> Uu; apply/lker0P=> v w; rewrite !lfunE; apply: mulrI. Qed.
@@ -1017,12 +1021,16 @@ rewrite !linearZ -!scalerAr -!scalerAl 2!linearZ /=; congr (_ *: (_ *: _)).
 by apply/eqP/fM; apply: memt_nth.
 Qed.
 
-Lemma ahomP {f : 'Hom(aT, rT)} : reflect (multiplicative f) (ahom_in {:aT} f).
+Lemma ahomP_tmp {f : 'Hom(aT, rT)} : reflect (monoid_morphism f) (ahom_in {:aT} f).
 Proof.
 apply: (iffP ahom_inP) => [[fM f1] | fRM_P]; last first.
-  by split=> [x y|]; [rewrite fRM_P.1|rewrite fRM_P.2].
+  by split=> [x y|]; [rewrite fRM_P.2|rewrite fRM_P.1].
 by split=> // x y; rewrite fM ?memvf.
 Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `ahomP_tmp` instead")]
+Lemma ahomP {f : 'Hom(aT, rT)} : reflect (multiplicative f) (ahom_in {:aT} f).
+Proof. by apply: (iffP ahomP_tmp) => [][]. Qed.
 
 Structure ahom := AHom {ahval :> 'Hom(aT, rT); _ : ahom_in {:aT} ahval}.
 
@@ -1038,17 +1046,24 @@ End Class_Def.
 
 Arguments ahom_in [aT rT].
 Arguments ahom_inP {aT rT f U}.
+#[warning="-deprecated-since-mathcomp-2.5.0"]
 Arguments ahomP {aT rT f}.
+Arguments ahomP_tmp {aT rT f}.
 
 Section LRMorphism.
 
 Variables aT rT sT : falgType K.
 
-Fact ahom_is_multiplicative (f : ahom aT rT) : multiplicative f.
-Proof. by apply/ahomP; case: f. Qed.
+Fact ahom_is_monoid_morphism (f : ahom aT rT) : monoid_morphism f.
+Proof. by apply/ahomP_tmp; case: f. Qed.
 #[hnf]
 HB.instance Definition _ (f : ahom aT rT) :=
-  GRing.isMultiplicative.Build aT rT f (ahom_is_multiplicative f).
+  GRing.isMonoidMorphism.Build aT rT f (ahom_is_monoid_morphism f).
+
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `ahom_is_monoid_morphism` instead")]
+Definition ahom_is_multiplicative (f : ahom aT rT) : multiplicative f :=
+  (fun p => (p.2, p.1)) (ahom_is_monoid_morphism f).
 
 Lemma ahomWin (f : ahom aT rT) U : ahom_in U f.
 Proof.

--- a/field/fieldext.v
+++ b/field/fieldext.v
@@ -180,10 +180,14 @@ Proof. by apply/(polyOverS (subvP (sub1v _)))/polyOver1P; exists p. Qed.
 Lemma sub_adjoin1v x E : (<<1; x>> <= E)%VS = (x \in E)%VS.
 Proof. by rewrite (sameP FadjoinP andP) sub1v. Qed.
 
-Fact vsval_multiplicative K : multiplicative (vsval : subvs_of K -> L).
+Fact vsval_monoid_morphism K : monoid_morphism (vsval : subvs_of K -> L).
 Proof. by split => //=; apply: algid1. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `subfx_eval_is_monoid_morphism` instead")]
+Definition vsval_is_multiplicative K :=
+  (fun g => (g.2,g.1)) (vsval_monoid_morphism K).
 HB.instance Definition _ (K : {subfield L}) :=
-  GRing.isMultiplicative.Build (subvs_of K) L vsval (vsval_multiplicative K).
+  GRing.isMonoidMorphism.Build (subvs_of K) L vsval (vsval_monoid_morphism K).
 
 Lemma vsval_invf K (w : subvs_of K) : val w^-1 = (vsval w)^-1.
 Proof.
@@ -198,7 +202,7 @@ HB.instance Definition _ K :=
 
 HB.instance Definition _ (K : {subfield L}) :=
   GRing.isSubPzSemiRing.Build L (pred_of_vspace K) (subvs_of K)
-    (rmorphM _, rmorph1 _).
+    (rmorph1 _, rmorphM _).
 (* Note that the nzRingType structure was built in the SubFalgType
    section of falgebra.v but the SubRing structure did not stand
    there, it is thus built only here *)
@@ -1151,43 +1155,55 @@ Qed.
 HB.instance Definition _ := GRing.ComNzRing_isField.Build subFExtend
   subfx_fieldAxiom subfx_inv0.
 
-Fact subfx_inj_is_additive : additive subfx_inj.
+Fact subfx_inj_is_zmod_morphism : zmod_morphism subfx_inj.
 Proof.
 by elim/quotW => x; elim/quotW => y; rewrite !piE /iotaFz linearB rmorphB.
 Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `subfx_inj_is_zmod_morphism` instead")]
+Definition subfx_inj_is_additive := subfx_inj_is_zmod_morphism.
 
-Fact subfx_inj_is_multiplicative : multiplicative subfx_inj.
+Fact subfx_inj_is_monoid_morphism : monoid_morphism subfx_inj.
 Proof.
-split; last by rewrite piE /iotaFz poly_rV_K ?rmorph1 ?size_poly1.
+split; first by rewrite piE /iotaFz poly_rV_K ?rmorph1 ?size_poly1.
 elim/quotW=> x; elim/quotW=> y; rewrite !piE /subfx_mul_rep /iotaFz.
 by rewrite poly_rV_modp_K iotaPz_modp rmorphM.
 Qed.
-
-HB.instance Definition _ := GRing.isAdditive.Build subFExtend L subfx_inj
-  subfx_inj_is_additive.
-HB.instance Definition _ := GRing.isMultiplicative.Build subFExtend L subfx_inj
-  subfx_inj_is_multiplicative.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `subfx_inj_is_monoid_morphism` instead")]
+Definition subfx_inj_is_multiplicative :=
+  (fun g => (g.2,g.1)) subfx_inj_is_monoid_morphism.
+HB.instance Definition _ := GRing.isZmodMorphism.Build subFExtend L subfx_inj
+  subfx_inj_is_zmod_morphism.
+HB.instance Definition _ := GRing.isMonoidMorphism.Build subFExtend L subfx_inj
+  subfx_inj_is_monoid_morphism.
 
 Definition subfx_eval := lift_embed subFExtend (fun q => poly_rV (q %% p0)).
 Canonical subfx_eval_morph := PiEmbed subfx_eval.
 
 Definition subfx_root := subfx_eval 'X.
 
-Lemma subfx_eval_is_additive : additive subfx_eval.
+Lemma subfx_eval_is_zmod_morphism : zmod_morphism subfx_eval.
 Proof. by move=> x y; apply/eqP; rewrite piE -linearB modpD modNp. Qed.
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `subfx_eval_is_zmod_morphism` instead")]
+Definition subfx_eval_is_additive := subfx_eval_is_zmod_morphism.
 
-Lemma subfx_eval_is_multiplicative : multiplicative subfx_eval.
+Lemma subfx_eval_is_monoid_morphism : monoid_morphism subfx_eval.
 Proof.
-split=> [x y|]; apply/eqP; rewrite piE.
-  by rewrite /subfx_mul_rep !poly_rV_modp_K !(modp_mul, mulrC _ y).
-by rewrite modp_small // size_poly1 -subn_gt0 subn1.
+split=> [|x y]; apply/eqP; rewrite piE.
+  by rewrite modp_small // size_poly1 -subn_gt0 subn1.
+by rewrite /subfx_mul_rep !poly_rV_modp_K !(modp_mul, mulrC _ y).
 Qed.
-
+#[warning="-deprecated-since-mathcomp-2.5.0", deprecated(since="mathcomp 2.5.0",
+      note="use `subfx_eval_is_monoid_morphism` instead")]
+Definition subfx_eval_is_multiplicative :=
+  (fun g => (g.2,g.1)) subfx_eval_is_monoid_morphism.
 HB.instance Definition _ :=
-  GRing.isAdditive.Build {poly F} subFExtend subfx_eval subfx_eval_is_additive.
+  GRing.isZmodMorphism.Build {poly F} subFExtend subfx_eval subfx_eval_is_zmod_morphism.
 HB.instance Definition _ :=
-  GRing.isMultiplicative.Build {poly F} subFExtend subfx_eval
-    subfx_eval_is_multiplicative.
+  GRing.isMonoidMorphism.Build {poly F} subFExtend subfx_eval
+    subfx_eval_is_monoid_morphism.
 
 Definition inj_subfx := (subfx_eval \o polyC).
 HB.instance Definition _ := GRing.RMorphism.on inj_subfx.
@@ -1376,11 +1392,11 @@ pose feL : fieldExtType F := HB.pack vL aL cuL unitM.
 exists feL; first by rewrite dimvf; apply: mul1n.
 exists toPF.
 have tol_lin: linear toL by move=> a q1 q2; rewrite -linearP -modpZl -modpD.
-have tol_mul : multiplicative (toL : {poly F} -> aL).
-  by split=> [q r|];
+have tol_mul : monoid_morphism (toL : {poly F} -> aL).
+  by split=> [|q r];
     apply: toPinj; rewrite !toL_K // modp_mul -!(mulrC r) modp_mul.
 pose toLlM := GRing.isLinear.Build _ _ _ _ toL tol_lin.
-pose toLmM := GRing.isMultiplicative.Build _ _ _ tol_mul.
+pose toLmM := GRing.isMonoidMorphism.Build _ _ _ tol_mul.
 pose toLLRM : {lrmorphism _ -> feL} := HB.pack toL toLlM toLmM.
 by exists toLLRM.
 Qed.

--- a/field/finfield.v
+++ b/field/finfield.v
@@ -432,22 +432,22 @@ have idfP x: reflect (f x = x) (x \in 1%VS).
     rewrite /q finField_genPoly rmorph_prod big_image /=.
     by apply: eq_bigr => b _; rewrite rmorphB /= map_polyX map_polyC.
   by rewrite root_prod_XsubC => /mapP[a]; exists a.
-have fA : additive f.
+have fA : zmod_morphism f.
   rewrite /f => x y; rewrite ?exprMn ?expr1n //.
   have [p _ pcharFp] := finPcharP F; rewrite (card_pprimeChar pcharFp).
   elim: (logn _ _) => // n IHn; rewrite expnSr !exprM {}IHn.
   by rewrite -(pchar_lalg L) in pcharFp; rewrite -pFrobenius_autE rmorphB.
-have fM : multiplicative f.
-  by rewrite /f; split=> [x y|]; rewrite ?exprMn ?expr1n //.
+have fM : monoid_morphism f.
+  by rewrite /f; split=> [|x y]; rewrite ?exprMn ?expr1n //.
 have fZ: scalable f.
   move=> a x; rewrite -[in LHS]mulr_algl fM.
   by rewrite (idfP _ _) ?mulr_algl ?memvZ // memv_line.
-pose faM := GRing.isAdditive.Build _ _ f fA.
-pose fmM := GRing.isMultiplicative.Build _ _ f fM.
+pose faM := GRing.isZmodMorphism.Build _ _ f fA.
+pose fmM := GRing.isMonoidMorphism.Build _ _ f fM.
 pose flM := GRing.isScalable.Build _ _ _ _ f fZ.
 pose fLRM : {lrmorphism _ -> _} := HB.pack f faM fmM flM.
 have /kAut_to_gal[alpha galLalpha Dalpha]: kAut 1 {:L} (linfun fLRM).
-  rewrite kAutfE; apply/kHomP; split=> [x y _ _ | x /idfP]; rewrite !lfunE //=.
+  rewrite kAutfE; apply/kHomP_tmp; split=> [x /idfP | x y _ _]; rewrite !lfunE //=.
   exact: (rmorphM fLRM).
 have{} Dalpha: alpha =1 f by move=> a; rewrite -Dalpha ?memvf ?lfunE.
 suffices <-: fixedField [set alpha] = 1%AS.

--- a/field/separable.v
+++ b/field/separable.v
@@ -459,9 +459,9 @@ Variable D : 'End(L).
 
 Let Dx E := - (map_poly D (minPoly E x)).[x] / ((minPoly E x)^`()).[x].
 
-Fact extendDerivation_additive_subproof E (adjEx := Fadjoin_poly E x) :
+Fact extendDerivation_zmod_morphism_subproof E (adjEx := Fadjoin_poly E x) :
   let body y (p := adjEx y) := (map_poly D p).[x] + p^`().[x] * Dx E in
-  additive body.
+  zmod_morphism body.
 Proof.
 move: Dx => C /= u v; rewrite /adjEx.
 rewrite raddfB /= derivB -/adjEx !hornerE /= raddfB /= !hornerE.
@@ -482,8 +482,8 @@ Section DerivationLinear.
 Variable (E : {subfield L}).
 Let body (y : L) (p := Fadjoin_poly E x y) : L :=
   (map_poly D p).[x] + p^`().[x] * Dx E.
-HB.instance Definition _ := @GRing.isAdditive.Build _ _ body
-  (extendDerivation_additive_subproof E).
+HB.instance Definition _ := @GRing.isZmodMorphism.Build _ _ body
+  (extendDerivation_zmod_morphism_subproof E).
 HB.instance Definition _ := @GRing.isScalable.Build _ _ _ _ body
   (extendDerivation_scalable_subproof E).
 Let extendDerivationLinear := Eval hnf in (body : {linear _ -> _}).


### PR DESCRIPTION
##### Motivation for this change

Fixes #1289

In the two following definitions the order is reversed:
```
Definition semi_additive (U V : nmodType) (f : U -> V) : Prop :=
  (f 0 = 0) * {morph f : x y / x + y}.

Definition multiplicative (R S : semiRingType) (f : R -> S) : Prop :=
  {morph f : x y / x * y}%R * (f 1 = 1).
```
The PR fixes the second one.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
