### PR TITLE
Rename semirings and rings to nzSemirings and nzRings

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -20,6 +20,56 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Renamed
 
+- in `ssralg.v`
+	+ `Nmodule_isSemiRing` -> `Nmodule_isNzSemiRing`
+	+ `isSemiRing` -> `isNzSemiRing`
+	+ `Zmodule_isRing` -> `Zmodule_isNzRing`
+	+ `isRing` -> `isNzRing`
+	+ `SemiRing_hasCommutativeMul` -> `SemiRing_hasCommutativeMul`
+	+ `Nmodule_isComSemiRing` -> `Nmodule_isComNzSemiRing`
+	+ `Ring_hasCommutativeMul` -> `NzRing_hasCommutativeMul`
+	+ `Zmodule_isComRing` -> `Zmodule_isComNzRing`
+	+ `Ring_hasMulInverse` -> `NzRing_hasMulInverse`
+	+ `ComRing_hasMulInverse` -> `ComNzRing_hasMulInverse`
+	+ `ComRing_isField` -> `ComNzRing_isField`
+	+ `isSubSemiRing` -> `isSubNzSemiRing`
+	+ `SubNmodule_isSubSemiRing` -> `SubNmodule_isSubNzSemiRing`
+	+ `SubSemiRing_isSubComSemiRing` -> `SubNzSemiRing_isSubComNzSemiRing`
+	+ `SubZmodule_isSubRing` -> `SubZmodule_isSubNzRing`
+	+ `SubRing_isSubComRing` -> `SubNzRing_isSubComNzRing`
+	+ `SubRing_SubLmodule_isSubLalgebra` -> `SubNzRing_SubLmodule_isSubLalgebra`
+	+ `SubChoice_isSubSemiRing` -> `SubChoice_isSubNzSemiRing`
+	+ `SubChoice_isSubComSemiRing` -> `SubChoice_isSubComNzSemiRing`
+	+ `SubChoice_isSubRing` -> `SubChoice_isSubNzRing`
+	+ `SubChoice_isSubComRing` -> `SubChoice_isSubComNzRing`
+	+ `semiRingType` -> `nzSemiRingType`
+	+ `ringType` -> `nzRingType`
+	+ `comSemiRingType` -> `comNzSemiRingType`
+	+ `comRingType` -> `comNzRingType`
+	+ `subSemiRingType` -> `subNzSemiRingType`
+	+ `subComSemiRingType` -> `subComNzSemiRingType`
+	+ `subRingType` -> `nzSubRingType`
+	+ ``subComNzRingType` -> `subComNzRingType`
+
+- in `ring_quotient.v`
+	+ `isRingQuotient` -> `isNzRingQuotient`
+	+ `ringQuotType` -> `nzRingQuotType`
+
+- in `finalg.v`
+	+ `isRing` -> `isNzRing`
+	+ `finSemiRingType`-> `finNzSemiRingType`
+	+ `finRingType` -> `finNzRingType`
+	+ `finComSemiRingType` -> `finComNzSemiRingType`
+	+ `finComRingType` -> `finComNzRingType`
+	+ `card_finRing_gt1` -> `card_finNzRing_gt1`
+
+- in `countalg.v`
+	+ `countSemiRingType`-> `countNzSemiRingType`
+	+ `countRingType` -> `countNzRingType`
+	+ `countComSemiRingType` -> `countComNzSemiRingType`
+	+ `countComRingType` -> `countComNzRingType`
+
+
 ### Removed
 
 ### Deprecated

--- a/mathcomp/algebra/countalg.v
+++ b/mathcomp/algebra/countalg.v
@@ -11,10 +11,10 @@ From mathcomp Require Import fintype bigop ssralg.
 (* not cover the left module / algebra interfaces, providing only            *)
 (*          countNmodType == countable nmodType interface                    *)
 (*          countZmodType == countable zmodType interface                    *)
-(*      countSemiRingType == countable semiRingType interface                *)
-(*          countRingType == countable ringType interface                    *)
-(*   countComSemiRingType == countable comSemiRingType interface             *)
-(*       countComRingType == countable comRingType interface                 *)
+(*    countNzSemiRingType == countable nzSemiRingType interface              *)
+(*        countNzRingType == countable nzRingType interface                  *)
+(* countComNzSemiRingType == countable comNzSemiRingType interface           *)
+(*     countComNzRingType == countable comNzRingType interface               *)
 (*      countUnitRingType == countable unitRingType interface                *)
 (*   countComUnitRingType == countable comUnitRingType interface             *)
 (*       countIdomainType == countable idomainType interface                 *)
@@ -43,17 +43,82 @@ HB.structure Definition Nmodule := {M of GRing.Nmodule M & Countable M}.
 #[short(type="countZmodType")]
 HB.structure Definition Zmodule := {M of GRing.Zmodule M & Countable M}.
 
-#[short(type="countSemiRingType")]
-HB.structure Definition SemiRing := {R of GRing.SemiRing R & Countable R}.
+#[short(type="countNzSemiRingType")]
+HB.structure Definition NzSemiRing := {R of GRing.NzSemiRing R & Countable R}.
 
-#[short(type="countRingType")]
-HB.structure Definition Ring := {R of GRing.Ring R & Countable R}.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use CountNzSemiRing  instead.")]
+Notation SemiRing R := (NzSemiRing R) (only parsing).
 
-#[short(type="countComSemiRingType")]
-HB.structure Definition ComSemiRing := {R of GRing.ComSemiRing R & Countable R}.
+Module SemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing.sort instead.")]
+Notation sort := (NzSemiRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing.on instead.")]
+Notation on R := (NzSemiRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing.copy instead.")]
+Notation copy T U := (NzSemiRing.copy T U) (only parsing).
+End SemiRing.
 
-#[short(type="countComRingType")]
-HB.structure Definition ComRing := {R of GRing.ComRing R & Countable R}.
+#[short(type="countNzRingType")]
+HB.structure Definition NzRing := {R of GRing.NzRing R & Countable R}.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use CountNzRing  instead.")]
+Notation Ring R := (NzRing R) (only parsing).
+
+Module Ring.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing.sort instead.")]
+Notation sort := (NzRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing.on instead.")]
+Notation on R := (NzRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing.copy instead.")]
+Notation copy T U := (NzRing.copy T U) (only parsing).
+End Ring.
+
+#[short(type="countComNzSemiRingType")]
+HB.structure Definition ComNzSemiRing :=
+  {R of GRing.ComNzSemiRing R & Countable R}.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use CountComNzSemiRing  instead.")]
+Notation ComSemiRing R := (ComNzSemiRing R) (only parsing).
+
+Module ComSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzSemiRing.sort instead.")]
+Notation sort := (ComNzSemiRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzSemiRing.on instead.")]
+Notation on R := (ComNzSemiRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzSemiRing.copy instead.")]
+Notation copy T U := (ComNzSemiRing.copy T U) (only parsing).
+End ComSemiRing.
+
+#[short(type="countComNzRingType")]
+HB.structure Definition ComNzRing := {R of GRing.ComNzRing R & Countable R}.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use CountComNzRing  instead.")]
+Notation ComRing R := (ComNzRing R) (only parsing).
+
+Module ComRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing.sort instead.")]
+Notation sort := (ComNzRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing.on instead.")]
+Notation on R := (ComNzRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing.copy instead.")]
+Notation copy T U := (ComNzRing.copy T U) (only parsing).
+End ComRing.
 
 #[short(type="countUnitRingType")]
 HB.structure Definition UnitRing := {R of GRing.UnitRing R & Countable R}.
@@ -80,11 +145,24 @@ HB.instance Definition _ (R : countNmodType) := Nmodule.on R^o.
 #[export]
 HB.instance Definition _ (R : countZmodType) := Zmodule.on R^o.
 #[export]
-HB.instance Definition _ (R : countSemiRingType) := SemiRing.on R^o.
+HB.instance Definition _ (R : countNzSemiRingType) := NzSemiRing.on R^o.
 #[export]
-HB.instance Definition _ (R : countRingType) := Ring.on R^o.
+HB.instance Definition _ (R : countNzRingType) := NzRing.on R^o.
 
 End CountRing.
 
 Import CountRing.
 HB.reexport.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use countNzSemiRingType instead.")]
+Notation countSemiRingType := (countNzSemiRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use countNzRingType instead.")]
+Notation countRingType := (countNzRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use countComNzSemiRingType instead.")]
+Notation countComSemiRingType := (countComNzSemiRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use countComNzRingType instead.")]
+Notation countComRingType := (countComNzRingType) (only parsing).

--- a/mathcomp/algebra/finalg.v
+++ b/mathcomp/algebra/finalg.v
@@ -12,17 +12,19 @@ From mathcomp Require Import ssralg countalg.
 (* allows type inference to function properly on expressions that mix        *)
 (* combinatorial and algebraic operators, e.g., [set x + y | x in A, y in A].*)
 (*                                                                           *)
-(*   finNmodType, finZmodType, finSemiRingType, finRingType, finComRingType, *)
-(*   finComSemiRingType, finUnitRingType, finComUnitRingType, finIdomType,   *)
-(*   finFieldType, finLmodType, finLalgType, finAlgType, finUnitAlgType      *)
+(*   finNmodType, finZmodType, finNzSemiRingType, finNzRingType,             *)
+(*   finComNzRingType, finComNzSemiRingType, finUnitRingType,                *)
+(*   finComUnitRingType, finIdomType, finFieldType, finLmodType,             *)
+(*   finLalgType, finAlgType, finUnitAlgType                                 *)
 (*      == the finite counterparts of nmodType, etc                          *)
 (* Note that a finFieldType is canonically decidable.                        *)
 (*   This file also provides direct tie-ins with finite group theory:        *)
 (*     [finGroupMixin of R for +%R] == structures for R                      *)
 (*                         {unit R} == the type of units of R, which has a   *)
 (*                                     canonical group structure             *)
-(*                FinRing.unit R Ux == the element of {unit R} corresponding *)
-(*                                     to x, where Ux : x \in GRing.unit     *)
+(*                FinRing.unit R Ux == the element of {unit R}               *)
+(*                                     corresponding to x,                   *)
+(*                                     where Ux : x \in GRing.unit           *)
 (*                           'U%act == the action by right multiplication of *)
 (*                                     {unit R} on R, via FinRing.unit_act   *)
 (*                                     (This is also a group action.)        *)
@@ -51,17 +53,82 @@ Notation "[ 'finGroupMixin' 'of' R 'for' +%R ]" :=
 End ZmoduleExports.
 HB.export ZmoduleExports.
 
-#[short(type="finSemiRingType")]
-HB.structure Definition SemiRing := {R of GRing.SemiRing R & Finite R}.
+#[short(type="finNzSemiRingType")]
+HB.structure Definition NzSemiRing := {R of GRing.NzSemiRing R & Finite R}.
 
-#[short(type="finRingType")]
-HB.structure Definition Ring := {R of GRing.Ring R & Finite R}.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use FinNzSemiRing instead.")]
+Notation SemiRing R := (NzSemiRing R) (only parsing).
 
-#[short(type="finComSemiRingType")]
-HB.structure Definition ComSemiRing := {R of GRing.ComSemiRing R & Finite R}.
+Module SemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing.sort instead.")]
+Notation sort := (NzSemiRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing.on instead.")]
+Notation on R := (NzSemiRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing.copy instead.")]
+Notation copy T U := (NzSemiRing.copy T U) (only parsing).
+End SemiRing.
 
-#[short(type="finComRingType")]
-HB.structure Definition ComRing := {R of GRing.ComRing R & Finite R}.
+#[short(type="finNzRingType")]
+HB.structure Definition NzRing := {R of GRing.NzRing R & Finite R}.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use FinNzRing instead.")]
+Notation Ring R := (NzRing R) (only parsing).
+
+Module Ring.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing.sort instead.")]
+Notation sort := (NzRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing.on instead.")]
+Notation on R := (NzRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing.copy instead.")]
+Notation copy T U := (NzRing.copy T U) (only parsing).
+End Ring.
+
+#[short(type="finComNzSemiRingType")]
+HB.structure Definition ComNzSemiRing :=
+  {R of GRing.ComNzSemiRing R & Finite R}.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use FinComNzSemiRing instead.")]
+Notation ComSemiRing R := (ComNzSemiRing R) (only parsing).
+
+Module ComSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzSemiRing.sort instead.")]
+Notation sort := (ComNzSemiRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzSemiRing.on instead.")]
+Notation on R := (ComNzSemiRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzSemiRing.copy instead.")]
+Notation copy T U := (ComNzSemiRing.copy T U) (only parsing).
+End ComSemiRing.
+
+#[short(type="finComNzRingType")]
+HB.structure Definition ComNzRing := {R of GRing.ComNzRing R & Finite R}.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use FinComNzRing instead.")]
+Notation ComRing R := (ComNzRing R) (only parsing).
+
+Module ComRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing.sort instead.")]
+Notation sort := (ComNzRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing.on instead.")]
+Notation on R := (ComNzRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing.copy instead.")]
+Notation copy T U := (ComNzRing.copy T U) (only parsing).
+End ComRing.
 
 #[short(type="finUnitRingType")]
 HB.structure Definition UnitRing := {R of GRing.UnitRing R & Finite R}.
@@ -77,15 +144,15 @@ HB.structure Definition IntegralDomain :=
 HB.structure Definition Field := {R of GRing.Field R & Finite R}.
 
 #[short(type="finLmodType")]
-HB.structure Definition Lmodule (R : ringType) :=
+HB.structure Definition Lmodule (R : nzRingType) :=
   {M of GRing.Lmodule R M & Finite M}.
 
 #[short(type="finLalgType")]
-HB.structure Definition Lalgebra (R : ringType) :=
+HB.structure Definition Lalgebra (R : nzRingType) :=
   {M of GRing.Lalgebra R M & Finite M}.
 
 #[short(type="finAlgType")]
-HB.structure Definition Algebra (R : ringType) :=
+HB.structure Definition Algebra (R : nzRingType) :=
   {M of GRing.Algebra R M & Finite M}.
 
 #[short(type="finUnitAlgType")]
@@ -115,13 +182,23 @@ Proof. by apply/centsP=> x _ y _; apply: zmod_mulgC. Qed.
 End AdditiveGroup.
 
 #[export, non_forgetful_inheritance]
-HB.instance Definition _ (R : Ring.type) := [finGroupMixin of R for +%R].
-Coercion Ring_to_baseFinGroup (R : Ring.type) := BaseFinGroup.clone R _.
-Coercion Ring_to_finGroup (R : Ring.type) := FinGroup.clone R _.
+HB.instance Definition _ (R : NzRing.type) := [finGroupMixin of R for +%R].
+Coercion NzRing_to_baseFinGroup (R : NzRing.type) := BaseFinGroup.clone R _.
+Coercion NzRing_to_finGroup (R : NzRing.type) := FinGroup.clone R _.
 
-HB.factory Record isRing R of Ring R := {}.
+HB.factory Record isNzRing R of NzRing R := {}.
 
-HB.builders Context R of isRing R.
+Module isRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use isNzRing.Build instead.")]
+Notation Build R := (isNzRing.Build R) (only parsing).
+End isRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use isNzRing instead.")]
+Notation isRing R := (isNzRing R) (only parsing).
+
+HB.builders Context R of isNzRing R.
   Definition is_inv (x y : R) := (x * y == 1) && (y * x == 1).
   Definition unit := [qualify a x : R | [exists y, is_inv x y]].
   Definition inv x := odflt x (pick (is_inv x)).
@@ -150,13 +227,14 @@ HB.builders Context R of isRing R.
   Qed.
 
   HB.instance Definition _ :=
-    GRing.Ring_hasMulInverse.Build R mulVr mulrV intro_unit invr_out.
+    GRing.NzRing_hasMulInverse.Build R mulVr mulrV intro_unit invr_out.
 HB.end.
 
 #[export, non_forgetful_inheritance]
-HB.instance Definition _ (R : ComRing.type) := [finGroupMixin of R for +%R].
-Coercion ComRing_to_baseFinGroup (R : ComRing.type) := BaseFinGroup.clone R _.
-Coercion ComRing_to_finGroup (R : ComRing.type) := FinGroup.clone R _.
+HB.instance Definition _ (R : ComNzRing.type) := [finGroupMixin of R for +%R].
+Coercion ComNzRing_to_baseFinGroup (R : ComNzRing.type) :=
+  BaseFinGroup.clone R _.
+Coercion ComNzRing_to_finGroup (R : ComNzRing.type) := FinGroup.clone R _.
 
 
 #[export, non_forgetful_inheritance]
@@ -195,7 +273,8 @@ Proof. by move=> u; apply/val_inj/(mulVr (valP u)). Qed.
   unit_muluA unit_mul1u unit_mulVu.
 
 Lemma val_unit1 : val (1%g : unit_of) = 1. Proof. by []. Qed.
-Lemma val_unitM x y : val (x * y : unit_of)%g = val x * val y. Proof. by []. Qed.
+Lemma val_unitM x y : val (x * y : unit_of)%g = val x * val y.
+Proof. by []. Qed.
 Lemma val_unitV x : val (x^-1 : unit_of)%g = (val x)^-1. Proof. by []. Qed.
 Lemma val_unitX n x : val (x ^+ n : unit_of)%g = val x ^+ n.
 Proof. by case: n; last by elim=> //= n ->. Qed.
@@ -277,46 +356,47 @@ HB.builders Context F of isField F.
 HB.end.
 
 #[export, non_forgetful_inheritance]
-HB.instance Definition _ (R : ringType) (M : Lmodule.type R) :=
+HB.instance Definition _ (R : nzRingType) (M : Lmodule.type R) :=
   [finGroupMixin of M for +%R].
 
-Coercion Lmodule_to_baseFinGroup (R : ringType) (M : Lmodule.type R) :=
+Coercion Lmodule_to_baseFinGroup (R : nzRingType) (M : Lmodule.type R) :=
   BaseFinGroup.clone M _.
-Coercion Lmodule_to_finGroup (R : ringType) (M : Lmodule.type R) : finGroupType :=
+Coercion Lmodule_to_finGroup (R : nzRingType) (M : Lmodule.type R)
+    : finGroupType :=
   FinGroup.clone (M : Type) _.
 
 #[export, non_forgetful_inheritance]
-HB.instance Definition _ (R : ringType) (M : Lalgebra.type R) :=
+HB.instance Definition _ (R : nzRingType) (M : Lalgebra.type R) :=
   [finGroupMixin of M for +%R].
-Coercion Lalgebra_to_baseFinGroup (R : ringType) (M : Lalgebra.type R) :=
+Coercion Lalgebra_to_baseFinGroup (R : nzRingType) (M : Lalgebra.type R) :=
   BaseFinGroup.clone M _.
-Coercion Lalgebra_to_finGroup (R : ringType) (M : Lalgebra.type R) :=
+Coercion Lalgebra_to_finGroup (R : nzRingType) (M : Lalgebra.type R) :=
   FinGroup.clone M _.
 
 #[export, non_forgetful_inheritance]
-HB.instance Definition _ (R : ringType) (M : Algebra.type R) :=
+HB.instance Definition _ (R : nzRingType) (M : Algebra.type R) :=
   [finGroupMixin of M for +%R].
-Coercion Algebra_to_baseFinGroup (R : ringType) (M : Algebra.type R) :=
+Coercion Algebra_to_baseFinGroup (R : nzRingType) (M : Algebra.type R) :=
   BaseFinGroup.clone M _.
-Coercion Algebra_to_finGroup (R : ringType) (M : Algebra.type R) :=
+Coercion Algebra_to_finGroup (R : nzRingType) (M : Algebra.type R) :=
   FinGroup.clone M _.
 
 #[export, non_forgetful_inheritance]
 HB.instance Definition _ (R : unitRingType) (M : UnitAlgebra.type R) :=
   [finGroupMixin of M for +%R].
-Coercion UnitAlgebra_to_baseFinGroup (R : unitRingType) (M : UnitAlgebra.type R) :=
-  BaseFinGroup.clone M _.
+Coercion UnitAlgebra_to_baseFinGroup
+  (R : unitRingType) (M : UnitAlgebra.type R) := BaseFinGroup.clone M _.
 Coercion UnitAlgebra_to_finGroup (R : unitRingType) (M : UnitAlgebra.type R) :=
   FinGroup.clone M _.
 
 Module RegularExports.
 HB.instance Definition _ (R : finZmodType) := Zmodule.on R^o.
-HB.instance Definition _ (R : finRingType) := Ring.on R^o.
-HB.instance Definition _ (R : finComRingType) := Ring.on R^o.
-HB.instance Definition _ (R : finUnitRingType) := Ring.on R^o.
-HB.instance Definition _ (R : finComUnitRingType) := Ring.on R^o.
-HB.instance Definition _ (R : finIdomainType) := Ring.on R^o.
-HB.instance Definition _ (R : finFieldType) := Ring.on R^o.
+HB.instance Definition _ (R : finNzRingType) := NzRing.on R^o.
+HB.instance Definition _ (R : finComNzRingType) := NzRing.on R^o.
+HB.instance Definition _ (R : finUnitRingType) := NzRing.on R^o.
+HB.instance Definition _ (R : finComUnitRingType) := NzRing.on R^o.
+HB.instance Definition _ (R : finIdomainType) := NzRing.on R^o.
+HB.instance Definition _ (R : finFieldType) := NzRing.on R^o.
 End RegularExports.
 HB.export RegularExports.
 
@@ -341,8 +421,25 @@ End FinRing.
 Import FinRing.
 HB.reexport.
 
-Lemma card_finRing_gt1 (R : finRingType) : 1 < #|R|.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use finNzSemiRingType instead.")]
+Notation finSemiRingType := (finNzSemiRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use finNzRingType instead.")]
+Notation finRingType := (finNzRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use finComNzSemiRingType instead.")]
+Notation finComSemiRingType := (finComNzSemiRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use finComNzRingType instead.")]
+Notation finComRingType := (finComNzRingType) (only parsing).
+
+Lemma card_finNzRing_gt1 (R : finNzRingType) : 1 < #|R|.
 Proof. by rewrite (cardD1 0) (cardD1 1) !inE GRing.oner_neq0. Qed.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use card_finNzRing_gt1 instead.")]
+Notation card_finRing_gt1 := (card_finNzRing_gt1) (only parsing).
 
 Notation "{ 'unit' R }" := (unit_of R)
   (at level 0, format "{ 'unit'  R }") : type_scope.
@@ -351,10 +448,12 @@ Notation "''U'" := (unit_action _) (at level 8) : action_scope.
 Notation "''U'" := (unit_groupAction _) (at level 8) : groupAction_scope.
 
 Lemma card_finField_unit (F : finFieldType) : #|[set: {unit F}]| = #|F|.-1.
-by rewrite -(cardC1 0) cardsT card_sub; apply: eq_card => x; rewrite GRing.unitfE.
+Proof.
+rewrite -(cardC1 0) cardsT card_sub; apply: eq_card => x.
+by rewrite GRing.unitfE.
 Qed.
 
 (* Finite Algebraic structure for bool *)
 
-#[hnf] HB.instance Definition _ := GRing.Ring.on bool.
+#[hnf] HB.instance Definition _ := GRing.NzRing.on bool.
 #[hnf] HB.instance Definition _ := isField.Build bool.

--- a/mathcomp/algebra/fraction.v
+++ b/mathcomp/algebra/fraction.v
@@ -27,7 +27,7 @@ Reserved Notation "{ 'fraction' T }" (at level 0, format "{ 'fraction'  T }").
 Reserved Notation "x %:F" (at level 2, format "x %:F").
 
 Section FracDomain.
-Variable R : ringType.
+Variable R : nzRingType.
 
 (* ratios are pairs of R, such that the second member is nonzero *)
 Inductive ratio := mkRatio { frac :> R * R; _ : frac.2 != 0 }.
@@ -245,7 +245,7 @@ Proof. by rewrite piE equivfE !numden_Ratio ?mul1r ?oner_eq0. Qed.
 
 (* fractions form a commutative ring *)
 HB.instance Definition _ :=
-  GRing.Zmodule_isComRing.Build type mulA mulC mul1_l mul_addl nonzero1.
+  GRing.Zmodule_isComNzRing.Build type mulA mulC mul1_l mul_addl nonzero1.
 
 Lemma mulV_l : forall a, a != 0%:F -> mul (inv a) a = 1%:F.
 Proof.
@@ -264,7 +264,7 @@ Qed.
 
 (* fractions form a ring with explicit unit *)
 (* fractions form a field *)
-HB.instance Definition _ := GRing.ComRing_isField.Build type mulV_l inv0.
+HB.instance Definition _ := GRing.ComNzRing_isField.Build type mulV_l inv0.
 
 End FracField.
 End FracField.

--- a/mathcomp/algebra/intdiv.v
+++ b/mathcomp/algebra/intdiv.v
@@ -466,7 +466,7 @@ Qed.
 Lemma Qnat_dvd (m d : nat) : (d %| m)%N -> (m%:R / d%:R : rat) \is a Num.nat.
 Proof. by move=> h; rewrite natrEint divr_ge0 ?ler0n // !pmulrn Qint_dvdz. Qed.
 
-Lemma dvdz_charf (R : ringType) p : p \in [char R] ->
+Lemma dvdz_charf (R : nzRingType) p : p \in [char R] ->
   forall n : int, (p %| n)%Z = (n%:~R == 0 :> R).
 Proof.
 move=> charRp [] n; rewrite [LHS](dvdn_charf charRp)//.

--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -111,13 +111,13 @@ From mathcomp Require Import prime binomial ssralg countalg finalg zmodp bigop.
 (*                   back into into an m x n rectangular matrix.              *)
 (* In 'M[R]_(m, n), R can be any type, but 'M[R]_(m, n) inherits the eqType,  *)
 (* choiceType, countType, finType, zmodType structures of R; 'M[R]_(m, n)     *)
-(* also has a natural lmodType R structure when R has a ringType structure.   *)
+(* also has a natural lmodType R structure when R has a nzRingType structure. *)
 (* Because the type of matrices specifies their dimension, only non-trivial   *)
 (* square matrices (of type 'M[R]_n.+1) can inherit the ring structure of R;  *)
 (* indeed they then have an algebra structure (lalgType R, or algType R if R  *)
-(* is a comRingType, or even unitAlgType if R is a comUnitRingType).          *)
+(* is a comNzRingType, or even unitAlgType if R is a comUnitRingType).        *)
 (*   We thus provide separate syntax for the general matrix multiplication,   *)
-(* and other operations for matrices over a ringType R:                       *)
+(* and other operations for matrices over a nzRingType R:                     *)
 (*         A *m B == the matrix product of A and B; the width of A must be    *)
 (*                   equal to the height of B.                                *)
 (*           a%:M == the scalar matrix with a's on the main diagonal; in      *)
@@ -2252,9 +2252,9 @@ End MapZmodMatrix.
 
 Section MatrixAlgebra.
 
-Variable R : semiRingType.
+Variable R : nzSemiRingType.
 
-Section SemiRingModule.
+Section NzSemiRingModule.
 
 (* The ring module/vector space structure *)
 
@@ -2283,7 +2283,7 @@ Proof. by apply/matrixP=> i j; rewrite !mxE mulrDr. Qed.
 Lemma scalemxA x y A : x *m: (y *m: A) = (x * y) *m: A.
 Proof. by apply/matrixP=> i j; rewrite !mxE mulrA. Qed.
 
-End SemiRingModule.
+End NzSemiRingModule.
 
 Lemma trmx_delta m n i j : (delta_mx i j)^T = delta_mx j i :> 'M[R]_(n, m).
 Proof. by apply/matrixP=> i' j'; rewrite !mxE andbC. Qed.
@@ -2714,7 +2714,7 @@ End Trace.
 
 (* The matrix ring structure requires a structural condition (dimension of *)
 (* the form n.+1) to satisfy the nontriviality condition we have imposed.  *)
-Section MatrixSemiRing.
+Section MatrixNzSemiRing.
 
 Variable n' : nat.
 Local Notation n := n'.+1.
@@ -2722,7 +2722,7 @@ Local Notation n := n'.+1.
 Lemma matrix_nonzero1 : 1%:M != 0 :> 'M[R]_n.
 Proof. by apply/eqP=> /matrixP/(_ 0 0)/eqP; rewrite !mxE oner_eq0. Qed.
 
-HB.instance Definition _ := GRing.Nmodule_isSemiRing.Build 'M[R]_n
+HB.instance Definition _ := GRing.Nmodule_isNzSemiRing.Build 'M[R]_n
   (@mulmxA n n n n) (@mul1mx n n) (@mulmx1 n n)
   (@mulmxDl n n n) (@mulmxDr n n n) (@mul0mx n n n) (@mulmx0 n n n)
   matrix_nonzero1.
@@ -2735,7 +2735,7 @@ Proof. by split=> //; apply: scalar_mxM. Qed.
 HB.instance Definition _ := GRing.isMultiplicative.Build R 'M_n (@scalar_mx _ n)
   scalar_mx_is_multiplicative.
 
-End MatrixSemiRing.
+End MatrixNzSemiRing.
 
 Section LiftPerm.
 
@@ -2811,7 +2811,7 @@ Notation "A *m B" := (mulmx A B) : ring_scope.
 Notation "\tr A" := (mxtrace A) : ring_scope.
 
 (* Non-commutative transpose requires multiplication in the converse ring.   *)
-Lemma trmx_mul_rev (R : semiRingType) m n p
+Lemma trmx_mul_rev (R : nzSemiRingType) m n p
     (A : 'M[R]_(m, n)) (B : 'M[R]_(n, p)) :
   (A *m B)^T = (B : 'M[R^c]_(n, p))^T *m (A : 'M[R^c]_(m, n))^T.
 Proof.
@@ -2820,7 +2820,7 @@ Qed.
 
 HB.instance Definition _ (M : countNmodType) m n :=
   [Countable of 'M[M]_(m, n) by <:].
-HB.instance Definition _ (R : countSemiRingType) n :=
+HB.instance Definition _ (R : countNzSemiRingType) n :=
   [Countable of 'M[R]_n.+1 by <:].
 
 Section FinNmodMatrix.
@@ -2832,17 +2832,17 @@ HB.instance Definition _ := [Finite of MV by <:].
 End FinNmodMatrix.
 
 #[compress_coercions]
-HB.instance Definition _ (R : finSemiRingType) (m n : nat) :=
+HB.instance Definition _ (R : finNzSemiRingType) (m n : nat) :=
   FinRing.Nmodule.on 'M[R]_(m, n).
 
 #[compress_coercions]
-HB.instance Definition _ (R : finSemiRingType) n :=
+HB.instance Definition _ (R : finNzSemiRingType) n :=
   [Finite of 'M[R]_n.+1 by <:].
 
 (* Parametricity over the algebra structure. *)
-Section MapSemiRingMatrix.
+Section MapNzSemiRingMatrix.
 
-Variables (aR rR : semiRingType) (f : {rmorphism aR -> rR}).
+Variables (aR rR : nzSemiRingType) (f : {rmorphism aR -> rR}).
 Local Notation "A ^f" := (map_mx f A) : ring_scope.
 
 Section FixedSize.
@@ -2890,7 +2890,7 @@ HB.instance Definition _ n' :=
   GRing.isMultiplicative.Build 'M[aR]_n'.+1 'M[rR]_n'.+1 (map_mx f)
     (map_mx_is_multiplicative n').
 
-End MapSemiRingMatrix.
+End MapNzSemiRingMatrix.
 
 Section CommMx.
 (***********************************************************************)
@@ -2908,7 +2908,7 @@ Section CommMx.
 (* The boolean version comm_mxb is designed to be used with seq.allrel *)
 (***********************************************************************)
 
-Context {R : semiRingType} {n : nat}.
+Context {R : nzSemiRingType} {n : nat}.
 Implicit Types (f g p : 'M[R]_n) (fs : seq 'M[R]_n) (d : 'rV[R]_n) (I : Type).
 
 Definition comm_mx  f g : Prop := f *m g =  g *m f.
@@ -2962,12 +2962,12 @@ Proof. by rewrite /comm_mxb /= all2rel_cons //= eqxx. Qed.
 End CommMx.
 Notation all_comm_mx := (allrel comm_mxb).
 
-Lemma comm_mxE (R : ringType) (n : nat) : @comm_mx R n.+1 = @GRing.comm _.
+Lemma comm_mxE (R : nzRingType) (n : nat) : @comm_mx R n.+1 = @GRing.comm _.
 Proof. by []. Qed.
 
 Section ComMatrix.
 (* Lemmas for matrices with coefficients in a commutative ring *)
-Variable R : comSemiRingType.
+Variable R : comNzSemiRingType.
 
 Section AssocLeft.
 
@@ -3019,14 +3019,14 @@ Arguments comm_mx_scalar {R n}.
 Arguments comm_scalar_mx {R n}.
 Arguments diag_mx_comm {R n}.
 
-HB.instance Definition _ (R : finComSemiRingType) (n' : nat) :=
+HB.instance Definition _ (R : finComNzSemiRingType) (n' : nat) :=
   [Finite of 'M[R]_n'.+1 by <:].
 
 #[global] Hint Resolve comm_mx_scalar comm_scalar_mx : core.
 
 Section MatrixAlgebra.
 
-Variable R : ringType.
+Variable R : nzRingType.
 
 Section RingModule.
 
@@ -3299,7 +3299,7 @@ Section MatrixRing.
 Variable n' : nat.
 Local Notation n := n'.+1.
 
-HB.instance Definition _ := GRing.SemiRing.on 'M[R]_n.
+HB.instance Definition _ := GRing.NzSemiRing.on 'M[R]_n.
 HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build R 'M[R]_n
   (@scalemxAl n n n).
 
@@ -3335,7 +3335,7 @@ Notation "'\adj' A" := (adjugate A) : ring_scope.
 
 HB.instance Definition _ (M : countZmodType) m n :=
   [Countable of 'M[M]_(m, n) by <:].
-HB.instance Definition _ (R : countRingType) n :=
+HB.instance Definition _ (R : countNzRingType) n :=
   [Countable of 'M[R]_n.+1 by <:].
 
 Section FinZmodMatrix.
@@ -3350,17 +3350,17 @@ HB.instance Definition _ := [finGroupMixin of MV for +%R].
 End FinZmodMatrix.
 
 #[compress_coercions]
-HB.instance Definition _ (R : finRingType) (m n : nat) :=
+HB.instance Definition _ (R : finNzRingType) (m n : nat) :=
   FinRing.Zmodule.on 'M[R]_(m, n).
 
 #[compress_coercions]
-HB.instance Definition _ (R : finRingType) n :=
+HB.instance Definition _ (R : finNzRingType) n :=
   [Finite of 'M[R]_n.+1 by <:].
 
 (* Parametricity over the algebra structure. *)
 Section MapRingMatrix.
 
-Variables (aR rR : ringType) (f : {rmorphism aR -> rR}).
+Variables (aR rR : nzRingType) (f : {rmorphism aR -> rR}).
 Local Notation "A ^f" := (map_mx f A) : ring_scope.
 
 Section FixedSize.
@@ -3411,10 +3411,10 @@ Section CommMx.
 (***********************************************************************)
 (************* Commutation property specialized to 'M[R]_n *************)
 (***********************************************************************)
-(* See comment on top of SemiRing section CommMx above.                *)
+(* See comment on top of NzSemiRing section CommMx above.                *)
 (***********************************************************************)
 
-Context {R : ringType} {n : nat}.
+Context {R : nzRingType} {n : nat}.
 Implicit Types (f g p : 'M[R]_n) (fs : seq 'M[R]_n) (d : 'rV[R]_n) (I : Type).
 
 Lemma comm_mxN f g : comm_mx f g -> comm_mx f (- g).
@@ -3429,7 +3429,7 @@ End CommMx.
 
 Section ComMatrix.
 (* Lemmas for matrices with coefficients in a commutative ring *)
-Variable R : comRingType.
+Variable R : comNzRingType.
 
 Section AssocLeft.
 
@@ -3739,7 +3739,7 @@ End ComMatrix.
 Arguments lin_mul_row {R m n} u.
 Arguments lin_mulmx {R m n p} A.
 
-HB.instance Definition _ (R : finComRingType) (n' : nat) :=
+HB.instance Definition _ (R : finComNzRingType) (n' : nat) :=
   [Finite of 'M[R]_n'.+1 by <:].
 
 (*****************************************************************************)
@@ -3849,7 +3849,7 @@ End Defs.
 Variable n' : nat.
 Local Notation n := n'.+1.
 
-HB.instance Definition _ := GRing.Ring_hasMulInverse.Build 'M[R]_n
+HB.instance Definition _ := GRing.NzRing_hasMulInverse.Build 'M[R]_n
   (@mulVmx n) (@mulmxV n) (@intro_unitmx n) (@invmx_out n).
 
 (* Lemmas requiring that the coefficients are in a unit ring *)
@@ -4221,7 +4221,7 @@ HB.instance Definition _ (zmodS : zmodClosed M) :=
 End mxOverZmodule.
 
 Section mxOverRing.
-Context {R : ringType} {m n : nat}.
+Context {R : nzRingType} {m n : nat}.
 
 Lemma mxOver_scalar S c : 0 \in S -> c \in S -> c%:M \is a @mxOver n n R S.
 Proof. by move=> S0 cS; apply/mxOverP => i j; rewrite !mxE; case: eqP. Qed.
@@ -4269,7 +4269,7 @@ Qed.
 End mxOverRing.
 
 Section mxRingOver.
-Context {R : ringType} {n : nat}.
+Context {R : nzRingType} {n : nat}.
 
 Section semiring.
 Variable S : semiringClosed R.
@@ -4642,7 +4642,7 @@ Qed.
 End BlockRowZmod.
 
 Section BlockRowRing.
-Context {R : ringType} {n : nat} {q_ : 'I_n -> nat}.
+Context {R : nzRingType} {n : nat} {q_ : 'I_n -> nat}.
 Notation sq := (\sum_i q_ i)%N.
 Implicit Type (s : 'I_sq).
 
@@ -4713,7 +4713,7 @@ Qed.
 End BlockColZmod.
 
 Section BlockColRing.
-Context {R : ringType} {n : nat} {p_ : 'I_n -> nat}.
+Context {R : nzRingType} {n : nat} {p_ : 'I_n -> nat}.
 Notation sp := (\sum_i p_ i)%N.
 Implicit Type (s : 'I_sp).
 
@@ -4789,7 +4789,7 @@ Qed.
 End BlockMatrixZmod.
 
 Section BlockMatrixRing.
-Context {R : ringType} {p q : nat} {p_ : 'I_p -> nat} {q_ : 'I_q -> nat}.
+Context {R : nzRingType} {p q : nat} {p_ : 'I_p -> nat} {q_ : 'I_q -> nat}.
 Notation sp := (\sum_i p_ i)%N.
 Notation sq := (\sum_i q_ i)%N.
 
@@ -4828,7 +4828,7 @@ Qed.
 
 End BlockMatrixRing.
 
-Lemma mul_mxblock {R : ringType} {p q r : nat}
+Lemma mul_mxblock {R : nzRingType} {p q r : nat}
     {p_ : 'I_p -> nat} {q_ : 'I_q -> nat} {r_ : 'I_r -> nat}
     (A_ : forall i j, 'M[R]_(p_ i, q_ j)) (B_ : forall j k, 'M_(q_ j, r_ k)) :
   \mxblock_(i, j) A_ i j *m \mxblock_(j, k) B_ j k =
@@ -4992,7 +4992,7 @@ Qed.
 
 Section SquareBlockMatrixRing.
 Import tagnat.
-Context {R : ringType} {p : nat} {p_ : 'I_p -> nat}.
+Context {R : nzRingType} {p : nat} {p_ : 'I_p -> nat}.
 Notation sp := (\sum_i p_ i)%N.
 Implicit Type (s : 'I_sp).
 
@@ -5038,7 +5038,7 @@ Qed.
 
 End SquareBlockMatrixRing.
 
-Lemma mul_mxrow_mxdiag {R : ringType} {p : nat} {p_ : 'I_p -> nat} m
+Lemma mul_mxrow_mxdiag {R : nzRingType} {p : nat} {p_ : 'I_p -> nat} m
     (R_ : forall i, 'M[R]_(m, p_ i)) (D_ : forall i, 'M[R]_(p_ i)) :
   \mxrow_i R_ i *m \mxdiag_i D_ i = \mxrow_i (R_ i *m D_ i).
 Proof.
@@ -5046,7 +5046,7 @@ apply: trmx_inj; rewrite trmx_mul_rev !tr_mxrow tr_mxdiag mul_mxdiag_mxcol.
 by apply/ eq_mxcol => i; rewrite trmx_mul_rev.
 Qed.
 
-Lemma mul_mxblock_mxdiag {R : ringType} {p q : nat}
+Lemma mul_mxblock_mxdiag {R : nzRingType} {p q : nat}
   {p_ : 'I_p -> nat} {q_ : 'I_q -> nat}
     (B_ : forall i j, 'M[R]_(p_ i, q_ j)) (D_ : forall j, 'M[R]_(q_ j)) :
   \mxblock_(i, j) B_ i j *m \mxdiag_j D_ j = \mxblock_(i, j) (B_ i j *m D_ j).
@@ -5054,7 +5054,7 @@ Proof.
 by rewrite !mxblockEh mul_mxrow_mxdiag; under eq_mxrow do rewrite mxcol_mul.
 Qed.
 
-Lemma mul_mxdiag_mxblock {R : ringType} {p q : nat}
+Lemma mul_mxdiag_mxblock {R : nzRingType} {p q : nat}
   {p_ : 'I_p -> nat} {q_ : 'I_q -> nat}
     (D_ : forall j, 'M[R]_(p_ j)) (B_ : forall i j, 'M[R]_(p_ i, q_ j)):
   \mxdiag_j D_ j *m \mxblock_(i, j) B_ i j = \mxblock_(i, j) (D_ i *m B_ i j).
@@ -5062,10 +5062,10 @@ Proof.
 by rewrite !mxblockEv mul_mxdiag_mxcol; under eq_mxcol do rewrite mul_mxrow.
 Qed.
 
-Definition Vandermonde (R : ringType) (m n : nat) (a : 'rV[R]_n) :=
+Definition Vandermonde (R : nzRingType) (m n : nat) (a : 'rV[R]_n) :=
   \matrix_(i < m, j < n) a 0 j ^+ i.
 
-Lemma det_Vandermonde (R : comRingType) (n : nat) (a : 'rV[R]_n) :
+Lemma det_Vandermonde (R : comNzRingType) (n : nat) (a : 'rV[R]_n) :
   \det (Vandermonde n a) = \prod_(i < n) \prod_(j < n | i < j) (a 0 j - a 0 i).
 Proof.
 set V := @Vandermonde R.

--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -118,7 +118,7 @@ Import Pdiv.Idomain.
 (* Row vector <-> bounded degree polynomial bijection *)
 Section RowPoly.
 
-Variables (R : ringType) (d : nat).
+Variables (R : nzRingType) (d : nat).
 Implicit Types u v : 'rV[R]_d.
 Implicit Types p q : {poly R}.
 
@@ -169,7 +169,7 @@ Arguments poly_rV_K {R d} [p] le_p_d.
 
 Section Resultant.
 
-Variables (R : ringType) (p q : {poly R}).
+Variables (R : nzRingType) (p q : {poly R}).
 
 Let dS := ((size q).-1 + (size p).-1)%N.
 Local Notation band r := (lin1_mx (poly_rV \o r \o* rVpoly)).
@@ -190,7 +190,7 @@ End Resultant.
 
 Prenex Implicits Sylvester_mx resultant.
 
-Lemma resultant_in_ideal (R : comRingType) (p q : {poly R}) :
+Lemma resultant_in_ideal (R : comNzRingType) (p q : {poly R}) :
     size p > 1 -> size q > 1 ->
   {uv : {poly R} * {poly R} | size uv.1 < size q /\ size uv.2 < size p
   & (resultant p q)%:P = uv.1 * p + uv.2 * q}.
@@ -311,7 +311,7 @@ Qed.
 
 Section HornerMx.
 
-Variables (R : comRingType) (n' : nat).
+Variables (R : comNzRingType) (n' : nat).
 Local Notation n := n'.+1.
 Implicit Types (A B : 'M[R]_n) (p q : {poly R}).
 
@@ -385,7 +385,7 @@ Prenex Implicits horner_mx powers_mx.
 
 Section CharPoly.
 
-Variables (R : ringType) (n : nat) (A : 'M[R]_n).
+Variables (R : nzRingType) (n : nat) (A : 'M[R]_n).
 Implicit Types p q : {poly R}.
 
 Definition char_poly_mx := 'X%:M - map_mx (@polyC R) A.
@@ -460,7 +460,7 @@ End CharPoly.
 
 Prenex Implicits char_poly_mx char_poly.
 
-Lemma mx_poly_ring_isom (R : ringType) n' (n := n'.+1) :
+Lemma mx_poly_ring_isom (R : nzRingType) n' (n := n'.+1) :
   exists phi : {rmorphism 'M[{poly R}]_n -> {poly 'M[R]_n}},
   [/\ bijective phi,
       forall p, phi p%:M = map_poly scalar_mx p,
@@ -500,7 +500,7 @@ exists phiRM; split=> // [p | A]; apply/polyP=> k; apply/matrixP=> i j.
 by rewrite coef_phi !mxE !coefC; case k; last rewrite /= mxE.
 Qed.
 
-Theorem Cayley_Hamilton (R : comRingType) n' (A : 'M[R]_n'.+1) :
+Theorem Cayley_Hamilton (R : comNzRingType) n' (A : 'M[R]_n'.+1) :
   horner_mx A (char_poly A) = 0.
 Proof.
 have [phi [_ phiZ phiC _]] := mx_poly_ring_isom R n'.
@@ -521,7 +521,7 @@ rewrite (big_morph _ (fun p q => hornerM p q a) (hornerC 1 a)).
 by apply: eq_bigr => i _; rewrite !mxE !(hornerE, hornerMn).
 Qed.
 
-Lemma char_poly_trig {R : comRingType} n (A : 'M[R]_n) : is_trig_mx A ->
+Lemma char_poly_trig {R : comNzRingType} n (A : 'M[R]_n) : is_trig_mx A ->
   char_poly A = \prod_(i < n) ('X - (A i i)%:P).
 Proof.
 move=> /is_trig_mxP Atrig; rewrite /char_poly det_trig.
@@ -529,11 +529,11 @@ move=> /is_trig_mxP Atrig; rewrite /char_poly det_trig.
 by apply/is_trig_mxP => i j lt_ij; rewrite !mxE -val_eqE ltn_eqF ?Atrig ?subrr.
 Qed.
 
-Definition companionmx {R : ringType} (p : seq R) (d := (size p).-1) :=
+Definition companionmx {R : nzRingType} (p : seq R) (d := (size p).-1) :=
   \matrix_(i < d, j < d)
     if (i == d.-1 :> nat) then - p`_j else (i.+1 == j :> nat)%:R.
 
