### PR TITLE
Generalize eqfun and eqrel to dependent functions

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -359,6 +359,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 	 `Zp_mul_addl`, `Zp_inv_out`
 	 generalized from `'I_p.+1` to `'I_p`.
 
+- in `ssrfun.v`
+	+ generalized `eqfun` and `eqrel` to dependent function typesk
+
 ### Renamed
 
 - in `binomial.v`

--- a/mathcomp/ssreflect/fingraph.v
+++ b/mathcomp/ssreflect/fingraph.v
@@ -286,7 +286,7 @@ by apply: eq_card => x; rewrite !inE andbC.
 Qed.
 
 Lemma eq_root e e' : e =2 e' -> root e =1 root e'.
-Proof. by move=> eq_e x; rewrite /root (eq_pick (eq_connect eq_e x)). Qed.
+Proof. by move=> eq_e x; rewrite /root (eq_pick (@eq_connect _ _ eq_e x)). Qed.
 
 Lemma eq_roots e e' : e =2 e' -> roots e =1 roots e'.
 Proof. by move=> eq_e x; rewrite /roots (eq_root eq_e). Qed.
@@ -902,7 +902,7 @@ Proof. exact: eq_n_comp eq_fconnect. Qed.
 
 Lemma eq_finv : finv f =1 finv f'.
 Proof.
-by move=> x; rewrite /finv /order (eq_card (eq_fconnect x)) (eq_iter eq_f).
+by move=> x; rewrite /finv /order (eq_card (@eq_fconnect x)) (eq_iter eq_f).
 Qed.
 
 Lemma eq_froot : froot f =1 froot f'.
@@ -922,7 +922,7 @@ Lemma finv_inv : finv (finv f) =1 f.
 Proof. exact: (finv_eq_can (f_finv injf)). Qed.
 
 Lemma order_finv : order (finv f) =1 order f.
-Proof. by move=> x; apply: eq_card (same_fconnect_finv injf x). Qed.
+Proof. by move=> x; apply: eq_card (@same_fconnect_finv _ _ injf x). Qed.
 
 Lemma order_set_finv n : order_set (finv f) n =i order_set f n.
 Proof. by move=> x; rewrite !inE order_finv. Qed.

--- a/mathcomp/ssreflect/ssrfun.v
+++ b/mathcomp/ssreflect/ssrfun.v
@@ -19,6 +19,14 @@ Unset Printing Implicit Defensive.
 
 Open Scope function_scope.
 
+Definition eqfun (B : Type) (A : B -> Type) (f g : forall b, A b) : Prop :=
+  forall x, f x = g x.
+Definition eqrel (C : Type) (B : C -> Type) (A : forall c, B c -> Type)
+    (f g : forall c (b : B c), A c b) : Prop :=
+  forall x y, f x y = g x y.
+
+Global Typeclasses Opaque eqfun eqrel.
+
 Notation "f ^~ y" := (fun x => f x y) : function_scope.
 Notation "@^~ x" := (fun f => f x) : function_scope.
 


### PR DESCRIPTION
##### Motivation for this change

Generalizes eqfun and eqrel to dependent functions (which will be useful when we will want and be able to put instances on dependent function types). This changes the implicit arguments of `_ =2 _` since now, in `(f =2 g) x y`, `x` appears in the type of `y`.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
