### PR TITLE
Characteristic for all

### DIFF
--- a/mathcomp/algebra/poly.v
+++ b/mathcomp/algebra/poly.v
@@ -670,9 +670,8 @@ Proof. by rewrite rmorph_nat. Qed.
 
 Lemma char_poly : [char {poly R}] =i [char R].
 Proof.
-move=> p; rewrite !inE; congr (_ && _).
-apply/eqP/eqP=> [/(congr1 val) /=|]; last by rewrite -polyC_natr => ->.
-by rewrite polyseq0 -polyC_natr polyseqC; case: eqP.
+move=> p; rewrite !inE -polyC_natr polyC_eq0.
+by under eq_forallb do rewrite -polyC_natr polyC_eq0.
 Qed.
 
 Lemma size_Msign p n : size ((-1) ^+ n * p) = size p.

--- a/mathcomp/algebra/qpoly.v
+++ b/mathcomp/algebra/qpoly.v
@@ -602,11 +602,10 @@ Proof. by elim: p => //= p IH; rewrite !mulrS poly_of_qpolyD IH. Qed.
 
 Lemma char_qpoly : [char {poly %/ h}] =i [char A].
 Proof.
-move=> p; rewrite !inE; congr (_ && _).
-apply/eqP/eqP=> [/(congr1 val) /=|pE]; last first.
-  by apply: val_inj => //=; rewrite qpolyC_natr /= -polyC_natr pE.
-rewrite !qpolyC_natr -!polyC_natr => /(congr1 val) /=.
-by rewrite polyseqC polyseq0; case: eqP.
+move=> p; rewrite !inE.
+rewrite -(inj_eq val_inj)/= qpolyC_natr -polyC_natr  polyC_eq0.
+by under eq_forallb do rewrite
+  -(inj_eq val_inj)/= qpolyC_natr -polyC_natr polyC_eq0.
 Qed.
 
 Lemma poly_of_qpolyM (p q : {poly %/ h}) :

--- a/mathcomp/algebra/ssrint.v
+++ b/mathcomp/algebra/ssrint.v
@@ -759,9 +759,32 @@ Proof. exact: rmorph_prod. Qed.
 
 End ZintBigMorphism.
 
-Section Frobenius.
+Section PrimeFrobenius.
 
 Variable R : ringType.
+Implicit Types x y : R.
+
+Variable p : nat.
+Hypothesis p_pr : prime.prime p.
+Hypothesis charFp : p \in [char R].
+
+Local Notation "x ^f" := (Frobenius_aut charFp x).
+
+Lemma Frobenius_autMz_prime x n : (x *~ n)^f = x^f *~ n.
+Proof.
+case: n=> n /=; first exact: GRing.Frobenius_autMn_prime.
+rewrite !NegzE !mulrNz GRing.Frobenius_autN_prime//.
+by rewrite GRing.Frobenius_autMn_prime.
+Qed.
+
+Lemma Frobenius_aut_int_prime n : (n%:~R)^f = n%:~R.
+Proof. by rewrite Frobenius_autMz_prime Frobenius_aut1. Qed.
+
+End PrimeFrobenius.
+
+Section Frobenius.
+
+Variable R : idomainType.
 Implicit Types x y : R.
 
 Variable p : nat.
@@ -770,13 +793,10 @@ Hypothesis charFp : p \in [char R].
 Local Notation "x ^f" := (Frobenius_aut charFp x).
 
 Lemma Frobenius_autMz x n : (x *~ n)^f = x^f *~ n.
-Proof.
-case: n=> n /=; first exact: Frobenius_autMn.
-by rewrite !NegzE !mulrNz Frobenius_autN Frobenius_autMn.
-Qed.
+Proof. exact/Frobenius_autMz_prime/charf_prime/charFp. Qed.
 
 Lemma Frobenius_aut_int n : (n%:~R)^f = n%:~R.
-Proof. by rewrite Frobenius_autMz Frobenius_aut1. Qed.
+Proof. exact/Frobenius_aut_int_prime/charf_prime/charFp. Qed.
 
 End Frobenius.
 