-Lemma companionmxK {R : comRingType} (p : {poly R}) :
+Lemma companionmxK {R : comNzRingType} (p : {poly R}) :
    p \is monic -> char_poly (companionmx p) = p.
 Proof.
 pose D n : 'M[{poly R}]_n := \matrix_(i, j)
@@ -573,7 +573,7 @@ apply/matrixP=> i j; rewrite !mxE -!val_eqE /= /bump /=.
 by rewrite leqNgt ltn_ord add0n add1n [_ == _.-2.+1]ltn_eqF.
 Qed.
 
-Lemma mulmx_delta_companion (R : ringType) (p : seq R)
+Lemma mulmx_delta_companion (R : nzRingType) (p : seq R)
   (i: 'I_(size p).-1) (i_small : i.+1 < (size p).-1):
   delta_mx 0 i *m companionmx p = delta_mx 0 (Ordinal i_small) :> 'rV__.
 Proof.
@@ -583,11 +583,11 @@ rewrite ltn_eqF ?big1 ?addr0 1?eq_sym //; last first.
 by move=> k /negPf ki_eqF; rewrite !mxE eqxx ki_eqF mul0r.
 Qed.
 
-Lemma row'_col'_char_poly_mx {R : ringType} m i (M : 'M[R]_m) :
+Lemma row'_col'_char_poly_mx {R : nzRingType} m i (M : 'M[R]_m) :
   row' i (col' i (char_poly_mx M)) = char_poly_mx (row' i (col' i M)).
 Proof. by apply/matrixP => k l; rewrite !mxE (inj_eq lift_inj). Qed.
 
-Lemma char_block_diag_mx {R : ringType} m n (A : 'M[R]_m) (B : 'M[R]_n) :
+Lemma char_block_diag_mx {R : nzRingType} m n (A : 'M[R]_m) (B : 'M[R]_n) :
   char_poly_mx (block_mx A 0 0 B) =
   block_mx (char_poly_mx A) 0 0 (char_poly_mx B).
 Proof.
@@ -778,7 +778,7 @@ Arguments horner_rVpoly_inj {F n' A} [u1 u2] eq_u12A : rename.
 (* Parametricity. *)
 Section MapRingMatrix.
 
-Variables (aR rR : ringType) (f : {rmorphism aR -> rR}).
+Variables (aR rR : nzRingType) (f : {rmorphism aR -> rR}).
 Local Notation "A ^f" := (map_mx (GRing.RMorphism.sort f) A) : ring_scope.
 Local Notation fp := (map_poly (GRing.RMorphism.sort f)).
 Variables (d n : nat) (A : 'M[aR]_n).
@@ -805,7 +805,7 @@ End MapRingMatrix.
 
 Section MapResultant.
 
-Lemma map_resultant (aR rR : ringType) (f : {rmorphism {poly aR} -> rR}) p q :
+Lemma map_resultant (aR rR : nzRingType) (f : {rmorphism {poly aR} -> rR}) p q :
     f (lead_coef p) != 0 -> f (lead_coef q) != 0 ->
   f (resultant p q)= resultant (map_poly f p) (map_poly f q).
 Proof.
@@ -818,7 +818,7 @@ End MapResultant.
 
 Section MapComRing.
 
-Variables (aR rR : comRingType) (f : {rmorphism aR -> rR}).
+Variables (aR rR : comNzRingType) (f : {rmorphism aR -> rR}).
 Local Notation "A ^f" := (map_mx f A) : ring_scope.
 Local Notation fp := (map_poly f).
 Variables (n' : nat) (A : 'M[aR]_n'.+1).
@@ -1037,12 +1037,12 @@ End MapKermxPoly.
 
 Section IntegralOverRing.
 
-Definition integralOver (R K : ringType) (RtoK : R -> K) (z : K) :=
+Definition integralOver (R K : nzRingType) (RtoK : R -> K) (z : K) :=
   exists2 p, p \is monic & root (map_poly RtoK p) z.
 
 Definition integralRange R K RtoK := forall z, @integralOver R K RtoK z.
 
-Variables (B R K : ringType) (BtoR : B -> R) (RtoK : {rmorphism R -> K}).
+Variables (B R K : nzRingType) (BtoR : B -> R) (RtoK : {rmorphism R -> K}).
 
 Lemma integral_rmorph x :
   integralOver BtoR x -> integralOver (RtoK \o BtoR) (RtoK x).
@@ -1069,7 +1069,7 @@ End IntegralOverRing.
 
 Section IntegralOverComRing.
 
-Variables (R K : comRingType) (RtoK : {rmorphism R -> K}).
+Variables (R K : comNzRingType) (RtoK : {rmorphism R -> K}).
 
 Lemma integral_horner_root w (p q : {poly K}) :
     p \is monic -> root p w ->

--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -13,10 +13,11 @@ From mathcomp Require Import div ssralg countalg binomial.
 (*           {poly R} == the type of polynomials with coefficients of type R, *)
 (*                       represented as lists with a non zero last element    *)
 (*                       (big endian representation); the coefficient type R  *)
-(*                       must have a canonical ringType structure cR. In fact *)
-(*                       {poly R} denotes the concrete type polynomial cR; R  *)
-(*                       is just a phantom argument that lets type inference  *)
-(*                       reconstruct the (hidden) ringType structure cR.      *)
+(*                       must have a canonical nzRingType structure cR. In    *)
+(*                       fact {poly R} denotes the concrete type polynomial   *)
+(*                       cR; R is just a phantom argument that lets type      *)
+(*                       inferencereconstruct the (hidden) nzRingType         *)
+(*                       structure cR.                                        *)
 (*          p : seq R == the big-endian sequence of coefficients of p, via    *)
 (*                       the coercion polyseq : polynomial >-> seq.           *)
 (*             Poly s == the polynomial with coefficient sequence s (ignoring *)
@@ -24,7 +25,7 @@ From mathcomp Require Import div ssralg countalg binomial.
 (* \poly_(i < n) E(i) == the polynomial of degree at most n - 1 whose         *)
 (*                       coefficients are given by the general term E(i)      *)
 (*  0, 1, - p, p + q, == the usual ring operations: {poly R} has a canonical  *)
-(* p * q, p ^+ n, ...    ringType structure, which is commutative / integral  *)
+(* p * q, p ^+ n, ...    nzRingType structure, which is commutative / integral*)
 (*                       when R is commutative / integral, respectively.      *)
 (*      polyC c, c%:P == the constant polynomial c                            *)
 (*                 'X == the (unique) variable                                *)
@@ -134,7 +135,7 @@ Local Notation simp := Monoid.simpm.
 
 Section Polynomial.
 
-Variable R : semiRingType.
+Variable R : nzSemiRingType.
 
 (* Defines a polynomial as a sequence with <> 0 last element *)
 Record polynomial := Polynomial {polyseq :> seq R; _ : last 1 polyseq != 0}.
@@ -159,7 +160,7 @@ Notation "{ 'poly' T }" := (polynomial T) : type_scope.
 
 Section SemiPolynomialTheory.
 
-Variable R : semiRingType.
+Variable R : nzSemiRingType.
 Implicit Types (a b c x y z : R) (p q r d : {poly R}).
 
 Definition lead_coef p := p`_(size p).-1.
@@ -491,7 +492,7 @@ Qed.
 Fact poly1_neq0 : 1%:P != 0 :> {poly R}.
 Proof. by rewrite polyC_eq0 oner_neq0. Qed.
 
-HB.instance Definition _ := GRing.Nmodule_isSemiRing.Build (polynomial R)
+HB.instance Definition _ := GRing.Nmodule_isNzSemiRing.Build (polynomial R)
   mul_polyA mul_1poly mul_poly1 mul_polyDl mul_polyDr mul_0poly mul_poly0
   poly1_neq0.
 
@@ -589,7 +590,7 @@ End SemiPolynomialTheory.
 
 Section PolynomialTheory.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Implicit Types (a b c x y z : R) (p q r d : {poly R}).
 
 Local Notation "c %:P" := (polyC c).
@@ -1874,7 +1875,7 @@ Section MapPoly.
 
 Section Definitions.
 
-Variables (aR rR : ringType) (f : aR -> rR).
+Variables (aR rR : nzRingType) (f : aR -> rR).
 
 Definition map_poly (p : {poly aR}) := \poly_(i < size p) f p`_i.
 
@@ -1894,11 +1895,11 @@ Definition horner_morph u of commr_rmorph u := fun p => (map_poly p).[u].
 
 End Definitions.
 
-Variables aR rR : ringType.
+Variables aR rR : nzRingType.
 
 Section Combinatorial.
 
-Variables (iR : ringType) (f : aR -> rR).
+Variables (iR : nzRingType) (f : aR -> rR).
 Local Notation "p ^f" := (map_poly f p) : ring_scope.
 
 Lemma map_poly0 : 0^f = 0.
@@ -1978,7 +1979,7 @@ Proof. by move=> /eq_in_map_poly_id0; apply; rewrite //?raddf0. Qed.
 
 Section Additive.
 
-Variables (iR : ringType) (f : {additive aR -> rR}).
+Variables (iR : nzRingType) (f : {additive aR -> rR}).
 
 Local Notation "p ^f" := (map_poly (GRing.Additive.sort f) p) : ring_scope.
 
@@ -2123,7 +2124,7 @@ Proof. by apply/polyP => i; rewrite !(coef_map, coef_nderivn) //= rmorphMn. Qed.
 
 End MapPoly.
 
-Lemma mapf_root (F : fieldType) (R : ringType) (f : {rmorphism F -> R})
+Lemma mapf_root (F : fieldType) (R : nzRingType) (f : {rmorphism F -> R})
   (p : {poly F}) (x : F) : root (map_poly f p) (f x) = root p x.
 Proof. by rewrite !rootE horner_map fmorph_eq0. Qed.
 
@@ -2131,7 +2132,7 @@ Proof. by rewrite !rootE horner_map fmorph_eq0. Qed.
 (* with respect to these.                                                 *)
 Section MorphPoly.
 
-Variable (aR rR : ringType) (pf : {rmorphism {poly aR} -> rR}).
+Variable (aR rR : nzRingType) (pf : {rmorphism {poly aR} -> rR}).
 
 Lemma poly_morphX_comm : commr_rmorph (pf \o polyC) (pf 'X).
 Proof. by move=> a; rewrite /GRing.comm /= -!rmorphM // commr_polyX. Qed.
@@ -2148,7 +2149,7 @@ Notation "p ^:P" := (map_poly polyC p) : ring_scope.
 
 Section PolyCompose.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Implicit Types p q : {poly R}.
 
 Definition comp_poly q p := p^:P.[q].
@@ -2263,7 +2264,7 @@ End PolyCompose.
 
 Notation "p \Po q" := (comp_poly q p) : ring_scope.
 
-Lemma map_comp_poly (aR rR : ringType) (f : {rmorphism aR -> rR}) p q :
+Lemma map_comp_poly (aR rR : nzRingType) (f : {rmorphism aR -> rR}) p q :
   map_poly f (p \Po q) = map_poly f p \Po map_poly f q.
 Proof.
 elim/poly_ind: p => [|p a IHp]; first by rewrite !raddf0.
@@ -2273,7 +2274,7 @@ Qed.
 
 Section Surgery.
 
-Variable R : ringType.
+Variable R : nzRingType.
 
 Implicit Type p q : {poly R}.
 
@@ -2535,9 +2536,9 @@ Definition coefE :=
    coef_deriv, coef_nderivn, coef_derivn, coef_map, coef_sum,
    coef_comp_poly_Xn, coef_comp_poly).
 
-Section PolynomialComRing.
+Section PolynomialComNzRing.
 
-Variable R : comRingType.
+Variable R : comNzRingType.
 Implicit Types p q : {poly R}.
 
 Fact poly_mul_comm p q : p * q = q * p.
@@ -2546,7 +2547,7 @@ apply/polyP=> i; rewrite coefM coefMr.
 by apply: eq_bigr => j _; rewrite mulrC.
 Qed.
 
-HB.instance Definition _ := GRing.Ring_hasCommutativeMul.Build (polynomial R)
+HB.instance Definition _ := GRing.NzRing_hasCommutativeMul.Build (polynomial R)
   poly_mul_comm.
 HB.instance Definition _ := GRing.Lalgebra_isComAlgebra.Build R (polynomial R).
 
@@ -2718,7 +2719,7 @@ Qed.
 
 Definition derivCE := (derivE, deriv_exp).
 
-End PolynomialComRing.
+End PolynomialComNzRing.
 
 Section PolynomialIdomain.
 
@@ -2764,7 +2765,7 @@ Qed.
 Fact poly_inv_out : {in [predC poly_unit], poly_inv =1 id}.
 Proof. by rewrite /poly_inv => p /negbTE/= ->. Qed.
 
-HB.instance Definition _ := GRing.ComRing_hasMulInverse.Build (polynomial R)
+HB.instance Definition _ := GRing.ComNzRing_hasMulInverse.Build (polynomial R)
   poly_mulVp poly_intro_unit poly_inv_out.
 
 HB.instance Definition _ := GRing.ComUnitRing_isIntegral.Build (polynomial R)
@@ -2948,9 +2949,9 @@ End PolynomialIdomain.
 
 (* FIXME: these are seamingly artificial ways to close the inheritance graph *)
 (*    We make parameters more and more precise to trigger completion by HB   *)
-HB.instance Definition _ (R : countRingType) :=
+HB.instance Definition _ (R : countNzRingType) :=
   [Countable of polynomial R by <:].
-HB.instance Definition _ (R : countComRingType) :=
+HB.instance Definition _ (R : countComNzRingType) :=
   [Countable of polynomial R by <:].
 HB.instance Definition _ (R : countUnitRingType) :=
   [Countable of polynomial R by <:].
@@ -2961,7 +2962,7 @@ HB.instance Definition _ (R : countIdomainType) :=
 
 Section MapFieldPoly.
 
-Variables (F : fieldType) (R : ringType) (f : {rmorphism F -> R}).
+Variables (F : fieldType) (R : nzRingType) (f : {rmorphism F -> R}).
 
 Local Notation "p ^f" := (map_poly f p) : ring_scope.
 

--- a/mathcomp/algebra/polyXY.v
+++ b/mathcomp/algebra/polyXY.v
@@ -51,9 +51,9 @@ Notation "p ^:P" := (p ^ polyC) (at level 2, format "p ^:P") : ring_scope.
 Notation "p .[ x , y ]" := (p.[x%:P].[y])
   (at level 2, left associativity, format "p .[ x ,  y ]") : ring_scope.
 
-Section PolyXY_Ring.
+Section PolyXY_NzRing.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Implicit Types (u : {poly {poly R}}) (p q : {poly R}) (x : R).
 
 Fact swapXY_key : unit. Proof. by []. Qed.
@@ -178,20 +178,20 @@ Proof. by rewrite /poly_XaY rmorph0 comp_poly0. Qed.
 Lemma poly_XmY0 : poly_XmY 0 = 0.
 Proof. by rewrite /poly_XmY rmorph0 comp_poly0. Qed.
 
-End PolyXY_Ring.
+End PolyXY_NzRing.
 
 Prenex Implicits swapXY sizeY poly_XaY poly_XmY sub_annihilant div_annihilant.
 Prenex Implicits swapXYK.
 
-Lemma swapXY_map (R S : ringType) (f : {additive R -> S}) u :
+Lemma swapXY_map (R S : nzRingType) (f : {additive R -> S}) u :
   swapXY (u ^ map_poly f) = swapXY u ^ map_poly f.
 Proof.
 by apply/polyP=> i; apply/polyP=> j; rewrite !(coef_map, coef_swapXY).
 Qed.
 
-Section PolyXY_ComRing.
+Section PolyXY_ComNzRing.
 
-Variable R : comRingType.
+Variable R : comNzRingType.
 Implicit Types (u : {poly {poly R}}) (p : {poly R}) (x y : R).
 
 Lemma horner_swapXY u x : (swapXY u).[x%:P] = u ^ eval x.
@@ -213,7 +213,7 @@ Proof. by rewrite horner_comp !hornerE. Qed.
 Lemma horner_poly_XmY p v : (poly_XmY p).[v] = p \Po (v * 'X).
 Proof. by rewrite horner_comp !hornerE. Qed.
 
-End PolyXY_ComRing.
+End PolyXY_ComNzRing.
 
 Section PolyXY_Idomain.
 

--- a/mathcomp/algebra/polydiv.v
+++ b/mathcomp/algebra/polydiv.v
@@ -5,13 +5,14 @@ From mathcomp Require Import fintype bigop ssralg poly.
 
 (******************************************************************************)
 (* This file provides a library for the basic theory of Euclidean and pseudo- *)
-(* Euclidean division for polynomials over ring structures.                   *)
+(* Euclidean division for polynomials over non trivial ring structures.       *)
 (* The library defines two versions of the pseudo-euclidean division: one for *)
-(* coefficients in a (not necessarily commutative) ring structure and one for *)
-(* coefficients equipped with a structure of integral domain. From the latter *)
-(* we derive the definition of the usual Euclidean division for coefficients  *)
-(* in a field. Only the definition of the pseudo-division for coefficients in *)
-(* an integral domain is exported by default and benefits from notations.     *)
+(* coefficients in a (not necessarily commutative) non-trivial ring structure *)
+(* and one for coefficients equipped with a structure of integral domain.     *)
+(* From the latter we derive the definition of the usual Euclidean division   *)
+(* for coefficients in a field. Only the definition of the pseudo-division    *)
+(* for coefficients in an integral domain is exported by default and benefits *)
+(* from notations.                                                            *)
 (* Also, the only theory exported by default is the one of division for       *)
 (* polynomials with coefficients in a field.                                  *)
 (* Other definitions and facts are qualified using name spaces indicating the *)
@@ -69,7 +70,7 @@ From mathcomp Require Import fintype bigop ssralg poly.
 (*                                                                            *)
 (*  Pdiv.Ring :                                                               *)
 (*   redivp p q == pseudo-division of p by q with p q : {poly R} where R is   *)
-(*                 a ringType.                                                *)
+(*                 a nzRingType.                                              *)
 (*                 Computes (k, quo, rem) : nat * {poly r} * {poly R},        *)
 (*                 such that if rem = 0 then quo * q = p * (lead_coef q ^+ k) *)
 (*                                                                            *)
@@ -78,12 +79,12 @@ From mathcomp Require Import fintype bigop ssralg poly.
 (*   rscalp p q == exponent (first component) computed by (redivp p q).       *)
 (*   rdvdp p q  == tests the nullity of the remainder of the pseudo-division  *)
 (*                 of p by q.                                                 *)
-(*   rgcdp p q  == analogue of gcdp for coefficients in a ringType.           *)
-(*   rgdcop p q == analogue of gdcop for coefficients in a ringType.          *)
-(*rcoprimep p q == analogue of coprimep p q for coefficients in a ringType.   *)
+(*   rgcdp p q  == analogue of gcdp for coefficients in a nzRingType.         *)
+(*   rgdcop p q == analogue of gdcop for coefficients in a nzRingType.        *)
+(*rcoprimep p q == analogue of coprimep p q for coefficients in a nzRingType. *)
 (*                                                                            *)
 (* Pdiv.RingComRreg : theory of the operations defined in Pdiv.Ring, when the *)
-(*   ring of coefficients is canonically commutative (R : comRingType) and    *)
+(*   ring of coefficients is canonically commutative (R : comNzRingType) and  *)
 (*   the leading coefficient of the divisor is both right regular and         *)
 (*   commutes as a constant polynomial with the divisor itself                *)
 (*                                                                            *)
@@ -112,7 +113,7 @@ Module CommonRing.
 
 Section RingPseudoDivision.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Implicit Types d p q r : {poly R}.
 
 (* Pseudo division, defined on an arbitrary ring *)
@@ -411,7 +412,7 @@ Import CommonRing.
 
 Section ComRegDivisor.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Variable d : {poly R}.
 Hypothesis Cdl : GRing.comm d (lead_coef d)%:P.
 Hypothesis Rreg : GRing.rreg (lead_coef d).
@@ -517,7 +518,7 @@ Import RingComRreg.
 
 Section RingMonic.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Implicit Types p q r : {poly R}.
 
 Section MonicDivisor.
@@ -673,7 +674,7 @@ End RingMonic.
 
 Section ComRingMonic.
 
-Variable R : comRingType.
+Variable R : comNzRingType.
 Implicit Types p q r : {poly R}.
 Variable d : {poly R}.
 Hypothesis mond : d \is monic.
@@ -708,7 +709,7 @@ Import RingMonic.
 
 Section ExtraMonicDivisor.
 
-Variable R : ringType.
+Variable R : nzRingType.
 
 Implicit Types d p q r : {poly R}.
 
@@ -741,7 +742,7 @@ Import RingComRreg.
 
 Section CommutativeRingPseudoDivision.
 
-Variable R : comRingType.
+Variable R : comNzRingType.
 
 Implicit Types d p q m n r : {poly R}.
 
@@ -880,7 +881,7 @@ Qed.
 Hint Resolve lc_expn_scalp_neq0 : core.
 
 Variant edivp_spec (m d : {poly R}) :
-                                     nat * {poly R} * {poly R} -> bool -> Type :=
+                                    nat * {poly R} * {poly R} -> bool -> Type :=
 |Redivp_spec k (q r: {poly R}) of
   (lead_coef d ^+ k) *: m = q * d + r & lead_coef d \notin GRing.unit &
   (d != 0 -> size r < size d) : edivp_spec m d (k, q, r) false
@@ -1058,7 +1059,8 @@ Proof.
 have [-> | nq0] := eqVneq q 0; first by rewrite modp0 mulr0.
 have rlcq : GRing.rreg (lead_coef q) by apply/rregP; rewrite lead_coef_eq0.
 have hC : GRing.comm q (lead_coef q)%:P by red; rewrite mulrC.
-by rewrite modpE; case: ifP => ulcq; rewrite RingComRreg.rmodp_mull // scaler0.
+rewrite modpE; case: ifP => ulcq; rewrite RingComRreg.rmodp_mull //.
+exact: scaler0.
 Qed.
 
 Lemma modp_mulr d p : (d * p) %% d = 0. Proof. by rewrite mulrC modp_mull. Qed.
@@ -1300,7 +1302,8 @@ case: (eqVneq n 0) => [-> _ /dvd0pP -> // | nn0].
 rewrite dvdp_eq; set c1 := _ ^+ _; set q1 := _ %/ _; move/eqP=> Hq1.
 rewrite dvdp_eq; set c2 := _ ^+ _; set q2 := _ %/ _; move/eqP=> Hq2.
 have sn0 : c1 * c2 != 0 by rewrite mulf_neq0 // expf_neq0 // lead_coef_eq0.
-by apply: (@eq_dvdp _ (q2 * q1) _ _ sn0); rewrite -scalerA Hq2 scalerAr Hq1 mulrA.
+apply: (@eq_dvdp _ (q2 * q1) _ _ sn0).
+by rewrite -scalerA Hq2 scalerAr Hq1 mulrA.
 Qed.
 
 Lemma dvdp_mulIl p q : p %| p * q. Proof. exact/dvdp_mulr/dvdpp. Qed.
@@ -1393,7 +1396,7 @@ Lemma eqpP m n :
           (m %= n).
 Proof.
 apply: (iffP idP) => [| [[c1 c2]/andP[nz_c1 nz_c2 eq_cmn]]]; last first.
-  rewrite /eqp (@eq_dvdp c2 c1%:P) -?eq_cmn ?mul_polyC // (@eq_dvdp c1 c2%:P) //.
+  rewrite /eqp (@eq_dvdp c2 c1%:P) -?eq_cmn ?mul_polyC // (@eq_dvdp c1 c2%:P)//.
   by rewrite eq_cmn mul_polyC.
 case: (eqVneq m 0) => [-> /andP [/dvd0pP -> _] | m_nz].
   by exists (1, 1); rewrite ?scaler0 // oner_eq0.
@@ -1578,7 +1581,7 @@ Qed.
 
 Lemma eqp_rdiv_div p q : rdivp p q %= divp p q.
 Proof.
-rewrite divpE eqp_sym; case: ifP=> ulcq //; apply: eqp_scale; rewrite invr_eq0 //.
+rewrite divpE eqp_sym; case: ifP=> ulcq//; apply: eqp_scale; rewrite invr_eq0//.
 by apply: expf_neq0; apply: contraTneq ulcq => ->; rewrite unitr0.
 Qed.
 
@@ -2363,7 +2366,7 @@ Proof.
 have/factor_theorem [q /(canRL (subrK _)) Dp]: root (p - p.[c]%:P) c.
   by rewrite /root !hornerE subrr.
 rewrite modpE /= lead_coefXsubC unitr1 expr1n invr1 scale1r [in LHS]Dp.
-rewrite RingMonic.rmodp_addl_mul_small // ?monicXsubC // size_XsubC size_polyC.
+rewrite RingMonic.rmodp_addl_mul_small // ?monicXsubC// size_XsubC size_polyC.
 by case: (p.[c] == 0).
 Qed.
 
@@ -3103,7 +3106,7 @@ Lemma Bezout_eq1_coprimepP p q :
   reflect (exists u, u.1 * p + u.2 * q = 1) (coprimep p q).
 Proof.
 apply: (iffP idP)=> [hpq|]; last first.
-  by case=> [[u v]] /= e; apply/Bezout_coprimepP; exists (u, v); rewrite e eqpxx.
+  by case=> -[u v] /= e; apply/Bezout_coprimepP; exists (u, v); rewrite e eqpxx.
 case/Bezout_coprimepP: hpq => [[u v]] /=.
 case/eqpP=> [[c1 c2]] /andP /= [c1n0 c2n0] e.
 exists (c2^-1 *: (c1 *: u), c2^-1 *: (c1 *: v)); rewrite /= -!scalerAl.
@@ -3167,7 +3170,8 @@ suff n_small : (n < (size q).+1)%N by exact: (gti (Ordinal n_small)).
 by rewrite ltnS ltnW// -(size_exp_XsubC _ x) dvdp_leq.
 Qed.
 
-Lemma mup_leq x q n : q != 0 -> (mup x q <= n)%N = ~~ (('X - x%:P) ^+ n.+1 %| q).
+Lemma mup_leq x q n : q != 0 ->
+  (mup x q <= n)%N = ~~ (('X - x%:P) ^+ n.+1 %| q).
 Proof. by move=> qN0; rewrite leqNgt mup_geq. Qed.
 
 Lemma mup_ltn x q n : q != 0 -> (mup x q < n)%N = ~~ (('X - x%:P) ^+ n %| q).
@@ -3236,7 +3240,7 @@ End Multiplicity.
 
 Section FieldRingMap.
 
-Variable rR : ringType.
+Variable rR : nzRingType.
 
 Variable f : {rmorphism F -> rR}.
 Local Notation "p ^f" := (map_poly f p) : ring_scope.

--- a/mathcomp/algebra/qpoly.v
+++ b/mathcomp/algebra/qpoly.v
@@ -59,7 +59,7 @@ Reserved Notation "{ 'poly' '%/' p }"
   (at level 0, p at level 2, format "{ 'poly'  '%/'  p }").
 
 Section poly_of_size_zmod.
-Context {R : ringType}.
+Context {R : nzRingType}.
 Implicit Types (n : nat).
 
 Section poly_of_size.
@@ -138,14 +138,14 @@ Hint Resolve size_npoly npoly_is_a_poly_of_size : core.
 Arguments poly_of_size_pred _ _ _ /.
 Arguments npoly : clear implicits.
 
-HB.instance Definition _ (R : countRingType) n :=
+HB.instance Definition _ (R : countNzRingType) n :=
   [Countable of {poly_n R} by <:].
 
-HB.instance Definition _  (R : finRingType) n : isFinite {poly_n R} :=
+HB.instance Definition _  (R : finNzRingType) n : isFinite {poly_n R} :=
   CanIsFinite (@npoly_rV_K R n).
 
 Section npoly_theory.
-Context (R : ringType) {n : nat}.
+Context (R : nzRingType) {n : nat}.
 
 Lemma polyn_is_linear : linear (@polyn _ _ : {poly_n R} -> _).
 Proof. by []. Qed.
@@ -194,7 +194,7 @@ Arguments npolyp {R} n p.
 
 Section fin_npoly.
 
-Variable R : finRingType.
+Variable R : finNzRingType.
 Variable n : nat.
 Implicit Types p q : {poly_n R}.
 
@@ -411,7 +411,7 @@ Notation "x .-lagrange_" := (tnth x.-lagrange) : ring_scope.
 
 Section Qpoly.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Variable h : {poly R}.
 
 Definition mk_monic := 
@@ -424,7 +424,7 @@ Notation "{ 'poly' '%/' p }" := (qpoly p) : type_scope.
  
 Section QpolyProp.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Variable h : {poly R}.
 
 Lemma monic_mk_monic : (mk_monic h) \is monic.
@@ -526,23 +526,23 @@ End QpolyProp.
 
 Notation "'qX" := (qpolyX _) : ring_scope.
 
-Lemma mk_monic_X (R : ringType) : mk_monic 'X = 'X :> {poly R}.
+Lemma mk_monic_X (R : nzRingType) : mk_monic 'X = 'X :> {poly R}.
 Proof. by rewrite /mk_monic size_polyX monicX. Qed.
 
-Lemma mk_monic_Xn (R : ringType) n : mk_monic 'X^n = 'X^n.-1.+1 :> {poly R}.
+Lemma mk_monic_Xn (R : nzRingType) n : mk_monic 'X^n = 'X^n.-1.+1 :> {poly R}.
 Proof. by case: n => [|n]; rewrite /mk_monic size_polyXn monicXn /= ?expr1. Qed.
 
-Lemma card_qpoly (R : finRingType) (h : {poly R}):
+Lemma card_qpoly (R : finNzRingType) (h : {poly R}):
    #|{poly %/ h}| = #|R| ^ (size (mk_monic h)).-1.
 Proof. by rewrite card_npoly. Qed.
 
-Lemma card_monic_qpoly (R : finRingType) (h : {poly R}):
+Lemma card_monic_qpoly (R : finNzRingType) (h : {poly R}):
   1 < size h -> h \is monic ->  #|{poly %/ h}| = #|R| ^ (size h).-1.
 Proof. by move=> sh_gt1 hM; rewrite card_qpoly /mk_monic sh_gt1 hM. Qed.
 
 Section QRing.
 
-Variable A : comRingType.
+Variable A : comNzRingType.
 Variable h : {poly A}.
 
 (* Ring operations *)
@@ -565,9 +565,9 @@ Qed.
 Lemma qpoly_mul_addl : left_distributive (@qpoly_mul A h) +%R.
 Proof. by move=> p q r; rewrite -!(qpoly_mulC r) qpoly_mul_addr. Qed.
 
-HB.instance Definition _ := GRing.Zmodule_isComRing.Build {poly__ A} qpoly_mulA
+HB.instance Definition _ := GRing.Zmodule_isComNzRing.Build {poly__ A} qpoly_mulA
   qpoly_mulC (@qpoly_mul1z _ h) qpoly_mul_addl (@qpoly_nontrivial _ h).
-HB.instance Definition _ := GRing.ComRing.on {poly %/ h}.
+HB.instance Definition _ := GRing.ComNzRing.on {poly %/ h}.
 
 Lemma in_qpoly1 : in_qpoly h 1 = 1.
 Proof.
@@ -735,7 +735,7 @@ Qed.
 Lemma qpoly_inv_out (p : {poly %/ h}) : ~~ coprimep hQ p -> qpoly_inv p = p.
 Proof. by rewrite /qpoly_inv => /negPf->. Qed.
 
-HB.instance Definition _ := GRing.ComRing_hasMulInverse.Build {poly__ _}
+HB.instance Definition _ := GRing.ComNzRing_hasMulInverse.Build {poly__ _}
   qpoly_mulVz qpoly_intro_unit qpoly_inv_out.
 HB.instance Definition _ := GRing.ComUnitAlgebra.on {poly %/ h}.
 

--- a/mathcomp/algebra/rat.v
+++ b/mathcomp/algebra/rat.v
@@ -497,7 +497,7 @@ Qed.
 Fact nonzero1q : oneq != zeroq. Proof. by []. Qed.
 
 HB.instance Definition _ :=
-  GRing.Zmodule_isComRing.Build rat mulqA mulqC mul1q mulq_addl nonzero1q.
+  GRing.Zmodule_isComNzRing.Build rat mulqA mulqC mul1q mulq_addl nonzero1q.
 
 Fact mulVq x : x != 0 -> mulq (invq x) x = 1.
 Proof.
@@ -508,7 +508,7 @@ Qed.
 
 Fact invq0 : invq 0 = 0. Proof. exact/eqP. Qed.
 
-HB.instance Definition _ := GRing.ComRing_isField.Build rat mulVq invq0.
+HB.instance Definition _ := GRing.ComNzRing_isField.Build rat mulVq invq0.
 
 Lemma numq_eq0 x : (numq x == 0) = (x == 0).
 Proof.

--- a/mathcomp/algebra/ring_quotient.v
+++ b/mathcomp/algebra/ring_quotient.v
@@ -32,12 +32,12 @@ From mathcomp Require Import seq ssralg generic_quotient.
 (*                               quotient  of  the  parameters  z,  n and a,  *)
 (*                               respectively                                 *)
 (*                               The HB class is called ZmodQuotient.         *)
-(* ringQuotType T e z n a o m == ring  obtained  by quotienting  type T with  *)
-(*                               the relation e  and  whose zero opposite,    *)
-(*                               addition, one, and multiplication are  the   *)
-(*                               images  in  the  quotient  of the parameters *)
-(*                               z, n, a, o, m, respectively                  *)
-(*                               The HB class is called RingQuotient.         *)
+(* nzRingQuotType T e z n a o m == non trivial ring  obtained  by quotienting *)
+(*                               type T with the relation e  and  whose zero  *)
+(*                               opposite, addition, one, and multiplication  *)
+(*                               are  the images  in  the  quotient  of the   *)
+(*                               parameters z, n, a, o, m, respectively       *)
+(*                               The HB class is called NzRingQuotient.       *)
 (*   unitRingQuotType ... u i == As in the previous cases, instance of unit   *)
 (*                               ring whose unit predicate  is obtained from  *)
 (*                               u and the inverse from i                     *)
@@ -133,37 +133,53 @@ Variable eqT : rel T.
 Variables (zeroT : T) (oppT : T -> T) (addT : T -> T -> T).
 Variables (oneT : T) (mulT : T -> T -> T).
  *)
-HB.mixin Record isRingQuotient T eqT zeroT oppT
+HB.mixin Record isNzRingQuotient T eqT zeroT oppT
 addT (oneT : T) (mulT : T -> T -> T) (Q : Type)
-  of ZmodQuotient T eqT zeroT oppT addT Q & GRing.Ring Q:=
+  of ZmodQuotient T eqT zeroT oppT addT Q & GRing.NzRing Q:=
   {
     pi_oner : \pi_Q oneT = 1;
     pi_mulr : {morph \pi_Q : x y / mulT x y >-> x * y}
   }.
 
-#[short(type="ringQuotType")]
-HB.structure Definition RingQuotient T eqT zeroT oppT addT oneT mulT :=
-  {Q of isRingQuotient T eqT zeroT oppT addT oneT mulT Q &
-   ZmodQuotient T eqT zeroT oppT addT Q & GRing.Ring Q }.
+Module isRingQuotient.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use isNzRingQuotient.Build instead.")]
+Notation Build T eqT zeroT oppT addT oneT mulT Q :=
+  (isNzRingQuotient.Build T eqT zeroT oppT addT oneT mulT Q) (only parsing).
+End isRingQuotient.
 
-Section ringQuotient.
-(*Clash with the module name RingQuotient*)
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use isNzRingQuotient instead.")]
+Notation isRingQuotient T eqT zeroT oppT addT oneT mulT Q :=
+  (isNzRingQuotient T eqT zeroT oppT addT oneT mulT Q) (only parsing).
+
+#[short(type="nzRingQuotType")]
+HB.structure Definition NzRingQuotient T eqT zeroT oppT addT oneT mulT :=
+  {Q of isNzRingQuotient T eqT zeroT oppT addT oneT mulT Q &
+   ZmodQuotient T eqT zeroT oppT addT Q & GRing.NzRing Q }.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use nzRingQuotType instead.")]
+Notation ringQuotType := (nzRingQuotType) (only parsing).
+
+Section nzRingQuotient.
+(*Clash with the module name NzRingQuotient*)
 
 Variable (T : Type).
 Variable eqT : rel T.
 Variables (zeroT : T) (oppT : T -> T) (addT : T -> T -> T) (oneT : T) (mulT : T -> T -> T).
-Implicit Type rqT : RingQuotient.type eqT zeroT oppT addT oneT mulT.
+Implicit Type rqT : NzRingQuotient.type eqT zeroT oppT addT oneT mulT.
 
 Canonical pi_one_quot_morph rqT := PiMorph (@pi_oner _ _ _ _ _ _ _ rqT).
 Canonical pi_mul_quot_morph rqT := PiMorph2 (@pi_mulr _ _ _ _ _ _ _ rqT).
 
-End ringQuotient.
+End nzRingQuotient.
 
 Section PiRMorphism.
 
-Variables (R : ringType) (equivR : rel R) (zeroR : R).
+Variables (R : nzRingType) (equivR : rel R) (zeroR : R).
 
-Variable Q : @ringQuotType R equivR zeroR -%R +%R 1 *%R.
+Variable Q : @nzRingQuotType R equivR zeroR -%R +%R 1 *%R.
 
 Lemma pi_is_multiplicative : multiplicative \pi_Q.
 Proof. by split; do ?move=> x y /=; rewrite !piE. Qed.
@@ -174,7 +190,7 @@ HB.instance Definition _ := GRing.isMultiplicative.Build R Q \pi_Q
 End PiRMorphism.
 
 HB.mixin Record isUnitRingQuotient T eqT zeroT oppT addT oneT mulT (unitT : pred T) (invT : T -> T)
-  (Q : Type) of RingQuotient T eqT zeroT oppT addT oneT mulT Q & GRing.UnitRing Q :=
+  (Q : Type) of NzRingQuotient T eqT zeroT oppT addT oneT mulT Q & GRing.UnitRing Q :=
   {
     pi_unitr : {mono \pi_Q : x / unitT x >-> x \in GRing.unit};
     pi_invr : {morph \pi_Q : x / invT x >-> x^-1}
@@ -182,7 +198,7 @@ HB.mixin Record isUnitRingQuotient T eqT zeroT oppT addT oneT mulT (unitT : pred
 
 #[short(type="unitRingQuotType")]
 HB.structure Definition UnitRingQuotient T eqT zeroT oppT addT oneT mulT unitT invT :=
-  {Q of isUnitRingQuotient T eqT zeroT oppT addT oneT mulT unitT invT Q & GRing.UnitRing Q & isQuotient T Q & isEqQuotient T eqT Q & isZmodQuotient T eqT zeroT oppT addT Q & isRingQuotient T eqT zeroT oppT addT oneT mulT Q}.
+  {Q of isUnitRingQuotient T eqT zeroT oppT addT oneT mulT unitT invT Q & GRing.UnitRing Q & isQuotient T Q & isEqQuotient T eqT Q & isZmodQuotient T eqT zeroT oppT addT Q & isNzRingQuotient T eqT zeroT oppT addT oneT mulT Q}.
 
 Section UnitRingQuot.
 Variable (T : Type).
@@ -197,13 +213,13 @@ Canonical pi_inv_quot_morph urqT := PiMorph1 (@pi_invr _ _ _ _ _ _ _ _ _ urqT).
 
 End UnitRingQuot.
 
-Definition proper_ideal (R : ringType) (S : {pred R}) : Prop :=
+Definition proper_ideal (R : nzRingType) (S : {pred R}) : Prop :=
   1 \notin S /\ forall a, {in S, forall u, a * u \in S}.
 
-Definition prime_idealr_closed (R : ringType) (S : {pred R}) : Prop :=
+Definition prime_idealr_closed (R : nzRingType) (S : {pred R}) : Prop :=
   forall u v, u * v \in S -> (u \in S) || (v \in S).
 
-Definition idealr_closed (R : ringType) (S : {pred R}) :=
+Definition idealr_closed (R : nzRingType) (S : {pred R}) :=
   [/\ 0 \in S, 1 \notin S & forall a, {in S &, forall u v, a * u + v \in S}].
 
 Lemma idealr_closed_nontrivial R S : @idealr_closed R S -> proper_ideal S.
@@ -212,7 +228,7 @@ Proof. by case=> S0 S1 hS; split => // a x xS; rewrite -[_ * _]addr0 hS. Qed.
 Lemma idealr_closedB R S : @idealr_closed R S -> zmod_closed S.
 Proof. by case=> S0 _ hS; split=> // x y xS yS; rewrite -mulN1r addrC hS. Qed.
 
-HB.mixin Record isProperIdeal (R : ringType) (S : R -> bool) := {
+HB.mixin Record isProperIdeal (R : nzRingType) (S : R -> bool) := {
   proper_ideal_subproof : proper_ideal S
 }.
 
@@ -220,18 +236,18 @@ HB.mixin Record isProperIdeal (R : ringType) (S : R -> bool) := {
 HB.structure Definition ProperIdeal R := {S of isProperIdeal R S}.
 
 #[short(type="idealr")]
-HB.structure Definition Idealr (R : ringType) :=
+HB.structure Definition Idealr (R : nzRingType) :=
   {S of GRing.ZmodClosed R S & ProperIdeal R S}.
 
-HB.mixin Record isPrimeIdealrClosed (R : ringType) (S : R -> bool) := {
+HB.mixin Record isPrimeIdealrClosed (R : nzRingType) (S : R -> bool) := {
   prime_idealr_closed_subproof : prime_idealr_closed S
 }.
 
 #[short(type="prime_idealr")]
-HB.structure Definition PrimeIdealr (R : ringType) :=
+HB.structure Definition PrimeIdealr (R : nzRingType) :=
   {S of Idealr R S & isPrimeIdealrClosed R S}.
 
-HB.factory Record isIdealr (R : ringType) (S : R -> bool) := {
+HB.factory Record isIdealr (R : nzRingType) (S : R -> bool) := {
   idealr_closed_subproof : idealr_closed S
 }.
 
@@ -243,7 +259,7 @@ HB.instance Definition _ := isProperIdeal.Build R S
 HB.end.
 
 Section IdealTheory.
-Variables (R : ringType) (idealrI : idealr R).
+Variables (R : nzRingType) (idealrI : idealr R).
 Local Notation I := (idealrI : pred R).
 
 Lemma idealr1 : 1 \in I = false.
@@ -258,7 +274,7 @@ End IdealTheory.
 
 Section PrimeIdealTheory.
 
-Variables (R : comRingType) (pidealI : prime_idealr R).
+Variables (R : comNzRingType) (pidealI : prime_idealr R).
 Local Notation I := (pidealI : pred R).
 
 Lemma prime_idealrM u v : (u * v \in I) = (u \in I) || (v \in I).
@@ -346,7 +362,7 @@ Notation "{ 'quot' I }" := (quot I) : type_scope.
 
 Section RingQuotient.
 
-Variables (R : comRingType) (idealI : idealr R).
+Variables (R : comNzRingType) (idealI : idealr R).
 Local Notation I := (idealI : pred R).
 
 Definition one : {quot idealI} := lift_cst {quot idealI} 1.
@@ -383,18 +399,18 @@ Lemma nonzero1q: one != 0.
 Proof. by rewrite piE equivE subr0 idealr1. Qed.
 
 #[export]
-HB.instance Definition _ := GRing.Zmodule_isComRing.Build (quot idealI)
+HB.instance Definition _ := GRing.Zmodule_isComNzRing.Build (quot idealI)
   mulqA mulqC mul1q mulq_addl nonzero1q.
 
 #[export]
-HB.instance Definition _ := @isRingQuotient.Build
+HB.instance Definition _ := @isNzRingQuotient.Build
   R (equiv idealI) 0 -%R +%R 1%R *%R (quot idealI) (lock _) pi_mul.
 
 End RingQuotient.
 
 Section IDomainQuotient.
 
-Variables (R : comRingType) (I : prime_idealr R).
+Variables (R : comNzRingType) (I : prime_idealr R).
 
 Lemma rquot_IdomainAxiom (x y : {quot I}): x * y = 0 -> (x == 0) || (y == 0).
 Proof.

--- a/mathcomp/algebra/sesquilinear.v
+++ b/mathcomp/algebra/sesquilinear.v
@@ -13,7 +13,7 @@ From mathcomp Require Import zmodp poly order ssrnum matrix mxalgebra vector.
 (*               M ^t phi := (M ^T) ^ phi                                     *)
 (*                           Notation in scope form_scope.                    *)
 (* involutive_rmorphism R == the type of involutive functions                 *)
-(*                           R has type ringType.                             *)
+(*                           R has type nzRingType.                           *)
 (*                           The HB class is InvolutiveRMorphism.             *)
 (*                                                                            *)
 (* {bilinear U -> U' -> V | s & s'} == the type of bilinear forms which are   *)
@@ -38,7 +38,7 @@ From mathcomp Require Import zmodp poly order ssrnum matrix mxalgebra vector.
 (* {hermitian U for eps & theta} == hermitian/skew-hermitian form             *)
 (*                           eps is a boolean flag,                           *)
 (*                           (false -> hermitian, true -> skew-hermitian),    *)
-(*                           theta is a function R -> R (R : ringType).       *)
+(*                           theta is a function R -> R (R : nzRingType).     *)
 (*                           The HB class is Hermitian.                       *)
 (*                           *%R is used as a the first scaling operator.     *)
 (*                           theta \; *R is used as the second scaling        *)
@@ -130,20 +130,20 @@ Notation "M ^ phi" := (map_mx phi M) : form_scope.
 Notation "M ^t phi" := ((M ^T) ^ phi) : form_scope.
 
 (* TODO: move? *)
-Lemma eq_map_mx_id (R : ringType) m n (M : 'M[R]_(m, n)) (f : R -> R) :
+Lemma eq_map_mx_id (R : nzRingType) m n (M : 'M[R]_(m, n)) (f : R -> R) :
   f =1 id -> M ^ f = M.
 Proof. by move=> /eq_map_mx->; rewrite map_mx_id. Qed.
 
-HB.mixin Record isInvolutive (R : ringType) (f : R -> R) :=
+HB.mixin Record isInvolutive (R : nzRingType) (f : R -> R) :=
   { involutive_subproof : involutive f }.
 
 (* TODO: move? *)
 #[short(type="involutive_rmorphism")]
-HB.structure Definition InvolutiveRMorphism (R : ringType) :=
+HB.structure Definition InvolutiveRMorphism (R : nzRingType) :=
   { f of @GRing.RMorphism R R f & @isInvolutive R f }.
 
 Section InvolutiveTheory.
-Variable R : ringType.
+Variable R : nzRingType.
 
 Let idfunK : involutive (@idfun R). Proof. by []. Qed.
 
@@ -181,7 +181,7 @@ Notation "[ 'revop' revop 'of' op ]" :=
   (@RevOp _ _ _ revop op (fun _ _ => erefl))
   (at level 0, format "[ 'revop'  revop  'of'  op ]") : form_scope.*)
 
-HB.mixin Record isBilinear (R : ringType) (U U' : lmodType R) (V : zmodType)
+HB.mixin Record isBilinear (R : nzRingType) (U U' : lmodType R) (V : zmodType)
     (s : R -> V -> V) (s' : R -> V -> V) (f : U -> U' -> V) := {
   additivel_subproof : forall u', additive (f ^~ u') ;
   additiver_subproof : forall u, additive (f u) ;
@@ -190,16 +190,16 @@ HB.mixin Record isBilinear (R : ringType) (U U' : lmodType R) (V : zmodType)
 }.
 
 #[short(type="bilinear")]
-HB.structure Definition Bilinear (R : ringType) (U U' : lmodType R)
+HB.structure Definition Bilinear (R : nzRingType) (U U' : lmodType R)
     (V : zmodType) (s : R -> V -> V) (s' : R -> V -> V) :=
   {f of isBilinear R U U' V s s' f}.
 
-Definition bilinear_for (R : ringType) (U U' : lmodType R) (V : zmodType)
+Definition bilinear_for (R : nzRingType) (U U' : lmodType R) (V : zmodType)
     (s : GRing.Scale.law R V) (s' : GRing.Scale.law R V) (f : U -> U' -> V) :=
   ((forall u', GRing.linear_for (s : R -> V -> V) (f ^~ u'))
   * (forall u, GRing.linear_for s' (f u)))%type.
 
-HB.factory Record bilinear_isBilinear (R : ringType) (U U' : lmodType R)
+HB.factory Record bilinear_isBilinear (R : nzRingType) (U U' : lmodType R)
     (V : zmodType) (s : GRing.Scale.law R V) (s' : GRing.Scale.law R V)
     (f : U -> U' -> V) := {
   bilinear_subproof : bilinear_for s s' f
@@ -217,7 +217,7 @@ Module BilinearExports.
 
 Module Bilinear.
 Section bilinear.
-Variables (R : ringType) (U U' : lmodType R) (V : zmodType) (s s' : R -> V -> V).
+Variables (R : nzRingType) (U U' : lmodType R) (V : zmodType) (s s' : R -> V -> V).
 
 Local Notation bilinear f := (bilinear_for *:%R *:%R f).
 Local Notation biscalar f := (bilinear_for *%R *%R f).
@@ -264,18 +264,18 @@ End BilinearExports.
 Export BilinearExports.
 
 #[non_forgetful_inheritance]
-HB.instance Definition _ (R : ringType) (U U' : lmodType R) (V : zmodType)
+HB.instance Definition _ (R : nzRingType) (U U' : lmodType R) (V : zmodType)
     (s : R -> V -> V) (s' : R -> V -> V)
   (f : {bilinear U -> U' -> V | s & s'}) (u : U)
   := @GRing.isAdditive.Build U' V (f u) (@additiver_subproof _ _ _ _ _ _ f u).
 
 #[non_forgetful_inheritance]
-HB.instance Definition _ (R : ringType) (U U' : lmodType R) (V : zmodType)
+HB.instance Definition _ (R : nzRingType) (U U' : lmodType R) (V : zmodType)
     (s : R -> V -> V) (s' : R -> V -> V) (f : @bilinear R U U' V s s') (u : U)
   := @GRing.isScalable.Build _ _ _ _ (f u) (@linearr_subproof _ _ _ _ _ _ f u).
 
 Section applyr.
-Variables (R : ringType) (U U' : lmodType R) (V : zmodType)
+Variables (R : nzRingType) (U U' : lmodType R) (V : zmodType)
   (s s' : R -> V -> V).
 
 Definition applyr_head t (f : U -> U' -> V) u v := let: tt := t in f v u.
@@ -298,7 +298,7 @@ Coercion Bilinear.wrap : Bilinear.map_class >-> Bilinear.wrapped.
 Canonical Bilinear.wrap.
 
 Section BilinearTheory.
-Variable R : ringType.
+Variable R : nzRingType.
 
 Section GenericProperties.
 Variables (U U' : lmodType R) (V : zmodType) (s : R -> V -> V) (s' : R -> V -> V).
@@ -366,7 +366,7 @@ End GenericProperties.
 
 Section BidirectionalLinearZ.
 Variables (U U' : lmodType R) (V : zmodType) (s s' : R -> V -> V).
-Variables (S : ringType) (h : GRing.Scale.law S V) (h' : GRing.Scale.law S V).
+Variables (S : nzRingType) (h : GRing.Scale.law S V) (h' : GRing.Scale.law S V).
 
 Lemma linearZl z (c : S) (a : R) (h_c := h c)
     (f : Bilinear.map_for_left U U' s s' a h_c) u :
@@ -393,11 +393,11 @@ End BidirectionalLinearZ.
 End BilinearTheory.
 
 (* TODO
-Canonical rev_mulmx (R : ringType) m n p := [revop mulmxr of @mulmx R m n p].
+Canonical rev_mulmx (R : nzRingType) m n p := [revop mulmxr of @mulmx R m n p].
 *)
 
-(*Canonical mulmx_bilinear (R : comRingType) m n p := [bilinear of @mulmx R m n p].*)
-Lemma mulmx_is_bilinear (R : comRingType) m n p : bilinear_for
+(*Canonical mulmx_bilinear (R : comNzRingType) m n p := [bilinear of @mulmx R m n p].*)
+Lemma mulmx_is_bilinear (R : comNzRingType) m n p : bilinear_for
   (GRing.Scale.Law.clone _ _ *:%R _) (GRing.Scale.Law.clone _ _ *:%R _)
   (@mulmx R m n p).
 Proof.
@@ -406,7 +406,7 @@ split=> [u'|u] a x y /=.
 - by rewrite mulmxDr scalemxAr.
 Qed.
 
-HB.instance Definition _ (R : comRingType) m n p := bilinear_isBilinear.Build R
+HB.instance Definition _ (R : comNzRingType) m n p := bilinear_isBilinear.Build R
   [the lmodType R of 'M[R]_(m, n)] [the lmodType R of 'M[R]_(n, p)]
   [the zmodType of 'M[R]_(m, p)] _ _ (@mulmx R m n p)
   (mulmx_is_bilinear R m n p).
@@ -457,12 +457,12 @@ Proof. by rewrite/form=> -> u v; rewrite mulmx0 mul0mx mxE. Qed.
 
 End BilinearForms.
 
-HB.mixin Record isHermitianSesquilinear (R : ringType) (U : lmodType R)
+HB.mixin Record isHermitianSesquilinear (R : nzRingType) (U : lmodType R)
     (eps : bool) (theta : R -> R) (f : U -> U -> R) := {
   hermitian_subproof : forall x y : U, f x y = (-1) ^+ eps * theta (f y x)
 }.
 
-HB.structure Definition Hermitian (R : ringType) (U : lmodType R)
+HB.structure Definition Hermitian (R : nzRingType) (U : lmodType R)
     (eps : bool) (theta : R -> R) :=
   {f of @Bilinear R U U _ ( *%R ) (theta \; *%R) f &
         @isHermitianSesquilinear R U eps theta f}.
@@ -472,16 +472,16 @@ Notation "{ 'hermitian' U 'for' eps & theta }" := (@Hermitian.type _ U eps theta
 
 (* duplicate to trick HB *)
 #[non_forgetful_inheritance]
-HB.instance Definition _ (R : ringType) (U : lmodType R)
+HB.instance Definition _ (R : nzRingType) (U : lmodType R)
     (eps : bool) (theta : R -> R) (f : {hermitian U for eps & theta}) (u : U) :=
   @GRing.isAdditive.Build _ _ (f u) (@additiver_subproof _ _ _ _ _ _ f u).
 
 #[non_forgetful_inheritance]
-HB.instance Definition _ (R : ringType) (U : lmodType R)
+HB.instance Definition _ (R : nzRingType) (U : lmodType R)
     (eps : bool) (theta : R -> R) (f : {hermitian U for eps & theta}) (u : U) :=
   @GRing.isScalable.Build _ _ _ _ (f u) (@linearr_subproof _ _ _ _ _ _ f u).
 
-(*Variables (R : ringType) (U : lmodType R) (eps : bool) (theta : R -> R).
+(*Variables (R : nzRingType) (U : lmodType R) (eps : bool) (theta : R -> R).
 Implicit Types phU : phant U.
 
 Local Coercion GRing.Scale.op : GRing.Scale.law >-> Funclass.
@@ -757,18 +757,18 @@ Notation "{ 'skew_symmetric' U }" := ({hermitian U for true & idfun})
 Notation "{ 'hermitian_sym' U 'for' theta }" := ({hermitian U for false & theta})
   (at level 0, format "{ 'hermitian_sym'  U  'for'  theta }") : ring_scope.
 
-Definition is_skew (R : ringType) (eps : bool) (theta : R -> R)
+Definition is_skew (R : nzRingType) (eps : bool) (theta : R -> R)
   (U : lmodType R) (form : {hermitian U for eps & theta}) :=
   (eps = true) /\ (theta =1 id).
-Definition is_sym (R : ringType) (eps : bool) (theta : R -> R)
+Definition is_sym (R : nzRingType) (eps : bool) (theta : R -> R)
   (U : lmodType R) (form : {hermitian U for eps & theta}) :=
   (eps = false) /\ (theta =1 id).
-Definition is_hermsym  (R : ringType) (eps : bool) (theta : R -> R)
+Definition is_hermsym  (R : nzRingType) (eps : bool) (theta : R -> R)
   (U : lmodType R) (form : {hermitian U for eps & theta}) :=
   (eps = false).
 
 Section HermitianModuleTheory.
-Variables (R : ringType) (eps : bool) (theta : {rmorphism R -> R}).
+Variables (R : nzRingType) (eps : bool) (theta : {rmorphism R -> R}).
 Variables (U : lmodType R) (form : {hermitian U for eps & theta}).
 
 Local Notation "''[' u , v ]" := (form u%R v%R) : ring_scope.
@@ -839,7 +839,7 @@ Arguments pairwise_orthogonal {R eps theta U} form s.
 Arguments orthonormal {R eps theta U} form s.
 
 Section HermitianIsometry.
-Variables (R : ringType) (eps : bool) (theta : {rmorphism R -> R}).
+Variables (R : nzRingType) (eps : bool) (theta : {rmorphism R -> R}).
 Variables (U1 U2 : lmodType R) (form1 : {hermitian U1 for eps & theta})
           (form2 : {hermitian U2 for eps & theta}).
 

--- a/mathcomp/algebra/ssralg.v
+++ b/mathcomp/algebra/ssralg.v
@@ -18,15 +18,16 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                    The HB class is called Nmodule.                         *)
 (*        zmodType == additive abelian group (Nmodule with an opposite)       *)
 (*                    The HB class is called Zmodule.                         *)
-(*    semiRingType == non-commutative semi rings                              *)
+(*  semiNzRingType == non-commutative non-trivial semi rings                  *)
 (*                    (NModule with a multiplication)                         *)
-(*                    The HB class is called SemiRing.                        *)
+(*                    The HB class is called NzSemiRing.                      *)
 (* comSemiRingType == commutative semi rings                                  *)
 (*                    The HB class is called ComSemiRing.                     *)
-(*        ringType == non-commutative rings (semi rings with an opposite)     *)
-(*                    The HB class is called Ring.                            *)
-(*     comRingType == commutative rings                                       *)
-(*                    The HB class is called ComRing.                         *)
+(*      nzRingType == non-commutative non-trivial rings                       *)
+(*                    (semi rings with an opposite)                           *)
+(*                    The HB class is called NzRing.                          *)
+(*     comNzRingType == commutative non-trivial rings                         *)
+(*                    The HB class is called ComNzRing.                       *)
 (*      lmodType R == module with left multiplication by external scalars     *)
 (*                    in the ring R                                           *)
 (*                    The HB class is called Lmodule.                         *)
@@ -62,18 +63,19 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*         subZmodType V P == join of zmodType and subType (P : pred V)       *)
 (*                            such that val is additive                       *)
 (*                            The HB class is called SubZmodule.              *)
-(*     subSemiRingType R P == join of semiRingType and subType (P : pred R)   *)
-(*                            such that val is a semiring morphism            *)
-(*                            The HB class is called SubSemiRing.             *)
-(*  subComSemiRingType R P == join of comSemiRingType and subType (P : pred R)*)
+(*   subNzSemiRingType R P == join of semiNzRingType and                      *)
+(*                            subType (P : pred R) such that val is a         *)
+(*                            semiring morphism                               *)
+(*                            The HB class is called SubNzSemiRing.           *)
+(*subComNzSemiRingType R P == join of comNzSemiRingType and                   *)
+(*                            subType (P : pred R) such that val is a morphism*)
+(*                            The HB class is called SubComNzSemiRing.        *)
+(*       subNzRingType R P == join of nzRingType and subType (P : pred R)     *)
 (*                            such that val is a morphism                     *)
-(*                            The HB class is called SubComSemiRing.          *)
-(*         subRingType R P == join of ringType and subType (P : pred R)       *)
+(*                            The HB class is called SubNzRing.               *)
+(*    subComNzRingType R P == join of comNzRingType and subType (P : pred R)  *)
 (*                            such that val is a morphism                     *)
-(*                            The HB class is called SubRing.                 *)
-(*      subComRingType R P == join of comRingType and subType (P : pred R)    *)
-(*                            such that val is a morphism                     *)
-(*                            The HB class is called SubComRing.              *)
+(*                            The HB class is called SubComNzRing.            *)
 (*       subLmodType R V P == join of lmodType and subType (P : pred V)       *)
 (*                            such that val is scalable                       *)
 (*                            The HB class is called SubLmodule.              *)
@@ -102,7 +104,8 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                            nmodType (resp. zmodType) instances U and V.    *)
 (*                            The HB class is called Additive.                *)
 (*      {rmorphism R -> S} == semi ring (resp. ring) morphism between         *)
-(*                            semiRingType (resp. ringType) instances R and S.*)
+(*                            semiNzRingType (resp. nzRingType) instances     *)
+(*                            R and S.                                        *)
 (*                            The HB class is called RMorphism.               *)
 (*     {linear U -> V | s} == linear functions of type U -> V, where U is a   *)
 (*                            left module over a ring R, V is a Z-module, and *)
@@ -130,7 +133,8 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                  The HB class is called AddClosed.                         *)
 (*  zmodClosed V == predicate closed under opposite and addition on V         *)
 (*                  The HB class is called ZmodClosed.                        *)
-(* mulr2Closed R == predicate closed under multiplication on R : semiRingType *)
+(* mulr2Closed R == predicate closed under multiplication on                  *)
+(*                  R : semiNzRingType                                        *)
 (*                  The HB class is called Mul2Closed.                        *)
 (*  mulrClosed R == predicate closed under multiplication and for 1           *)
 (*                  The HB class is called MulClosed.                         *)
@@ -185,9 +189,9 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                          base type is a zmodType and whose predicate's     *)
 (*                          is a zmodClosed                                   *)
 (*                                                                            *)
-(*  * SemiRing (non-commutative semirings):                                   *)
+(*  * NzSemiRing (non-commutative non-trivial semirings):                     *)
 (*                    R^c == the converse (semi)ring for R: R^c is convertible*)
-(*                           to R but when R has a canonical (semi)RingType   *)
+(*                           to R but when R has a canonical (semi)NzRingType *)
 (*                           structure R^c has the converse one:              *)
 (*                           if x y : R^c, then x * y = (y : R) * (x : R)     *)
 (*                      1 == the multiplicative identity element of a semiring*)
@@ -218,37 +222,38 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                           products (1 and x * y in S for x, y in S)        *)
 (*      semiring_closed S <-> collective predicate S is closed under semiring *)
 (*                           operations (0, 1, x + y and x * y in S)          *)
-(* [SubNmodule_isSubSemiRing of R by <:] ==                                   *)
-(* [SubChoice_isSubSemiRing of R by <:] == semiRingType mixin for a           *)
-(*                           subType whose base type is a semiRingType and    *)
+(* [SubNmodule_isSubNzSemiRing of R by <:] ==                                 *)
+(* [SubChoice_isSubNzSemiRing of R by <:] == semiNzRingType mixin for a       *)
+(*                           subType whose base type is a nzSemiRingType and  *)
 (*                           whose predicate's is a semiringClosed            *)
 (*                                                                            *)
-(*  * Ring (non-commutative rings):                                           *)
-(*         GRing.sign R b := (-1) ^+ b in R : ringType, with b : bool         *)
+(*  * NzRing (non-commutative non-trivial rings):                             *)
+(*         GRing.sign R b := (-1) ^+ b in R : nzRingType, with b : bool       *)
 (*                           This is a parsing-only helper notation, to be    *)
 (*                           used for defining more specific instances.       *)
 (*         smulr_closed S <-> collective predicate S is closed under products *)
 (*                           and opposite (-1 and x * y in S for x, y in S)   *)
 (*       subring_closed S <-> collective predicate S is closed under ring     *)
 (*                           operations (1, x - y and x * y in S)             *)
-(* [SubZmodule_isSubRing of R by <:] ==                                       *)
-(* [SubChoice_isSubRing of R by <:] == ringType mixin for a subType whose base*)
-(*                           type is a ringType and whose predicate's is a    *)
+(* [SubZmodule_isSubNzRing of R by <:] ==                                     *)
+(* [SubChoice_isSubNzRing of R by <:] == nzRingType mixin for a subType whose *)
+(*                           base                                             *)
+(*                           type is a nzRingType and whose predicate's is a  *)
 (*                           subringClosed                                    *)
 (*                                                                            *)
-(*  * ComSemiRing (commutative SemiRings):                                    *)
-(* [SubNmodule_isSubComSemiRing of R by <:] ==                                *)
-(* [SubChoice_isSubComSemiRing of R by <:] == comSemiRingType mixin for a     *)
-(*                           subType whose base type is a comSemiRingType and *)
-(*                           whose predicate's is a semiringClosed            *)
+(*  * ComNzSemiRing (commutative NzSemiRings):                                *)
+(* [SubNmodule_isSubComNzSemiRing of R by <:] ==                              *)
+(* [SubChoice_isSubComNzSemiRing of R by <:] == comNzSemiRingType mixin for a *)
+(*                           subType whose base type is a comNzSemiRingType   *)
+(*                          and whose predicate's is a semiringClosed         *)
 (*                                                                            *)
-(*  * ComRing (commutative Rings):                                            *)
-(* [SubZmodule_isSubComRing of R by <:] ==                                    *)
-(* [SubChoice_isSubComRing of R by <:] == comRingType mixin for a             *)
-(*                           subType whose base type is a comRingType and     *)
+(*  * ComNzRing (commutative NzRings):                                        *)
+(* [SubZmodule_isSubComNzRing of R by <:] ==                                  *)
+(* [SubChoice_isSubComNzRing of R by <:] == comNzRingType mixin for a         *)
+(*                           subType whose base type is a comNzRingType and   *)
 (*                           whose predicate's is a subringClosed             *)
 (*                                                                            *)
-(*  * UnitRing (Rings whose units have computable inverses):                  *)
+(*  * UnitRing (NzRings whose units have computable inverses):                *)
 (*     x \is a GRing.unit <=> x is a unit (i.e., has an inverse)              *)
 (*                   x^-1 == the ring inverse of x, if x is a unit, else x    *)
 (*                  x / y == x divided by y (notation for x * y^-1)           *)
@@ -260,7 +265,7 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                           and opposite (-1 and x / y in S, for x, y in S)  *)
 (*      divring_closed S <-> collective predicate S is closed under unitRing  *)
 (*                           operations (1, x - y and x / y in S)             *)
-(* [SubRing_isSubUnitRing of R by <:] ==                                      *)
+(* [SubNzRing_isSubUnitRing of R by <:] ==                                    *)
 (* [SubChoice_isSubUnitRing of R by <:] == unitRingType mixin for a subType   *)
 (*                           whose base type is a unitRingType and whose      *)
 (*                           predicate's is a divringClosed and whose ring    *)
@@ -328,15 +333,15 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                                                                            *)
 (*  * Lalgebra (left algebra, ring with scaling that associates on the left): *)
 (*                    R^o == the regular algebra of R: R^o is convertible to  *)
-(*                           R, but when R has a ringType structure then R^o  *)
-(*                           extends it to an lalgType structure by letting R *)
-(*                           act on itself: if x : R and y : R^o then         *)
-(*                           x *: y = x * (y : R)                             *)
+(*                           R, but when R has a nzRingType structure then    *)
+(*                           R^o extends it to an lalgType structure by       *)
+(*                           letting R act on itself: if x : R and y : R^o    *)
+(*                           then x *: y = x * (y : R)                        *)
 (*                   k%:A == the image of the scalar k in an L-algebra; this  *)
 (*                           is simply notation for k *: 1                    *)
 (*        subalg_closed S <-> collective predicate S is closed under lalgType *)
 (*                           operations (1, a *: u + v and u * v in S)        *)
-(* [SubRing_SubLmodule_isSubLalgebra of V by <:] ==                           *)
+(* [SubNzRing_SubLmodule_isSubLalgebra of V by <:] ==                         *)
 (* [SubChoice_isSubLalgebra of V by <:] == mixin axiom for a subType of an    *)
 (*                           lalgType                                         *)
 (*                                                                            *)
@@ -373,12 +378,12 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (* * RMorphism (semiring or ring morphisms):                                  *)
 (*       multiplicative f <-> f of type R -> S is multiplicative, i.e., f     *)
 (*                           maps 1 and * in R to 1 and * in S, respectively  *)
-(*                           R and S must have canonical semiRingType         *)
+(*                           R and S must have canonical nzSemiRingType       *)
 (*                           instances                                        *)
 (*     {rmorphism R -> S} == the interface type for semiring morphisms; both  *)
-(*                           R and S must have semiRingType instances         *)
-(*                           When both R and S have ringType instances, it is *)
-(*                           a ring morphism.                                 *)
+(*                           R and S must have nzSemiRingType instances       *)
+(*                           When both R and S have nzRingType instances, it  *)
+(*                           is a ring morphism.                              *)
 (*                        := GRing.RMorphism.type R S                         *)
 (*                                                                            *)
 (*  -> If R and S are UnitRings the f also maps units to units and inverses   *)
@@ -396,27 +401,27 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*       scalable_for s f <-> f of type U -> V is scalable for the scaling    *)
 (*                           operator s of type R -> V -> V, i.e.,            *)
 (*                           f morphs a *: _ to s a _; R, U, and V must be a  *)
-(*                           ringType, an lmodType R, and a zmodType,         *)
+(*                           nzRingType, an lmodType R, and a zmodType,       *)
 (*                           respectively.                                    *)
 (*                        := forall a, {morph f : u / a *: u >-> s a u}       *)
 (*             scalable f <-> f of type U -> V is scalable, i.e., f morphs    *)
 (*                           scaling on U to scaling on V, a *: _ to a *: _;  *)
 (*                           U and V must be an lmodType R for the same       *)
-(*                           ringType R.                                      *)
+(*                           nzRingType R.                                    *)
 (*                        := scalable_for *:%R f                              *)
 (*         linear_for s f <-> f of type U -> V is linear for s of type        *)
 (*                           R -> V -> V, i.e.,                               *)
 (*                           f (a *: u + v) = s a (f u) + f v;                *)
-(*                           R, U, and V must be a ringType, an lmodType R,   *)
+(*                           R, U, and V must be a nzRingType, an lmodType R, *)
 (*                           and a zmodType, respectively.                    *)
 (*               linear f <-> f of type U -> V is linear, i.e.,               *)
 (*                           f (f *: u + v) = a *: f u + f v;                 *)
 (*                           U and V must be lmodType R for the same          *)
-(*                           ringType R.                                      *)
+(*                           nzRingType R.                                    *)
 (*                        := linear_for *:%R f                                *)
 (*               scalar f <-> f of type U -> R is a scalar function, i.e.,    *)
 (*                           f (a *: u + v) = a * f u + f v;                  *)
-(*                           R and U must be a ringType and an lmodType R,    *)
+(*                           R and U must be a nzRingType and an lmodType R,  *)
 (*                           respectively.                                    *)
 (*                        := linear_for *%R f                                 *)
 (*    {linear U -> V | s} == the interface type for functions linear for the  *)
@@ -424,12 +429,12 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                           structure that encapsulates two properties       *)
 (*                           semi_additive f and scalable_for s f for         *)
 (*                           functions f : U -> V; R, U, and V must be a      *)
-(*                           ringType, an lmodType R, and a zmodType,         *)
+(*                           nzRingType, an lmodType R, and a zmodType,       *)
 (*                           respectively                                     *)
 (*                        := @GRing.Linear.type R U V s                       *)
 (*        {linear U -> V} == the interface type for linear functions, of type *)
 (*                           U -> V where both U and V must be lmodType R for *)
-(*                           the same ringType R                              *)
+(*                           the same nzRingType R                            *)
 (*                        := {linear U -> V | *:%R}                           *)
 (*             {scalar U} == the interface type for scalar functions of type  *)
 (*                           U -> R where U must be an lmodType R             *)
@@ -462,12 +467,12 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*                           i.e., the join of ring morphisms                 *)
 (*                           {rmorphism A -> B} and linear functions          *)
 (*                           {linear A -> B | s}; R, A, and B must be a       *)
-(*                           ringType, an lalgType R, and a ringType,         *)
+(*                           nzRingType, an lalgType R, and a nzRingType,     *)
 (*                           respectively                                     *)
 (*                        := @GRing.LRMorphism.type R A B s                   *)
 (*    {lrmorphism A -> B} == the interface type for algebra morphisms, where  *)
-(*                           A and B must be lalgType R for the same ringType *)
-(*                           R                                                *)
+(*                           A and B must be lalgType R for the same          *)
+(*                           nzRingType R                                     *)
 (*                        := {lrmorphism A -> B | *:%R}                       *)
 (*  -> Linear and rmorphism properties do not need to be specialized for      *)
 (*     as we supply inheritance join instances in both directions.            *)
@@ -879,7 +884,7 @@ Arguments opprK {V}.
 Arguments oppr_inj {V} [x1 x2].
 Arguments telescope_sumr_eq {V n m} f u.
 
-HB.mixin Record Nmodule_isSemiRing R of Nmodule R := {
+HB.mixin Record Nmodule_isNzSemiRing R of Nmodule R := {
   one : R;
   mul : R -> R -> R;
   mulrA : associative mul;
@@ -892,10 +897,37 @@ HB.mixin Record Nmodule_isSemiRing R of Nmodule R := {
   oner_neq0 : one != 0
 }.
 
-#[short(type="semiRingType")]
-HB.structure Definition SemiRing := { R of Nmodule_isSemiRing R & Nmodule R }.
+Module Nmodule_isSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use Nmodule_isNzSemiRing.Build instead.")]
+Notation Build R := (Nmodule_isNzSemiRing.Build R) (only parsing).
+End Nmodule_isSemiRing.
 
-HB.factory Record isSemiRing R of Choice R := {
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use Nmodule_isNzSemiRing instead.")]
+Notation Nmodule_isSemiRing R := (Nmodule_isNzSemiRing R) (only parsing).
+
+#[short(type="nzSemiRingType")]
+HB.structure Definition NzSemiRing :=
+  { R of Nmodule_isNzSemiRing R & Nmodule R }.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing instead.")]
+Notation SemiRing R := (NzSemiRing R) (only parsing).
+
+Module SemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing.sort instead.")]
+Notation sort := (NzSemiRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing.on instead.")]
+Notation on R := (NzSemiRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing.copy instead.")]
+Notation copy T U := (NzSemiRing.copy T U) (only parsing).
+End SemiRing.
+
+HB.factory Record isNzSemiRing R of Choice R := {
   zero : R;
   add : R -> R -> R;
   one : R;
@@ -912,17 +944,29 @@ HB.factory Record isSemiRing R of Choice R := {
   mulr0 : right_zero zero mul;
   oner_neq0 : one != zero
 }.
-HB.builders Context R of isSemiRing R.
+
+Module isSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use isNzSemiRing.Build instead.")]
+Notation Build R := (isNzSemiRing.Build R) (only parsing).
+End isSemiRing.
+
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use isNzSemiRing instead.")]
+Notation isSemiRing R := (isNzSemiRing R) (only parsing).
+
+HB.builders Context R of isNzSemiRing R.
   HB.instance Definition _ := @isNmodule.Build R
     zero add addrA addrC add0r.
-  HB.instance Definition _ := @Nmodule_isSemiRing.Build R
+  HB.instance Definition _ := @Nmodule_isNzSemiRing.Build R
     one mul mulrA mul1r mulr1 mulrDl mulrDr mul0r mulr0 oner_neq0.
 HB.end.
 
-Module SemiRingExports.
-Bind Scope ring_scope with SemiRing.sort.
-End SemiRingExports.
-HB.export SemiRingExports.
+Module NzSemiRingExports.
+Bind Scope ring_scope with NzSemiRing.sort.
+End NzSemiRingExports.
+HB.export NzSemiRingExports.
 
 Definition exp R x n := iterop n (@mul R) x (@one R).
 Arguments exp : simpl never.
@@ -944,7 +988,7 @@ Local Notation "\prod_ ( m <= i < n ) F" := (\big[*%R/1%R]_(m <= i < n) F%R).
 (* The ``field'' characteristic; the definition, and many of the theorems,   *)
 (* has to apply to rings as well; indeed, we need the Frobenius automorphism *)
 (* results for a non commutative ring in the proof of Gorenstein 2.6.3.      *)
-Definition char (R : semiRingType) : nat_pred :=
+Definition char (R : nzSemiRingType) : nat_pred :=
   [pred p | prime p & p%:R == 0 :> R].
 
 Local Notation has_char0 L := (char L =i pred0).
@@ -953,9 +997,9 @@ Local Notation has_char0 L := (char L =i pred0).
 Definition converse R : Type := R.
 Local Notation "R ^c" := (converse R) (at level 2, format "R ^c") : type_scope.
 
-Section SemiRingTheory.
+Section NzSemiRingTheory.
 
-Variable R : semiRingType.
+Variable R : nzSemiRingType.
 Implicit Types x y : R.
 
 Lemma oner_eq0 : (1 == 0 :> R) = false. Proof. exact: negbTE oner_neq0. Qed.
@@ -1291,12 +1335,28 @@ Lemma semiring_closedM : semiring_closed -> mulr_closed. Proof. by case. Qed.
 
 End ClosedPredicates.
 
-End SemiRingTheory.
+End NzSemiRingTheory.
 
-#[short(type="ringType")]
-HB.structure Definition Ring := { R of SemiRing R & Zmodule R }.
+#[short(type="nzRingType")]
+HB.structure Definition NzRing := { R of NzSemiRing R & Zmodule R }.
 
-HB.factory Record Zmodule_isRing R of Zmodule R := {
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing instead.")]
+Notation Ring R := (NzRing R) (only parsing).
+
+Module Ring.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing.sort instead.")]
+Notation sort := (NzRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing.on instead.")]
+Notation on R := (NzRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing.copy instead.")]
+Notation copy T U := (NzRing.copy T U) (only parsing).
+End Ring.
+
+HB.factory Record Zmodule_isNzRing R of Zmodule R := {
   one : R;
   mul : R -> R -> R;
   mulrA : associative mul;
@@ -1306,18 +1366,29 @@ HB.factory Record Zmodule_isRing R of Zmodule R := {
   mulrDr : right_distributive mul +%R;
   oner_neq0 : one != 0
 }.
-HB.builders Context R of Zmodule_isRing R.
+
+Module Zmodule_isRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use Zmodule_isNzRing.Build instead.")]
+Notation Build R := (Zmodule_isNzRing.Build R) (only parsing).
+End Zmodule_isRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use Zmodule_isNzRing instead.")]
+Notation Zmodule_isRing R := (Zmodule_isNzRing R) (only parsing).
+
+HB.builders Context R of Zmodule_isNzRing R.
   Local Notation "1" := one.
   Local Notation "x * y" := (mul x y).
   Lemma mul0r : @left_zero R R 0 mul.
   Proof. by move=> x; apply: (addIr (1 * x)); rewrite -mulrDl !add0r mul1r. Qed.
   Lemma mulr0 : @right_zero R R 0 mul.
   Proof. by move=> x; apply: (addIr (x * 1)); rewrite -mulrDr !add0r mulr1. Qed.
-  HB.instance Definition _ := Nmodule_isSemiRing.Build R
+  HB.instance Definition _ := Nmodule_isNzSemiRing.Build R
     mulrA mul1r mulr1 mulrDl mulrDr mul0r mulr0 oner_neq0.
 HB.end.
 
-HB.factory Record isRing R of Choice R := {
+HB.factory Record isNzRing R of Choice R := {
   zero : R;
   opp : R -> R;
   add : R -> R -> R;
@@ -1334,25 +1405,36 @@ HB.factory Record isRing R of Choice R := {
   mulrDr : right_distributive mul add;
   oner_neq0 : one != zero
 }.
-HB.builders Context R of isRing R.
+
+Module isRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use isNzRing.Build instead.")]
+Notation Build R := (isNzRing.Build R) (only parsing).
+End isRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use isNzRing instead.")]
+Notation isRing R := (isNzRing R) (only parsing).
+
+HB.builders Context R of isNzRing R.
   HB.instance Definition _ := @isZmodule.Build R
     zero opp add addrA addrC add0r addNr.
-  HB.instance Definition _ := @Zmodule_isRing.Build R
+  HB.instance Definition _ := @Zmodule_isNzRing.Build R
     one mul mulrA mul1r mulr1 mulrDl mulrDr oner_neq0.
 HB.end.
 
-Module RingExports.
-Bind Scope ring_scope with Ring.sort.
-End RingExports.
-HB.export RingExports.
+Module NzRingExports.
+Bind Scope ring_scope with NzRing.sort.
+End NzRingExports.
+HB.export NzRingExports.
 
 Notation sign R b := (exp (- @one R) (nat_of_bool b)) (only parsing).
 
 Local Notation "- 1" := (- (1)) : ring_scope.
 
-Section RingTheory.
+Section NzRingTheory.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Implicit Types x y : R.
 
 Lemma mulrN x y : x * (- y) = - (x * y).
@@ -1551,7 +1633,7 @@ Qed.
 
 End ClosedPredicates.
 
-End RingTheory.
+End NzRingTheory.
 
 Section ConverseRing.
 #[export]
@@ -1563,25 +1645,25 @@ HB.instance Definition _ (U : nmodType) := Nmodule.on U^c.
 #[export]
 HB.instance Definition _ (U : zmodType) := Zmodule.on U^c.
 #[export]
-HB.instance Definition _ (R : semiRingType) :=
+HB.instance Definition _ (R : nzSemiRingType) :=
   let mul' (x y : R) := y * x in
   let mulrA' x y z := esym (mulrA z y x) in
   let mulrDl' x y z := mulrDr z x y in
   let mulrDr' x y z := mulrDl y z x in
-  Nmodule_isSemiRing.Build R^c
+  Nmodule_isNzSemiRing.Build R^c
     mulrA' mulr1 mul1r mulrDl' mulrDr' mulr0 mul0r oner_neq0.
 #[export]
-HB.instance Definition _ (R : ringType) := SemiRing.on R^c.
+HB.instance Definition _ (R : nzRingType) := NzSemiRing.on R^c.
 End ConverseRing.
 
-Lemma rev_prodr (R : semiRingType)
+Lemma rev_prodr (R : nzSemiRingType)
   (I : Type) (r : seq I) (P : pred I) (E : I -> R) :
   \prod_(i <- r | P i) (E i : R^c) = \prod_(i <- rev r | P i) E i.
 Proof. by rewrite rev_big_rev. Qed.
 
 Section SemiRightRegular.
 
-Variable R : semiRingType.
+Variable R : nzSemiRingType.
 Implicit Types x y : R.
 
 Lemma mulIr_eq0 x y : rreg x -> (y * x == 0) = (y == 0).
@@ -1606,7 +1688,7 @@ End SemiRightRegular.
 
 Section RightRegular.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Implicit Types x y : R.
 
 Lemma mulIr0_rreg x : (forall y, y * x = 0 -> y = 0) -> rreg x.
@@ -1617,7 +1699,7 @@ Proof. exact: (@lregN R^c). Qed.
 
 End RightRegular.
 
-HB.mixin Record Zmodule_isLmodule (R : ringType) V of Zmodule V := {
+HB.mixin Record Zmodule_isLmodule (R : nzRingType) V of Zmodule V := {
   scale : R -> V -> V;
   scalerA : forall a b v, scale a (scale b v) = scale (a * b) v;
   scale1r : left_id 1 scale;
@@ -1625,7 +1707,7 @@ HB.mixin Record Zmodule_isLmodule (R : ringType) V of Zmodule V := {
   scalerDl : forall v, {morph scale^~ v: a b / a + b}
 }.
 #[short(type="lmodType")]
-HB.structure Definition Lmodule (R : ringType) :=
+HB.structure Definition Lmodule (R : nzRingType) :=
   {M of Zmodule M & Zmodule_isLmodule R M}.
 
 (* FIXME: see #1126 and #1127 *)
@@ -1641,7 +1723,7 @@ Local Notation "a *: v" := (scale a v) : ring_scope.
 
 Section LmoduleTheory.
 
-Variables (R : ringType) (V : lmodType R).
+Variables (R : nzRingType) (V : lmodType R).
 Implicit Types (a b c : R) (u v : V).
 
 Lemma scale0r v : 0 *: v = 0.
@@ -1718,12 +1800,12 @@ End ClosedPredicates.
 
 End LmoduleTheory.
 
-HB.mixin Record Lmodule_isLalgebra R V of Ring V & Lmodule R V := {
+HB.mixin Record Lmodule_isLalgebra R V of NzRing V & Lmodule R V := {
   scalerAl : forall (a : R) (u v : V), a *: (u * v) = (a *: u) * v
 }.
 #[short(type="lalgType")]
 HB.structure Definition Lalgebra R :=
-  {A of Lmodule_isLalgebra R A & Ring A & Lmodule R A}.
+  {A of Lmodule_isLalgebra R A & NzRing A & Lmodule R A}.
 
 Module LalgExports.
 Bind Scope ring_scope with Lalgebra.sort.
@@ -1743,21 +1825,21 @@ HB.instance Definition _ (V : nmodType) := Nmodule.on V^o.
 #[export]
 HB.instance Definition _ (V : zmodType) := Zmodule.on V^o.
 #[export]
-HB.instance Definition _ (R : semiRingType) := SemiRing.on R^o.
+HB.instance Definition _ (R : nzSemiRingType) := NzSemiRing.on R^o.
 #[export]
-HB.instance Definition _ (R : ringType) := Ring.on R^o.
+HB.instance Definition _ (R : nzRingType) := NzRing.on R^o.
 #[export]
-HB.instance Definition _ (R : ringType) :=
+HB.instance Definition _ (R : nzRingType) :=
   @Zmodule_isLmodule.Build R R^o
     (@mul R) (@mulrA R) (@mul1r R) (@mulrDr R) (fun v a b => mulrDl a b v).
 #[export]
-HB.instance Definition _ (R : ringType) :=
+HB.instance Definition _ (R : nzRingType) :=
   Lmodule_isLalgebra.Build R R^o mulrA.
 End RegularAlgebra.
 
 Section LalgebraTheory.
 
-Variables (R : ringType) (A : lalgType R).
+Variables (R : nzRingType) (A : lalgType R).
 Implicit Types x y : A.
 
 Lemma mulr_algl a x : (a *: 1) * x = a *: x.
@@ -1832,7 +1914,7 @@ End LiftedZmod.
 
 (* Lifted multiplication. *)
 Section LiftedSemiRing.
-Variables (R : semiRingType) (T : Type).
+Variables (R : nzSemiRingType) (T : Type).
 Implicit Type f : T -> R.
 Definition mull_fun a f x := a * f x.
 Definition mulr_fun a f x := f x * a.
@@ -1841,7 +1923,7 @@ End LiftedSemiRing.
 
 (* Lifted linear operations. *)
 Section LiftedScale.
-Variables (R : ringType) (U : Type) (V : lmodType R) (A : lalgType R).
+Variables (R : nzRingType) (U : Type) (V : lmodType R) (A : lalgType R).
 Definition scale_fun a (f : U -> V) x := a *: f x.
 Definition in_alg k : A := k%:A.
 End LiftedScale.
@@ -1897,7 +1979,7 @@ End Properties.
 
 Section SemiRingProperties.
 
-Variables (R S : semiRingType) (f : {additive R -> S}).
+Variables (R S : nzSemiRingType) (f : {additive R -> S}).
 
 Lemma raddfMnat n x : f (n%:R * x) = n%:R * f x.
 Proof. by rewrite !mulr_natl raddfMn. Qed.
@@ -1939,7 +2021,7 @@ End AddFun.
 
 Section MulFun.
 
-Variables (R : semiRingType) (U : nmodType) (a : R) (f : {additive U -> R}).
+Variables (R : nzSemiRingType) (U : nmodType) (a : R) (f : {additive U -> R}).
 
 Fact mull_fun_is_semi_additive : semi_additive (a \*o f).
 Proof. by split=> [|x y]; rewrite /= ?raddf0 ?mulr0// raddfD mulrDr. Qed.
@@ -1981,7 +2063,7 @@ End Properties.
 
 Section RingProperties.
 
-Variables (R S : ringType) (f : {additive R -> S}).
+Variables (R S : nzRingType) (f : {additive R -> S}).
 
 Lemma raddfMsign n x : f ((-1) ^+ n * x) = (-1) ^+ n * f x.
 Proof. by rewrite !(mulr_sign, =^~ signr_odd) (fun_if f) raddfN. Qed.
@@ -2021,7 +2103,7 @@ End AddFun.
 
 Section ScaleFun.
 
-Variables (R : ringType) (U : zmodType) (V : lmodType R).
+Variables (R : nzRingType) (U : zmodType) (V : lmodType R).
 Variables (a : R) (f : {additive U -> V}).
 
 #[export]
@@ -2033,14 +2115,14 @@ End ScaleFun.
 
 End AdditiveTheory.
 
-Definition multiplicative (R S : semiRingType) (f : R -> S) : Prop :=
+Definition multiplicative (R S : nzSemiRingType) (f : R -> S) : Prop :=
   {morph f : x y / x * y}%R * (f 1 = 1).
 
-HB.mixin Record isMultiplicative (R S : semiRingType) (f : R -> S) := {
+HB.mixin Record isMultiplicative (R S : nzSemiRingType) (f : R -> S) := {
   rmorphism_subproof : multiplicative f
 }.
 
-HB.structure Definition RMorphism (R S : semiRingType) :=
+HB.structure Definition RMorphism (R S : nzSemiRingType) :=
   {f of @Additive R S f & isMultiplicative R S f}.
 (* FIXME: remove the @ once
    https://github.com/math-comp/hierarchy-builder/issues/319 is fixed *)
@@ -2055,7 +2137,7 @@ Section RmorphismTheory.
 
 Section Properties.
 
-Variables (R S : semiRingType) (f : {rmorphism R -> S}).
+Variables (R S : nzSemiRingType) (f : {rmorphism R -> S}).
 
 Lemma rmorph0 : f 0 = 0. Proof. exact: raddf0. Qed.
 Lemma rmorphD : {morph f : x y / x + y}. Proof. exact: raddfD. Qed.
@@ -2096,7 +2178,7 @@ End Properties.
 
 Section Projections.
 
-Variables (R S T : semiRingType).
+Variables (R S T : nzSemiRingType).
 Variables (f : {rmorphism S -> T}) (g : {rmorphism R -> S}).
 
 Fact idfun_is_multiplicative : multiplicative (@idfun R).
@@ -2115,7 +2197,7 @@ End Projections.
 
 Section Properties.
 
-Variables (R S : ringType) (f : {rmorphism R -> S}).
+Variables (R S : nzRingType) (f : {rmorphism R -> S}).
 
 Lemma rmorphN : {morph f : x / - x}. Proof. exact: raddfN. Qed.
 Lemma rmorphB : {morph f: x y / x - y}. Proof. exact: raddfB. Qed.
@@ -2132,7 +2214,7 @@ End Properties.
 
 Section InAlgebra.
 
-Variables (R : ringType) (A : lalgType R).
+Variables (R : nzRingType) (A : lalgType R).
 
 Fact in_alg_is_additive : additive (in_alg A).
 Proof. move=> x y; exact: scalerBl. Qed.
@@ -2153,7 +2235,7 @@ End RmorphismTheory.
 
 Module Scale.
 
-HB.mixin Record isLaw (R : ringType) (V : zmodType) (op : R -> V -> V) := {
+HB.mixin Record isLaw (R : nzRingType) (V : zmodType) (op : R -> V -> V) := {
   N1op_subproof : op (-1) =1 -%R;
   op_additive_subproof : forall a, additive (op a);
 }.
@@ -2164,12 +2246,12 @@ Definition law := Law.type.
 
 Section ScaleLaw.
 
-Variables (R : ringType) (V : zmodType) (s_law : law R V).
+Variables (R : nzRingType) (V : zmodType) (s_law : law R V).
 
 Lemma N1op : s_law (-1) =1 -%R. Proof. exact: N1op_subproof. Qed.
 Fact opB a : additive (s_law a). Proof. exact: op_additive_subproof. Qed.
 
-Variables (aR : ringType) (nu : {rmorphism aR -> R}).
+Variables (aR : nzRingType) (nu : {rmorphism aR -> R}).
 Fact compN1op : (nu \; s_law) (-1) =1 -%R.
 Proof. by move=> v; rewrite /= rmorphN1 N1op. Qed.
 
@@ -2181,51 +2263,51 @@ End Scale.
 Export Scale.Exports.
 
 #[export]
-HB.instance Definition _ (R : ringType) := Scale.isLaw.Build R R *%R
+HB.instance Definition _ (R : nzRingType) := Scale.isLaw.Build R R *%R
   (@mulN1r R) (@mulrBr R).
 
 #[export]
-HB.instance Definition _ (R : ringType) (U : lmodType R) :=
+HB.instance Definition _ (R : nzRingType) (U : lmodType R) :=
   Scale.isLaw.Build R U *:%R (@scaleN1r R U) (@scalerBr R U).
 
 #[export]
-HB.instance Definition _ (R : ringType) (V : zmodType) (s : Scale.law R V)
-    (aR : ringType) (nu : {rmorphism aR -> R}) :=
+HB.instance Definition _ (R : nzRingType) (V : zmodType) (s : Scale.law R V)
+    (aR : nzRingType) (nu : {rmorphism aR -> R}) :=
   Scale.isLaw.Build aR V (nu \; s)
     (@Scale.compN1op _ _ s _ nu) (fun a => Scale.opB _ _).
 
 #[export, non_forgetful_inheritance]
-HB.instance Definition _ (R : ringType) (V : zmodType) (s : Scale.law R V) a :=
+HB.instance Definition _ (R : nzRingType) (V : zmodType) (s : Scale.law R V) a :=
  isAdditive.Build V V (s a) (Scale.opB s a).
 
-Definition scalable_for (R : ringType) (U : lmodType R) (V : zmodType)
+Definition scalable_for (R : nzRingType) (U : lmodType R) (V : zmodType)
     (s : R -> V -> V) (f : U -> V) :=
   forall a, {morph f : u / a *: u >-> s a u}.
 
-HB.mixin Record isScalable (R : ringType) (U : lmodType R) (V : zmodType)
+HB.mixin Record isScalable (R : nzRingType) (U : lmodType R) (V : zmodType)
     (s : R -> V -> V) (f : U -> V) := {
   linear_subproof : scalable_for s f;
 }.
 
-HB.structure Definition Linear (R : ringType) (U : lmodType R) (V : zmodType)
+HB.structure Definition Linear (R : nzRingType) (U : lmodType R) (V : zmodType)
     (s : R -> V -> V) :=
   {f of @Additive U V f & isScalable R U V s f}.
 
-Definition linear_for (R : ringType) (U : lmodType R) (V : zmodType)
+Definition linear_for (R : nzRingType) (U : lmodType R) (V : zmodType)
     (s : R -> V -> V) (f : U -> V) :=
   forall a, {morph f : u v / a *: u + v >-> s a u + v}.
 
-Lemma additive_linear (R : ringType) (U : lmodType R) V
+Lemma additive_linear (R : nzRingType) (U : lmodType R) V
   (s : Scale.law R V) (f : U -> V) : linear_for s f -> additive f.
 Proof. by move=> Lsf x y; rewrite -scaleN1r addrC Lsf Scale.N1op addrC. Qed.
 
-Lemma scalable_linear (R : ringType) (U : lmodType R) V
+Lemma scalable_linear (R : nzRingType) (U : lmodType R) V
   (s : Scale.law R V) (f : U -> V) : linear_for s f -> scalable_for s f.
 Proof.
 by move=> Lsf a v; rewrite -[a *:v](addrK v) (additive_linear Lsf) Lsf addrK.
 Qed.
 
-HB.factory Record isLinear (R : ringType) (U : lmodType R) (V : zmodType)
+HB.factory Record isLinear (R : nzRingType) (U : lmodType R) (V : zmodType)
     (s : Scale.law R V) (f : U -> V) := {
   linear_subproof : linear_for s f;
 }.
@@ -2242,7 +2324,7 @@ Notation linear f := (linear_for *:%R f).
 Notation scalar f := (linear_for *%R f).
 Module Linear.
 Section Linear.
-Variables (R : ringType) (U : lmodType R) (V : zmodType) (s : R -> V -> V).
+Variables (R : nzRingType) (U : lmodType R) (V : zmodType) (s : R -> V -> V).
 (* Support for right-to-left rewriting with the generic linearZ rule. *)
 Local Notation mapUV := (@Linear.type R U V s).
 Definition map_class := mapUV.
@@ -2271,7 +2353,7 @@ HB.export LinearExports.
 
 Section LinearTheory.
 
-Variable R : ringType.
+Variable R : nzRingType.
 
 Section GenericProperties.
 
@@ -2324,7 +2406,7 @@ Variables (U : lmodType R) (V : zmodType) (s : R -> V -> V).
 (*   Most of this machinery will be invisible to a casual user, because all  *)
 (* the projections and default instances involved are declared as coercions. *)
 
-Variables (S : ringType) (h : Scale.law S V).
+Variables (S : nzRingType) (h : Scale.law S V).
 
 Lemma linearZ c a (h_c := h c) (f : Linear.map_for U s a h_c) u :
   f (a *: u) = h_c (Linear.wrap f u).
@@ -2426,7 +2508,7 @@ End LinearLalg.
 
 End LinearTheory.
 
-HB.structure Definition LRMorphism (R : ringType) (A : lalgType R) (B : ringType)
+HB.structure Definition LRMorphism (R : nzRingType) (A : lalgType R) (B : nzRingType)
     (s : R -> B -> B) :=
   {f of @RMorphism A B f & isScalable R A B s f}.
 (* FIXME: remove the @ once
@@ -2442,7 +2524,8 @@ HB.export LRMorphismExports.
 
 Section LRMorphismTheory.
 
-Variables (R : ringType) (A B : lalgType R) (C : ringType) (s : R -> C -> C).
+Variables (R : nzRingType) (A B : lalgType R) (C : nzRingType)
+  (s : R -> C -> C).
 Variables (f : {lrmorphism A -> B}) (g : {lrmorphism B -> C | s}).
 
 #[export] HB.instance Definition _ := RMorphism.on (@idfun A).
@@ -2453,19 +2536,47 @@ Proof. by rewrite linearZ rmorph1. Qed.
 
 End LRMorphismTheory.
 
-HB.mixin Record SemiRing_hasCommutativeMul R of SemiRing R := {
+HB.mixin Record NzSemiRing_hasCommutativeMul R of NzSemiRing R := {
   mulrC : commutative (@mul R)
 }.
-#[short(type="comSemiRingType")]
-HB.structure Definition ComSemiRing :=
-  {R of SemiRing R & SemiRing_hasCommutativeMul R}.
 
-Module ComSemiRingExports.
-Bind Scope ring_scope with ComSemiRing.sort.
-End ComSemiRingExports.
-HB.export ComSemiRingExports.
+Module SemiRing_hasCommutativeMul.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing_hasCommutativeMul.Build instead.")]
+Notation Build R := (NzSemiRing_hasCommutativeMul.Build R) (only parsing).
+End SemiRing_hasCommutativeMul.
 
-HB.factory Record Nmodule_isComSemiRing R of Nmodule R := {
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzSemiRing_hasCommutativeMul instead.")]
+Notation SemiRing_hasCommutativeMul R :=
+  (NzSemiRing_hasCommutativeMul R) (only parsing).
+
+#[short(type="comNzSemiRingType")]
+HB.structure Definition ComNzSemiRing :=
+  {R of NzSemiRing R & NzSemiRing_hasCommutativeMul R}.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzSemiRing instead.")]
+Notation ComSemiRing R := (ComNzSemiRing R) (only parsing).
+
+Module ComSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzSemiRing.sort instead.")]
+Notation sort := (ComNzSemiRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzSemiRing.on instead.")]
+Notation on R := (ComNzSemiRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzSemiRing.copy instead.")]
+Notation copy T U := (ComNzSemiRing.copy T U) (only parsing).
+End ComSemiRing.
+
+Module ComNzSemiRingExports.
+Bind Scope ring_scope with ComNzSemiRing.sort.
+End ComNzSemiRingExports.
+HB.export ComNzSemiRingExports.
+
+HB.factory Record Nmodule_isComNzSemiRing R of Nmodule R := {
   one : R;
   mul : R -> R -> R;
   mulrA : associative mul;
@@ -2475,19 +2586,30 @@ HB.factory Record Nmodule_isComSemiRing R of Nmodule R := {
   mul0r : left_zero zero mul;
   oner_neq0 : one != zero
 }.
-HB.builders Context R of Nmodule_isComSemiRing R.
+
+Module Nmodule_isComSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use Nmodule_isComNzSemiRing.Build instead.")]
+Notation Build R := (Nmodule_isComNzSemiRing.Build R) (only parsing).
+End Nmodule_isComSemiRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use Nmodule_isComNzSemiRing instead.")]
+Notation Nmodule_isComSemiRing R := (Nmodule_isComNzSemiRing R) (only parsing).
+
+HB.builders Context R of Nmodule_isComNzSemiRing R.
   Definition mulr1 := Monoid.mulC_id mulrC mul1r.
   Definition mulrDr := Monoid.mulC_dist mulrC mulrDl.
   Lemma mulr0 : right_zero zero mul.
   Proof. by move=> x; rewrite mulrC mul0r. Qed.
-  HB.instance Definition _ := Nmodule_isSemiRing.Build R
+  HB.instance Definition _ := Nmodule_isNzSemiRing.Build R
     mulrA mul1r mulr1 mulrDl mulrDr mul0r mulr0 oner_neq0.
-  HB.instance Definition _ := SemiRing_hasCommutativeMul.Build R mulrC.
+  HB.instance Definition _ := NzSemiRing_hasCommutativeMul.Build R mulrC.
 HB.end.
 
 Section ComSemiRingTheory.
 
-Variable R : comSemiRingType.
+Variable R : comNzSemiRingType.
 Implicit Types x y : R.
 
 #[export]
@@ -2553,23 +2675,51 @@ have{charRn} /p_natP[e ->]: p.-nat n by rewrite -(eq_pnat _ (charf_eq charRp)).
 by elim: e => // e IHe; rewrite !expnSr !exprM IHe -Frobenius_autE rmorphD.
 Qed.
 
-Lemma rmorph_comm (S : semiRingType) (f : {rmorphism R -> S}) x y :
+Lemma rmorph_comm (S : nzSemiRingType) (f : {rmorphism R -> S}) x y :
   comm (f x) (f y).
 Proof. by red; rewrite -!rmorphM mulrC. Qed.
 
 End ComSemiRingTheory.
 
-#[short(type="comRingType")]
-HB.structure Definition ComRing := {R of Ring R & ComSemiRing R}.
+#[short(type="comNzRingType")]
+HB.structure Definition ComNzRing := {R of NzRing R & ComNzSemiRing R}.
 
-HB.factory Record Ring_hasCommutativeMul R of Ring R := {
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing instead.")]
+Notation ComRing R := (ComNzRing R) (only parsing).
+
+Module ComRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing.sort instead.")]
+Notation sort := (ComNzRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing.on instead.")]
+Notation on R := (ComNzRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing.copy instead.")]
+Notation copy T U := (ComNzRing.copy T U) (only parsing).
+End ComRing.
+
+HB.factory Record NzRing_hasCommutativeMul R of NzRing R := {
   mulrC : commutative (@mul R)
 }.
-HB.builders Context R of Ring_hasCommutativeMul R.
-HB.instance Definition _ := SemiRing_hasCommutativeMul.Build R mulrC.
+
+Module Ring_hasCommutativeMul.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing_hasCommutativeMul.Build instead.")]
+Notation Build R := (NzRing_hasCommutativeMul.Build R) (only parsing).
+End Ring_hasCommutativeMul.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing_hasCommutativeMul instead.")]
+Notation Ring_hasCommutativeMul R :=
+  (NzRing_hasCommutativeMul R) (only parsing).
+
+HB.builders Context R of NzRing_hasCommutativeMul R.
+HB.instance Definition _ := NzSemiRing_hasCommutativeMul.Build R mulrC.
 HB.end.
 
-HB.factory Record Zmodule_isComRing R of Zmodule R := {
+HB.factory Record Zmodule_isComNzRing R of Zmodule R := {
   one : R;
   mul : R -> R -> R;
   mulrA : associative mul;
@@ -2578,22 +2728,33 @@ HB.factory Record Zmodule_isComRing R of Zmodule R := {
   mulrDl : left_distributive mul add;
   oner_neq0 : one != zero
 }.
-HB.builders Context R of Zmodule_isComRing R.
+
+Module Zmodule_isComRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use Zmodule_isComNzRing.Build instead.")]
+Notation Build R := (Zmodule_isComNzRing.Build R) (only parsing).
+End Zmodule_isComRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use Zmodule_isComNzRing instead.")]
+Notation Zmodule_isComRing R := (Zmodule_isComNzRing R) (only parsing).
+
+HB.builders Context R of Zmodule_isComNzRing R.
   Definition mulr1 := Monoid.mulC_id mulrC mul1r.
   Definition mulrDr := Monoid.mulC_dist mulrC mulrDl.
-  HB.instance Definition _ := Zmodule_isRing.Build R
+  HB.instance Definition _ := Zmodule_isNzRing.Build R
     mulrA mul1r mulr1 mulrDl mulrDr oner_neq0.
-  HB.instance Definition _ := Ring_hasCommutativeMul.Build R mulrC.
+  HB.instance Definition _ := NzRing_hasCommutativeMul.Build R mulrC.
 HB.end.
 
-Module ComRingExports.
-Bind Scope ring_scope with ComRing.sort.
-End ComRingExports.
-HB.export ComRingExports.
+Module ComNzRingExports.
+Bind Scope ring_scope with ComNzRing.sort.
+End ComNzRingExports.
+HB.export ComNzRingExports.
 
-Section ComRingTheory.
+Section ComNzRingTheory.
 
-Variable R : comRingType.
+Variable R : comNzRingType.
 Implicit Types x y : R.
 
 Lemma exprBn x y n :
@@ -2635,13 +2796,13 @@ HB.instance Definition _ := isScalable.Build R U V *:%R (b \*: f)
 
 End ScaleLinear.
 
-End ComRingTheory.
+End ComNzRingTheory.
 
-HB.mixin Record Lalgebra_isAlgebra (R : ringType) V of Lalgebra R V := {
+HB.mixin Record Lalgebra_isAlgebra (R : nzRingType) V of Lalgebra R V := {
   scalerAr : forall k (x y : V), k *: (x * y) = x * (k *: y);
 }.
 #[short(type="algType")]
-HB.structure Definition Algebra (R : ringType) :=
+HB.structure Definition Algebra (R : nzRingType) :=
   {A of Lalgebra_isAlgebra R A & Lalgebra R A}.
 
 Module AlgExports.
@@ -2649,8 +2810,8 @@ Bind Scope ring_scope with Algebra.sort.
 End AlgExports.
 HB.export AlgExports.
 
-HB.factory Record Lalgebra_isComAlgebra R V of ComRing V & Lalgebra R V := {}.
-HB.builders Context (R : ringType) V of Lalgebra_isComAlgebra R V.
+HB.factory Record Lalgebra_isComAlgebra R V of ComNzRing V & Lalgebra R V := {}.
+HB.builders Context (R : nzRingType) V of Lalgebra_isComAlgebra R V.
 
 Lemma scalarAr k (x y : V) : k *: (x * y) = x * (k *: y).
 Proof. by rewrite mulrC scalerAl mulrC. Qed.
@@ -2661,7 +2822,7 @@ HB.instance Definition lalgebra_is_algebra : Lalgebra_isAlgebra R V :=
 HB.end.
 
 #[short(type="comAlgType")]
-HB.structure Definition ComAlgebra R := {V of ComRing V & Algebra R V}.
+HB.structure Definition ComAlgebra R := {V of ComNzRing V & Algebra R V}.
 
 Module ComAlgExports.
 Bind Scope ring_scope with ComAlgebra.sort.
@@ -2669,20 +2830,20 @@ End ComAlgExports.
 HB.export ComAlgExports.
 
 Section AlgebraTheory.
-Variables (R : comRingType).
+Variables (R : comNzRingType).
 #[export]
 HB.instance Definition _ :=
-  SemiRing_hasCommutativeMul.Build R^c (fun _ _ => mulrC _ _).
+  NzSemiRing_hasCommutativeMul.Build R^c (fun _ _ => mulrC _ _).
 #[export]
-HB.instance Definition _ := ComSemiRing.on R^o.
+HB.instance Definition _ := ComNzSemiRing.on R^o.
 #[export]
 HB.instance Definition _ := Lalgebra_isComAlgebra.Build R R^o.
 End AlgebraTheory.
 
 Section AlgebraTheory.
 
-(* TODO: MC-1 port (R has been changed from comRingType to ringType) *)
-Variables (R : ringType) (A : algType R).
+(* TODO: MC-1 port (R has been changed from comNzRingType to nzRingType) *)
+Variables (R : nzRingType) (A : algType R).
 Implicit Types (k : R) (x y : A).
 
 Lemma scalerCA k x y : k *: x * y = x * (k *: y).
@@ -2726,7 +2887,7 @@ HB.instance Definition _ := isScalable.Build R U A *:%R (a \*o f)
 
 End AlgebraTheory.
 
-HB.mixin Record Ring_hasMulInverse R of Ring R := {
+HB.mixin Record NzRing_hasMulInverse R of NzRing R := {
   unit_subdef : pred R;
   inv : R -> R;
   mulVr_subproof : {in unit_subdef, left_inverse 1 inv *%R};
@@ -2734,8 +2895,19 @@ HB.mixin Record Ring_hasMulInverse R of Ring R := {
   unitrP_subproof : forall x y, y * x = 1 /\ x * y = 1 -> unit_subdef x;
   invr_out_subproof : {in [predC unit_subdef], inv =1 id}
 }.
+
+Module Ring_hasMulInverse.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing_hasMulInverse.Build instead.")]
+Notation Build R := (NzRing_hasMulInverse.Build R) (only parsing).
+End Ring_hasMulInverse.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use NzRing_hasMulInverse instead.")]
+Notation Ring_hasMulInverse R := (NzRing_hasMulInverse R) (only parsing).
+
 #[short(type="unitRingType")]
-HB.structure Definition UnitRing := {R of Ring_hasMulInverse R & Ring R}.
+HB.structure Definition UnitRing := {R of NzRing_hasMulInverse R & NzRing R}.
 
 Module UnitRingExports.
 Bind Scope ring_scope with UnitRing.sort.
@@ -2743,7 +2915,7 @@ End UnitRingExports.
 HB.export UnitRingExports.
 
 Definition unit_pred {R : unitRingType} :=
-  Eval cbv [ unit_subdef Ring_hasMulInverse.unit_subdef ] in
+  Eval cbv [ unit_subdef NzRing_hasMulInverse.unit_subdef ] in
     (fun u : R => unit_subdef u).
 Arguments unit_pred _ _ /.
 Definition unit {R : unitRingType} := [qualify a u : R | unit_pred u].
@@ -2952,7 +3124,7 @@ Proof. by case=> [yx1 xy1]; apply/unitrP; exists y. Qed.
 
 #[export]
 HB.instance Definition _ :=
-  Ring_hasMulInverse.Build R^c mulrV mulVr rev_unitrP invr_out.
+  NzRing_hasMulInverse.Build R^c mulrV mulVr rev_unitrP invr_out.
 
 #[export]
 HB.instance Definition _ := UnitRing.on R^o.
@@ -3032,7 +3204,7 @@ Proof. by move=> Uy; rewrite rmorphM /= rmorphV. Qed.
 End UnitRingMorphism.
 
 #[short(type="comUnitRingType")]
-HB.structure Definition ComUnitRing := {R of ComRing R & UnitRing R}.
+HB.structure Definition ComUnitRing := {R of ComNzRing R & UnitRing R}.
 
 Module ComUnitRingExports.
 Bind Scope ring_scope with ComUnitRing.sort.
@@ -3040,7 +3212,7 @@ End ComUnitRingExports.
 HB.export ComUnitRingExports.
 
 (* TODO_HB: fix the name (was ComUnitRingMixin) *)
-HB.factory Record ComRing_hasMulInverse R of ComRing R := {
+HB.factory Record ComNzRing_hasMulInverse R of ComNzRing R := {
   unit : {pred R};
   inv : R -> R;
   mulVx : {in unit, left_inverse 1 inv *%R};
@@ -3048,7 +3220,17 @@ HB.factory Record ComRing_hasMulInverse R of ComRing R := {
   invr_out : {in [predC unit], inv =1 id}
 }.
 
-HB.builders Context R of ComRing_hasMulInverse R.
+Module ComRing_hasMulInverse.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing_hasMulInverse.Build instead.")]
+Notation Build R := (ComNzRing_hasMulInverse.Build R) (only parsing).
+End ComRing_hasMulInverse.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing_hasMulInverse instead.")]
+Notation ComRing_hasMulInverse R := (ComNzRing_hasMulInverse R) (only parsing).
+
+HB.builders Context R of ComNzRing_hasMulInverse R.
 
 Fact mulC_mulrV : {in unit, right_inverse 1 inv *%R}.
 Proof. by move=> x Ux /=; rewrite mulrC mulVx. Qed.
@@ -3057,7 +3239,7 @@ Fact mulC_unitP x y : y * x = 1 /\ x * y = 1 -> unit x.
 Proof. by case=> yx _; apply: unitPl yx. Qed.
 
 HB.instance Definition _ :=
-  Ring_hasMulInverse.Build R mulVx mulC_mulrV mulC_unitP invr_out.
+  NzRing_hasMulInverse.Build R mulVx mulC_mulrV mulC_unitP invr_out.
 
 HB.end.
 
@@ -3847,7 +4029,7 @@ End EvalTerm.
 
 Prenex Implicits dnf_rterm.
 
-Definition integral_domain_axiom (R : ringType) :=
+Definition integral_domain_axiom (R : nzRingType) :=
   forall x y : R, x * y = 0 -> (x == 0) || (y == 0).
 
 HB.mixin Record ComUnitRing_isIntegral R of ComUnitRing R := {
@@ -4015,12 +4197,23 @@ HB.instance Definition _ :=
 HB.instance Definition _ := UnitRing_isField.Build R fieldP.
 HB.end.
 
-HB.factory Record ComRing_isField R of ComRing R := {
+HB.factory Record ComNzRing_isField R of ComNzRing R := {
   inv : R -> R;
   mulVf : forall x, x != 0 -> inv x * x = 1;
   invr0 : inv 0 = 0;
 }.
-HB.builders Context R of ComRing_isField R.
+
+Module ComRing_isField.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing_isField.Build instead.")]
+Notation Build R := (ComNzRing_isField.Build R) (only parsing).
+End ComRing_isField.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing_isField instead.")]
+Notation ComRing_isField R := (ComNzRing_isField R) (only parsing).
+
+HB.builders Context R of ComNzRing_isField R.
 
 Fact intro_unit (x y : R) : y * x = 1 -> x != 0.
 Proof.
@@ -4031,8 +4224,8 @@ Qed.
 Fact inv_out : {in predC (predC1 0), inv =1 id}.
 Proof. by move=> x /negbNE/eqP->; exact: invr0. Qed.
 
-HB.instance Definition _ : ComRing_hasMulInverse R :=
-  ComRing_hasMulInverse.Build R mulVf intro_unit inv_out.
+HB.instance Definition _ : ComNzRing_hasMulInverse R :=
+  ComNzRing_hasMulInverse.Build R mulVf intro_unit inv_out.
 
 HB.instance Definition _ : ComUnitRing_isField R :=
   ComUnitRing_isField.Build R (fun x x_neq_0 => x_neq_0).
@@ -4139,7 +4332,7 @@ Qed.
 
 Section FieldMorphismInj.
 
-Variables (R : ringType) (f : {rmorphism F -> R}).
+Variables (R : nzRingType) (f : {rmorphism F -> R}).
 
 Lemma fmorph_eq0 x : (f x == 0) = (x == 0).
 Proof.
@@ -4406,7 +4599,7 @@ HB.instance Definition qe_is_def_field : Field_isDecField F :=
 HB.end.
 
 (* Axiom == all non-constant monic polynomials have a root *)
-Definition closed_field_axiom (R : ringType) :=
+Definition closed_field_axiom (R : nzRingType) :=
   forall n (P : nat -> R), n > 0 ->
    exists x : R, x ^+ n = \sum_(i < n) P i * (x ^+ i).
 
@@ -4435,7 +4628,7 @@ Qed.
 
 End ClosedFieldTheory.
 
-Lemma lalgMixin (R : ringType) (A : lalgType R) (B : lmodType R) (f : B -> A) :
+Lemma lalgMixin (R : nzRingType) (A : lalgType R) (B : lmodType R) (f : B -> A) :
      phant B -> injective f -> scalable f ->
    forall mulB, {morph f : x y / mulB x y >-> x * y} ->
  forall a u v, a *: (mulB u v) = mulB (a *: u) v.
@@ -4443,11 +4636,11 @@ Proof.
 by move=> _ injf fZ mulB fM a x y; apply: injf; rewrite !(fZ, fM) scalerAl.
 Qed.
 
-Lemma comRingMixin (R : comRingType) (T : ringType) (f : T -> R) :
+Lemma comRingMixin (R : comNzRingType) (T : nzRingType) (f : T -> R) :
   phant T -> injective f -> {morph f : x y / x * y} -> commutative (@mul T).
 Proof. by move=> _ inj_f fM x y; apply: inj_f; rewrite !fM mulrC. Qed.
 
-Lemma algMixin (R : ringType) (A : algType R) (B : lalgType R) (f : B -> A) :
+Lemma algMixin (R : nzRingType) (A : algType R) (B : lalgType R) (f : B -> A) :
     phant B -> injective f -> {morph f : x y / x * y} -> scalable f ->
   forall k (x y : B), k *: (x * y) = x * (k *: y).
 Proof.
@@ -4464,11 +4657,11 @@ HB.mixin Record isOppClosed (V : zmodType) (S : {pred V}) := {
   rpredNr : oppr_closed S
 }.
 
-HB.mixin Record isMul2Closed (R : semiRingType) (S : {pred R}) := {
+HB.mixin Record isMul2Closed (R : nzSemiRingType) (S : {pred R}) := {
   rpredM : mulr_2closed S
 }.
 
-HB.mixin Record isMul1Closed (R : semiRingType) (S : {pred R}) := {
+HB.mixin Record isMul1Closed (R : nzSemiRingType) (S : {pred R}) := {
   rpred1 : 1 \in S
 }.
 
@@ -4476,7 +4669,7 @@ HB.mixin Record isInvClosed (R : unitRingType) (S : {pred R}) := {
   rpredVr : invr_closed S
 }.
 
-HB.mixin Record isScaleClosed (R : ringType) (V : lmodType R)
+HB.mixin Record isScaleClosed (R : nzRingType) (V : lmodType R)
     (S : {pred V}) := {
   rpredZ : scaler_closed S
 }.
@@ -4499,19 +4692,19 @@ HB.structure Definition Mul2Closed R := {S of isMul2Closed R S}.
 HB.structure Definition MulClosed R := {S of Mul2Closed R S & isMul1Closed R S}.
 
 #[short(type="smulClosed")]
-HB.structure Definition SmulClosed (R : ringType) :=
+HB.structure Definition SmulClosed (R : nzRingType) :=
   {S of OppClosed R S & MulClosed R S}.
 
 #[short(type="semiring2Closed")]
-HB.structure Definition Semiring2Closed (R : semiRingType) :=
+HB.structure Definition Semiring2Closed (R : nzSemiRingType) :=
   {S of AddClosed R S & Mul2Closed R S}.
 
 #[short(type="semiringClosed")]
-HB.structure Definition SemiringClosed (R : semiRingType) :=
+HB.structure Definition SemiringClosed (R : nzSemiRingType) :=
   {S of AddClosed R S & MulClosed R S}.
 
 #[short(type="subringClosed")]
-HB.structure Definition SubringClosed (R : ringType) :=
+HB.structure Definition SubringClosed (R : nzRingType) :=
   {S of ZmodClosed R S & MulClosed R S}.
 
 #[short(type="divClosed")]
@@ -4523,11 +4716,11 @@ HB.structure Definition SdivClosed (R : unitRingType) :=
   {S of SmulClosed R S & isInvClosed R S}.
 
 #[short(type="submodClosed")]
-HB.structure Definition SubmodClosed (R : ringType) (V : lmodType R) :=
+HB.structure Definition SubmodClosed (R : nzRingType) (V : lmodType R) :=
   {S of ZmodClosed V S & isScaleClosed R V S}.
 
 #[short(type="subalgClosed")]
-HB.structure Definition SubalgClosed (R : ringType) (A : lalgType R) :=
+HB.structure Definition SubalgClosed (R : nzRingType) (A : lalgType R) :=
   {S of SubringClosed A S & isScaleClosed R A S}.
 
 #[short(type="divringClosed")]
@@ -4535,7 +4728,7 @@ HB.structure Definition DivringClosed (R : unitRingType) :=
   {S of SubringClosed R S & isInvClosed R S}.
 
 #[short(type="divalgClosed")]
-HB.structure Definition DivalgClosed (R : ringType) (A : unitAlgType R) :=
+HB.structure Definition DivalgClosed (R : nzRingType) (A : unitAlgType R) :=
   {S of DivringClosed A S & isScaleClosed R A S}.
 
 (* Factories for stability properties *)
@@ -4551,7 +4744,7 @@ HB.instance Definition _ := isAddClosed.Build V S
   (zmod_closedD zmod_closed_subproof).
 HB.end.
 
-HB.factory Record isMulClosed (R : semiRingType) (S : {pred R}) := {
+HB.factory Record isMulClosed (R : nzSemiRingType) (S : {pred R}) := {
   rpred1M : mulr_closed S
 }.
 
@@ -4560,7 +4753,7 @@ HB.instance Definition _ := isMul2Closed.Build R S (proj2 rpred1M).
 HB.instance Definition _ := isMul1Closed.Build R S (proj1 rpred1M).
 HB.end.
 
-HB.factory Record isSmulClosed (R : ringType) (S : R -> bool) := {
+HB.factory Record isSmulClosed (R : nzRingType) (S : R -> bool) := {
   smulr_closed_subproof : smulr_closed S
 }.
 
@@ -4571,7 +4764,7 @@ HB.instance Definition _ := isOppClosed.Build R S
   (smulr_closedN smulr_closed_subproof).
 HB.end.
 
-HB.factory Record isSemiringClosed (R : semiRingType) (S : R -> bool) := {
+HB.factory Record isSemiringClosed (R : nzSemiRingType) (S : R -> bool) := {
   semiring_closed_subproof : semiring_closed S
 }.
 
@@ -4582,7 +4775,7 @@ HB.instance Definition _ := isMulClosed.Build R S
   (semiring_closedM semiring_closed_subproof).
 HB.end.
 
-HB.factory Record isSubringClosed (R : ringType) (S : R -> bool) := {
+HB.factory Record isSubringClosed (R : nzRingType) (S : R -> bool) := {
   subring_closed_subproof : subring_closed S
 }.
 
@@ -4615,7 +4808,7 @@ HB.instance Definition _ := isSmulClosed.Build R S
   (sdivr_closedM sdivr_closed_subproof).
 HB.end.
 
-HB.factory Record isSubmodClosed (R : ringType) (V : lmodType R)
+HB.factory Record isSubmodClosed (R : nzRingType) (V : lmodType R)
     (S : V -> bool) := {
   submod_closed_subproof : submod_closed S
 }.
@@ -4627,7 +4820,7 @@ HB.instance Definition _ := isScaleClosed.Build R V S
   (submod_closedZ submod_closed_subproof).
 HB.end.
 
-HB.factory Record isSubalgClosed (R : ringType) (A : lalgType R)
+HB.factory Record isSubalgClosed (R : nzRingType) (A : lalgType R)
     (S : A -> bool) := {
   subalg_closed_subproof : subalg_closed S
 }.
@@ -4737,7 +4930,7 @@ End ZmodulePred.
 
 Section SemiRingPred.
 
-Variables (R : semiRingType).
+Variables (R : nzSemiRingType).
 
 Section Mul.
 
@@ -4765,7 +4958,7 @@ End SemiRingPred.
 
 Section RingPred.
 
-Variables (R : ringType).
+Variables (R : nzRingType).
 
 Lemma rpredMsign (S : opprClosed R) n x : ((-1) ^+ n * x \in S) = (x \in S).
 Proof. by rewrite -signr_odd mulr_sign; case: ifP => // _; rewrite rpredN. Qed.
@@ -4785,7 +4978,7 @@ End RingPred.
 
 Section LmodPred.
 
-Variables (R : ringType) (V : lmodType R).
+Variables (R : nzRingType) (V : lmodType R).
 
 Lemma rpredZsign (S : opprClosed V) n u : ((-1) ^+ n *: u \in S) = (u \in S).
 Proof. by rewrite -signr_odd scaler_sign fun_if if_arg rpredN if_same. Qed.
@@ -4803,7 +4996,7 @@ End LmodPred.
 
 Section LalgPred.
 
-Variables (R : ringType) (A : lalgType R).
+Variables (R : nzRingType) (A : lalgType R).
 
 Lemma subalgClosedP (algS : subalgClosed A) : subalg_closed algS.
 Proof.
@@ -5020,17 +5213,43 @@ Proof. by move=> x y; rewrite !SubK. Qed.
 HB.instance Definition _ := isSubZmodule.Build V S U valB.
 HB.end.
 
-HB.mixin Record isSubSemiRing (R : semiRingType) (S : pred R) U
-    of SubNmodule R S U & SemiRing U := {
+HB.mixin Record isSubNzSemiRing (R : nzSemiRingType) (S : pred R) U
+    of SubNmodule R S U & NzSemiRing U := {
   valM_subproof : multiplicative (val : U -> R);
 }.
 
-#[short(type="subSemiRingType")]
-HB.structure Definition SubSemiRing (R : semiRingType) (S : pred R) :=
-  { U of SubNmodule R S U & SemiRing U & isSubSemiRing R S U }.
+Module isSubSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use ComNzRing_isField.Build instead.")]
+Notation Build R S U := (isSubNzSemiRing.Build R S U) (only parsing).
+End isSubSemiRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use isSubNzSemiRing instead.")]
+Notation isSubSemiRing R S U := (isSubNzSemiRing R S U) (only parsing).
+
+#[short(type="subNzSemiRingType")]
+HB.structure Definition SubNzSemiRing (R : nzSemiRingType) (S : pred R) :=
+  { U of SubNmodule R S U & NzSemiRing U & isSubNzSemiRing R S U }.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzSemiRing instead.")]
+Notation SubSemiRing R := (SubNzSemiRing R) (only parsing).
+
+Module SubSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzSemiRing.sort instead.")]
+Notation sort := (SubNzSemiRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzSemiRing.on instead.")]
+Notation on R := (SubNzSemiRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzSemiRing.copy instead.")]
+Notation copy T U := (SubNzSemiRing.copy T U) (only parsing).
+End SubSemiRing.
 
 Section multiplicative.
-Context (R : semiRingType) (S : pred R) (U : SubSemiRing.type S).
+Context (R : nzSemiRingType) (S : pred R) (U : SubNzSemiRing.type S).
 Notation val := (val : U -> R).
 #[export]
 HB.instance Definition _ := isMultiplicative.Build U R val valM_subproof.
@@ -5039,12 +5258,23 @@ Lemma valM : {morph val : x y / x * y}. Proof. exact: rmorphM. Qed.
 Lemma valM1 : multiplicative val. Proof. exact: valM_subproof. Qed.
 End multiplicative.
 
-HB.factory Record SubNmodule_isSubSemiRing (R : semiRingType) S U
+HB.factory Record SubNmodule_isSubNzSemiRing (R : nzSemiRingType) S U
     of SubNmodule R S U := {
   mulr_closed_subproof : mulr_closed S
 }.
 
-HB.builders Context R S U of SubNmodule_isSubSemiRing R S U.
+Module SubNmodule_isSubSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNmodule_isSubNzSemiRing.Build instead.")]
+Notation Build R S U := (SubNmodule_isSubNzSemiRing.Build R S U) (only parsing).
+End SubNmodule_isSubSemiRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNmodule_isSubNzSemiRing instead.")]
+Notation SubNmodule_isSubSemiRing R S U :=
+  (SubNmodule_isSubNzSemiRing R S U) (only parsing).
+
+HB.builders Context R S U of SubNmodule_isSubNzSemiRing R S U.
 
 HB.instance Definition _ := isMulClosed.Build R S mulr_closed_subproof.
 
@@ -5072,37 +5302,92 @@ Lemma mulr0 : right_zero 0%R mulU.
 Proof. by move=> x; apply: val_inj; rewrite SubK val0 mulr0. Qed.
 Lemma oner_neq0 : oneU != 0.
 Proof. by rewrite -(inj_eq val_inj) SubK raddf0 oner_neq0. Qed.
-HB.instance Definition _ := Nmodule_isSemiRing.Build U
+HB.instance Definition _ := Nmodule_isNzSemiRing.Build U
   mulrA mul1r mulr1 mulrDl mulrDr mul0r mulr0 oner_neq0.
 
 Lemma valM : multiplicative (val : U -> R).
 Proof. by split=> [x y|] /=; rewrite !SubK. Qed.
-HB.instance Definition _ := isSubSemiRing.Build R S U valM.
+HB.instance Definition _ := isSubNzSemiRing.Build R S U valM.
 HB.end.
 
-#[short(type="subComSemiRingType")]
-HB.structure Definition SubComSemiRing (R : semiRingType) S :=
-  {U of SubSemiRing R S U & ComSemiRing U}.
+#[short(type="subComNzSemiRingType")]
+HB.structure Definition SubComNzSemiRing (R : nzSemiRingType) S :=
+  {U of SubNzSemiRing R S U & ComNzSemiRing U}.
 
-HB.factory Record SubSemiRing_isSubComSemiRing (R : comSemiRingType) S U
-    of SubSemiRing R S U := {}.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubComNzSemiRing instead.")]
+Notation SubComSemiRing R := (SubComNzSemiRing R) (only parsing).
 
-HB.builders Context R S U of SubSemiRing_isSubComSemiRing R S U.
+Module SubComSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubComNzSemiRing.sort instead.")]
+Notation sort  := (SubComNzSemiRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubComNzSemiRing.on instead.")]
+Notation on R := (SubComNzSemiRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubComNzSemiRing.copy instead.")]
+Notation copy T U := (SubComNzSemiRing.copy T U) (only parsing).
+End SubComSemiRing.
+
+HB.factory Record SubNzSemiRing_isSubComNzSemiRing (R : comNzSemiRingType) S U
+    of SubNzSemiRing R S U := {}.
+
+Module SubSemiRing_isSubComSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzSemiRing_isSubComNzSemiRing.Build instead.")]
+Notation Build R S U :=
+  (SubNzSemiRing_isSubComNzSemiRing.Build R S U) (only parsing).
+End SubSemiRing_isSubComSemiRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzSemiRing_isSubComNzSemiRing instead.")]
+Notation SubSemiRing_isSubComSemiRing R S U :=
+  (SubNzSemiRing_isSubComNzSemiRing R S U) (only parsing).
+
+HB.builders Context R S U of SubNzSemiRing_isSubComNzSemiRing R S U.
 Lemma mulrC : @commutative U U *%R.
 Proof. by move=> x y; apply: val_inj; rewrite !rmorphM mulrC. Qed.
-HB.instance Definition _ := SemiRing_hasCommutativeMul.Build U mulrC.
+HB.instance Definition _ := NzSemiRing_hasCommutativeMul.Build U mulrC.
 HB.end.
 
-#[short(type="subRingType")]
-HB.structure Definition SubRing (R : ringType) (S : pred R) :=
-  { U of SubSemiRing R S U & Ring U & isSubZmodule R S U }.
+#[short(type="nzSubRingType")]
+HB.structure Definition SubNzRing (R : nzRingType) (S : pred R) :=
+  { U of SubNzSemiRing R S U & NzRing U & isSubZmodule R S U }.
 
-HB.factory Record SubZmodule_isSubRing (R : ringType) S U
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzRing instead.")]
+Notation SubRing R := (SubNzRing R) (only parsing).
+
+Module SubRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzRing.sort instead.")]
+Notation sort := (SubNzRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzRing.on instead.")]
+Notation on R := (SubNzRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzRing.copy instead.")]
+Notation copy T U := (SubNzRing.copy T U) (only parsing).
+End SubRing.
+
+HB.factory Record SubZmodule_isSubNzRing (R : nzRingType) S U
     of SubZmodule R S U := {
   subring_closed_subproof : subring_closed S
 }.
 
-HB.builders Context R S U of SubZmodule_isSubRing R S U.
+Module SubZmodule_isSubRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubZmodule_isSubNzRing.Build instead.")]
+Notation Build R S U := (SubZmodule_isSubNzRing.Build R S U) (only parsing).
+End SubZmodule_isSubRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubZmodule_isSubNzRing instead.")]
+Notation SubZmodule_isSubRing R S U :=
+  (SubZmodule_isSubNzRing R S U) (only parsing).
+
+HB.builders Context R S U of SubZmodule_isSubNzRing R S U.
 
 HB.instance Definition _ := isSubringClosed.Build R S subring_closed_subproof.
 
@@ -5110,46 +5395,73 @@ Let inU v Sv : U := Sub v Sv.
 Let oneU : U := inU (@rpred1 _ (MulClosed.clone R S _)).
 Let mulU (u1 u2 : U) := inU (rpredM _ _ (valP u1) (valP u2)).
 
-HB.instance Definition _ := SubNmodule_isSubSemiRing.Build R S U
+HB.instance Definition _ := SubNmodule_isSubNzSemiRing.Build R S U
   (smulr_closedM (subring_closedM subring_closed_subproof)).
 HB.end.
 
-#[short(type="subComRingType")]
-HB.structure Definition SubComRing (R : ringType) S :=
-  {U of SubRing R S U & ComRing U}.
+#[short(type="subComNzRingType")]
+HB.structure Definition SubComNzRing (R : nzRingType) S :=
+  {U of SubNzRing R S U & ComNzRing U}.
 
-HB.factory Record SubRing_isSubComRing (R : comRingType) S U
-    of SubRing R S U := {}.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubComNzRing instead.")]
+Notation SubComRing R := (SubComNzRing R) (only parsing).
 
-HB.builders Context R S U of SubRing_isSubComRing R S U.
+Module SubComRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubComNzRing.sort instead.")]
+Notation sort := (SubComNzRing.sort) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubComNzRing.on instead.")]
+Notation on R := (SubComNzRing.on R) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubComNzRing.copy instead.")]
+Notation copy T U := (SubComNzRing.copy T U) (only parsing).
+End SubComRing.
+
+HB.factory Record SubNzRing_isSubComNzRing (R : comNzRingType) S U
+    of SubNzRing R S U := {}.
+
+Module SubRing_isSubComRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzRing_isSubComNzRing.Build instead.")]
+Notation Build R S U := (SubNzRing_isSubComNzRing.Build R S U) (only parsing).
+End SubRing_isSubComRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzRing_isSubComNzRing instead.")]
+Notation SubRing_isSubComRing R S U :=
+  (SubNzRing_isSubComNzRing R S U) (only parsing).
+
+HB.builders Context R S U of SubNzRing_isSubComNzRing R S U.
 Lemma mulrC : @commutative U U *%R.
 Proof. by move=> x y; apply: val_inj; rewrite !rmorphM mulrC. Qed.
-HB.instance Definition _ := Ring_hasCommutativeMul.Build U mulrC.
+HB.instance Definition _ := NzRing_hasCommutativeMul.Build U mulrC.
 HB.end.
 
-HB.mixin Record isSubLmodule (R : ringType) (V : lmodType R) (S : pred V)
+HB.mixin Record isSubLmodule (R : nzRingType) (V : lmodType R) (S : pred V)
    W of SubZmodule V S W & Lmodule R W := {
  valZ : scalable (val : W -> V);
 }.
 
 #[short(type="subLmodType")]
-HB.structure Definition SubLmodule (R : ringType) (V : lmodType R)
+HB.structure Definition SubLmodule (R : nzRingType) (V : lmodType R)
     (S : pred V) :=
   { W of SubZmodule V S W & Zmodule_isLmodule R W & isSubLmodule R V S W}.
 
 Section linear.
-Context (R : ringType) (V : lmodType R) (S : pred V) (W : SubLmodule.type S).
+Context (R : nzRingType) (V : lmodType R) (S : pred V) (W : SubLmodule.type S).
 Notation val := (val : W -> V).
 #[export]
 HB.instance Definition _ := isScalable.Build R W V *:%R val valZ.
 End linear.
 
-HB.factory Record SubZmodule_isSubLmodule (R : ringType) (V : lmodType R) S W
+HB.factory Record SubZmodule_isSubLmodule (R : nzRingType) (V : lmodType R) S W
     of SubZmodule V S W := {
   submod_closed_subproof : submod_closed S
 }.
 
-HB.builders Context (R : ringType) (V : lmodType R) S W
+HB.builders Context (R : nzRingType) (V : lmodType R) S W
   of SubZmodule_isSubLmodule R V S W.
 
 HB.instance Definition _ := isSubmodClosed.Build R V S submod_closed_subproof.
@@ -5177,27 +5489,39 @@ HB.instance Definition _ := isSubLmodule.Build R V S W valZ.
 HB.end.
 
 #[short(type="subLalgType")]
-HB.structure Definition SubLalgebra (R : ringType) (V : lalgType R) S :=
-  {W of SubRing V S W & @SubLmodule R V S W & Lalgebra R W}.
+HB.structure Definition SubLalgebra (R : nzRingType) (V : lalgType R) S :=
+  {W of SubNzRing V S W & @SubLmodule R V S W & Lalgebra R W}.
 
-HB.factory Record SubRing_SubLmodule_isSubLalgebra (R : ringType)
-    (V : lalgType R) S W of SubRing V S W & @SubLmodule R V S W := {}.
+HB.factory Record SubNzRing_SubLmodule_isSubLalgebra (R : nzRingType)
+    (V : lalgType R) S W of SubNzRing V S W & @SubLmodule R V S W := {}.
 
-HB.builders Context (R : ringType) (V : lalgType R) S W
-  of SubRing_SubLmodule_isSubLalgebra R V S W.
+Module SubRing_SubLmodule_isSubLalgebra.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzRing_SubLmodule_isSubLalgebra.Build instead.")]
+Notation Build R V S U :=
+  (SubNzRing_SubLmodule_isSubLalgebra.Build R V S U) (only parsing).
+End SubRing_SubLmodule_isSubLalgebra.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubNzRing_SubLmodule_isSubLalgebra instead.")]
+Notation SubRing_SubLmodule_isSubLalgebra R V S U :=
+  (SubNzRing_SubLmodule_isSubLalgebra R V S U) (only parsing).
+
+HB.builders Context (R : nzRingType) (V : lalgType R) S W
+  of SubNzRing_SubLmodule_isSubLalgebra R V S W.
 Lemma scalerAl (a : R) (u v : W) : a *: (u * v) = a *: u * v.
 Proof. by apply: val_inj; rewrite !(linearZ, rmorphM)/= linearZ scalerAl. Qed.
 HB.instance Definition _ := Lmodule_isLalgebra.Build R W scalerAl.
 HB.end.
 
 #[short(type="subAlgType")]
-HB.structure Definition SubAlgebra (R : ringType) (V : algType R) S :=
+HB.structure Definition SubAlgebra (R : nzRingType) (V : algType R) S :=
   {W of @SubLalgebra R V S W & Algebra R W}.
 
-HB.factory Record SubLalgebra_isSubAlgebra (R : ringType)
+HB.factory Record SubLalgebra_isSubAlgebra (R : nzRingType)
     (V : algType R) S W of @SubLalgebra R V S W := {}.
 
-HB.builders Context (R : ringType) (V : algType R) S W
+HB.builders Context (R : nzRingType) (V : algType R) S W
   of SubLalgebra_isSubAlgebra R V S W.
 Lemma scalerAr (k : R) (x y : W) : k *: (x * y) = x * (k *: y).
 Proof. by apply: val_inj; rewrite !(linearZ, rmorphM)/= linearZ scalerAr. Qed.
@@ -5205,15 +5529,15 @@ HB.instance Definition _ := Lalgebra_isAlgebra.Build R W scalerAr.
 HB.end.
 
 #[short(type="subUnitRingType")]
-HB.structure Definition SubUnitRing (R : ringType) (S : pred R) :=
-  {U of SubRing R S U & UnitRing U}.
+HB.structure Definition SubUnitRing (R : nzRingType) (S : pred R) :=
+  {U of SubNzRing R S U & UnitRing U}.
 
-HB.factory Record SubRing_isSubUnitRing (R : unitRingType) S U
-    of SubRing R S U := {
+HB.factory Record SubNzRing_isSubUnitRing (R : unitRingType) S U
+    of SubNzRing R S U := {
   divring_closed_subproof : divring_closed S
 }.
 
-HB.builders Context (R : unitRingType) S U of SubRing_isSubUnitRing R S U.
+HB.builders Context (R : unitRingType) S U of SubNzRing_isSubUnitRing R S U.
 
 HB.instance Definition _ := isDivringClosed.Build R S divring_closed_subproof.
 
@@ -5236,17 +5560,17 @@ Lemma invr_out : {in [pred x | val x \isn't a unit], invU =1 id}.
 Proof.
 by move=> x /[!inE] xNU; apply: val_inj; rewrite SubK invr_out.
 Qed.
-HB.instance Definition _ := Ring_hasMulInverse.Build U
+HB.instance Definition _ := NzRing_hasMulInverse.Build U
   mulVr divrr unitrP invr_out.
 HB.end.
 
 #[short(type="subComUnitRingType")]
 HB.structure Definition SubComUnitRing (R : comUnitRingType) (S : pred R) :=
-  {U of SubComRing R S U & SubUnitRing R S U}.
+  {U of SubComNzRing R S U & SubUnitRing R S U}.
 
 #[short(type="subIdomainType")]
 HB.structure Definition SubIntegralDomain (R : idomainType) (S : pred R) :=
-  {U of SubComRing R S U & IntegralDomain U}.
+  {U of SubComNzRing R S U & IntegralDomain U}.
 
 HB.factory Record SubComUnitRing_isSubIntegralDomain (R : idomainType) S U
   of SubComUnitRing R S U := {}.
@@ -5278,58 +5602,103 @@ Qed.
 HB.instance Definition _ := UnitRing_isField.Build U fieldP.
 HB.end.
 
-HB.factory Record SubChoice_isSubSemiRing (R : semiRingType) S U
+HB.factory Record SubChoice_isSubNzSemiRing (R : nzSemiRingType) S U
     of SubChoice R S U := {
   semiring_closed_subproof : semiring_closed S
 }.
 
-HB.builders Context (R : semiRingType) S U of SubChoice_isSubSemiRing R S U.
+Module SubChoice_isSubSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubChoice_isSubNzSemiRing.Build instead.")]
+Notation Build R S U := (SubChoice_isSubNzSemiRing.Build R S U) (only parsing).
+End SubChoice_isSubSemiRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubChoice_isSubNzSemiRing instead.")]
+Notation SubChoice_isSubSemiRing R S U :=
+  (SubChoice_isSubNzSemiRing R S U) (only parsing).
+
+HB.builders Context (R : nzSemiRingType) S U of SubChoice_isSubNzSemiRing R S U.
 HB.instance Definition _ := SubChoice_isSubNmodule.Build R S U
   (semiring_closedD semiring_closed_subproof).
-HB.instance Definition _ := SubNmodule_isSubSemiRing.Build R S U
+HB.instance Definition _ := SubNmodule_isSubNzSemiRing.Build R S U
   (semiring_closedM semiring_closed_subproof).
 HB.end.
 
-HB.factory Record SubChoice_isSubComSemiRing (R : comSemiRingType) S U
+HB.factory Record SubChoice_isSubComNzSemiRing (R : comNzSemiRingType) S U
     of SubChoice R S U := {
   semiring_closed_subproof : semiring_closed S
 }.
 
-HB.builders Context (R : comSemiRingType) S U
-  of SubChoice_isSubComSemiRing R S U.
-HB.instance Definition _ := SubChoice_isSubSemiRing.Build R S U
+Module SubChoice_isSubComSemiRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubChoice_isSubComNzSemiRing.Build instead.")]
+Notation Build R S U :=
+  (SubChoice_isSubComNzSemiRing.Build R S U) (only parsing).
+End SubChoice_isSubComSemiRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubChoice_isSubComNzSemiRing instead.")]
+Notation SubChoice_isSubComSemiRing R S U :=
+  (SubChoice_isSubComNzSemiRing R S U) (only parsing).
+
+HB.builders Context (R : comNzSemiRingType) S U
+  of SubChoice_isSubComNzSemiRing R S U.
+HB.instance Definition _ := SubChoice_isSubNzSemiRing.Build R S U
   semiring_closed_subproof.
-HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
+HB.instance Definition _ := SubNzSemiRing_isSubComNzSemiRing.Build R S U.
 HB.end.
 
-HB.factory Record SubChoice_isSubRing (R : ringType) S U of SubChoice R S U := {
+HB.factory Record SubChoice_isSubNzRing (R : nzRingType) S U of SubChoice R S U := {
   subring_closed_subproof : subring_closed S
 }.
 
-HB.builders Context (R : ringType) S U of SubChoice_isSubRing R S U.
+Module SubChoice_isSubRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubChoice_isSubNzRing.Build instead.")]
+Notation Build R S U := (SubChoice_isSubNzRing.Build R S U) (only parsing).
+End SubChoice_isSubRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubChoice_isSubNzRing instead.")]
+Notation SubChoice_isSubRing R S U :=
+  (SubChoice_isSubNzRing R S U) (only parsing).
+
+HB.builders Context (R : nzRingType) S U of SubChoice_isSubNzRing R S U.
 HB.instance Definition _ := SubChoice_isSubZmodule.Build R S U
   (subring_closedB subring_closed_subproof).
-HB.instance Definition _ := SubZmodule_isSubRing.Build R S U
+HB.instance Definition _ := SubZmodule_isSubNzRing.Build R S U
   subring_closed_subproof.
 HB.end.
 
-HB.factory Record SubChoice_isSubComRing (R : comRingType) S U
+HB.factory Record SubChoice_isSubComNzRing (R : comNzRingType) S U
     of SubChoice R S U := {
   subring_closed_subproof : subring_closed S
 }.
 
-HB.builders Context (R : comRingType) S U of SubChoice_isSubComRing R S U.
-HB.instance Definition _ := SubChoice_isSubRing.Build R S U
+Module SubChoice_isSubComRing.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubChoice_isSubComNzRing.Build instead.")]
+Notation Build R S U := (SubChoice_isSubComNzRing.Build R S U) (only parsing).
+End SubChoice_isSubComRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use SubChoice_isSubComNzRing instead.")]
+Notation SubChoice_isSubComRing R S U :=
+  (SubChoice_isSubComNzRing R S U) (only parsing).
+
+HB.builders Context (R : comNzRingType) S U of SubChoice_isSubComNzRing R S U.
+HB.instance Definition _ := SubChoice_isSubNzRing.Build R S U
   subring_closed_subproof.
-HB.instance Definition _ := SubRing_isSubComRing.Build R S U.
+HB.instance Definition _ := SubNzRing_isSubComNzRing.Build R S U.
 HB.end.
 
-HB.factory Record SubChoice_isSubLmodule (R : ringType) (V : lmodType R) S W
+HB.factory Record SubChoice_isSubLmodule (R : nzRingType) (V : lmodType R) S W
     of SubChoice V S W := {
   submod_closed_subproof : submod_closed S
 }.
 
-HB.builders Context (R : ringType) (V : lmodType R) S W
+HB.builders Context (R : nzRingType) (V : lmodType R) S W
   of SubChoice_isSubLmodule R V S W.
 HB.instance Definition _ := SubChoice_isSubZmodule.Build V S W
   (submod_closedB submod_closed_subproof).
@@ -5337,26 +5706,26 @@ HB.instance Definition _ := SubZmodule_isSubLmodule.Build R V S W
   submod_closed_subproof.
 HB.end.
 
-HB.factory Record SubChoice_isSubLalgebra (R : ringType) (A : lalgType R) S W
+HB.factory Record SubChoice_isSubLalgebra (R : nzRingType) (A : lalgType R) S W
     of SubChoice A S W := {
   subalg_closed_subproof : subalg_closed S
 }.
 
-HB.builders Context (R : ringType) (A : lalgType R) S W
+HB.builders Context (R : nzRingType) (A : lalgType R) S W
   of SubChoice_isSubLalgebra R A S W.
-HB.instance Definition _ := SubChoice_isSubRing.Build A S W
+HB.instance Definition _ := SubChoice_isSubNzRing.Build A S W
   (subalg_closedBM subalg_closed_subproof).
 HB.instance Definition _ := SubZmodule_isSubLmodule.Build R A S W
   (subalg_closedZ subalg_closed_subproof).
-HB.instance Definition _ := SubRing_SubLmodule_isSubLalgebra.Build R A S W.
+HB.instance Definition _ := SubNzRing_SubLmodule_isSubLalgebra.Build R A S W.
 HB.end.
 
-HB.factory Record SubChoice_isSubAlgebra (R : ringType) (A : algType R) S W
+HB.factory Record SubChoice_isSubAlgebra (R : nzRingType) (A : algType R) S W
     of SubChoice A S W := {
   subalg_closed_subproof : subalg_closed S
 }.
 
-HB.builders Context (R : ringType) (A : algType R) S W
+HB.builders Context (R : nzRingType) (A : algType R) S W
   of SubChoice_isSubAlgebra R A S W.
 HB.instance Definition _ := SubChoice_isSubLalgebra.Build R A S W
   subalg_closed_subproof.
@@ -5369,9 +5738,9 @@ HB.factory Record SubChoice_isSubUnitRing (R : unitRingType) S U
 }.
 
 HB.builders Context (R : unitRingType) S U of SubChoice_isSubUnitRing R S U.
-HB.instance Definition _ := SubChoice_isSubRing.Build R S U
+HB.instance Definition _ := SubChoice_isSubNzRing.Build R S U
   (divring_closedBM divring_closed_subproof).
-HB.instance Definition _ := SubRing_isSubUnitRing.Build R S U
+HB.instance Definition _ := SubNzRing_isSubUnitRing.Build R S U
   divring_closed_subproof.
 HB.end.
 
@@ -5382,9 +5751,9 @@ HB.factory Record SubChoice_isSubComUnitRing (R : comUnitRingType) S U
 
 HB.builders Context (R : comUnitRingType) S U
   of SubChoice_isSubComUnitRing R S U.
-HB.instance Definition _ := SubChoice_isSubComRing.Build R S U
+HB.instance Definition _ := SubChoice_isSubComNzRing.Build R S U
   (divring_closedBM divring_closed_subproof).
-HB.instance Definition _ := SubRing_isSubUnitRing.Build R S U
+HB.instance Definition _ := SubNzRing_isSubUnitRing.Build R S U
   divring_closed_subproof.
 HB.end.
 
@@ -5410,36 +5779,84 @@ Notation "[ 'SubChoice_isSubZmodule' 'of' U 'by' <: ]" :=
   (SubChoice_isSubZmodule.Build _ _ U (zmodClosedP _))
   (at level 0, format "[ 'SubChoice_isSubZmodule'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubNmodule_isSubNzSemiRing' 'of' U 'by' <: ]" :=
+  (SubNmodule_isSubNzSemiRing.Build _ _ U (@rpred1M _ _))
+  (at level 0, format "[ 'SubNmodule_isSubNzSemiRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use [ SubNmodule_isSubNzSemiRing of U by <: ] instead.")]
 Notation "[ 'SubNmodule_isSubSemiRing' 'of' U 'by' <: ]" :=
-  (SubNmodule_isSubSemiRing.Build _ _ U (@rpred1M _ _))
+  (SubNmodule_isSubNzSemiRing.Build _ _ U (@rpred1M _ _))
   (at level 0, format "[ 'SubNmodule_isSubSemiRing'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubChoice_isSubNzSemiRing' 'of' U 'by' <: ]" :=
+  (SubChoice_isSubNzSemiRing.Build _ _ U (semiringClosedP _))
+  (at level 0, format "[ 'SubChoice_isSubNzSemiRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use [ 'SubChoice_isSubNzSemiRing' of U by <: ] instead.")]
 Notation "[ 'SubChoice_isSubSemiRing' 'of' U 'by' <: ]" :=
-  (SubChoice_isSubSemiRing.Build _ _ U (semiringClosedP _))
+  (SubChoice_isSubNzSemiRing.Build _ _ U (semiringClosedP _))
   (at level 0, format "[ 'SubChoice_isSubSemiRing'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubNzSemiRing_isSubComNzSemiRing' 'of' U 'by' <: ]" :=
+  (SubNzSemiRing_isSubComNzSemiRing.Build _ _ U)
+  (at level 0, format "[ 'SubNzSemiRing_isSubComNzSemiRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.4.0",
+        note="Use [ 'SubNzSemiRing_isSubComNzSemiRing' of U by <: ] instead.")]
 Notation "[ 'SubSemiRing_isSubComSemiRing' 'of' U 'by' <: ]" :=
-  (SubSemiRing_isSubComSemiRing.Build _ _ U)
+  (SubNzSemiRing_isSubComNzSemiRing.Build _ _ U)
   (at level 0, format "[ 'SubSemiRing_isSubComSemiRing'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubChoice_isSubComNzSemiRing' 'of' U 'by' <: ]" :=
+  (SubChoice_isSubComNzSemiRing.Build _ _ U (semiringClosedP _))
+  (at level 0, format "[ 'SubChoice_isSubComNzSemiRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use [ 'SubChoice_isSubComNzSemiRing' of U by <: ] instead.")]
 Notation "[ 'SubChoice_isSubComSemiRing' 'of' U 'by' <: ]" :=
-  (SubChoice_isSubComSemiRing.Build _ _ U (semiringClosedP _))
+  (SubChoice_isSubComNzSemiRing.Build _ _ U (semiringClosedP _))
   (at level 0, format "[ 'SubChoice_isSubComSemiRing'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubZmodule_isSubNzRing' 'of' U 'by' <: ]" :=
+  (SubZmodule_isSubNzRing.Build _ _ U (subringClosedP _))
+  (at level 0, format "[ 'SubZmodule_isSubNzRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use [ 'SubZmodule_isSubNzRing' of U by <: ] instead.")]
 Notation "[ 'SubZmodule_isSubRing' 'of' U 'by' <: ]" :=
-  (SubZmodule_isSubRing.Build _ _ U (subringClosedP _))
+  (SubZmodule_isSubNzRing.Build _ _ U (subringClosedP _))
   (at level 0, format "[ 'SubZmodule_isSubRing'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubChoice_isSubNzRing' 'of' U 'by' <: ]" :=
+  (SubChoice_isSubNzRing.Build _ _ U (subringClosedP _))
+  (at level 0, format "[ 'SubChoice_isSubNzRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use [ 'SubChoice_isSubNzRing' of U by <: ] instead.")]
 Notation "[ 'SubChoice_isSubRing' 'of' U 'by' <: ]" :=
-  (SubChoice_isSubRing.Build _ _ U (subringClosedP _))
+  (SubChoice_isSubNzRing.Build _ _ U (subringClosedP _))
   (at level 0, format "[ 'SubChoice_isSubRing'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubNzRing_isSubComNzRing' 'of' U 'by' <: ]" :=
+  (SubNzRing_isSubComNzRing.Build _ _ U)
+  (at level 0, format "[ 'SubNzRing_isSubComNzRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use [ 'SubNzRing_isSubComNzRing' of U by <: ] instead.")]
 Notation "[ 'SubRing_isSubComRing' 'of' U 'by' <: ]" :=
-  (SubRing_isSubComRing.Build _ _ U)
+  (SubNzRing_isSubComNzRing.Build _ _ U)
   (at level 0, format "[ 'SubRing_isSubComRing'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubChoice_isSubComNzRing' 'of' U 'by' <: ]" :=
+  (SubChoice_isSubComNzRing.Build _ _ U (subringClosedP _))
+  (at level 0, format "[ 'SubChoice_isSubComNzRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use [ 'SubChoice_isSubComNzRing' of U by <: ] instead.")]
 Notation "[ 'SubChoice_isSubComRing' 'of' U 'by' <: ]" :=
-  (SubChoice_isSubComRing.Build _ _ U (subringClosedP _))
+  (SubChoice_isSubComNzRing.Build _ _ U (subringClosedP _))
   (at level 0, format "[ 'SubChoice_isSubComRing'  'of'  U  'by'  <: ]")
   : form_scope.
 Notation "[ 'SubZmodule_isSubLmodule' 'of' U 'by' <: ]" :=
@@ -5450,8 +5867,15 @@ Notation "[ 'SubChoice_isSubLmodule' 'of' U 'by' <: ]" :=
   (SubChoice_isSubLmodule.Build _ _ _ U (submodClosedP _))
   (at level 0, format "[ 'SubChoice_isSubLmodule'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubNzRing_SubLmodule_isSubLalgebra' 'of' U 'by' <: ]" :=
+  (SubNzRing_SubLmodule_isSubLalgebra.Build _ _ _ U)
+  (at level 0,
+    format "[ 'SubNzRing_SubLmodule_isSubLalgebra'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.4.0",
+      note="Use [ 'SubNzRing_SubLmodule_isSubLalgebra' of U by <: ] instead.")]
 Notation "[ 'SubRing_SubLmodule_isSubLalgebra' 'of' U 'by' <: ]" :=
-  (SubRing_SubLmodule_isSubLalgebra.Build _ _ _ U)
+  (SubNzRing_SubLmodule_isSubLalgebra.Build _ _ _ U)
   (at level 0, format "[ 'SubRing_SubLmodule_isSubLalgebra'  'of'  U  'by'  <: ]")
   : form_scope.
 Notation "[ 'SubChoice_isSubLalgebra' 'of' U 'by' <: ]" :=
@@ -5466,8 +5890,14 @@ Notation "[ 'SubChoice_isSubAlgebra' 'of' U 'by' <: ]" :=
   (SubChoice_isSubAlgebra.Build _ _ _ U (subalgClosedP _))
   (at level 0, format "[ 'SubChoice_isSubAlgebra'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubNzRing_isSubUnitRing' 'of' U 'by' <: ]" :=
+  (SubNzRing_isSubUnitRing.Build _ _ U (divringClosedP _))
+  (at level 0, format "[ 'SubNzRing_isSubUnitRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use [ 'SubNzRing_isSubUnitRing' of U by <: ] instead.")]
 Notation "[ 'SubRing_isSubUnitRing' 'of' U 'by' <: ]" :=
-  (SubRing_isSubUnitRing.Build _ _ U (divringClosedP _))
+  (SubNzRing_isSubUnitRing.Build _ _ U (divringClosedP _))
   (at level 0, format "[ 'SubRing_isSubUnitRing'  'of'  U  'by'  <: ]")
   : form_scope.
 Notation "[ 'SubChoice_isSubUnitRing' 'of' U 'by' <: ]" :=
@@ -5480,7 +5910,8 @@ Notation "[ 'SubChoice_isSubComUnitRing' 'of' U 'by' <: ]" :=
   : form_scope.
 Notation "[ 'SubComUnitRing_isSubIntegralDomain' 'of' U 'by' <: ]" :=
   (SubComUnitRing_isSubIntegralDomain.Build _ _ U)
-  (at level 0, format "[ 'SubComUnitRing_isSubIntegralDomain'  'of'  U  'by'  <: ]")
+  (at level 0,
+    format "[ 'SubComUnitRing_isSubIntegralDomain'  'of'  U  'by'  <: ]")
   : form_scope.
 Notation "[ 'SubChoice_isSubIntegralDomain' 'of' U 'by' <: ]" :=
   (SubChoice_isSubIntegralDomain.Build _ _ U (divringClosedP _))
@@ -6008,6 +6439,31 @@ Export AllExports.
 Export Scale.Exports.
 Export ClosedExports.
 
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use nzSemiRingType instead.")]
+Notation semiRingType := (nzSemiRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use nzRingType instead.")]
+Notation ringType := (nzRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use comNzSemiRingType instead.")]
+Notation comSemiRingType := (comNzSemiRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use comNzRingType instead.")]
+Notation comRingType := (comNzRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use subNzSemiRingType instead.")]
+Notation subSemiRingType := (subNzSemiRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use subComNzSemiRingType instead.")]
+Notation subComSemiRingType := (subComNzSemiRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use nzSubRingType instead.")]
+Notation subRingType := (nzSubRingType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use subComNzRingType instead.")]
+Notation subComNzRingType := (subComNzRingType) (only parsing).
+
 Variant Ione := IOne : Ione.
 Inductive Inatmul :=
   | INatmul : Ione -> nat -> Inatmul
@@ -6228,7 +6684,7 @@ Section FinFunSemiRing.
 (* As rings require 1 != 0 in order to lift a ring structure over finfuns     *)
 (* we need evidence that the domain is non-empty.                             *)
 
-Variable (aT : finType) (R : semiRingType) (a : aT).
+Variable (aT : finType) (R : nzSemiRingType) (a : aT).
 
 Definition ffun_one : {ffun aT -> R} := [ffun => 1].
 Definition ffun_mul (f g : {ffun aT -> R}) := [ffun x => f x * g x].
@@ -6255,7 +6711,7 @@ Proof. by apply/eqP => /ffunP/(_ a)/eqP; rewrite !ffunE oner_eq0. Qed.
 HB.instance Definition _ := Nmodule_isSemiRing.Build {ffun aT -> R}
   ffun_mulA ffun_mul_1l ffun_mul_1r ffun_mul_addl ffun_mul_addr
   ffun_mul_0l ffun_mul_0r ffun1_nonzero.
-Definition ffun_semiring : semiRingType := {ffun aT -> R}.
+Definition ffun_semiring : nzSemiRingType := {ffun aT -> R}.
 *)
 
 End FinFunSemiRing.
@@ -6265,20 +6721,20 @@ Section FinFunRing.
 (* As rings require 1 != 0 in order to lift a ring structure over finfuns     *)
 (* we need evidence that the domain is non-empty.                             *)
 
-Variable (aT : finType) (R : ringType) (a : aT).
+Variable (aT : finType) (R : nzRingType) (a : aT).
 
 (* TODO_HB: doesn't work in combination with ffun_semiring above *)
-HB.instance Definition _ := Zmodule_isRing.Build {ffun aT -> R}
+HB.instance Definition _ := Zmodule_isNzRing.Build {ffun aT -> R}
   (@ffun_mulA _ _) (@ffun_mul_1l _ _) (@ffun_mul_1r _ _)
   (@ffun_mul_addl _ _) (@ffun_mul_addr _ _) (@ffun1_nonzero _ _ a).
-Definition ffun_ring : ringType := {ffun aT -> R}.
+Definition ffun_ring : nzRingType := {ffun aT -> R}.
 
 End FinFunRing.
 
 (* TODO_HB do FinFunComSemiRing once above is fixed *)
 Section FinFunComRing.
 
-Variable (aT : finType) (R : comRingType) (a : aT).
+Variable (aT : finType) (R : comNzRingType) (a : aT).
 
 Fact ffun_mulC : commutative (@ffun_mul aT R).
 Proof. by move=> f1 f2; apply/ffunP=> i; rewrite !ffunE mulrC. Qed.
@@ -6293,7 +6749,7 @@ End FinFunComRing.
 
 Section FinFunLmod.
 
-Variable (R : ringType) (aT : finType) (rT : lmodType R).
+Variable (R : nzRingType) (aT : finType) (rT : lmodType R).
 
 Implicit Types f g : {ffun aT -> rT}.
 
@@ -6363,7 +6819,7 @@ End PairZmod.
 
 Section PairSemiRing.
 
-Variables R1 R2 : semiRingType.
+Variables R1 R2 : nzSemiRingType.
 
 Definition mul_pair (x y : R1 * R2) := (x.1 * y.1, x.2 * y.2).
 
@@ -6392,7 +6848,7 @@ Fact pair_one_neq0 : (1, 1) != 0 :> R1 * R2.
 Proof. by rewrite xpair_eqE oner_eq0. Qed.
 
 #[export]
-HB.instance Definition _ := Nmodule_isSemiRing.Build (R1 * R2)%type
+HB.instance Definition _ := Nmodule_isNzSemiRing.Build (R1 * R2)%type
   pair_mulA pair_mul1l pair_mul1r pair_mulDl pair_mulDr pair_mul0r pair_mulr0
   pair_one_neq0.
 
@@ -6409,27 +6865,27 @@ End PairSemiRing.
 
 Section PairComSemiRing.
 
-Variables R1 R2 : comSemiRingType.
+Variables R1 R2 : comNzSemiRingType.
 
 Fact pair_mulC : commutative (@mul_pair R1 R2).
 Proof. by move=> x y; congr (_, _); apply: mulrC. Qed.
 
 #[export]
-HB.instance Definition _ := SemiRing_hasCommutativeMul.Build (R1 * R2)%type
+HB.instance Definition _ := NzSemiRing_hasCommutativeMul.Build (R1 * R2)%type
   pair_mulC.
 
 End PairComSemiRing.
 
 (* TODO: HB.saturate *)
 #[export]
-HB.instance Definition _ (R1 R2 : ringType) := SemiRing.on (R1 * R1)%type.
+HB.instance Definition _ (R1 R2 : nzRingType) := NzSemiRing.on (R1 * R1)%type.
 #[export]
-HB.instance Definition _ (R1 R2 : comRingType) := SemiRing.on (R1 * R1)%type.
+HB.instance Definition _ (R1 R2 : comNzRingType) := NzSemiRing.on (R1 * R1)%type.
 (* /TODO *)
 
 Section PairLmod.
 
-Variables (R : ringType) (V1 V2 : lmodType R).
+Variables (R : nzRingType) (V1 V2 : lmodType R).
 
 Definition scale_pair a (v : V1 * V2) : V1 * V2 := (a *: v.1, a *: v.2).
 
@@ -6462,7 +6918,7 @@ End PairLmod.
 
 Section PairLalg.
 
-Variables (R : ringType) (A1 A2 : lalgType R).
+Variables (R : nzRingType) (A1 A2 : lalgType R).
 
 Fact pair_scaleAl a (u v : A1 * A2) : a *: (u * v) = (a *: u) * v.
 Proof. by congr (_, _); apply: scalerAl. Qed.
@@ -6480,8 +6936,8 @@ End PairLalg.
 
 Section PairAlg.
 
-(* TODO: MC-1 port (R has been changed from comRingType to ringType) *)
-Variables (R : ringType) (A1 A2 : algType R).
+(* TODO: MC-1 port (R has been changed from comNzRingType to nzRingType) *)
+Variables (R : nzRingType) (A1 A2 : algType R).
 
 Fact pair_scaleAr a (u v : A1 * A2) : a *: (u * v) = u * (a *: v).
 Proof. by congr (_, _); apply: scalerAr. Qed.
@@ -6523,7 +6979,7 @@ Lemma pair_invr_out : {in [predC pair_unitr], pair_invr =1 id}.
 Proof. by rewrite /pair_invr => x /negPf/= ->. Qed.
 
 #[export]
-HB.instance Definition _ := Ring_hasMulInverse.Build (R1 * R2)%type
+HB.instance Definition _ := NzRing_hasMulInverse.Build (R1 * R2)%type
   pair_mulVl pair_mulVr pair_unitP pair_invr_out.
 
 End PairUnitRing.
@@ -6533,13 +6989,13 @@ End PairUnitRing.
 HB.instance Definition _ (R1 R2 : comUnitRingType) :=
   UnitRing.on (R1 * R2)%type.
 #[export]
-HB.instance Definition _ (R : ringType) (A1 A2 : comAlgType R) :=
+HB.instance Definition _ (R : nzRingType) (A1 A2 : comAlgType R) :=
   Algebra.on (A1 * A2)%type.
 #[export]
-HB.instance Definition _ (R : ringType) (A1 A2 : unitAlgType R) :=
+HB.instance Definition _ (R : nzRingType) (A1 A2 : unitAlgType R) :=
   Algebra.on (A1 * A2)%type.
 #[export]
-HB.instance Definition _ (R : ringType) (A1 A2 : comUnitAlgType R) :=
+HB.instance Definition _ (R : nzRingType) (A1 A2 : comUnitAlgType R) :=
   Algebra.on (A1 * A2)%type.
 (* /TODO *)
 
@@ -6575,7 +7031,7 @@ Section Test2.
 Variables (R : comUnitRingType) (A : unitAlgType R) (S : divalgClosed A).
 
 HB.instance Definition _ := [SubZmodule_isSubLmodule of B S by <:].
-HB.instance Definition _ := [SubRing_SubLmodule_isSubLalgebra of B S by <:].
+HB.instance Definition _ := [SubNzRing_SubLmodule_isSubLalgebra of B S by <:].
 HB.instance Definition _ := [SubLalgebra_isSubAlgebra of B S by <:].
 
 End Test2.
@@ -6584,7 +7040,7 @@ Section Test3.
 
 Variables (F : fieldType) (S : divringClosed F).
 
-HB.instance Definition _ := [SubRing_isSubComRing of B S by <:].
+HB.instance Definition _ := [SubRing_isSubComNzRing of B S by <:].
 HB.instance Definition _ := [SubComUnitRing_isSubIntegralDomain of B S by <:].
 HB.instance Definition _ := [SubIntegralDomain_isSubField of B S by <:].
 
@@ -6597,7 +7053,7 @@ End Test3.
 (* Algebraic structure of bool *)
 
 HB.instance Definition _ := isZmodule.Build bool addbA addbC addFb addbb.
-HB.instance Definition _ := Zmodule_isComRing.Build bool
+HB.instance Definition _ := Zmodule_isComNzRing.Build bool
   andbA andbC andTb andb_addl isT.
 
 Fact mulVb (b : bool) : b != 0 -> b * b = 1.
@@ -6606,7 +7062,7 @@ Proof. by case: b. Qed.
 Fact invb_out (x y : bool) : y * x = 1 -> x != 0.
 Proof. by case: x; case: y. Qed.
 
-HB.instance Definition _ := ComRing_hasMulInverse.Build bool
+HB.instance Definition _ := ComNzRing_hasMulInverse.Build bool
   mulVb invb_out (fun x => fun => erefl x).
 
 Lemma bool_fieldP : Field.axiom bool. Proof. by []. Qed.
@@ -6616,13 +7072,13 @@ HB.instance Definition _ := ComUnitRing_isField.Build bool bool_fieldP.
 (* Algebraic structure of nat *)
 
 HB.instance Definition _ := isNmodule.Build nat addnA addnC add0n.
-HB.instance Definition _ := Nmodule_isComSemiRing.Build nat
+HB.instance Definition _ := Nmodule_isComNzSemiRing.Build nat
   mulnA mulnC mul1n mulnDl mul0n erefl.
 
 HB.instance Definition _ (V : nmodType) (x : V) :=
   isSemiAdditive.Build nat V (natmul x) (mulr0n x, mulrnDr x).
 
-HB.instance Definition _ (R : semiRingType) :=
+HB.instance Definition _ (R : nzSemiRingType) :=
   isMultiplicative.Build nat R (natmul 1) (natrM R, mulr1n 1).
 
 Lemma natr0E : 0 = 0%N. Proof. by []. Qed.

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -326,7 +326,7 @@ Qed.
 
 Lemma nonzero1z : 1%Z != 0. Proof. by []. Qed.
 
-Definition comMixin := GRing.Zmodule_isComRing.Build int
+Definition comMixin := GRing.Zmodule_isComNzRing.Build int
   mulzA mulzC mul1z mulz_addl nonzero1z.
 
 End intRing.
@@ -377,7 +377,7 @@ Proof. exact. Qed.
 Lemma idomain_axiomz m n : m * n = 0 -> (m == 0) || (n == 0).
 Proof. by case: m n => [[|m]|m] [[|n]|n]. Qed.
 
-Definition comMixin := GRing.ComRing_hasMulInverse.Build int
+Definition comMixin := GRing.ComNzRing_hasMulInverse.Build int
   mulVz unitzPl invz_out.
 
 End intUnitRing.
@@ -630,7 +630,7 @@ Proof. by rewrite pmulrn intz. Qed.
 Section RintMod.
 
 Local Coercion Posz : nat >-> int.
-Variable R : ringType.
+Variable R : nzRingType.
 
 Implicit Types m n : int.
 Implicit Types x y z : R.
@@ -677,7 +677,7 @@ Lemma mul2z n : 2%:Z * n = n + n. Proof. by rewrite mulrC -mulrzz. Qed.
 
 Section LMod.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Variable V : (lmodType R).
 Local Coercion Posz : nat >-> int.
 
@@ -711,7 +711,7 @@ End Additive.
 
 Section Multiplicative.
 
-Variables (R S : ringType) (f : {rmorphism R -> S}).
+Variables (R S : nzRingType) (f : {rmorphism R -> S}).
 
 Lemma rmorphMz : forall n, {morph f : x / x *~ n}. Proof. exact: raddfMz. Qed.
 
@@ -722,7 +722,7 @@ End Multiplicative.
 
 Section Linear.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Variables (U V : lmodType R) (f : {linear U -> V}).
 
 Lemma linearMn : forall n, {morph f : x / x *~ n}. Proof. exact: raddfMz. Qed.
@@ -735,7 +735,7 @@ Proof. by move=> z u; rewrite -[z]intz !scaler_int raddfMz. Qed.
 
 Section Zintmul1rMorph.
 
-Variable R : ringType.
+Variable R : nzRingType.
 
 Lemma commrMz (x y : R) n : GRing.comm x y -> GRing.comm x (y *~ n).
 Proof. by rewrite /GRing.comm=> com_xy; rewrite mulrzAr mulrzAl com_xy. Qed.
@@ -747,7 +747,7 @@ End Zintmul1rMorph.
 
 Section ZintBigMorphism.
 
-Variable R : ringType.
+Variable R : nzRingType.
 
 Lemma sumMz : forall I r (P : pred I) F,
  (\sum_(i <- r | P i) F i)%N%:~R = \sum_(i <- r | P i) ((F i)%:~R) :> R.
@@ -761,7 +761,7 @@ End ZintBigMorphism.
 
 Section Frobenius.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Implicit Types x y : R.
 
 Variable p : nat.
@@ -1498,7 +1498,7 @@ Lemma sgz_eq (R R' : realDomainType) (x : R) (y : R') :
   (sgz x == sgz y) = ((x == 0) == (y == 0)) && ((0 < x) == (0 < y)).
 Proof. by do 2!case: sgzP. Qed.
 
-Lemma intr_sign (R : ringType) s : ((-1) ^+ s)%:~R = (-1) ^+ s :> R.
+Lemma intr_sign (R : nzRingType) s : ((-1) ^+ s)%:~R = (-1) ^+ s :> R.
 Proof. exact: rmorph_sign. Qed.
 
 Section Absz.
@@ -1702,7 +1702,7 @@ End NormInt.
 
 Section PolyZintRing.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Implicit Types x y z: R.
 Implicit Types m n : int.
 Implicit Types i j k : nat.
@@ -1734,10 +1734,10 @@ Lemma rpredMz (M : zmodType) (S : zmodClosed M) m :
   {in S, forall u, u *~ m \in S}.
 Proof. by case: m => n u Su; rewrite ?rpredN ?rpredMn. Qed.
 
-Lemma rpred_int (R : ringType) (S : subringClosed R) m : m%:~R \in S.
+Lemma rpred_int (R : nzRingType) (S : subringClosed R) m : m%:~R \in S.
 Proof. by rewrite rpredMz ?rpred1. Qed.
 
-Lemma rpredZint (R : ringType) (M : lmodType R) (S : zmodClosed M) m :
+Lemma rpredZint (R : nzRingType) (M : lmodType R) (S : zmodClosed M) m :
   {in S, forall u, m%:~R *: u \in S}.
 Proof. by move=> u Su; rewrite /= scaler_int rpredMz. Qed.
 

--- a/mathcomp/algebra/ssrnum.v
+++ b/mathcomp/algebra/ssrnum.v
@@ -127,7 +127,7 @@ Notation "[ 'normedZmodType' R 'of' T ]" := (@clone _ (Phant R) T _ _ id)
 End NormedZmoduleExports.
 HB.export NormedZmoduleExports.
 
-HB.mixin Record isNumRing R of GRing.Ring R & POrderedZmodule R
+HB.mixin Record isNumRing R of GRing.NzRing R & POrderedZmodule R
   & NormedZmodule (POrderedZmodule.clone R _) R := {
  addr_gt0 : forall x y : R, 0 < x -> 0 < y -> 0 < (x + y);
  ger_leVge : forall x y : R, 0 <= x -> 0 <= y -> (x <= y) || (y <= x);
@@ -1458,10 +1458,14 @@ Proof. by move=> x_lt0; rewrite -(mulr0n x) ler_nMn2l. Qed.
 
 (* x positive and y right *)
 Lemma pmulr_rlt0 x y : 0 < x -> (x * y < 0) = (y < 0).
-Proof. by move=> x_gt0; rewrite -oppr_gt0 -mulrN pmulr_rgt0 // oppr_gt0. Qed.
+Proof.
+by move=> x_gt0; rewrite -[LHS]oppr_gt0 -mulrN pmulr_rgt0 // oppr_gt0.
+Qed.
 
 Lemma pmulr_rle0 x y : 0 < x -> (x * y <= 0) = (y <= 0).
-Proof. by move=> x_gt0; rewrite -oppr_ge0 -mulrN pmulr_rge0 // oppr_ge0. Qed.
+Proof.
+by move=> x_gt0; rewrite -[LHS]oppr_ge0 -mulrN pmulr_rge0 // oppr_ge0.
+Qed.
 
 (* x positive and y left *)
 Lemma pmulr_lgt0 x y : 0 < x -> (0 < y * x) = (0 < y).
@@ -2499,7 +2503,7 @@ have y1_gt0: 0 < y1 by rewrite lt_def y1nz (le_trans _ le_xy1).
 have [x2_0 | x2nz] := eqVneq x2 0.
   apply/leifP; rewrite -le_xy2 x2_0 eq_sym (negPf y2nz) andbF mulr0.
   by rewrite mulr_gt0 // lt_def y2nz -x2_0 le_xy2.
-have:= le_xy2; rewrite -(mono_leif (ler_pM2l y1_gt0)).
+have:= le_xy2; rewrite -[X in X -> _](mono_leif (ler_pM2l y1_gt0)).
 by apply: leif_trans; rewrite (mono_leif (ler_pM2r _)) // lt_def x2nz.
 Qed.
 

--- a/mathcomp/algebra/vector.v
+++ b/mathcomp/algebra/vector.v
@@ -12,7 +12,7 @@ From mathcomp Require Import ssralg matrix mxalgebra zmodp.
 (*                                                                            *)
 (*           vectType R == interface structure for finite dimensional (more   *)
 (*                         precisely, detachable) vector spaces over R, which *)
-(*                         should be at least a ringType                      *)
+(*                         should be at least a nzRingType                    *)
 (*                         The HB class is called Vector.                     *)
 (*     Vector.axiom n M <-> type M is linearly isomorphic to 'rV_n            *)
 (*                         := {v2r : M -> 'rV_n| linear v2r & bijective v2r}  *)
@@ -119,16 +119,16 @@ Delimit Scope vspace_scope with VS.
 Import GRing.Theory.
 
 (* Finite dimension vector space *)
-Definition vector_axiom_def (R : ringType) n (V : lmodType R) :=
+Definition vector_axiom_def (R : nzRingType) n (V : lmodType R) :=
   {v2r : V -> 'rV[R]_n | linear v2r & bijective v2r}.
 Arguments vector_axiom_def [R] n%N V%type.
 
-HB.mixin Record Lmodule_hasFinDim (R : ringType) (V : Type) of GRing.Lmodule R V :=
+HB.mixin Record Lmodule_hasFinDim (R : nzRingType) (V : Type) of GRing.Lmodule R V :=
   { dim : nat;
     vector_subdef : vector_axiom_def dim V }.
 
 #[mathcomp(axiom="vector_axiom_def"), short(type="vectType")]
-HB.structure Definition Vector (R : ringType) :=
+HB.structure Definition Vector (R : nzRingType) :=
   { V of Lmodule_hasFinDim R V & GRing.Lmodule R V }.
 
 #[deprecated(since="mathcomp 2.2.0", note="Use Vector.axiom instead.")]
@@ -141,7 +141,7 @@ Section OtherDefs.
 Local Coercion dim : Vector.type >-> nat.
 Inductive space (K : fieldType) (vT : Vector.type K) :=
   Space (mx : 'M[K]_vT) & <<mx>>%MS == mx.
-Inductive hom (R : ringType) (vT wT : Vector.type R) :=
+Inductive hom (R : nzRingType) (vT wT : Vector.type R) :=
   Hom of 'M[R]_(vT, wT).
 End OtherDefs.
 (* /FIXME *)
@@ -169,7 +169,7 @@ End VectorExports.
 Module VectorInternalTheory.
 
 Section Iso.
-Variables (R : ringType) (vT rT : vectType R).
+Variables (R : nzRingType) (vT rT : vectType R).
 Local Coercion dim : Vector.type >-> nat.
 
 Fact v2r_subproof : Vector.axiom vT vT. Proof. exact: vector_subdef. Qed.
@@ -219,7 +219,7 @@ Proof. exact: genmxE. Qed.
 End Vspace.
 
 Section Hom.
-Variables (R : ringType) (aT rT : vectType R).
+Variables (R : nzRingType) (aT rT : vectType R).
 Definition f2mx (f : 'Hom(aT, rT)) := let: Hom A := f in A.
 HB.instance Definition _ : isSub _ _ 'Hom(aT, rT) := [isNew for f2mx].
 End Hom.
@@ -1222,7 +1222,7 @@ Notation directv S := (directv_def (Phantom _ S%VS)).
 (* Linear functions over a vectType *)
 Section LfunDefs.
 
-Variable R : ringType.
+Variable R : nzRingType.
 Implicit Types aT vT rT : vectType R.
 
 Fact lfun_key : unit. Proof. by []. Qed.
@@ -1270,7 +1270,7 @@ Notation limg f := (lfun_img f fullv).
 
 Section LfunZmodType.
 
-Variables (R : ringType) (aT rT : vectType R).
+Variables (R : nzRingType) (aT rT : vectType R).
 Implicit Types f g h : 'Hom(aT, rT).
 
 HB.instance Definition _ := [Choice of 'Hom(aT, rT) by <:].
@@ -1327,7 +1327,7 @@ Arguments fun_of_lfunK {R aT rT}.
 
 Section LfunVectType.
 
-Variables (R : comRingType) (aT rT : vectType R).
+Variables (R : comNzRingType) (aT rT : vectType R).
 Implicit Types f : 'Hom(aT, rT).
 
 Definition scale_lfun k f := linfun (k \*: f).
@@ -1368,7 +1368,7 @@ End LfunVectType.
 
 Section CompLfun.
 
-Variables (R : ringType) (wT aT vT rT : vectType R).
+Variables (R : nzRingType) (wT aT vT rT : vectType R).
 Implicit Types (f : 'Hom(vT, rT)) (g : 'Hom(aT, vT)) (h : 'Hom(wT, aT)).
 
 Lemma id_lfunE u: \1%VF u = u :> aT. Proof. exact: lfunE. Qed.
@@ -1408,7 +1408,7 @@ Definition lfun_simp :=
 
 Section ScaleCompLfun.
 
-Variables (R : comRingType) (aT vT rT : vectType R).
+Variables (R : comNzRingType) (aT vT rT : vectType R).
 Implicit Types (f : 'Hom(vT, rT)) (g : 'Hom(aT, vT)).
 
 Lemma comp_lfunZl k f g : (k *: (f \o g) = (k *: f) \o g)%VF.
@@ -1714,7 +1714,7 @@ Section LfunAlgebra.
 (* of the algebra library (there is currently no actual use of the End(vT)    *)
 (* algebra structure). Also note that the unit ring structure is missing.     *)
 
-Variables (R : comRingType) (vT : vectType R).
+Variables (R : comNzRingType) (vT : vectType R).
 Hypothesis vT_proper : dim vT > 0.
 
 Fact lfun1_neq0 : \1%VF != 0 :> 'End(vT).
@@ -1729,18 +1729,31 @@ Prenex Implicits comp_lfunA comp_lfun1l comp_lfun1r comp_lfunDl comp_lfunDr.
  * as canonical, so mixins and structures are built separately, and we        *
  * don't use HB.instance Definition _ := ...                                  *
  *  This is ok, but maybe we could introduce an alias                         *)
-Definition lfun_comp_ringMixin := GRing.Zmodule_isRing.Build 'End(vT)
+Definition lfun_comp_nzRingMixin := GRing.Zmodule_isNzRing.Build 'End(vT)
   comp_lfunA comp_lfun1l comp_lfun1r comp_lfunDl comp_lfunDr lfun1_neq0.
-Definition lfun_comp_ringType : ringType :=
-  HB.pack 'End(vT) lfun_comp_ringMixin.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use lfun_comp_nzRingMixin instead.")]
+Notation lfun_comp_ringMixin := (lfun_comp_nzRingMixin) (only parsing).
+
+Definition lfun_comp_nzRingType : nzRingType :=
+  HB.pack 'End(vT) lfun_comp_nzRingMixin.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use lfun_comp_nzRingType instead.")]
+Notation lfun_comp_ringType := (lfun_comp_nzRingType) (only parsing).
 
 (* In the standard endomorphism ring product is categorical composition. *)
-Definition lfun_ringType : ringType := lfun_comp_ringType^c.
+Definition lfun_nzRingType : nzRingType := lfun_comp_nzRingType^c.
 
-Definition lfun_lalgMixin := GRing.Lmodule_isLalgebra.Build R lfun_ringType
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use lfun_nzRingType instead.")]
+Notation lfun_ringType := (lfun_nzRingType) (only parsing).
+
+Definition lfun_lalgMixin := GRing.Lmodule_isLalgebra.Build R lfun_nzRingType
   (fun k x y => comp_lfunZr k y x).
 Definition lfun_lalgType : lalgType R :=
-  HB.pack 'End(vT) lfun_ringType lfun_lalgMixin.
+  HB.pack 'End(vT) lfun_nzRingType lfun_lalgMixin.
 
 Definition lfun_algMixin := GRing.Lalgebra_isAlgebra.Build R lfun_lalgType
   (fun k x y => comp_lfunZl k y x).
@@ -1941,7 +1954,7 @@ Arguments vsprojK {K vT U} [x] Ux.
 
 Section MatrixVectType.
 
-Variables (R : ringType) (m n : nat).
+Variables (R : nzRingType) (m n : nat).
 
 (* The apparently useless => /= in line 1 of the proof performs some evar     *)
 (* expansions that the Ltac interpretation of exists is incapable of doing.   *)
@@ -1960,7 +1973,7 @@ End MatrixVectType.
 (* A ring is a one-dimension vector space *)
 Section RegularVectType.
 
-Variable R : ringType.
+Variable R : nzRingType.
 
 Fact regular_vect_iso : Vector.axiom 1 R^o.
 Proof.
@@ -1974,7 +1987,7 @@ End RegularVectType.
 (* External direct product of two vectTypes. *)
 Section ProdVector.
 
-Variables (R : ringType) (vT1 vT2 : vectType R).
+Variables (R : nzRingType) (vT1 vT2 : vectType R).
 
 Fact pair_vect_iso : Vector.axiom (dim vT1 + dim vT2) (vT1 * vT2).
 Proof.
@@ -1995,7 +2008,7 @@ End ProdVector.
 (* Function from a finType into a ring form a vectype. *)
 Section FunVectType.
 
-Variable (I : finType) (R : ringType) (vT : vectType R).
+Variable (I : finType) (R : nzRingType) (vT : vectType R).
 
 (* Type unification with exist is again a problem in this proof. *)
 Fact ffun_vect_iso : Vector.axiom (#|I| * dim vT) {ffun I -> vT}.

--- a/mathcomp/algebra/zmodp.v
+++ b/mathcomp/algebra/zmodp.v
@@ -240,7 +240,7 @@ Notation big_ord1 := big_ord1 (only parsing).
 #[deprecated(since="mathcomp 2.3.0", note="Use bigop.big_ord1_cond instead.")]
 Notation big_ord1_cond := big_ord1_cond (only parsing).
 
-Section ZpRing.
+Section ZpNzRing.
 
 Variable p' : nat.
 Local Notation p := p'.+2.
@@ -248,10 +248,10 @@ Local Notation p := p'.+2.
 Lemma Zp_nontrivial : Zp1 != 0 :> 'I_p. Proof. by []. Qed.
 
 HB.instance Definition _ :=
-  GRing.Zmodule_isComRing.Build 'I_p
+  GRing.Zmodule_isComNzRing.Build 'I_p
     (@Zp_mulA _) (@Zp_mulC _) (@Zp_mul1z _) (@Zp_mul_addl _) Zp_nontrivial.
 HB.instance Definition _ :=
-  GRing.ComRing_hasMulInverse.Build 'I_p
+  GRing.ComNzRing_hasMulInverse.Build 'I_p
     (@Zp_mulVz _) (@Zp_intro_unit _) (@Zp_inv_out _).
 
 Lemma Zp_nat n : n%:R = inZp n :> 'I_p.
@@ -275,7 +275,7 @@ apply: val_inj => /=; elim: n => [|n IHn] //.
 by rewrite expgS /= IHn expnS modnMmr.
 Qed.
 
-End ZpRing.
+End ZpNzRing.
 
 Definition Zp_trunc p := p.-2.
 
@@ -286,7 +286,7 @@ Notation "''F_' p" := 'Z_(pdiv p)
 
 Arguments natr_Zp {p'} x.
 
-Section ZpRing.
+Section ZpNzRing.
 
 Import GRing.Theory.
 
@@ -302,7 +302,7 @@ Proof. by apply: (addIr 1); rewrite addrNK add_Zp_1 ord_predK. Qed.
 Lemma add_N1_Zp p (x : 'Z_p) : -1 + x = ord_pred x.
 Proof. by rewrite addrC sub_Zp_1. Qed.
 
-End ZpRing.
+End ZpNzRing.
 
 Section Groups.
 

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -270,10 +270,14 @@ Proof.
 by apply/eqP=> /cfunP/(_ 1%g)/eqP; rewrite cfun1Egen cfunE group1 oner_eq0.
 Qed.
 
-HB.instance Definition _ := GRing.Zmodule_isComRing.Build classfun
+HB.instance Definition _ := GRing.Zmodule_isComNzRing.Build classfun
   cfun_mulA cfun_mulC cfun_mul1 cfun_mulD cfun_nz1.
 
-Definition cfun_ringType : ringType := classfun.
+Definition cfun_nzRingType : nzRingType := classfun.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use cfun_nzRingType instead.")]
+Notation cfun_ringType := (cfun_nzRingType) (only parsing).
 
 Lemma expS_cfunE phi n x : (phi ^+ n.+1) x = phi x ^+ n.+1.
 Proof. by elim: n => //= n IHn; rewrite !cfunE IHn. Qed.
@@ -292,7 +296,7 @@ Fact cfun_inv0id : {in [predC cfun_unit], cfun_inv =1 id}.
 Proof. by rewrite /cfun_inv => phi /negbTE/= ->. Qed.
 
 HB.instance Definition _ :=
-   GRing.ComRing_hasMulInverse.Build classfun cfun_mulV cfun_unitP cfun_inv0id.
+   GRing.ComNzRing_hasMulInverse.Build classfun cfun_mulV cfun_unitP cfun_inv0id.
 
 Fact cfun_scaleA a b phi :
   cfun_scale a (cfun_scale b phi) = cfun_scale (a * b) phi.
@@ -417,7 +421,7 @@ Notation "''CF' ( G )" := (classfun G) : type_scope.
 Notation "''CF' ( G )" := (@fullv _ (cfun_vectType G)) : vspace_scope.
 Notation "''1_' A" := (cfun_indicator _ A) : ring_scope.
 Notation "''CF' ( G , A )" := (classfun_on G A) : ring_scope.
-Notation "1" := (@GRing.one (cfun_ringType _)) (only parsing) : cfun_scope.
+Notation "1" := (@GRing.one (cfun_nzRingType _)) (only parsing) : cfun_scope.
 
 (* FIX ME this has changed *)
 Notation conjC := Num.conj_op.
@@ -574,7 +578,7 @@ Arguments cfun_onP {A phi}.
 Lemma cfun_on0 A phi x : phi \in 'CF(G, A) -> x \notin A -> phi x = 0.
 Proof. by move/cfun_onP; apply. Qed.
 
-Lemma sum_by_classes (R : ringType) (F : gT -> R) :
+Lemma sum_by_classes (R : nzRingType) (F : gT -> R) :
     {in G &, forall g h, F (g ^ h) = F g} ->
   \sum_(g in G) F g = \sum_(xG in classes G) #|xG|%:R * F (repr xG).
 Proof.

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -61,7 +61,7 @@ Local Open Scope ring_scope.
 (* (this is only surjective when F is a prime field 'F_p), with moduleules    *)
 (* corresponding to subgroups stabilized by the external action.              *)
 
-Section FinRingRepr.
+Section FinNzRingRepr.
 
 Variable (R : finComUnitRingType) (gT : finGroupType).
 Variables (G : {group gT}) (n : nat) (rG : mx_representation R G n).
@@ -85,7 +85,7 @@ by apply/morphicP=> /= u v _ _; rewrite !actpermE /= /mx_repr_act mulmxDl.
 Qed.
 Canonical Structure mx_repr_groupAction := GroupAction mx_repr_is_groupAction.
 
-End FinRingRepr.
+End FinNzRingRepr.
 
 Notation "''MR' rG" := (mx_repr_action rG)
   (at level 10, rG at level 8) : action_scope.

--- a/mathcomp/character/mxrepresentation.v
+++ b/mathcomp/character/mxrepresentation.v
@@ -5162,7 +5162,7 @@ Qed.
 Lemma gen_ntriv : gen1 != 0.
 Proof. by rewrite -(inj_eq mxval_inj) mxval_gen1 mxval0 oner_eq0. Qed.
 
-#[export] HB.instance Definition _ := GRing.Zmodule_isComRing.Build FA
+#[export] HB.instance Definition _ := GRing.Zmodule_isComNzRing.Build FA
     gen_mulA gen_mulC gen_mul1r gen_mulDr gen_ntriv.
 
 Lemma mxval1 : mxval 1 = 1%:M. Proof. exact: mxval_gen1. Qed.
@@ -5197,7 +5197,7 @@ Qed.
 Lemma gen_invr0 : genV 0 = 0.
 Proof. by apply: mxval_inj; rewrite mxval_genV !mxval0 -{2}invr0. Qed.
 
-#[export] HB.instance Definition _ := GRing.ComRing_isField.Build FA
+#[export] HB.instance Definition _ := GRing.ComNzRing_isField.Build FA
   gen_mulVr gen_invr0.
 
 Lemma mxvalV : {morph mxval : x / x^-1 >-> invmx x}.

--- a/mathcomp/field/algC.v
+++ b/mathcomp/field/algC.v
@@ -13,7 +13,7 @@ From mathcomp Require Import algebraics_fundamentals.
 (* filed with an automorphism of order 2; this amounts to the purely          *)
 (* algebraic contents of the Fundamenta Theorem of Algebra.                   *)
 (*       algC == the closed, countable field of algebraic numbers.            *)
-(*  algCeq, algCring, ..., algCnumField == structures for algC.               *)
+(*  algCeq, algCnzRing, ..., algCnumField == structures for algC.               *)
 (* The ssrnum interfaces are implemented for algC as follows:                 *)
 (*     x <= y <=> (y - x) is a nonnegative real                               *)
 (*      x < y <=> (y - x) is a (strictly) positive real                       *)
@@ -393,7 +393,7 @@ Fact one_nz : one != 0 :> type.
 Proof. by rewrite -(inj_eq CtoL_inj) !LtoC_K oner_eq0. Qed.
 
 HB.instance Definition _ :=
-  GRing.Zmodule_isComRing.Build type mulA mulC mul1 mulD one_nz.
+  GRing.Zmodule_isComNzRing.Build type mulA mulC mul1 mulD one_nz.
 
 Fact CtoL_is_multiplicative : multiplicative CtoL.
 Proof. by split=> [u v|]; rewrite !LtoC_K. Qed.
@@ -408,7 +408,7 @@ Qed.
 
 Fact inv0 : inv 0 = 0. Proof. by apply: CtoL_inj; rewrite !LtoC_K invr0. Qed.
 
-HB.instance Definition _ := GRing.ComRing_isField.Build type mulVf inv0.
+HB.instance Definition _ := GRing.ComNzRing_isField.Build type mulVf inv0.
 
 Fact closedFieldAxiom : GRing.closed_field_axiom type.
 Proof.
@@ -549,7 +549,10 @@ Delimit Scope C_expanded_scope with Cx.
 Open Scope C_core_scope.
 Notation algCeq := (type : eqType).
 Notation algCzmod := (type : zmodType).
-Notation algCring := (type : ringType).
+Notation algCnzRing := (type : nzRingType).
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use algCnzRing instead.")]
+Notation algCring := (type : nzRingType).
 Notation algCuring := (type : unitRingType).
 Notation algCnum := (type : numDomainType).
 Notation algCfield := (type : fieldType).

--- a/mathcomp/field/closed_field.v
+++ b/mathcomp/field/closed_field.v
@@ -705,8 +705,8 @@ pose IaM := GRing.isAddClosed.Build _ I (idealr_closedB I_ideal).
 pose IoM := GRing.isOppClosed.Build _ I (idealr_closedB I_ideal).
 pose IpM := isProperIdeal.Build _ I (idealr_closed_nontrivial I_ideal).
 pose Iid : idealr _ := HB.pack I IaM IoM IpM.
-pose EMixin := GRing.Ring_hasCommutativeMul.Build _ (@Quotient.mulqC _ Iid).
-pose E : comRingType := HB.pack _ EMixin.
+pose EMixin := GRing.NzRing_hasCommutativeMul.Build _ (@Quotient.mulqC _ Iid).
+pose E : comNzRingType := HB.pack _ EMixin.
 pose PtoE : {rmorphism {poly F} -> E} := \pi_E%qT.
 have PtoEd i: PtoE (d i) = 0.
   by apply/eqP; rewrite piE Quotient.equivE subr0; apply/memI; exists i.
@@ -726,7 +726,7 @@ have EmulV : forall x, x != 0 -> Einv x * x = 1.
   rewrite piE /= -[z]reprK -(rmorphM PtoE) -Quotient.idealrBE.
   rewrite -[X in _ - X]uv1 opprD addNKr -mulNr.
   by apply/memI; exists i; apply: dvdp_mull.
-pose EfieldMixin := GRing.ComRing_isField.Build _ EmulV Einv0.
+pose EfieldMixin := GRing.ComNzRing_isField.Build _ EmulV Einv0.
 pose Efield : fieldType := HB.pack E EfieldMixin.
 pose EIsCountable := isCountable.Build E (pcan_pickleK (can_pcan (reprK))).
 pose Ecount : countFieldType := HB.pack E Efield EIsCountable.
@@ -741,10 +741,10 @@ Qed.
 Lemma countable_algebraic_closure (F : countFieldType) :
   {K : countClosedFieldType & {FtoK : {rmorphism F -> K} | integralRange FtoK}}.
 Proof.
-pose minXp (R : ringType) (p : {poly R}) := if size p > 1 then p else 'X.
+pose minXp (R : nzRingType) (p : {poly R}) := if size p > 1 then p else 'X.
 have minXp_gt1 R p: size (minXp R p) > 1.
   by rewrite /minXp; case: ifP => // _; rewrite size_polyX.
-have minXpE (R : ringType) (p : {poly R}) : size p > 1 -> minXp R p = p.
+have minXpE (R : nzRingType) (p : {poly R}) : size p > 1 -> minXp R p = p.
   by rewrite /minXp => ->.
 have ext1 p := countable_field_extension (minXp_gt1 _ p).
 pose ext1fT E p := tag (ext1 E p).
@@ -867,14 +867,14 @@ have KmulD: left_distributive Kmul Kadd.
   move=> u v w; have [i [x ->] [[y ->] [z ->]]] := KtoE3 u v w.
   by rewrite -!(EtoK_M, EtoK_D) mulrDl.
 have Kone_nz: FtoK 1 != FtoK 0 by rewrite EtoKeq0 oner_neq0.
-pose KringMixin := GRing.Zmodule_isComRing.Build _
+pose KringMixin := GRing.Zmodule_isComNzRing.Build _
   KmulA KmulC Kmul1 KmulD Kone_nz.
-pose Kring : comRingType := HB.pack K Kzmod KringMixin cntK.
+pose Kring : comNzRingType := HB.pack K Kzmod KringMixin cntK.
 have KmulV: forall x : Kring, x != 0 -> (Kinv x : Kring) * x = 1.
   move=> u; have [i [x ->]] := KtoE u; rewrite EtoKeq0 => nz_x.
   by rewrite -EtoK_V -[_ * _]EtoK_M mulVf ?EtoK_1.
 have Kinv0: Kinv (FtoK 0) = FtoK 0 by rewrite -EtoK_V invr0.
-pose KfieldMixin := GRing.ComRing_isField.Build _ KmulV Kinv0.
+pose KfieldMixin := GRing.ComNzRing_isField.Build _ KmulV Kinv0.
 pose Kfield : fieldType := HB.pack K Kring KfieldMixin.
 have EtoKAdd i : additive (EtoK i : E i -> Kfield).
   by move=> x y; rewrite EtoK_D EtoK_N.

--- a/mathcomp/field/cyclotomic.v
+++ b/mathcomp/field/cyclotomic.v
@@ -27,9 +27,9 @@ Local Open Scope ring_scope.
 
 Section CyclotomicPoly.
 
-Section Ring.
+Section NzRing.
 
-Variable R : ringType.
+Variable R : nzRingType.
 
 Definition cyclotomic (z : R) n :=
   \prod_(k < n | coprime k n) ('X - (z ^+ k)%:P).
@@ -45,7 +45,7 @@ rewrite totient_count_coprime -big_mkcond big_mkord -sum1_card.
 by apply: eq_bigl => k; rewrite coprime_sym.
 Qed.
 
-End Ring.
+End NzRing.
 
 Lemma separable_Xn_sub_1 (R : idomainType) n :
   n%:R != 0 :> R -> @separable_poly R ('X^n - 1).
@@ -160,7 +160,7 @@ have defXn1: cyclotomic z n * pZtoC q = 'X^n - 1.
   rewrite divnn n_gt0 rmorph_prod /=; congr (_ * _).
   apply: eq_big_seq => d; rewrite mem_rem_uniq ?inE //= inDn => /andP[n'd ddvn].
   by rewrite -IHn ?dvdn_prim_root // ltn_neqAle n'd dvdn_leq.
-have mapXn1 (R1 R2 : ringType) (f : {rmorphism R1 -> R2}):
+have mapXn1 (R1 R2 : nzRingType) (f : {rmorphism R1 -> R2}):
   map_poly f ('X^n - 1) = 'X^n - 1.
 - by rewrite rmorphB /= rmorph1 map_polyXn.
 have nz_q: pZtoC q != 0.

--- a/mathcomp/field/falgebra.v
+++ b/mathcomp/field/falgebra.v
@@ -11,7 +11,7 @@ From mathcomp Require Import finalg zmodp matrix vector poly.
 (*       falgType K   == the interface type for F-algebras over K; it simply  *)
 (*                       joins the unitAlgType K and vectType K interfaces    *)
 (*                       The HB class is called Falgebra.                     *)
-(*   Any aT with an falgType structure inherits all the Vector, Ring and      *)
+(*   Any aT with an falgType structure inherits all the Vector, NzRing and    *)
 (* Algebra operations, and supports the following additional operations:      *)
 (*           \dim_A M == (\dim M %/ dim A)%N -- free module dimension         *)
 (*            amull u == the linear function v |-> u * v, for u, v : aT       *)
@@ -92,7 +92,7 @@ Import GRing.Theory.
 
 (* Finite dimensional algebra *)
 #[short(type="falgType")]
-HB.structure Definition Falgebra (R : ringType) :=
+HB.structure Definition Falgebra (R : nzRingType) :=
   { A of Vector R A & GRing.UnitAlgebra R A }.
 #[deprecated(since="mathcomp 2.0.0", note="Use falgType instead.")]
 Notation FalgType := falgType.
@@ -126,7 +126,7 @@ HB.builders Context K A of Algebra_isFalgebra K A.
   Lemma invr_out : {in [predC uam], vam =1 id}.
   Proof. by move=> u /negbTE/= ->. Qed.
 
-  HB.instance Definition _ := GRing.Ring_hasMulInverse.Build A
+  HB.instance Definition _ := GRing.NzRing_hasMulInverse.Build A
     mulVr divrr unitrP invr_out.
 HB.end.
 
@@ -149,7 +149,7 @@ Proof. by apply/esym/eqP; rewrite eqEdim subvf dim_vline oner_eq0 dimvf. Qed.
 
 Section Proper.
 
-Variables (R : ringType) (aT : falgType R).
+Variables (R : nzRingType) (aT : falgType R).
 
 Import VectorInternalTheory.
 
@@ -165,7 +165,7 @@ Module FalgLfun.
 
 Section FalgLfun.
 
-Variable (R : comRingType) (aT : falgType R).
+Variable (R : comNzRingType) (aT : falgType R).
 Implicit Types f g : 'End(aT).
 
 HB.instance Definition _ := GRing.Algebra.copy 'End(aT)
@@ -204,7 +204,7 @@ Qed.
 Lemma lfun_invr_out f : lker f != 0%VS -> lfun_invr f = f.
 Proof. by rewrite /lfun_invr => /negPf->. Qed.
 
-HB.instance Definition _ := GRing.Ring_hasMulInverse.Build 'End(aT)
+HB.instance Definition _ := GRing.NzRing_hasMulInverse.Build 'End(aT)
   lfun_mulRVr lfun_mulrRV lfun_unitrP lfun_invr_out.
 
 Lemma lfun_invE f : lker f == 0%VS -> f^-1%VF = f^-1.
@@ -960,7 +960,7 @@ Proof. move=> x y z; apply/val_inj/mulrDl. Qed.
 Fact subvs_mulDr : right_distributive subvs_mul +%R.
 Proof. move=> x y z; apply/val_inj/mulrDr. Qed.
 
-HB.instance Definition _ := GRing.Zmodule_isRing.Build (subvs_of A)
+HB.instance Definition _ := GRing.Zmodule_isNzRing.Build (subvs_of A)
   subvs_mulA subvs_mu1l subvs_mul1 subvs_mulDl subvs_mulDr (algid_neq0 _).
 
 Lemma subvs_scaleAl k (x y : subvs_of A) : k *: (x * y) = (k *: x) * y.

--- a/mathcomp/field/fieldext.v
+++ b/mathcomp/field/fieldext.v
@@ -81,8 +81,8 @@ Local Open Scope ring_scope.
 Import GRing.Theory.
 
 #[short(type="fieldExtType")]
-HB.structure Definition FieldExt (R : ringType) := {T of Falgebra R T &
-  GRing.Ring_hasCommutativeMul T & GRing.Field T}.
+HB.structure Definition FieldExt (R : nzRingType) := {T of Falgebra R T &
+  GRing.NzRing_hasCommutativeMul T & GRing.Field T}.
 
 Module FieldExtExports.
 Bind Scope ring_scope with FieldExt.sort.
@@ -197,14 +197,14 @@ HB.instance Definition _ K :=
   GRing.isDivClosed.Build L (pred_of_vspace K) (aspace_divr_closed K).
 
 HB.instance Definition _ (K : {subfield L}) :=
-  GRing.isSubSemiRing.Build L (pred_of_vspace K) (subvs_of K)
+  GRing.isSubNzSemiRing.Build L (pred_of_vspace K) (subvs_of K)
     (rmorphM _, rmorph1 _).
-(* Note that the ringType structure was built in the SubFalgType
+(* Note that the nzRingType structure was built in the SubFalgType
    section of falgebra.v but the SubRing structure did not stand
    there, it is thus built only here *)
 
 HB.instance Definition _ (K : {subfield L}) :=
-  [SubRing_isSubComRing of subvs_of K by <:].
+  [SubNzRing_isSubComNzRing of subvs_of K by <:].
 HB.instance Definition _ (K : {subfield L}) :=
   [SubComUnitRing_isSubIntegralDomain of subvs_of K by <:].
 
@@ -1101,7 +1101,7 @@ rewrite !piE /equiv_subfext /iotaFz !linear0.
 by rewrite poly_rV_K ?rmorph1 ?oner_eq0 // size_poly1.
 Qed.
 
-HB.instance Definition _ := GRing.Zmodule_isComRing.Build subFExtend
+HB.instance Definition _ := GRing.Zmodule_isComNzRing.Build subFExtend
   mulfxA mulfxC mul1fx mulfx_addl nonzero1fx.
 
 Definition subfx_poly_inv (q : {poly F}) : {poly F} :=
@@ -1147,7 +1147,7 @@ apply/eqP; rewrite !piE /equiv_subfext /iotaFz /subfx_inv_rep !linear0.
 by rewrite /subfx_poly_inv rmorph0 eqxx mod0p !linear0.
 Qed.
 
-HB.instance Definition _ := GRing.ComRing_isField.Build subFExtend
+HB.instance Definition _ := GRing.ComNzRing_isField.Build subFExtend
   subfx_fieldAxiom subfx_inv0.
 
 Fact subfx_inj_is_additive : additive subfx_inj.
@@ -1350,8 +1350,8 @@ have mulD: left_distributive mul +%R.
   move=> x y z; apply: toPinj; rewrite /toPF raddfD /= -!/(toPF _).
   by rewrite !toL_K /toPF raddfD mulrDl modpD.
 have nzL1: L1 != 0 by rewrite -(inj_eq toPinj) L1K /toPF raddf0 oner_eq0.
-pose mulM := GRing.Zmodule_isComRing.Build _ mulA mulC mul1 mulD nzL1.
-pose rL : comRingType := HB.pack vL mulM.
+pose mulM := GRing.Zmodule_isComNzRing.Build _ mulA mulC mul1 mulD nzL1.
+pose rL : comNzRingType := HB.pack vL mulM.
 have mulZlM : GRing.Lmodule_isLalgebra F rL.
   constructor => a x y; apply: toPinj.
   by rewrite toL_K /toPF !linearZ /= -!/(toPF _) toL_K -scalerAl modpZl.
@@ -1411,8 +1411,8 @@ Qed.
 (*   move=> x y z; apply: canLR rVpolyK _. *)
 (*   by rewrite !raddfD mulrDl /= !toL_K /toL modpD. *)
 (* have nzL1: L1 != 0 by rewrite -(can_eq rVpolyK) L1K raddf0 oner_eq0. *)
-(* pose mulM := GRing.Zmodule_isComRing.Build vL mulA mulC mul1 mulD nzL1. *)
-(* pose rL := ComRingType vL mulM. *)
+(* pose mulM := GRing.Zmodule_isComNzRing.Build vL mulA mulC mul1 mulD nzL1. *)
+(* pose rL := ComNzRingType vL mulM. *)
 (* have mulZlM : GRing.Lmodule_isLalgebra F rL. *)
 (*   constructor => a x y; apply: canRL rVpolyK _. *)
 (*   by rewrite !linearZ /= toL_K -scalerAl modpZl. *)

--- a/mathcomp/field/finfield.v
+++ b/mathcomp/field/finfield.v
@@ -21,15 +21,15 @@ From mathcomp Require ssrnum ssrint archimedean algC cyclotomic.
 (*                              an F with a finFieldType structure; this      *)
 (*                              should not be made canonical                  *)
 (*           finvect_type vT == alias of vT : vecType R equipped with         *)
-(*                              canonical instances for finType, finRing,     *)
+(*                              canonical instances for finType, finNzRing,   *)
 (*                              etc structures (including FinFieldExtType     *)
 (*                              above) for abstract vectType, falgType and    *)
 (*                              fieldExtType over a finFieldType              *)
-(*      PrimeCharType charRp == the carrier of a ringType R such that         *)
+(*      PrimeCharType charRp == the carrier of a nzRingType R such that       *)
 (*                              charRp : p \in [char R] holds. This type has  *)
-(*                              canonical ringType, ..., fieldType structures *)
-(*                              compatible with those of R, as well as        *)
-(*                              canonical lmodType 'F_p, ..., algType 'F_p    *)
+(*                              canonical nzRingType, ..., fieldType          *)
+(*                              structures compatible with those of R, as well*)
+(*                              as canonical lmodType 'F_p, ..., algType 'F_p *)
 (*                              structures, plus an falgType structure if R   *)
 (*                              is a finUnitRingType and a splittingFieldType *)
 (*                              structure if R is a finFieldType              *)
@@ -60,17 +60,25 @@ Unset Printing Implicit Defensive.
 Import GroupScope GRing.Theory FinRing.Theory.
 Local Open Scope ring_scope.
 
-Section FinRing.
+Section FinNzRing.
 
-Variable R : finRingType.
+Variable R : finNzRingType.
 
-Lemma finRing_nontrivial : [set: R] != 1%g.
+Lemma finNzRing_nontrivial : [set: R] != 1%g.
 Proof. by apply/trivgPn; exists 1; rewrite ?inE ?oner_neq0. Qed.
 
-Lemma finRing_gt1 : 1 < #|R|.
-Proof. by rewrite -cardsT cardG_gt1 finRing_nontrivial. Qed.
+Lemma finNzRing_gt1 : 1 < #|R|.
+Proof. by rewrite -cardsT cardG_gt1 finNzRing_nontrivial. Qed.
 
-End FinRing.
+End FinNzRing.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use finNzRing_nontrivial instead.")]
+Notation finRing_nontrivial := (finNzRing_nontrivial) (only parsing).
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use finNzRing_gt1 instead.")]
+Notation finRing_gt1 := (finNzRing_gt1) (only parsing).
 
 Section FinField.
 
@@ -86,7 +94,7 @@ Definition finField_unit x (nz_x : x != 0) :=
 
 Lemma expf_card x : x ^+ #|F| = x :> F.
 Proof.
-rewrite -[RHS]mulr1 -(ltn_predK (finRing_gt1 F)) exprS.
+rewrite -[RHS]mulr1 -(ltn_predK (finNzRing_gt1 F)) exprS.
 apply/eqP; rewrite -subr_eq0 -mulrBr mulf_eq0 subr_eq0 -implyNb -unitfE.
 apply/implyP=> Ux; rewrite -(val_unitX _ (Sub x _)) -val_unit1 val_eqE.
 by rewrite -order_dvdn -card_finField_unit order_dvdG ?inE.
@@ -95,7 +103,7 @@ Qed.
 Lemma finField_genPoly : 'X^#|F| - 'X = \prod_x ('X - x%:P) :> {poly F}.
 Proof.
 set n := #|F|; set oppX := - 'X; set pF := LHS.
-have le_oppX_n: size oppX <= n by rewrite size_opp size_polyX finRing_gt1.
+have le_oppX_n: size oppX <= n by rewrite size_opp size_polyX finNzRing_gt1.
 have: size pF = (size (enum F)).+1 by rewrite -cardE size_addl size_polyXn.
 move/all_roots_prod_XsubC->; last by rewrite uniq_rootsE enum_uniq.
   by rewrite big_enum lead_coefDl ?size_polyXn // lead_coefXn scale1r.
@@ -119,7 +127,7 @@ Lemma card_finCharP p n : #|F| = (p ^ n)%N -> prime p -> p \in [char F].
 Proof.
 move=> oF pr_p; rewrite inE pr_p -order_dvdn.
 rewrite (abelem_order_p finField_is_abelem) ?inE ?oner_neq0 //=.
-have n_gt0: n > 0 by rewrite -(ltn_exp2l _ _ (prime_gt1 pr_p)) -oF finRing_gt1.
+have n_gt0: n > 0 by rewrite -(ltn_exp2l _ _ (prime_gt1 pr_p)) -oF finNzRing_gt1.
 by rewrite cardsT oF -(prednK n_gt0) pdiv_pfactor.
 Qed.
 
@@ -163,7 +171,7 @@ End CardVspace.
 Definition finvect_type (vT : Type) : predArgType := vT.
 
 Section FinVector.
-Variables (R : finRingType) (vT : vectType R).
+Variables (R : finNzRingType) (vT : vectType R).
 Local Notation fvT := (finvect_type vT).
 
 HB.instance Definition _ := Vector.on fvT.
@@ -209,7 +217,7 @@ Variable p : nat.
 
 Section PrimeCharRing.
 
-Variable R0 : ringType.
+Variable R0 : nzRingType.
 
 Definition PrimeCharType of p \in [char R0] : predArgType := R0.
 
@@ -217,7 +225,7 @@ Hypothesis charRp : p \in [char R0].
 Local Notation R := (PrimeCharType charRp).
 Implicit Types (a b : 'F_p) (x y : R).
 
-HB.instance Definition _ := GRing.Ring.on R.
+HB.instance Definition _ := GRing.NzRing.on R.
 
 Definition primeChar_scale a x := a%:R * x.
 Local Infix "*p:" := primeChar_scale (at level 40).
@@ -262,8 +270,8 @@ Local Notation type := @PrimeCharType.
 (* TODO: automatize parameter inference to do all of these *)
 HB.instance Definition _ (R : unitRingType) charRp :=
   GRing.UnitRing.on (type R charRp).
-HB.instance Definition _ (R : comRingType) charRp :=
-  GRing.ComRing.on (type R charRp).
+HB.instance Definition _ (R : comNzRingType) charRp :=
+  GRing.ComNzRing.on (type R charRp).
 HB.instance Definition _ (R : comUnitRingType) charRp :=
   GRing.ComUnitRing.on (type R charRp).
 HB.instance Definition _ (R : idomainType) charRp :=
@@ -271,9 +279,9 @@ HB.instance Definition _ (R : idomainType) charRp :=
 HB.instance Definition _ (R : fieldType) charRp :=
   GRing.Field.on (type R charRp).
 
-Section FinRing.
+Section FinNzRing.
 
-Variables (R0 : finRingType) (charRp : p \in [char R0]).
+Variables (R0 : finNzRingType) (charRp : p \in [char R0]).
 Local Notation R := (type _ charRp).
 
 HB.instance Definition _ := FinGroup.on R.
@@ -310,7 +318,7 @@ HB.instance Definition _ := Lmodule_hasFinDim.Build 'F_p R
 Lemma primeChar_dimf : \dim {: R : vectType 'F_p } = n.
 Proof. by rewrite dimvf. Qed.
 
-End FinRing.
+End FinNzRing.
 
 HB.instance Definition _ (R : finUnitRingType) charRp :=
   FinRing.UnitRing.on (type R charRp).
@@ -318,8 +326,8 @@ HB.instance Definition _ (R : finUnitRingType) charRp :=
   FinRing.UnitAlgebra.on (type R charRp).
 HB.instance Definition _ (R : finUnitRingType) charRp :=
   Falgebra.on (type R charRp).
-HB.instance Definition _ (R : finComRingType) charRp :=
-  FinRing.ComRing.on (type R charRp).
+HB.instance Definition _ (R : finComNzRingType) charRp :=
+  FinRing.ComNzRing.on (type R charRp).
 HB.instance Definition _ (R : finComUnitRingType) charRp :=
   FinRing.ComUnitRing.on (type R charRp).
 HB.instance Definition _ (R : finIdomainType) charRp :=
@@ -684,7 +692,7 @@ by rewrite -[aq d]expr1 -exprB ?leq_b1 ?unitfE ?rpredX.
 Qed.
 
 Definition FinDomainFieldType : finFieldType :=
- let cC := GRing.Ring_hasCommutativeMul.Build R finDomain_mulrC in
+ let cC := GRing.NzRing_hasCommutativeMul.Build R finDomain_mulrC in
  let cR : comUnitRingType := HB.pack R cC in
  let iC := GRing.ComUnitRing_isIntegral.Build cR domR in
  let iR : finIdomainType := HB.pack cR iC in

--- a/mathcomp/field/qfpoly.v
+++ b/mathcomp/field/qfpoly.v
@@ -66,7 +66,7 @@ Variable R : idomainType.
 Variable h : {poly R}.
 Hypothesis hI : monic_irreducible_poly h.
 
-HB.instance Definition _ := GRing.Ring.on {poly %/ h with hI}.
+HB.instance Definition _ := GRing.NzRing.on {poly %/ h with hI}.
 
 End iDomain.
 
@@ -137,13 +137,13 @@ Lemma card_qfpoly : #|{poly %/ h with hI}| = #|R| ^ (size h).-1.
 Proof. by rewrite card_monic_qpoly ?hI. Qed.
 
 Lemma card_qfpoly_gt1 : 1 < #|{poly %/ h with hI}|.
-Proof. by have := card_finRing_gt1 {poly %/ h with hI}. Qed.
+Proof. by have := card_finNzRing_gt1 {poly %/ h with hI}. Qed.
 
 End FinField.
 
 Section inPoly.
 
-Variable R : comRingType.
+Variable R : comNzRingType.
 Variable h : {poly R}.
 
 Lemma in_qpoly_comp_horner (p q : {poly R}) :
@@ -259,7 +259,7 @@ Definition gX : {unit qT} := FinRing.unit _ qX_in_unit.
 Lemma dvdp_order n : (h %| 'X^n - 1) = (gX ^+ n == 1)%g.
 Proof.
 have [hM hI] := primitive_mi.
-have eqr_add2r (r : ringType) (a b c : r) : (a + c == b + c) = (a == b).
+have eqr_add2r (r : nzRingType) (a b c : r) : (a + c == b + c) = (a == b).
   by apply/eqP/eqP => [H|->//]; rewrite -(addrK c a) H addrK.
 rewrite -val_eqE /= val_unitX /= -val_eqE /=.
 rewrite (poly_of_qpolyX) qpolyXE // mk_monicE //.
@@ -420,7 +420,7 @@ Proof.
 move=> /ltnW size_gt1.
 rewrite /plogp.
 case (boolP (primitive_poly p)) => // Hh; first by apply: qlogp_lt.
-by rewrite ltn_predRL (card_finRing_gt1 {poly %/ p}).
+by rewrite ltn_predRL (card_finNzRing_gt1 {poly %/ p}).
 Qed.
 
 Lemma plogp_X (p q : {poly F}) :

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -2160,7 +2160,7 @@ Section FimModAbelem.
 
 Import GRing.Theory FinRing.Theory.
 
-Lemma fin_lmod_char_abelem p (R : ringType) (V : finLmodType R):
+Lemma fin_lmod_char_abelem p (R : nzRingType) (V : finLmodType R):
   p \in [char R]%R -> p.-abelem [set: V].
 Proof.
 case/andP=> p_pr /eqP-pR0; apply/abelemP=> //.
@@ -2171,7 +2171,7 @@ Lemma fin_Fp_lmod_abelem p (V : finLmodType 'F_p) :
   prime p -> p.-abelem [set: V].
 Proof. by move/char_Fp/fin_lmod_char_abelem->. Qed.
 
-Lemma fin_ring_char_abelem p (R : finRingType) :
+Lemma fin_ring_char_abelem p (R : finNzRingType) :
   p \in [char R]%R -> p.-abelem [set: R].
 Proof. exact: fin_lmod_char_abelem R^o. Qed.
 


### PR DESCRIPTION
##### Motivation for this change

With the current definition, all rings are non-trivial, which causes a lot of problems. This PR adds a `nz` prefix to everything ring-related.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