--- a/mathcomp/algebra/zmodp.v
+++ b/mathcomp/algebra/zmodp.v
@@ -384,7 +384,7 @@ Lemma Fp_nat_mod m : (m %% p)%:R = m%:R :> 'F_p.
 Proof. by apply: ord_inj; rewrite !val_Fp_nat // modn_mod. Qed.
 
 Lemma char_Fp : p \in [char 'F_p].
-Proof. by rewrite !inE -Fp_nat_mod p_pr ?modnn. Qed.
+Proof. by apply/GRing.charf_prime0 => //; rewrite -Fp_nat_mod modnn. Qed.
 
 Lemma char_Fp_0 : p%:R = 0 :> 'F_p.
 Proof. exact: GRing.charf0 char_Fp. Qed.

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -783,7 +783,7 @@ have{Gregular} ntG: G :!=: 1%g.
   apply: contraL n_gt0; move/eqP=> G1; rewrite -leqNgt -(mxrank1 F n).
   rewrite -(mxrank0 F n n) -Gregular mxrankS //; apply/rfix_mxP=> x.
   by rewrite {1}G1 mul1mx => /set1P->; rewrite repr_mx1.
-have p_pr: prime p by case/andP: charFp.
+have p_pr := charf_prime charFp.
 have{ntG pG} [z]: {z | z \in 'Z(G) & #[z] = p}; last case/setIP=> Gz cGz ozp.
   apply: Cauchy => //; apply: contraR ntG; rewrite -p'natE // => p'Z.
   have pZ: p.-group 'Z(G) by rewrite (pgroupS (center_sub G)).
@@ -797,9 +797,11 @@ have{irrG faithfulG cGz1} Urz1: rG z - 1%:M \in unitmx.
   by rewrite !inE Gz mul1mx -order_eq1 ozp -implybNN neq_ltn orbC prime_gt1.
 do [case: n n_gt0 => // n' _; set n := n'.+1] in rG Urz1 *.
 have charMp: p \in [char 'M[F]_n].
-  exact: (rmorph_char (@scalar_mx F n)).
+  apply: (@rmorph_char _ _ (@scalar_mx F n)) => // x y.
+  move=> /(congr1 (fun m : 'M[F]_n => m 0 0)).
+  by rewrite !mxE !mulr1n.
 have{Urz1}: Frobenius_aut charMp (rG z - 1) \in GRing.unit by rewrite unitrX.
-rewrite (Frobenius_autB_comm _ (commr1 _)) Frobenius_aut1.
+rewrite (GRing.Frobenius_autB_prime_comm _ _ (commr1 _))// Frobenius_aut1.
 by rewrite -[_ (rG z)](repr_mxX rG) // -ozp expg_order repr_mx1 subrr unitr0.
 Qed.
 

--- a/mathcomp/field/algC.v
+++ b/mathcomp/field/algC.v
@@ -70,7 +70,7 @@ Proof.
   apply/eqP=> char2; apply: conj_nt => e; apply/eqP/idPn=> eJ.
   have opp_id x: - x = x :> L.
     by apply/esym/eqP; rewrite -addr_eq0 -mulr2n -mulr_natl char2 mul0r.
-  have{} char2: 2%N \in [char L] by apply/eqP.
+  have{} char2: 2%N \in [char L] by apply/GRing.charf_prime0.
   without loss{eJ} eJ: e / conj e = e + 1.
     move/(_ (e / (e + conj e))); apply.
     rewrite fmorph_div rmorphD /= conjK -{1}[conj e](addNKr e) mulrDl.

--- a/mathcomp/field/cyclotomic.v
+++ b/mathcomp/field/cyclotomic.v
@@ -270,7 +270,8 @@ have [|k_gt1] := leqP k 1; last have [p p_pr /dvdnP[k1 Dk]] := pdivP k_gt1.
   by rewrite -(subnKC g_gt1) -(subnKC (size_minCpoly z)) !addnS.
 move: cokn; rewrite Dk coprimeMl => /andP[cok1n].
 rewrite prime_coprime // (dvdn_charf (char_Fp p_pr)) => /co_fg {co_fg}.
-have charFpX: p \in [char {poly 'F_p}] by rewrite (rmorph_char polyC) ?char_Fp.
+have charFpX: p \in [char {poly 'F_p}].
+  by rewrite (rmorph_char polyC_inj) ?char_Fp.
 rewrite -(coprimep_pexpr _ _ (prime_gt0 p_pr)) -(Frobenius_autE charFpX).
 rewrite -[g]comp_polyXr map_comp_poly -horner_map /= Frobenius_autE -rmorphXn.
 rewrite -!map_poly_comp (@eq_map_poly _ _ _ (polyC \o *~%R 1)); last first.

--- a/mathcomp/field/separable.v
+++ b/mathcomp/field/separable.v
@@ -644,7 +644,7 @@ have [K'g]: g \is a polyOver K' /\ q \is a polyOver K'.
   by rewrite minPolyOver rpredB ?rpredX ?polyOverX // polyOverC memv_adjoin.
 have /dvdpP[c Dq]: 'X - x%:P %| q by rewrite dvdp_XsubCl root_minPoly.
 have co_c_g: coprimep c g.
-  have charPp: p \in [char {poly L}] := rmorph_char polyC charLp.
+  have charPp: p \in [char {poly L}] := rmorph_char polyC_inj charLp.
   rewrite /g polyC_exp -!(Frobenius_autE charPp) -rmorphB coprimep_expr //.
   have: separable_poly q := separable_elementS sKK' sepKx.
   by rewrite Dq separable_mul => /and3P[].

--- a/mathcomp/solvable/abelian.v
+++ b/mathcomp/solvable/abelian.v
@@ -2160,19 +2160,37 @@ Section FimModAbelem.
 
 Import GRing.Theory FinRing.Theory.
 
-Lemma fin_lmod_char_abelem p (R : ringType) (V : finLmodType R):
-  p \in [char R]%R -> p.-abelem [set: V].
+Lemma fin_lmod_char_abelem_prime p (R : ringType) (V : finLmodType R):
+  prime p -> p \in [char R]%R -> p.-abelem [set: V].
 Proof.
-case/andP=> p_pr /eqP-pR0; apply/abelemP=> //.
+move=> p_pr /andP[] /andP[] _ /eqP-pR0 _; apply/abelemP=> //.
 by split=> [|v _]; rewrite ?zmod_abelian // zmodXgE -scaler_nat pR0 scale0r.
 Qed.
 
 Lemma fin_Fp_lmod_abelem p (V : finLmodType 'F_p) :
   prime p -> p.-abelem [set: V].
-Proof. by move/char_Fp/fin_lmod_char_abelem->. Qed.
+Proof. by move=> /[dup] p_pr /char_Fp/fin_lmod_char_abelem_prime->. Qed.
 
-Lemma fin_ring_char_abelem p (R : finRingType) :
+Lemma fin_ring_char_abelem_prime p (R : finRingType) :
+  prime p -> p \in [char R]%R -> p.-abelem [set: R].
+Proof. exact: fin_lmod_char_abelem_prime R^o. Qed.
+
+End FimModAbelem.
+
+Section FimModAbelem.
+
+Import GRing.Theory FinRing.Theory.
+
+Lemma fin_lmod_char_abelem p (R : idomainType) (V : finLmodType R):
+  p \in [char R]%R -> p.-abelem [set: V].
+Proof.
+by move=> /[dup] pR; apply/fin_lmod_char_abelem_prime/charf_prime/pR.
+Qed.
+
+Lemma fin_ring_char_abelem p (R : finIdomainType) :
   p \in [char R]%R -> p.-abelem [set: R].
-Proof. exact: fin_lmod_char_abelem R^o. Qed.
+Proof.
+by move=> /[dup] pR; apply/(fin_lmod_char_abelem_prime R^o)/charf_prime/pR.
+Qed.
 
 End FimModAbelem.


### PR DESCRIPTION
##### Motivation for this change

As of now, the characteristic of a ring is always prime, which does not really make sense in general (e.g. for `'Z_4`). This is fixed by defining the characteristic of a ring as the minimal positive integer which is zero in the ring.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
