### PR TITLE
Rename char into pchar

### DIFF
--- a/algebra/intdiv.v
+++ b/algebra/intdiv.v
@@ -453,12 +453,15 @@ Lemma divzDr m n d :
   (d %| n)%Z -> ((m + n) %/ d)%Z = (m %/ d)%Z + (n %/ d)%Z.
 Proof. by move=> dv_n; rewrite addrC divzDl // addrC. Qed.
 
-Lemma dvdz_charf (R : nzRingType) p : p \in [char R] ->
+Lemma dvdz_pcharf (R : nzRingType) p : p \in [pchar R] ->
   forall n : int, (p %| n)%Z = (n%:~R == 0 :> R).
 Proof.
-move=> charRp [] n; rewrite [LHS](dvdn_charf charRp)//.
+move=> pcharRp [] n; rewrite [LHS](dvdn_pcharf pcharRp)//.
 by rewrite NegzE abszN rmorphN// oppr_eq0.
 Qed.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use dvdz_pcharf  instead.")]
+Notation dvdz_charf chRp := (dvdz_pcharf chRp).
 
 (* Greatest common divisor *)
 

--- a/algebra/poly.v
+++ b/algebra/poly.v
@@ -679,7 +679,7 @@ Lemma polyC_exp n : {morph (@polyC R) : c / c ^+ n}. Proof. exact: rmorphXn. Qed
 Lemma polyC_natr n : n%:R%:P = n%:R :> {poly R}.
 Proof. by rewrite rmorph_nat. Qed.
 
-Lemma char_poly : [char {poly R}] =i [char R].
+Lemma pchar_poly : [pchar {poly R}] =i [pchar R].
 Proof.
 move=> p; rewrite !inE; congr (_ && _).
 apply/eqP/eqP=> [/(congr1 val) /=|]; last by rewrite -polyC_natr => ->.
@@ -1823,6 +1823,9 @@ End PolynomialTheory.
 #[deprecated(since="mathcomp 2.4.0", note="renamed to `size_polyN`")]
 Notation size_opp := size_polyN (only parsing).
 
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar_poly instead.")]
+Notation char_poly := pchar_poly (only parsing).
+
 Prenex Implicits polyC polyCK Poly polyseqK lead_coef root horner polyOver.
 Arguments monic {R}.
 Notation "\poly_ ( i < n ) E" := (poly n (fun i => E)) : ring_scope.
@@ -1853,24 +1856,24 @@ Hypothesis prim_z : n.-primitive_root z.
 Import prime.
 Let n_gt0 := prim_order_gt0 prim_z.
 
-Lemma prim_root_charF p : (p %| n)%N -> p \in [char R] = false.
+Lemma prim_root_pcharF p : (p %| n)%N -> p \in [pchar R] = false.
 Proof.
-move=> pn; apply: contraTF isT => char_p; have p_prime := charf_prime char_p.
+move=> pn; apply: contraTF isT => pchar_p; have p_prime := pcharf_prime pchar_p.
 have /dvdnP[[|k] n_eq_kp] := pn; first by rewrite n_eq_kp in (n_gt0).
 have /eqP := prim_expr_order prim_z; rewrite n_eq_kp exprM.
-rewrite -Frobenius_autE -(Frobenius_aut1 char_p) -subr_eq0 -rmorphB/=.
-rewrite Frobenius_autE expf_eq0// prime_gt0//= subr_eq0 => /eqP.
+rewrite -pFrobenius_autE -(pFrobenius_aut1 pchar_p) -subr_eq0 -rmorphB/=.
+rewrite pFrobenius_autE expf_eq0// prime_gt0//= subr_eq0 => /eqP.
 move=> /eqP; rewrite -(prim_order_dvd prim_z) n_eq_kp.
 rewrite -[X in _ %| X]muln1 dvdn_pmul2l ?dvdn1// => /eqP peq1.
 by rewrite peq1 in p_prime.
 Qed.
 
-Lemma char_prim_root : [char R]^'.-nat n.
-Proof. by apply/pnatP=> // p pp pn; rewrite inE/= prim_root_charF. Qed.
+Lemma pchar_prim_root : [pchar R]^'.-nat n.
+Proof. by apply/pnatP=> // p pp pn; rewrite inE/= prim_root_pcharF. Qed.
 
 Lemma prim_root_pi_eq0 m : \pi(n).-nat m -> m%:R != 0 :> R.
 Proof.
-by rewrite natf_neq0; apply: sub_in_pnat => p _; apply: pnatPpi char_prim_root.
+by rewrite natf_neq0_pchar; apply: sub_in_pnat => p _; apply: pnatPpi pchar_prim_root.
 Qed.
 
 Lemma prim_root_dvd_eq0 m : (m %| n)%N -> m%:R != 0 :> R.
@@ -1883,6 +1886,11 @@ Lemma prim_root_natf_neq0 : n%:R != 0 :> R.
 Proof. by rewrite prim_root_dvd_eq0. Qed.
 
 End IdomainPrimRoot.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use prim_root_pcharF instead.")]
+Notation prim_root_charF := prim_root_pcharF (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar_prim_root instead.")]
+Notation char_prim_root := pchar_prim_root (only parsing).
 
 (* Container morphism. *)
 Section MapPoly.

--- a/algebra/qpoly.v
+++ b/algebra/qpoly.v
@@ -601,7 +601,7 @@ Proof. by []. Qed.
 Lemma qpolyC_natr p : (p%:R : {poly %/ h}) = p%:R :> {poly A}.
 Proof. by elim: p => //= p IH; rewrite !mulrS poly_of_qpolyD IH. Qed.
 
-Lemma char_qpoly : [char {poly %/ h}] =i [char A].
+Lemma pchar_qpoly : [pchar {poly %/ h}] =i [pchar A].
 Proof.
 move=> p; rewrite !inE; congr (_ && _).
 apply/eqP/eqP=> [/(congr1 val) /=|pE]; last first.
@@ -683,6 +683,9 @@ Lemma poly_of_qpolyZ (p : {poly %/ h}) a :
 Proof. by []. Qed.
 
 End QRing.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar_qpoly instead.")]
+Notation char_qpoly := (pchar_qpoly) (only parsing).
 
 Section Field.
 

--- a/algebra/rat.v
+++ b/algebra/rat.v
@@ -842,7 +842,7 @@ Lemma numqK : {in Num.int, cancel (fun x => numq x) intr}.
 Proof. by move=> _ /intrP [x ->]; rewrite numq_int. Qed.
 
 Lemma natq_div m n : (n %| m)%N -> (m %/ n)%:R = m%:R / n%:R :> rat.
-Proof. exact/char0_natf_div/char_num. Qed.
+Proof. exact/pchar0_natf_div/pchar_num. Qed.
 
 Section InRing.
 
@@ -1189,14 +1189,14 @@ rewrite size_map_poly_id0 ?intr_eq0 ?lead_coef_eq0// in fN1.
 have [/eqP/size_poly1P[c cN0 ->]|gN1] := eqVneq (size g) 1%N.
   by rewrite mulrC mul_polyC map_polyZ/= eqp_sym eqp_scale// intr_eq0.
 have c_neq0 : (lead_coef q)%:~R != 0 :> 'F_p
-   by rewrite -(dvdz_charf (char_Fp _)).
+   by rewrite -(dvdz_pcharf (pchar_Fp _)).
 have : map_poly (intr : int -> 'F_p) q = (lead_coef q)%:~R *: 'X^(size q).-1.
   apply/val_inj/(@eq_from_nth _ 0) => [|i]; rewrite size_map_poly_id0//.
     by rewrite size_scale// size_polyXn -polySpred.
   move=> i_small; rewrite coef_poly i_small coefZ coefXn lead_coefE.
   move: i_small; rewrite polySpred// ltnS/=.
   case: ltngtP => // [i_lt|->]; rewrite (mulr1, mulr0)//= => _.
-  by apply/eqP; rewrite -(dvdz_charf (char_Fp _))// dvd_pq.
+  by apply/eqP; rewrite -(dvdz_pcharf (pchar_Fp _))// dvd_pq.
 rewrite [in LHS]q_eq rmorphM/=.
 set c := (X in X *: _); set n := (_.-1).
 set pf := map_poly _ f; set pg := map_poly _ g => pfMpg.
@@ -1215,7 +1215,7 @@ have pfN1 : size pf != 1%N by rewrite size_map_poly_id0.
 have pgN1 : size pg != 1%N by rewrite size_map_poly_id0.
 have /(dvdXn _ pgN1) /eqP : pg %| c *: 'X^n by rewrite -pfMpg dvdp_mull.
 have /(dvdXn _ pfN1) /eqP : pf %| c *: 'X^n by rewrite -pfMpg dvdp_mulr.
-by rewrite !coef_map// -!(dvdz_charf (char_Fp _))//; apply: dvdz_mul.
+by rewrite !coef_map// -!(dvdz_pcharf (pchar_Fp _))//; apply: dvdz_mul.
 Qed.
 
 (* Connecting rationals to the ring and field tactics *)

--- a/algebra/sesquilinear.v
+++ b/algebra/sesquilinear.v
@@ -1032,13 +1032,19 @@ Lemma orthovD U V W : (U '_|_ V + W)%VS = (U '_|_ V)%VS && (U '_|_ W)%VS.
 Proof. by rewrite ![(U '_|_ _)%VS]orthov_sym orthoDv. Qed.
 
 Definition nondegenerate := radv == 0%VS.
-Definition is_symplectic := [/\ nondegenerate, is_skew form &
-                                2 \in [char F] -> forall u, '[u, u] = 0].
-Definition is_orthogonal := [/\ nondegenerate, is_sym form &
-                                2 \in [char F] -> forall u, '[u, u] = 0].
+Definition is_psymplectic := [/\ nondegenerate, is_skew form &
+                                2 \in [pchar F] -> forall u, '[u, u] = 0].
+Definition is_porthogonal := [/\ nondegenerate, is_sym form &
+                                2 \in [pchar F] -> forall u, '[u, u] = 0].
 Definition is_unitary := nondegenerate /\ (is_hermsym form).
 
 End HermitianFinVectTheory.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use is_psymplectic instead.")]
+Notation is_symplectic := is_psymplectic (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use is_porthogonal instead.")]
+Notation is_orthogonal := is_porthogonal (only parsing).
+
 Arguments orthogonalP {F eps theta vT form us vs}.
 Arguments orthovP {F eps theta vT form U V}.
 Arguments mem_orthovPn {F eps theta vT form V u}.

--- a/algebra/ssralg.v
+++ b/algebra/ssralg.v
@@ -270,16 +270,16 @@ From mathcomp Require Import choice fintype finfun bigop prime binomial.
 (*         GRing.comm x y <-> x and y commute, i.e., x * y = y * x            *)
 (*           GRing.lreg x <-> x if left-regular, i.e., *%R x is injective     *)
 (*           GRing.rreg x <-> x if right-regular, i.e., *%R^~ x is injective  *)
-(*               [char R] == the characteristic of R, defined as the set of   *)
+(*               [pchar R] == the characteristic of R, defined as the set of  *)
 (*                           prime numbers p such that p%:R = 0 in R          *)
-(*                           The set [char R] has at most one element, and is *)
+(*                           The set [pchar R] has at most one element, and is*)
 (*                           implemented as a pred_nat collective predicate   *)
-(*                           (see prime.v); thus the statement p \in [char R] *)
+(*                           (see prime.v); thus the statement p \in [pchar R]*)
 (*                           can be read as `R has characteristic p', while   *)
-(*                           [char R] =i pred0 means `R has characteristic 0' *)
+(*                           [pchar R] =i pred0 means `R has characteristic 0'*)
 (*                           when R is a field.                               *)
-(*     Frobenius_aut chRp == the Frobenius automorphism mapping x in R to     *)
-(*                           x ^+ p, where chRp : p \in [char R] is a proof   *)
+(*     pFrobenius_aut chRp == the Frobenius automorphism mapping x in R to    *)
+(*                           x ^+ p, where chRp : p \in [pchar R] is a proof  *)
 (*                           that R has (non-zero) characteristic p           *)
 (*          mulr_closed S <-> collective predicate S is closed under finite   *)
 (*                           products (1 and x * y in S for x, y in S)        *)
@@ -673,6 +673,7 @@ Reserved Notation "*%R" (at level 0, format " *%R").
 Reserved Notation "*:%R" (at level 0, format " *:%R").
 Reserved Notation "n %:R" (at level 2, left associativity, format "n %:R").
 Reserved Notation "k %:A" (at level 2, left associativity, format "k %:A").
+Reserved Notation "[ 'pchar' F ]" (at level 0, format "[ 'pchar'  F ]").
 Reserved Notation "[ 'char' F ]" (at level 0, format "[ 'char'  F ]").
 
 Reserved Notation "x %:T" (at level 2, left associativity, format "x %:T").
@@ -1167,10 +1168,16 @@ Local Notation "\prod_ ( m <= i < n ) F" := (\big[*%R/1%R]_(m <= i < n) F%R).
 (* The ``field'' characteristic; the definition, and many of the theorems,   *)
 (* has to apply to rings as well; indeed, we need the Frobenius automorphism *)
 (* results for a non commutative ring in the proof of Gorenstein 2.6.3.      *)
-Definition char (R : pzSemiRingType) : nat_pred :=
+Definition pchar (R : nzSemiRingType) : nat_pred :=
   [pred p | prime p & p%:R == 0 :> R].
 
-Local Notation has_char0 L := (char L =i pred0).
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar instead.")]
+Notation char := pchar (only parsing).
+
+Local Notation has_pchar0 L := (pchar L =i pred0).
+
+#[deprecated(since="mathcomp 2.4.0", note="Use has_pchar0 instead.")]
+Notation has_char0 L := (has_pchar0 L) (only parsing).
 
 (* Converse ring tag. *)
 Definition converse R : Type := R.
@@ -1414,8 +1421,6 @@ rewrite exprD1n !big_ord_recr big_ord0 /= add0r.
 by rewrite addrC addrA addrAC.
 Qed.
 
-Definition Frobenius_aut p of p \in char R := fun x => x ^+ p.
-
 Section ClosedPredicates.
 
 Variable S : {pred R}.
@@ -1445,81 +1450,84 @@ Proof. by case: s => [|y s] /negPf // ->; rewrite oner_eq0. Qed.
 Lemma lreg_neq0 x : lreg x -> x != 0.
 Proof. by move=> reg_x; rewrite -[x]mulr1 mulrI_eq0 ?oner_eq0. Qed.
 
+Definition pFrobenius_aut p of p \in pchar R := fun x => x ^+ p.
+
 (* FIXME: Generalize to `pzSemiRingType` once `char` has a sensible
    definition. *)
 Section FrobeniusAutomorphism.
 
 Variable p : nat.
-Hypothesis charFp : p \in char R.
+Hypothesis pcharFp : p \in pchar R.
 
-Lemma charf0 : p%:R = 0 :> R. Proof. by apply/eqP; case/andP: charFp. Qed.
-Lemma charf_prime : prime p. Proof. by case/andP: charFp. Qed.
-Hint Resolve charf_prime : core.
+Lemma pcharf0 : p%:R = 0 :> R. Proof. by apply/eqP; case/andP: pcharFp. Qed.
 
-Lemma mulrn_char x : x *+ p = 0. Proof. by rewrite -mulr_natl charf0 mul0r. Qed.
+Lemma pcharf_prime : prime p. Proof. by case/andP: pcharFp. Qed.
+Hint Resolve pcharf_prime : core.
 
-Lemma natr_mod_char n : (n %% p)%:R = n%:R :> R.
-Proof. by rewrite {2}(divn_eq n p) natrD mulrnA mulrn_char add0r. Qed.
+Lemma mulrn_pchar x : x *+ p = 0. Proof. by rewrite -mulr_natl pcharf0 mul0r. Qed.
 
-Lemma dvdn_charf n : (p %| n)%N = (n%:R == 0 :> R).
+Lemma natr_mod_pchar n : (n %% p)%:R = n%:R :> R.
+Proof. by rewrite {2}(divn_eq n p) natrD mulrnA mulrn_pchar add0r. Qed.
+
+Lemma dvdn_pcharf n : (p %| n)%N = (n%:R == 0 :> R).
 Proof.
-apply/idP/eqP=> [/dvdnP[n' ->]|n0]; first by rewrite natrM charf0 mulr0.
+apply/idP/eqP=> [/dvdnP[n' ->]|n0]; first by rewrite natrM pcharf0 mulr0.
 apply/idPn; rewrite -prime_coprime // => /eqnP pn1.
-have [a _ /dvdnP[b]] := Bezoutl n (prime_gt0 charf_prime).
+have [a _ /dvdnP[b]] := Bezoutl n (prime_gt0 pcharf_prime).
 move/(congr1 (fun m => m%:R : R))/eqP.
-by rewrite natrD !natrM charf0 n0 !mulr0 pn1 addr0 oner_eq0.
+by rewrite natrD !natrM pcharf0 n0 !mulr0 pn1 addr0 oner_eq0.
 Qed.
 
-Lemma charf_eq : char R =i (p : nat_pred).
+Lemma pcharf_eq : pchar R =i (p : nat_pred).
 Proof.
-move=> q; apply/andP/eqP=> [[q_pr q0] | ->]; last by rewrite charf0.
-by apply/eqP; rewrite eq_sym -dvdn_prime2 // dvdn_charf.
+move=> q; apply/andP/eqP=> [[q_pr q0] | ->]; last by rewrite pcharf0.
+by apply/eqP; rewrite eq_sym -dvdn_prime2 // dvdn_pcharf.
 Qed.
 
-Lemma bin_lt_charf_0 k : 0 < k < p -> 'C(p, k)%:R = 0 :> R.
-Proof. by move=> lt0kp; apply/eqP; rewrite -dvdn_charf prime_dvd_bin. Qed.
+Lemma bin_lt_pcharf_0 k : 0 < k < p -> 'C(p, k)%:R = 0 :> R.
+Proof. by move=> lt0kp; apply/eqP; rewrite -dvdn_pcharf prime_dvd_bin. Qed.
 
-Local Notation "x ^f" := (Frobenius_aut charFp x).
+Local Notation "x ^f" := (pFrobenius_aut pcharFp x).
 
-Lemma Frobenius_autE x : x^f = x ^+ p. Proof. by []. Qed.
-Local Notation fE := Frobenius_autE.
+Lemma pFrobenius_autE x : x^f = x ^+ p. Proof. by []. Qed.
+Local Notation f'E := pFrobenius_autE.
 
-Lemma Frobenius_aut0 : 0^f = 0.
-Proof. by rewrite fE -(prednK (prime_gt0 charf_prime)) exprS mul0r. Qed.
+Lemma pFrobenius_aut0 : 0^f = 0.
+Proof. by rewrite f'E -(prednK (prime_gt0 pcharf_prime)) exprS mul0r. Qed.
 
-Lemma Frobenius_aut1 : 1^f = 1.
-Proof. by rewrite fE expr1n. Qed.
+Lemma pFrobenius_aut1 : 1^f = 1.
+Proof. by rewrite f'E expr1n. Qed.
 
-Lemma Frobenius_autD_comm x y (cxy : comm x y) : (x + y)^f = x^f + y^f.
+Lemma pFrobenius_autD_comm x y (cxy : comm x y) : (x + y)^f = x^f + y^f.
 Proof.
-have defp := prednK (prime_gt0 charf_prime).
-rewrite !fE exprDn_comm // big_ord_recr subnn -defp big_ord_recl /= defp.
+have defp := prednK (prime_gt0 pcharf_prime).
+rewrite !f'E exprDn_comm // big_ord_recr subnn -defp big_ord_recl /= defp.
 rewrite subn0 mulr1 mul1r bin0 binn big1 ?addr0 // => i _.
-by rewrite -mulr_natl bin_lt_charf_0 ?mul0r //= -{2}defp ltnS (valP i).
+by rewrite -mulr_natl bin_lt_pcharf_0 ?mul0r //= -{2}defp ltnS (valP i).
 Qed.
 
-Lemma Frobenius_autMn x n : (x *+ n)^f = x^f *+ n.
+Lemma pFrobenius_autMn x n : (x *+ n)^f = x^f *+ n.
 Proof.
-elim: n => [|n IHn]; first exact: Frobenius_aut0.
-by rewrite !mulrS Frobenius_autD_comm ?IHn //; apply: commrMn.
+elim: n => [|n IHn]; first exact: pFrobenius_aut0.
+by rewrite !mulrS pFrobenius_autD_comm ?IHn //; apply: commrMn.
 Qed.
 
-Lemma Frobenius_aut_nat n : (n%:R)^f = n%:R.
-Proof. by rewrite Frobenius_autMn Frobenius_aut1. Qed.
+Lemma pFrobenius_aut_nat n : (n%:R)^f = n%:R.
+Proof. by rewrite pFrobenius_autMn pFrobenius_aut1. Qed.
 
-Lemma Frobenius_autM_comm x y : comm x y -> (x * y)^f = x^f * y^f.
+Lemma pFrobenius_autM_comm x y : comm x y -> (x * y)^f = x^f * y^f.
 Proof. exact: exprMn_comm. Qed.
 
-Lemma Frobenius_autX x n : (x ^+ n)^f = x^f ^+ n.
-Proof. by rewrite !fE -!exprM mulnC. Qed.
+Lemma pFrobenius_autX x n : (x ^+ n)^f = x^f ^+ n.
+Proof. by rewrite !f'E -!exprM mulnC. Qed.
 
 End FrobeniusAutomorphism.
 
 Section Char2.
 
-Hypothesis charR2 : 2 \in char R.
+Hypothesis pcharR2 : 2 \in pchar R.
 
-Lemma addrr_char2 x : x + x = 0. Proof. by rewrite -mulr2n mulrn_char. Qed.
+Lemma addrr_pchar2 x : x + x = 0. Proof. by rewrite -mulr2n mulrn_pchar. Qed.
 
 End Char2.
 
@@ -1578,9 +1586,43 @@ Bind Scope ring_scope with PzRing.sort.
 End PzRingExports.
 HB.export PzRingExports.
 
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_aut instead.")]
+Notation Frobenius_aut := pFrobenius_aut (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf0 instead.")]
+Notation charf0 := pcharf0 (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf_prime instead.")]
+Notation charf_prime := pcharf_prime (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use mulrn_pchar instead.")]
+Notation mulrn_char := mulrn_pchar (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use natr_mod_pchar instead.")]
+Notation natr_mod_char := natr_mod_pchar (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use dvdn_pcharf instead.")]
+Notation dvdn_charf := dvdn_pcharf (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf_eq instead.")]
+Notation charf_eq := pcharf_eq (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use bin_lt_pcharf_0 instead.")]
+Notation bin_lt_charf_0 := bin_lt_pcharf_0 (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autE instead.")]
+Notation Frobenius_autE := pFrobenius_autE (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_aut0 instead.")]
+Notation Frobenius_aut0 := pFrobenius_aut0 (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_aut1 instead.")]
+Notation Frobenius_aut1 := pFrobenius_aut1 (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autD_comm instead.")]
+Notation Frobenius_autD_comm := pFrobenius_autD_comm (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autMn instead.")]
+Notation Frobenius_autMn := pFrobenius_autMn (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_aut_nat instead.")]
+Notation Frobenius_aut_nat := pFrobenius_aut_nat (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autM_comm instead.")]
+Notation Frobenius_autM_comm := pFrobenius_autM_comm (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autX instead.")]
+Notation Frobenius_autX := pFrobenius_autX (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use addrr_pchar2 instead.")]
+Notation addrr_char2 := addrr_pchar2 (only parsing).
+
 #[short(type="nzRingType")]
 HB.structure Definition NzRing := { R of NzSemiRing R & Zmodule R }.
-
 #[deprecated(since="mathcomp 2.4.0",
              note="Use NzRing instead.")]
 Notation Ring R := (NzRing R) (only parsing).
@@ -1833,52 +1875,67 @@ Proof. by rewrite -signr_odd; case: odd; rewrite ?oppr_eq0 oner_eq0. Qed.
 Section FrobeniusAutomorphism.
 
 Variable p : nat.
-Hypothesis charFp : p \in char R.
+Hypothesis pcharFp : p \in pchar R.
 
-Hint Resolve charf_prime : core.
+Hint Resolve pcharf_prime : core.
 
-Local Notation "x ^f" := (Frobenius_aut charFp x).
+Local Notation "x ^f" := (pFrobenius_aut pcharFp x).
 
-Lemma Frobenius_autN x : (- x)^f = - x^f.
+Lemma pFrobenius_autN x : (- x)^f = - x^f.
 Proof.
 apply/eqP; rewrite -subr_eq0 opprK addrC.
-by rewrite -(Frobenius_autD_comm _ (commrN _)) // subrr Frobenius_aut0.
+by rewrite -(pFrobenius_autD_comm _ (commrN _)) // subrr pFrobenius_aut0.
 Qed.
 
-Lemma Frobenius_autB_comm x y : comm x y -> (x - y)^f = x^f - y^f.
+Lemma pFrobenius_autB_comm x y : comm x y -> (x - y)^f = x^f - y^f.
 Proof.
-by move/commrN/Frobenius_autD_comm->; rewrite Frobenius_autN.
+by move/commrN/pFrobenius_autD_comm->; rewrite pFrobenius_autN.
 Qed.
 
 End FrobeniusAutomorphism.
 
-Lemma exprNn_char x n : (char R).-nat n -> (- x) ^+ n = - (x ^+ n).
+Lemma exprNn_pchar x n : (pchar R).-nat n -> (- x) ^+ n = - (x ^+ n).
 Proof.
-pose p := pdiv n; have [|n_gt1 charRn] := leqP n 1; first by case: (n) => [|[]].
-have charRp: p \in char R by rewrite (pnatPpi charRn) // pi_pdiv.
-have /p_natP[e ->]: p.-nat n by rewrite -(eq_pnat _ (charf_eq charRp)).
+pose p := pdiv n; have [|n_gt1 pcharRn] := leqP n 1; first by case: (n) => [|[]].
+have pcharRp: p \in pchar R by rewrite (pnatPpi pcharRn) // pi_pdiv.
+have /p_natP[e ->]: p.-nat n by rewrite -(eq_pnat _ (pcharf_eq pcharRp)).
 elim: e => // e IHe; rewrite expnSr !exprM {}IHe.
-by rewrite -Frobenius_autE Frobenius_autN.
+by rewrite -pFrobenius_autE pFrobenius_autN.
 Qed.
 
 Section Char2.
 
-Hypothesis charR2 : 2 \in char R.
+Hypothesis pcharR2 : 2 \in pchar R.
 
-Lemma oppr_char2 x : - x = x.
-Proof. by apply/esym/eqP; rewrite -addr_eq0 addrr_char2. Qed.
+Lemma oppr_pchar2 x : - x = x.
+Proof. by apply/esym/eqP; rewrite -addr_eq0 addrr_pchar2. Qed.
 
-Lemma subr_char2 x y : x - y = x + y. Proof. by rewrite oppr_char2. Qed.
+Lemma subr_pchar2 x y : x - y = x + y. Proof. by rewrite oppr_pchar2. Qed.
 
-Lemma addrK_char2 x : involutive (+%R^~ x).
-Proof. by move=> y; rewrite /= -subr_char2 addrK. Qed.
+Lemma addrK_pchar2 x : involutive (+%R^~ x).
+Proof. by move=> y; rewrite /= -subr_pchar2 addrK. Qed.
 
-Lemma addKr_char2 x : involutive (+%R x).
-Proof. by move=> y; rewrite -{1}[x]oppr_char2 addKr. Qed.
+Lemma addKr_pchar2 x : involutive (+%R x).
+Proof. by move=> y; rewrite -{1}[x]oppr_pchar2 addKr. Qed.
 
 End Char2.
 
 End NzRingTheory.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autN instead.")]
+Notation Frobenius_autN := pFrobenius_autN (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autB_comm instead.")]
+Notation Frobenius_autB_comm := pFrobenius_autB_comm (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use exprNn_pchar instead.")]
+Notation exprNn_char := exprNn_pchar (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use oppr_pchar2 instead.")]
+Notation oppr_char2 := oppr_pchar2 (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use subr_pchar2 instead.")]
+Notation subr_char2 := subr_pchar2 (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use addrK_pchar2 instead.")]
+Notation addrK_char2 := addrK_pchar2 (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use addKr_pchar2 instead.")]
+Notation addKr_char2 := addKr_pchar2 (only parsing).
 
 Section ConverseRing.
 #[export]
@@ -2509,9 +2566,6 @@ Proof. by elim: n => [|n IHn] x; rewrite ?rmorph1 // !exprS rmorphM IHn. Qed.
 
 Lemma rmorph_nat n : f n%:R = n%:R. Proof. by rewrite rmorphMn rmorph1. Qed.
 
-Lemma rmorph_char p : p \in char R -> p \in char S.
-Proof. by rewrite !inE -rmorph_nat => /andP[-> /= /eqP->]; rewrite rmorph0. Qed.
-
 Lemma rmorph_eq_nat x n : injective f -> (f x == n%:R) = (x == n%:R).
 Proof. by move/inj_eq <-; rewrite rmorph_nat. Qed.
 
@@ -2525,6 +2579,12 @@ by split=> [x y|]; apply: (canLR fK); rewrite /= (rmorphM, rmorph1) ?f'K.
 Qed.
 
 End Properties.
+
+Lemma rmorph_pchar (R S : nzSemiRingType) (f : {rmorphism R -> S}) p :
+  p \in pchar R -> p \in pchar S.
+Proof.
+by rewrite !inE -(rmorph_nat f) => /andP[-> /= /eqP->]; rewrite rmorph0.
+Qed.
 
 Section Projections.
 
@@ -2584,6 +2644,9 @@ Lemma in_algE a : in_alg A a = a%:A. Proof. by []. Qed.
 End InSemiAlgebra.
 
 End RmorphismTheory.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use rmorph_pchar instead.")]
+Notation rmorph_char := rmorph_pchar (only parsing).
 
 Module Scale.
 
@@ -3161,33 +3224,33 @@ Implicit Types x y : R.
 
 Section FrobeniusAutomorphism.
 
-Variables (p : nat) (charRp : p \in char R).
+Variables (p : nat) (pcharRp : p \in pchar R).
 
-Lemma Frobenius_aut_is_semi_additive : semi_additive (Frobenius_aut charRp).
+Lemma pFrobenius_aut_is_semi_additive : semi_additive (pFrobenius_aut pcharRp).
 Proof.
-by split=> [|x y]; [exact: Frobenius_aut0 | exact/Frobenius_autD_comm/mulrC].
+by split=> [|x y]; [exact: pFrobenius_aut0 | exact/pFrobenius_autD_comm/mulrC].
 Qed.
 
-Lemma Frobenius_aut_is_multiplicative : multiplicative (Frobenius_aut charRp).
+Lemma pFrobenius_aut_is_multiplicative : multiplicative (pFrobenius_aut pcharRp).
 Proof.
-by split=> [x y|]; [exact/Frobenius_autM_comm/mulrC | exact: Frobenius_aut1].
+by split=> [x y|]; [exact/pFrobenius_autM_comm/mulrC | exact: pFrobenius_aut1].
 Qed.
 
 #[export]
-HB.instance Definition _ := isSemiAdditive.Build R R (Frobenius_aut charRp)
-  Frobenius_aut_is_semi_additive.
+HB.instance Definition _ := isSemiAdditive.Build R R (pFrobenius_aut pcharRp)
+  pFrobenius_aut_is_semi_additive.
 #[export]
-HB.instance Definition _ := isMultiplicative.Build R R (Frobenius_aut charRp)
-  Frobenius_aut_is_multiplicative.
+HB.instance Definition _ := isMultiplicative.Build R R (pFrobenius_aut pcharRp)
+  pFrobenius_aut_is_multiplicative.
 
 End FrobeniusAutomorphism.
 
-Lemma exprDn_char x y n : (char R).-nat n -> (x + y) ^+ n = x ^+ n + y ^+ n.
+Lemma exprDn_pchar x y n : (pchar R).-nat n -> (x + y) ^+ n = x ^+ n + y ^+ n.
 Proof.
-pose p := pdiv n; have [|n_gt1 charRn] := leqP n 1; first by case: (n) => [|[]].
-have charRp: p \in char R by rewrite (pnatPpi charRn) ?pi_pdiv.
-have{charRn} /p_natP[e ->]: p.-nat n by rewrite -(eq_pnat _ (charf_eq charRp)).
-by elim: e => // e IHe; rewrite !expnSr !exprM IHe -Frobenius_autE rmorphD.
+pose p := pdiv n; have [|n_gt1 pcharRn] := leqP n 1; first by case: (n) => [|[]].
+have pcharRp: p \in pchar R by rewrite (pnatPpi pcharRn) ?pi_pdiv.
+have{pcharRn} /p_natP[e ->]: p.-nat n by rewrite -(eq_pnat _ (pcharf_eq pcharRp)).
+by elim: e => // e IHe; rewrite !expnSr !exprM IHe -pFrobenius_autE rmorphD.
 Qed.
 
 (* FIXME: Generalize to `comPzSemiRingType` ? *)
@@ -3258,6 +3321,11 @@ Module ComPzRingExports.
 Bind Scope ring_scope with ComPzRing.sort.
 End ComPzRingExports.
 HB.export ComPzRingExports.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_aut_is_multiplicative instead.")]
+Notation Frobenius_aut_is_multiplicative := pFrobenius_aut_is_multiplicative (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use exprDn_pchar instead.")]
+Notation exprDn_char := exprDn_pchar (only parsing).
 
 #[short(type="comNzRingType")]
 HB.structure Definition ComNzRing := {R of NzRing R & ComNzSemiRing R}.
@@ -4697,7 +4765,7 @@ Lemma sqrf_eq0 x : (x ^+ 2 == 0) = (x == 0). Proof. exact: expf_eq0. Qed.
 Lemma expf_neq0 x m : x != 0 -> x ^+ m != 0.
 Proof. by move=> x_nz; rewrite expf_eq0; apply/nandP; right. Qed.
 
-Lemma natf_neq0 n : (n%:R != 0 :> R) = (char R)^'.-nat n.
+Lemma natf_neq0_pchar n : (n%:R != 0 :> R) = (pchar R)^'.-nat n.
 Proof.
 have [-> | /prod_prime_decomp->] := posnP n; first by rewrite eqxx.
 rewrite !big_seq; elim/big_rec: _ => [|[p e] s /=]; first by rewrite oner_eq0.
@@ -4705,28 +4773,28 @@ case/mem_prime_decomp=> p_pr _ _; rewrite pnatM pnatX eqn0Ngt orbC => <-.
 by rewrite natrM natrX mulf_eq0 expf_eq0 negb_or negb_and pnatE ?inE p_pr.
 Qed.
 
-Lemma natf0_char n : n > 0 -> n%:R == 0 :> R -> exists p, p \in char R.
+Lemma natf0_pchar n : n > 0 -> n%:R == 0 :> R -> exists p, p \in pchar R.
 Proof.
-move=> n_gt0 nR_0; exists (pdiv n`_(char R)).
+move=> n_gt0 nR_0; exists (pdiv n`_(pchar R)).
 apply: pnatP (pdiv_dvd _); rewrite ?part_pnat // ?pdiv_prime //.
-by rewrite ltn_neqAle eq_sym partn_eq1 // -natf_neq0 nR_0 /=.
+by rewrite ltn_neqAle eq_sym partn_eq1 // -natf_neq0_pchar nR_0 /=.
 Qed.
 
-Lemma charf'_nat n : (char R)^'.-nat n = (n%:R != 0 :> R).
+Lemma pcharf'_nat n : (pchar R)^'.-nat n = (n%:R != 0 :> R).
 Proof.
 have [-> | n_gt0] := posnP n; first by rewrite eqxx.
 apply/idP/idP => [|nz_n]; last first.
-  by apply/pnatP=> // p p_pr p_dvd_n; apply: contra nz_n => /dvdn_charf <-.
-apply: contraL => n0; have [// | p charRp] := natf0_char _ n0.
-have [p_pr _] := andP charRp; rewrite (eq_pnat _ (eq_negn (charf_eq charRp))).
-by rewrite p'natE // (dvdn_charf charRp) n0.
+  by apply/pnatP=> // p p_pr p_dvd_n; apply: contra nz_n => /dvdn_pcharf <-.
+apply: contraL => n0; have [// | p pcharRp] := natf0_pchar _ n0.
+have [p_pr _] := andP pcharRp; rewrite (eq_pnat _ (eq_negn (pcharf_eq pcharRp))).
+by rewrite p'natE // (dvdn_pcharf pcharRp) n0.
 Qed.
 
-Lemma charf0P : char R =i pred0 <-> (forall n, (n%:R == 0 :> R) = (n == 0)%N).
+Lemma pcharf0P : pchar R =i pred0 <-> (forall n, (n%:R == 0 :> R) = (n == 0)%N).
 Proof.
-split=> charF0 n; last by rewrite !inE charF0 andbC; case: eqP => // ->.
+split=> pcharF0 n; last by rewrite !inE pcharF0 andbC; case: eqP => // ->.
 have [-> | n_gt0] := posnP; first exact: eqxx.
-by apply/negP; case/natf0_char=> // p; rewrite charF0.
+by apply/negP; case/natf0_pchar=> // p; rewrite pcharF0.
 Qed.
 
 Lemma eqf_sqr x y : (x ^+ 2 == y ^+ 2) = (x == y) || (x == - y).
@@ -4764,6 +4832,15 @@ Proof. by apply: (iffP idP) => [/mulIf | /rreg_neq0]. Qed.
 HB.instance Definition _ := IntegralDomain.on R^o.
 
 End IntegralDomainTheory.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use natf_neq0_pchar instead.")]
+Notation natf_neq0 := natf_neq0_pchar (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use natf0_pchar instead.")]
+Notation natf0_char := natf0_pchar (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf'_nat instead.")]
+Notation charf'_nat := pcharf'_nat (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf0P instead.")]
+Notation charf0P := pcharf0P (only parsing).
 
 Arguments lregP {R x}.
 Arguments rregP {R x}.
@@ -4925,11 +5002,11 @@ Proof.
 by move=> ?; rewrite -mulr_suml -(divr1 a) eqr_div ?oner_eq0// mulr1 divr1.
 Qed.
 
-Lemma char0_natf_div :
-  char F =i pred0 -> forall m d, d %| m -> (m %/ d)%:R = m%:R / d%:R :> F.
+Lemma pchar0_natf_div :
+  pchar F =i pred0 -> forall m d, d %| m -> (m %/ d)%:R = m%:R / d%:R :> F.
 Proof.
-move/charf0P=> char0F m [|d] d_dv_m; first by rewrite divn0 invr0 mulr0.
-by rewrite natr_div // unitfE char0F.
+move/pcharf0P=> pchar0F m [|d] d_dv_m; first by rewrite divn0 invr0 mulr0.
+by rewrite natr_div // unitfE pchar0F.
 Qed.
 
 Section FieldMorphismInj.
@@ -4952,7 +5029,7 @@ Proof. exact: inj_eq fmorph_inj. Qed.
 Lemma fmorph_eq1 x : (f x == 1) = (x == 1).
 Proof. by rewrite -(inj_eq fmorph_inj) rmorph1. Qed.
 
-Lemma fmorph_char : char R =i char F.
+Lemma fmorph_pchar : pchar R =i pchar F.
 Proof. by move=> p; rewrite !inE -fmorph_eq0 rmorph_nat. Qed.
 
 End FieldMorphismInj.
@@ -5000,10 +5077,17 @@ Qed.
 
 End ModuleTheory.
 
-Lemma char_lalg (A : lalgType F) : char A =i char F.
+Lemma pchar_lalg (A : lalgType F) : pchar A =i pchar F.
 Proof. by move=> p; rewrite inE -scaler_nat scaler_eq0 oner_eq0 orbF. Qed.
 
 End FieldTheory.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar0_natf_div instead.")]
+Notation char0_natf_div := pchar0_natf_div (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use fmorph_pchar instead.")]
+Notation fmorph_char := fmorph_pchar (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar_lalg instead.")]
+Notation char_lalg := pchar_lalg (only parsing).
 
 Arguments fmorph_inj {F R} f [x1 x2].
 Arguments telescope_prodf_eq {F n m} f u.
@@ -6926,27 +7010,69 @@ Definition subrX1 := subrX1.
 Definition sqrrD1 := sqrrD1.
 Definition sqrrB1 := sqrrB1.
 Definition subr_sqr_1 := subr_sqr_1.
-Definition charf0 := charf0.
-Definition charf_prime := charf_prime.
-Definition mulrn_char := mulrn_char.
-Definition dvdn_charf := dvdn_charf.
-Definition charf_eq := charf_eq.
-Definition bin_lt_charf_0 := bin_lt_charf_0.
-Definition Frobenius_autE := Frobenius_autE.
-Definition Frobenius_aut0 := Frobenius_aut0.
-Definition Frobenius_aut1 := Frobenius_aut1.
-Definition Frobenius_autD_comm := Frobenius_autD_comm.
-Definition Frobenius_autMn := Frobenius_autMn.
-Definition Frobenius_aut_nat := Frobenius_aut_nat.
-Definition Frobenius_autM_comm := Frobenius_autM_comm.
-Definition Frobenius_autX := Frobenius_autX.
-Definition Frobenius_autN := Frobenius_autN.
-Definition Frobenius_autB_comm := Frobenius_autB_comm.
-Definition exprNn_char := exprNn_char.
-Definition addrr_char2 := addrr_char2.
-Definition oppr_char2 := oppr_char2.
-Definition addrK_char2 := addrK_char2.
-Definition addKr_char2 := addKr_char2.
+Definition pcharf0 := pcharf0.
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf0 instead.")]
+Definition charf0 := pcharf0.
+Definition pcharf_prime := pcharf_prime.
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf_prime instead.")]
+Definition charf_prime := pcharf_prime.
+Definition mulrn_pchar := mulrn_pchar.
+#[deprecated(since="mathcomp 2.4.0", note="Use mulrn_pchar instead.")]
+Definition mulrn_char := mulrn_pchar.
+Definition dvdn_pcharf := dvdn_pcharf.
+#[deprecated(since="mathcomp 2.4.0", note="Use dvdn_pcharf instead.")]
+Definition dvdn_charf := dvdn_pcharf.
+Definition pcharf_eq := pcharf_eq.
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf_eq instead.")]
+Definition charf_eq := pcharf_eq.
+Definition bin_lt_pcharf_0 := bin_lt_pcharf_0.
+#[deprecated(since="mathcomp 2.4.0", note="Use bin_lt_pcharf_0 instead.")]
+Definition bin_lt_charf_0 := bin_lt_pcharf_0.
+Definition pFrobenius_autE := pFrobenius_autE.
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autE instead.")]
+Definition Frobenius_autE := pFrobenius_autE.
+Definition pFrobenius_aut0 := pFrobenius_aut0.
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_aut0 instead.")]
+Definition Frobenius_aut0 := pFrobenius_aut0.
+Definition pFrobenius_aut1 := pFrobenius_aut1.
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_aut1 instead.")]
+Definition Frobenius_aut1 := pFrobenius_aut1.
+Definition pFrobenius_autD_comm := pFrobenius_autD_comm.
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autD_comm instead.")]
+Definition Frobenius_autD_comm := pFrobenius_autD_comm.
+Definition pFrobenius_autMn := pFrobenius_autMn.
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autMn instead.")]
+Definition Frobenius_autMn := pFrobenius_autMn.
+Definition pFrobenius_aut_nat := pFrobenius_aut_nat.
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_aut_nat instead.")]
+Definition Frobenius_aut_nat := pFrobenius_aut_nat.
+Definition pFrobenius_autM_comm := pFrobenius_autM_comm.
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autM_comm instead.")]
+Definition Frobenius_autM_comm := pFrobenius_autM_comm.
+Definition pFrobenius_autX := pFrobenius_autX.
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autX instead.")]
+Definition Frobenius_autX := pFrobenius_autX.
+Definition pFrobenius_autN := pFrobenius_autN.
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autN instead.")]
+Definition Frobenius_autN := pFrobenius_autN.
+Definition pFrobenius_autB_comm := pFrobenius_autB_comm.
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autB_comm instead.")]
+Definition Frobenius_autB_comm := pFrobenius_autB_comm.
+Definition exprNn_pchar := exprNn_pchar.
+#[deprecated(since="mathcomp 2.4.0", note="Use exprNn_pchar instead.")]
+Definition exprNn_char := exprNn_pchar.
+Definition addrr_pchar2 := addrr_pchar2.
+#[deprecated(since="mathcomp 2.4.0", note="Use addrr_pchar2 instead.")]
+Definition addrr_char2 := addrr_pchar2.
+Definition oppr_pchar2 := oppr_pchar2.
+#[deprecated(since="mathcomp 2.4.0", note="Use oppr_pchar2 instead.")]
+Definition oppr_char2 := oppr_pchar2.
+Definition addrK_pchar2 := addrK_pchar2.
+#[deprecated(since="mathcomp 2.4.0", note="Use addrK_pchar2 instead.")]
+Definition addrK_char2 := addrK_pchar2.
+Definition addKr_pchar2 := addKr_pchar2.
+#[deprecated(since="mathcomp 2.4.0", note="Use addKr_pchar2 instead.")]
+Definition addKr_char2 := addKr_pchar2.
 Definition iter_mulr := iter_mulr.
 Definition iter_mulr_1 := iter_mulr_1.
 Definition prodr_const := prodr_const.
@@ -6976,7 +7102,9 @@ Definition sqrrD := sqrrD.
 Definition sqrrB := sqrrB.
 Definition subr_sqr := subr_sqr.
 Definition subr_sqrDB := subr_sqrDB.
-Definition exprDn_char := exprDn_char.
+Definition exprDn_pchar := exprDn_pchar.
+#[deprecated(since="mathcomp 2.4.0", note="Use exprDn_pchar instead.")]
+Definition exprDn_char := exprDn_pchar.
 Definition mulrV := mulrV.
 Definition divrr := divrr.
 Definition mulVr := mulVr.
@@ -7068,7 +7196,9 @@ Definition rpredV := rpredV.
 Definition rpred_div := rpred_div.
 Definition rpredXN := rpredXN.
 Definition rpredZeq := rpredZeq.
-Definition char_lalg := char_lalg.
+Definition pchar_lalg := pchar_lalg.
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar_lalg instead.")]
+Definition char_lalg := pchar_lalg.
 Definition rpredMr := rpredMr.
 Definition rpredMl := rpredMl.
 Definition rpred_divr := rpred_divr.
@@ -7095,10 +7225,18 @@ Definition prodf_seq_neq0 := prodf_seq_neq0.
 Definition expf_eq0 := expf_eq0.
 Definition sqrf_eq0 := sqrf_eq0.
 Definition expf_neq0 := expf_neq0.
-Definition natf_neq0 := natf_neq0.
-Definition natf0_char := natf0_char.
-Definition charf'_nat := charf'_nat.
-Definition charf0P := charf0P.
+Definition natf_neq0_pchar := natf_neq0_pchar.
+#[deprecated(since="mathcomp 2.4.0", note="Use natf_neq0_pchar instead.")]
+Definition natf_neq0 := natf_neq0_pchar.
+Definition natf0_pchar := natf0_pchar.
+#[deprecated(since="mathcomp 2.4.0", note="Use natf0_pchar instead.")]
+Definition natf0_char := natf0_pchar.
+Definition pcharf'_nat := pcharf'_nat.
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf'_nat instead.")]
+Definition charf'_nat := pcharf'_nat.
+Definition pcharf0P := pcharf0P.
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf0P instead.")]
+Definition charf0P := pcharf0P.
 Definition eqf_sqr := eqf_sqr.
 Definition mulfI := mulfI.
 Definition mulIf := mulIf.
@@ -7130,7 +7268,9 @@ Definition addf_div := addf_div.
 Definition mulf_div := mulf_div.
 Definition eqr_div := eqr_div.
 Definition eqr_sum_div := eqr_sum_div.
-Definition char0_natf_div := char0_natf_div.
+Definition pchar0_natf_div := pchar0_natf_div.
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar0_natf_div instead.")]
+Definition char0_natf_div := pchar0_natf_div.
 Definition fpredMr := fpredMr.
 Definition fpredMl := fpredMl.
 Definition fpred_divr := fpred_divr.
@@ -7175,7 +7315,9 @@ Definition rmorph_prod := rmorph_prod.
 Definition rmorphXn := rmorphXn.
 Definition rmorphN1 := rmorphN1.
 Definition rmorph_sign := rmorph_sign.
-Definition rmorph_char := rmorph_char.
+Definition rmorph_pchar := rmorph_pchar.
+#[deprecated(since="mathcomp 2.4.0", note="Use rmorph_pchar instead.")]
+Definition rmorph_char := rmorph_pchar.
 Definition can2_rmorphism := can2_rmorphism.
 Definition rmorph_comm := rmorph_comm.
 Definition rmorph_unit := rmorph_unit.
@@ -7186,7 +7328,9 @@ Definition fmorph_inj := @fmorph_inj.
 Arguments fmorph_inj {F R} f [x1 x2].
 Definition fmorph_eq := fmorph_eq.
 Definition fmorph_eq1 := fmorph_eq1.
-Definition fmorph_char := fmorph_char.
+Definition fmorph_pchar := fmorph_pchar.
+#[deprecated(since="mathcomp 2.4.0", note="Use fmorph_pchar instead.")]
+Definition fmorph_char := fmorph_pchar.
 Definition fmorph_unit := fmorph_unit.
 Definition fmorphV := fmorphV.
 Definition fmorph_div := fmorph_div.
@@ -7353,10 +7497,16 @@ Notation "1" := (@one _) : ring_scope.
 Notation "- 1" := (opp 1) : ring_scope.
 
 Notation "n %:R" := (natmul 1 n) : ring_scope.
-Arguments GRing.char R%_type.
-Notation "[ 'char' R ]" := (GRing.char R) : ring_scope.
-Notation has_char0 R := (GRing.char R =i pred0).
-Notation Frobenius_aut chRp := (Frobenius_aut chRp).
+Arguments GRing.pchar R%_type.
+Notation "[ 'pchar' R ]" := (GRing.pchar R) : ring_scope.
+#[deprecated(since="mathcomp 2.4.0", note="Use [pchar R] instead.")]
+Notation "[ 'char' R ]" := (GRing.pchar R) : ring_scope.
+Notation has_pchar0 R := (GRing.pchar R =i pred0).
+#[deprecated(since="mathcomp 2.4.0", note="Use has_pchar0 instead.")]
+Notation has_char0 R := (GRing.pchar R =i pred0).
+Notation pFrobenius_aut chRp := (pFrobenius_aut chRp).
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_aut instead.")]
+Notation Frobenius_aut chRp := (pFrobenius_aut chRp).
 Notation "*%R" := (@mul _) : function_scope.
 Notation "x * y" := (mul x y) : ring_scope.
 Arguments exp : simpl never.

--- a/algebra/ssrint.v
+++ b/algebra/ssrint.v
@@ -765,20 +765,26 @@ Variable R : nzRingType.
 Implicit Types x y : R.
 
 Variable p : nat.
-Hypothesis charFp : p \in [char R].
+Hypothesis pcharFp : p \in [pchar R].
 
-Local Notation "x ^f" := (Frobenius_aut charFp x).
+Local Notation "x ^f" := (pFrobenius_aut pcharFp x).
 
-Lemma Frobenius_autMz x n : (x *~ n)^f = x^f *~ n.
+Lemma pFrobenius_autMz x n : (x *~ n)^f = x^f *~ n.
 Proof.
-case: n=> n /=; first exact: Frobenius_autMn.
-by rewrite !NegzE !mulrNz Frobenius_autN Frobenius_autMn.
+case: n=> n /=; first exact: pFrobenius_autMn.
+by rewrite !NegzE !mulrNz pFrobenius_autN pFrobenius_autMn.
 Qed.
 
-Lemma Frobenius_aut_int n : (n%:~R)^f = n%:~R.
-Proof. by rewrite Frobenius_autMz Frobenius_aut1. Qed.
+Lemma pFrobenius_aut_int n : (n%:~R)^f = n%:~R.
+Proof. by rewrite pFrobenius_autMz pFrobenius_aut1. Qed.
 
 End Frobenius.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_autMz instead.")]
+Notation Frobenius_autMz := (pFrobenius_autMz) (only parsing).
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pFrobenius_aut_int instead.")]
+Notation Frobenius_aut_int := (pFrobenius_aut_int) (only parsing).
 
 Section NumMorphism.
 

--- a/algebra/ssrnum.v
+++ b/algebra/ssrnum.v
@@ -598,7 +598,7 @@ Hint Extern 0 (is_true (@Order.lt ring_display _ _ _)) =>
 Lemma pnatr_eq0 n : (n%:R == 0 :> R) = (n == 0)%N.
 Proof. by case: n => [|n]; rewrite ?mulr0n ?eqxx // gt_eqF. Qed.
 
-Lemma char_num : [char R] =i pred0.
+Lemma pchar_num : [pchar R] =i pred0.
 Proof. by case=> // p /=; rewrite !inE pnatr_eq0 andbF. Qed.
 
 (* Properties of the norm. *)
@@ -770,6 +770,9 @@ Lemma addr_ge0 x y : 0 <= x -> 0 <= y -> 0 <= x + y.
 Proof. exact: addr_ge0. Qed.
 
 End NumIntegralDomainTheory.
+
+#[deprecated(since="mathcomp 2.4.0",note="Use pchar_num instead.")]
+Notation char_num := pchar_num (only parsing).
 
 Arguments ler01 {R}.
 Arguments ltr01 {R}.
@@ -2981,7 +2984,7 @@ Proof. by move=> z_lt0; rewrite mulrC ltr_ndivrMr ?[z * _]mulrC. Qed.
 Definition lter_ndivrMl := (ler_ndivrMl, ltr_ndivrMl).
 
 Lemma natf_div m d : (d %| m)%N -> (m %/ d)%:R = m%:R / d%:R :> F.
-Proof. by apply: char0_natf_div; apply: (@char_num F). Qed.
+Proof. by apply: pchar0_natf_div; apply: (@pchar_num F). Qed.
 
 Lemma normfV : {morph (norm : F -> F) : x / x ^-1}.
 Proof.

--- a/algebra/zmodp.v
+++ b/algebra/zmodp.v
@@ -320,7 +320,7 @@ Proof. by rewrite Zp_nat /= Zp_cast. Qed.
 Lemma Zp_nat_mod (p_gt1 : p > 1)m : (m %% p)%:R = m%:R :> 'Z_p.
 Proof. by apply: ord_inj; rewrite !val_Zp_nat // modn_mod. Qed.
 
-Lemma char_Zp : p > 1 -> p%:R = 0 :> 'Z_p.
+Lemma pchar_Zp : p > 1 -> p%:R = 0 :> 'Z_p.
 Proof. by move=> p_gt1; rewrite -Zp_nat_mod ?modnn. Qed.
 
 Lemma unitZpE x : p > 1 -> ((x%:R : 'Z_p) \is a GRing.unit) = coprime p x.
@@ -356,6 +356,9 @@ Proof. by apply/centsP=> u _ v _; apply: unit_Zp_mulgC. Qed.
 
 End Groups.
 
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar_Zp instead.")]
+Notation char_Zp := (pchar_Zp) (only parsing).
+
 (* Field structure for primes. *)
 
 Section PrimeField.
@@ -383,11 +386,11 @@ Proof. by rewrite Zp_nat /= Fp_cast. Qed.
 Lemma Fp_nat_mod m : (m %% p)%:R = m%:R :> 'F_p.
 Proof. by apply: ord_inj; rewrite !val_Fp_nat // modn_mod. Qed.
 
-Lemma char_Fp : p \in [char 'F_p].
+Lemma pchar_Fp : p \in [pchar 'F_p].
 Proof. by rewrite !inE -Fp_nat_mod p_pr ?modnn. Qed.
 
-Lemma char_Fp_0 : p%:R = 0 :> 'F_p.
-Proof. exact: GRing.charf0 char_Fp. Qed.
+Lemma pchar_Fp_0 : p%:R = 0 :> 'F_p.
+Proof. exact: GRing.pcharf0 pchar_Fp. Qed.
 
 Lemma unitFpE x : ((x%:R : 'F_p) \is a GRing.unit) = coprime p x.
 Proof. by rewrite pdiv_id // unitZpE // prime_gt1. Qed.
@@ -450,3 +453,9 @@ by rewrite tpermJ !perm_addr1X natr_Zp addrNK addrAC addrA.
 Qed.
 
 End Sym.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar_Fp instead.")]
+Notation char_Fp := (pchar_Fp) (only parsing).
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar_Fp_0 instead.")]
+Notation char_Fp_0 := (pchar_Fp_0) (only parsing).

--- a/character/character.v
+++ b/character/character.v
@@ -440,21 +440,22 @@ Definition standard_grepr :=
 Lemma mx_rsim_standard : mx_rsim rG standard_grepr.
 Proof.
 pose W i := oapp val 0 (soc i); pose S := (\sum_i W i)%MS.
-have C'G: [char algC]^'.-group G := algC'G G.
+have C'G: [pchar algC]^'.-group G := algC'G_pchar G.
 have [defS dxS]: (S :=: 1%:M)%MS /\ mxdirect S.
   rewrite /S mxdirectE /= !(bigID soc xpredT) /=.
   rewrite addsmxC big1 => [|i]; last by rewrite /W; case (soc i).
   rewrite adds0mx_id addnC (@big1 nat) ?add0n => [|i]; last first.
     by rewrite /W; case: (soc i); rewrite ?mxrank0.
-  have <-: Socle sG = 1%:M := reducible_Socle1 sG (mx_Maschke rG C'G).
+  have <-: Socle sG = 1%:M := reducible_Socle1 sG (mx_Maschke_pchar rG C'G).
   have [W0 _ | noW] := pickP sG; last first.
     suff no_i: (soc : pred iG) =1 xpred0 by rewrite /Socle !big_pred0 ?mxrank0.
     by move=> i; rewrite /soc; case: pickP => // W0; have:= noW W0.
   have irrK Wi: soc (standard_irr Wi) = Some Wi.
     rewrite /soc; case: pickP => [W' | /(_ Wi)] /= /eqP // eqWi.
     apply/eqP/socle_rsimP.
-    apply: mx_rsim_trans (rsim_irr_comp iG C'G (socle_irr _)) (mx_rsim_sym _).
-    by rewrite [irr_comp _ _]eqWi; apply: rsim_irr_comp (socle_irr _).
+    apply: mx_rsim_trans
+      (rsim_irr_comp_pchar iG C'G (socle_irr _)) (mx_rsim_sym _).
+    by rewrite [irr_comp _ _]eqWi; apply: rsim_irr_comp_pchar (socle_irr _).
   have bij_irr: {on [pred i | soc i], bijective standard_irr}.
     exists (odflt W0 \o soc) => [Wi _ | i]; first by rewrite /= irrK.
     by rewrite inE /soc /=; case: pickP => //= Wi; move/eqP.
@@ -473,7 +474,8 @@ apply: mx_rsim_dsum (modW) _ defS dxS _ => i.
 rewrite /W /standard_irr_coef /modW /soc; case: pickP => [Wi|_] /=; last first.
   rewrite /muln_grepr big_ord0.
   by exists 0 => [||x _]; rewrite /row_free ?mxrank0 ?mulmx0 ?mul0mx.
-by move/eqP=> <-; apply: mx_rsim_socle; apply: rsim_irr_comp (socle_irr Wi).
+move/eqP=> <-; apply: mx_rsim_socle.
+exact: rsim_irr_comp_pchar (socle_irr Wi).
 Qed.
 
 End StandardRepr.
@@ -550,7 +552,7 @@ Lemma NirrE : Nirr G = #|classes G|.
 Proof. by rewrite /pred_Nirr (cardD1 [1]) classes1. Qed.
 
 Fact Iirr_cast : Nirr G = #|sG|.
-Proof. by rewrite NirrE ?card_irr ?algC'G //; apply: groupC. Qed.
+Proof. by rewrite NirrE ?card_irr_pchar ?algC'G_pchar //; apply: groupC. Qed.
 
 Let offset := cast_ord (esym Iirr_cast) (enum_rank [1 sG]%irr).
 
@@ -634,7 +636,7 @@ by exists (Ordinal lt_i_G); rewrite (tnth_nth 0).
 Qed.
 
 Let sG := DecSocleType (regular_repr algC G).
-Let C'G := algC'G G.
+Let C'G := algC'G_pchar G.
 Let closG := @groupC _ G.
 Local Notation W i := (@socle_of_Iirr _ G i).
 Local Notation "''n_' i" := 'n_(W i).
@@ -674,14 +676,16 @@ Proof. by move=> irr_f j /irr_f; apply: cfIirrE. Qed.
 (* This is Isaacs, Corollary (2.7). *)
 Corollary irr_sum_square : \sum_i ('chi[G]_i 1%g) ^+ 2 = #|G|%:R.
 Proof.
-rewrite -(sum_irr_degree sG) // natr_sum (reindex _ (socle_of_Iirr_bij _)) /=.
+rewrite -(sum_irr_degree_pchar sG) // natr_sum.
+rewrite (reindex _ (socle_of_Iirr_bij _)) /=.
 by apply: eq_bigr => i _; rewrite irr1_degree natrX.
 Qed.
 
 (* This is Isaacs, Lemma (2.11). *)
 Lemma cfReg_sum : cfReg G = \sum_i 'chi_i 1%g *: 'chi_i.
 Proof.
-apply/cfun_inP=> x Gx; rewrite -cfReprReg cfunE Gx (mxtrace_regular sG) //=.
+apply/cfun_inP=> x Gx.
+rewrite -cfReprReg cfunE Gx (mxtrace_regular_pchar sG) //=.
 rewrite sum_cfunE (reindex _ (socle_of_Iirr_bij _)); apply: eq_bigr => i _.
 by rewrite -irrRepr cfRepr1 !cfunE Gx mulr_natl.
 Qed.
@@ -692,7 +696,8 @@ Let R_G := group_ring algC G.
 Lemma xcfun_annihilate i j A : i != j -> (A \in 'R_j)%MS -> ('chi_i).[A]%CF = 0.
 Proof.
 move=> neq_ij RjA; rewrite -irrRepr xcfun_repr.
-by rewrite (irr_repr'_op0 _ _ RjA) ?raddf0 // eq_sym (can_eq socle_of_IirrK).
+rewrite (irr_repr'_op0_pchar _ _ RjA) ?raddf0 //.
+by rewrite eq_sym (can_eq socle_of_IirrK).
 Qed.
 
 Lemma xcfunG phi x : x \in G -> phi.[aG x]%CF = phi x.
@@ -704,7 +709,7 @@ Lemma xcfun_mul_id i A :
   (A \in R_G)%MS -> ('chi_i).['e_i *m A]%CF = ('chi_i).[A]%CF.
 Proof.
 move=> RG_A; rewrite -irrRepr !xcfun_repr gring_opM //.
-by rewrite op_Wedderburn_id ?mul1mx.
+by rewrite op_Wedderburn_id_pchar ?mul1mx.
 Qed.
 
 Lemma xcfun_id i j : ('chi_i).['e_j]%CF = 'chi_i 1%g *+ (i == j).
@@ -781,7 +786,7 @@ Proof.
 apply: (iffP (irrP xi)) => [[i ->] | [[n rG] irr_rG ->]].
   by exists (Representation 'Chi_i); [apply: socle_irr | rewrite irrRepr].
 exists (irr_of_socle (irr_comp sG rG)); rewrite -irrRepr irr_of_socleK /=.
-exact/cfRepr_sim/rsim_irr_comp.
+exact/cfRepr_sim/rsim_irr_comp_pchar.
 Qed.
 
 (* This is Isaacs, Theorem (2.12). *)
@@ -1129,7 +1134,8 @@ move=> Gx; without loss cGG: G rG Gx / abelian G.
   move/(_ _ (subg_repr rG sXG) (cycle_id x) (cycle_abelian x)).
   by rewrite /= !cfunE !groupV Gx (cycle_id x) !group1.
 have [I U W simU W1 dxW]: mxsemisimple rG 1%:M.
-  rewrite -(reducible_Socle1 (DecSocleType rG) (mx_Maschke _ (algC'G G))).
+  rewrite -(reducible_Socle1 (DecSocleType rG)
+    (mx_Maschke_pchar _ (algC'G_pchar G))).
   exact: Socle_semisimple.
 have linU i: \rank (U i) = 1.
   by apply: mxsimple_abelian_linear cGG (simU i); apply: groupC.
@@ -1258,7 +1264,7 @@ apply/matrixP=> i j; rewrite !mxE -first_orthogonality_relation mulr_sumr.
 rewrite sum_by_classes => [|u v Gu Gv]; last by rewrite -conjVg !cfunJ.
 rewrite reindex_irr_class /=; apply/esym/eq_bigr=> k _.
 rewrite !mxE irr_inv // -/(g k) -divg_index -indexgI /=.
-rewrite (char0_natf_div Cchar) ?dvdn_indexg // index_cent1 invfM invrK.
+rewrite (pchar0_natf_div Cpchar) ?dvdn_indexg // index_cent1 invfM invrK.
 by rewrite repr_irr_classK mulrCA mulrA mulrCA.
 Qed.
 
@@ -2590,7 +2596,10 @@ Variables (gT : finGroupType) (G : {group gT}).
 Local Notation cfDet := (@cfDet gT G).
 
 Lemma cfDet_lin_char phi : cfDet phi \is a linear_char.
-Proof. by rewrite unlock; apply: rpred_prod => i _; apply: rpredX; apply: detRepr_lin_char. Qed.
+Proof.
+rewrite unlock; apply: rpred_prod => i _; apply: rpredX.
+exact: detRepr_lin_char.
+Qed.
 
 Lemma cfDetD :
   {in character &, {morph cfDet : phi psi / phi + psi >-> phi * psi}}.

--- a/character/classfun.v
+++ b/character/classfun.v
@@ -127,10 +127,13 @@ Proof. exact: natr_indexg_neq0. Qed.
 Lemma gt0CG G : 0 < #|G|%:R :> algC. Proof. exact: natrG_gt0. Qed.
 Lemma gt0CiG G B : 0 < #|G : B|%:R :> algC. Proof. exact: natr_indexg_gt0. Qed.
 
-Lemma algC'G G : [char algC]^'.-group G.
-Proof. by apply/pgroupP=> p _; rewrite inE /= char_num. Qed.
+Lemma algC'G_pchar G : [pchar algC]^'.-group G.
+Proof. by apply/pgroupP=> p _; rewrite inE /= pchar_num. Qed.
 
 End AlgC.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use algC'G_pchar instead.")]
+Notation algC'G := (algC'G_pchar) (only parsing).
 
 Section Defs.
 

--- a/character/mxabelem.v
+++ b/character/mxabelem.v
@@ -758,11 +758,11 @@ Arguments rVabelem_inj {p%_N gT E%_G} abelE ntE [v1%_R v2%_R] : rename.
 Section ModularRepresentation.
 
 Variables (F : fieldType) (p : nat) (gT : finGroupType).
-Hypothesis charFp : p \in [char F].
+Hypothesis pcharFp : p \in [pchar F].
 Implicit Types G H : {group gT}.
 
 (* This is Gorenstein, Lemma 2.6.3. *)
-Lemma rfix_pgroup_char G H n (rG : mx_representation F G n) :
+Lemma rfix_pgroup_pchar G H n (rG : mx_representation F G n) :
   n > 0 -> p.-group H -> H \subset G -> rfix_mx rG H != 0.
 Proof.
 move=> n_gt0 pH sHG; rewrite -(rfix_subg rG sHG).
@@ -784,7 +784,7 @@ have{Gregular} ntG: G :!=: 1%g.
   apply: contraL n_gt0; move/eqP=> G1; rewrite -leqNgt -(mxrank1 F n).
   rewrite -(mxrank0 F n n) -Gregular mxrankS //; apply/rfix_mxP=> x.
   by rewrite {1}G1 mul1mx => /set1P->; rewrite repr_mx1.
-have p_pr: prime p by case/andP: charFp.
+have p_pr: prime p by case/andP: pcharFp.
 have{ntG pG} [z]: {z | z \in 'Z(G) & #[z] = p}; last case/setIP=> Gz cGz ozp.
   apply: Cauchy => //; apply: contraR ntG; rewrite -p'natE // => p'Z.
   have pZ: p.-group 'Z(G) by rewrite (pgroupS (center_sub G)).
@@ -797,16 +797,17 @@ have{irrG faithfulG cGz1} Urz1: rG z - 1%:M \in unitmx.
   move/implyP: (subsetP faithfulG z).
   by rewrite !inE Gz mul1mx -order_eq1 ozp -implybNN neq_ltn orbC prime_gt1.
 do [case: n n_gt0 => // n' _; set n := n'.+1] in rG Urz1 *.
-have charMp: p \in [char 'M[F]_n].
-  exact: (rmorph_char (@scalar_mx F n)).
-have{Urz1}: Frobenius_aut charMp (rG z - 1) \in GRing.unit by rewrite unitrX.
-rewrite (Frobenius_autB_comm _ (commr1 _)) Frobenius_aut1.
+have pcharMp: p \in [pchar 'M[F]_n].
+  exact: (rmorph_pchar (@scalar_mx F n)).
+have{Urz1}: pFrobenius_aut pcharMp (rG z - 1) \in GRing.unit by rewrite unitrX.
+rewrite (pFrobenius_autB_comm _ (commr1 _)) pFrobenius_aut1.
 by rewrite -[_ (rG z)](repr_mxX rG) // -ozp expg_order repr_mx1 subrr unitr0.
 Qed.
 
 Variables (G : {group gT}) (n : nat) (rG : mx_representation F G n).
 
-Lemma pcore_sub_rstab_mxsimple M : mxsimple rG M -> 'O_p(G) \subset rstab rG M.
+Lemma pcore_sub_rstab_mxsimple_pchar M :
+  mxsimple rG M -> 'O_p(G) \subset rstab rG M.
 Proof.
 case=> modM nzM simM; have sGpG := pcore_sub p G.
 rewrite rfix_mx_rstabC //; set U := rfix_mx _ _.
@@ -814,29 +815,39 @@ have:= simM (M :&: U)%MS; rewrite sub_capmx submx_refl.
 apply; rewrite ?capmxSl //.
   by rewrite capmx_module // normal_rfix_mx_module ?pcore_normal.
 rewrite -(in_submodK (capmxSl _ _)) val_submod_eq0 -submx0.
-rewrite -(rfix_submod modM) // submx0 rfix_pgroup_char ?pcore_pgroup //.
+rewrite -(rfix_submod modM) // submx0 rfix_pgroup_pchar ?pcore_pgroup //.
 by rewrite lt0n mxrank_eq0.
 Qed.
 
-Lemma pcore_sub_rker_mx_irr : mx_irreducible rG -> 'O_p(G) \subset rker rG.
-Proof. exact: pcore_sub_rstab_mxsimple. Qed.
+Lemma pcore_sub_rker_mx_irr_pchar :
+  mx_irreducible rG -> 'O_p(G) \subset rker rG.
+Proof. exact: pcore_sub_rstab_mxsimple_pchar. Qed.
 
 (* This is Gorenstein, Lemma 3.1.3. *)
-Lemma pcore_faithful_mx_irr :
+Lemma pcore_faithful_mx_irr_pchar :
   mx_irreducible rG -> mx_faithful rG -> 'O_p(G) = 1%g.
 Proof.
 move=> irrG ffulG; apply/trivgP; apply: subset_trans ffulG.
-exact: pcore_sub_rstab_mxsimple.
+exact: pcore_sub_rstab_mxsimple_pchar.
 Qed.
 
 End ModularRepresentation.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use rfix_pgroup_pchar instead.")]
+Notation rfix_pgroup_char := (rfix_pgroup_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pcore_sub_rstab_mxsimple_pchar instead.")]
+Notation pcore_sub_rstab_mxsimple := (pcore_sub_rstab_mxsimple_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pcore_sub_rker_mx_irr_pchar instead.")]
+Notation pcore_sub_rker_mx_irr := (pcore_sub_rker_mx_irr_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pcore_faithful_mx_irr_pchar instead.")]
+Notation pcore_faithful_mx_irr := (pcore_faithful_mx_irr_pchar) (only parsing).
 
 Section Extraspecial.
 
 Variables (F : fieldType) (gT : finGroupType) (S : {group gT}) (p n : nat).
 Hypotheses (pS : p.-group S) (esS : extraspecial S).
 Hypothesis oSpn : #|S| = (p ^ n.*2.+1)%N.
-Hypotheses (splitF : group_splitting_field F S) (F'S : [char F]^'.-group S).
+Hypotheses (splitF : group_splitting_field F S) (F'S : [pchar F]^'.-group S).
 
 Let p_pr := extraspecial_prime pS esS.
 Let p_gt0 := prime_gt0 p_pr.
@@ -847,7 +858,7 @@ Let modIp' (i : 'I_p.-1) : (i.+1 %% p = i.+1)%N.
 Proof. by case: i => i; rewrite /= -ltnS prednK //; apply: modn_small. Qed.
 
 (* This is Aschbacher (34.9), parts (1)-(4). *)
-Theorem extraspecial_repr_structure (sS : irrType F S) :
+Theorem extraspecial_repr_structure_pchar (sS : irrType F S) :
   [/\ #|linear_irr sS| = (p ^ n.*2)%N,
       exists iphi : 'I_p.-1 -> sS, let phi i := irr_repr (iphi i) in
         [/\ injective iphi,
@@ -886,7 +897,7 @@ have nb_irr: #|sS| = (p ^ n.*2 + p.-1)%N.
   rewrite sum1dep_card setIdE (setIidPr _) 1?cardsE ?cardZcl; last first.
     by apply/subsetP=> zS /[!inE] /andP[].
   have pn_gt0: p ^ n.*2 > 0 by rewrite expn_gt0 p_gt0.
-  rewrite card_irr // oSpn expnS -(prednK pn_gt0) mulnS eqn_add2l.
+  rewrite card_irr_pchar // oSpn expnS -(prednK pn_gt0) mulnS eqn_add2l.
   rewrite (eq_bigr (fun _ => p)) => [|xS]; last first.
     case/andP=> SxS; rewrite inE SxS; case/imsetP: SxS => x Sx ->{xS} notZxS.
     have [y Sy ->] := repr_class S x; apply: p_maximal_index => //.
@@ -958,7 +969,7 @@ pose iphi i := irr_comp sS (rphi i); pose phi_ i := irr_repr (iphi i).
 have{} phi_ze i e: phi_ i (z ^+ e)%g = (w ^+ (e * i.+1)%N)%:M.
   rewrite /phi_ !{1}irr_center_scalar ?groupX ?irr_modeX //.
   suffices ->: irr_mode (iphi i) z = w ^+ i.+1 by rewrite mulnC exprM.
-  have:= mx_rsim_sym (rsim_irr_comp sS F'S (rphi_irr i)).
+  have:= mx_rsim_sym (rsim_irr_comp_pchar sS F'S (rphi_irr i)).
   case/mx_rsim_def=> B [B' _ homB]; rewrite /irr_mode homB // rphi_z.
   rewrite -{1}scalemx1 -scalemxAr -scalemxAl -{1}(repr_mx1 (rphi i)).
   by rewrite -homB // repr_mx1 scalemx1 mxE.
@@ -968,14 +979,14 @@ have inj_iphi: injective iphi.
   rewrite /irr_mode !{1}[irr_repr _ _]phi_ze !{1}mxE !mul1n.
   by rewrite (eq_prim_root_expr (prim_w 1 p_gt1)) !modIp'.
 have deg_phi i: irr_degree (iphi i) = irr_degree i0.
-  by case: (rsim_irr_comp sS F'S (rphi_irr i)).
+  by case: (rsim_irr_comp_pchar sS F'S (rphi_irr i)).
 have im_iphi: codom iphi =i ~: linS.
   apply/subset_cardP; last apply/subsetP=> _ /codomP[i ->].
     by rewrite card_image // card_ord cardsCs setCK nb_irr nb_lin addKn.
   by rewrite !inE /= (deg_phi i) in nlin_i0 *.
 split=> //; exists iphi; rewrite -/phi_.
 split=> // [i | ze | i].
-- have sim_i := rsim_irr_comp sS F'S (rphi_irr i).
+- have sim_i := rsim_irr_comp_pchar sS F'S (rphi_irr i).
   by rewrite -(mx_rsim_faithful sim_i) rphi_fful.
 - rewrite {1}defZ 2!inE andbC; case/andP.
   case/cyclePmin=> e; rewrite ozp => lt_e_p ->{ze}.
@@ -983,7 +994,7 @@ split=> // [i | ze | i].
   exists (w ^+ e) => [|i]; first by rewrite prim_w ?e_gt0.
   by rewrite phi_ze exprM.
 rewrite deg_phi {i}; set d := irr_degree i0.
-apply/eqP; move/eqP: (sum_irr_degree sS F'S splitF).
+apply/eqP; move/eqP: (sum_irr_degree_pchar sS F'S splitF).
 rewrite (bigID [in linS]) /= -/irr_degree.
 rewrite (eq_bigr (fun=> 1)) => [|i]; last by rewrite !inE; move/eqP->.
 rewrite sum1_card nb_lin.
@@ -1005,7 +1016,7 @@ Hypotheses (simU :  mxsimple rS U) (ffulU : rstab rS U == 1%g).
 Let sZS := center_sub S.
 Let rZ := subg_repr rS sZS.
 
-Lemma faithful_repr_extraspecial :
+Lemma faithful_repr_extraspecial_pchar :
  \rank U = (p ^ n)%N /\
    (forall V, mxsimple rS V -> mx_iso rZ U V -> mx_iso rS U V).
 Proof.
@@ -1017,20 +1028,20 @@ suffices IH V: mxsimple rS V -> mx_iso rZ U V ->
 move=> simV isoUV; wlog sS: / irrType F S by apply: socle_exists.
 have [[_ defS'] prZ] := esS.
 have{prZ} ntZ: 'Z(S) :!=: 1%g by case: eqP prZ => // ->; rewrite cards1.
-have [_ [iphi]] := extraspecial_repr_structure sS.
+have [_ [iphi]] := extraspecial_repr_structure_pchar sS.
 set phi := fun i => _ => [] [inj_phi im_phi _ phiZ dim_phi] _.
 have [modU nzU _]:= simU; pose rU := submod_repr modU.
 have nlinU: \rank U != 1.
   apply/eqP=> /(rker_linear rU); apply/negP; rewrite /rker rstab_submod.
   by rewrite (eqmx_rstab _ (val_submod1 _)) (eqP ffulU) defS' subG1.
 have irrU: mx_irreducible rU by apply/submod_mx_irr.
-have rsimU := rsim_irr_comp sS F'S irrU.
+have rsimU := rsim_irr_comp_pchar sS F'S irrU.
 set iU := irr_comp sS rU in rsimU; have [_ degU _ _]:= rsimU.
 have phiUP: iU \in codom iphi by rewrite im_phi !inE -degU.
 rewrite degU -(f_iinv phiUP) dim_phi eqxx /=; apply/(mxsimple_isoP simU).
 have [modV _ _]:= simV; pose rV := submod_repr modV.
 have irrV: mx_irreducible rV by apply/submod_mx_irr.
-have rsimV := rsim_irr_comp sS F'S irrV.
+have rsimV := rsim_irr_comp_pchar sS F'S irrV.
 set iV := irr_comp sS rV in rsimV; have [_ degV _ _]:= rsimV.
 have phiVP: iV \in codom iphi by rewrite im_phi !inE -degV -(mxrank_iso isoUV).
 pose jU := iinv phiUP; pose jV := iinv phiVP.
@@ -1057,3 +1068,12 @@ by rewrite mxE (eq_prim_root_expr prim_w) !modIp'.
 Qed.
 
 End Extraspecial.
+
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use extraspecial_repr_structure_pchar instead.")]
+Notation extraspecial_repr_structure := (extraspecial_repr_structure_pchar)
+  (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use faithful_repr_extraspecial_pchar instead.")]
+Notation faithful_repr_extraspecial := (faithful_repr_extraspecial_pchar)
+  (only parsing).

--- a/character/mxrepresentation.v
+++ b/character/mxrepresentation.v
@@ -1154,8 +1154,8 @@ Lemma add_sub_fact_mod m (W : 'M_(m, n)) :
   val_submod (in_submod W) + val_factmod (in_factmod W) = W.
 Proof.
 rewrite /val_submod /val_factmod /= -!mulmxA -mulmxDr.
-rewrite addrC ![in X in X + _](mulmxA (pid_mx _)) pid_mx_id // (mulmxA (col_ebase _)).
-rewrite (mulmxA _ _ (row_ebase _)) mulmx_ebase.
+rewrite addrC ![in X in X + _](mulmxA (pid_mx _)) pid_mx_id //.
+rewrite (mulmxA (col_ebase _)) (mulmxA _ _ (row_ebase _)) mulmx_ebase.
 rewrite (mulmxA (pid_mx _)) pid_mx_id // mulmxA -mulmxDl -mulmxDr.
 by rewrite subrK mulmx1 mulmxA mulmxKV ?row_ebase_unit.
 Qed.
@@ -1849,9 +1849,9 @@ exists (W :&: U)%MS; first exact: capmx_module.
 by apply/mxdirect_addsP; rewrite capmxA (mxdirect_addsP dxU1W) cap0mx.
 Qed.
 
-Lemma mx_Maschke : [char F]^'.-group G -> mx_completely_reducible 1%:M.
+Lemma mx_Maschke_pchar : [pchar F]^'.-group G -> mx_completely_reducible 1%:M.
 Proof.
-rewrite /pgroup charf'_nat; set nG := _%:R => nzG U => /mxmoduleP Umod _.
+rewrite /pgroup pcharf'_nat; set nG := _%:R => nzG U => /mxmoduleP Umod _.
 pose phi := nG^-1 *: (\sum_(x in G) rG x^-1 *m pinvmx U *m U *m rG x).
 have phiG x: x \in G -> phi *m rG x = rG x *m phi.
   move=> Gx; rewrite -scalemxAl -scalemxAr; congr (_ *: _).
@@ -3053,8 +3053,8 @@ exists (in_submod V (val_submod 1%:M *m f)) => // [|x Gx].
   rewrite in_submodK; last by rewrite -defV submxMr ?val_submodP.
   by rewrite val_submod1 -defV submxMr ?val_submod1.
 rewrite -in_submodJ; last by rewrite -defV submxMr ?val_submodP.
-rewrite -(hom_mxP (submx_trans (val_submodP _) homf)) //.
-by rewrite -(val_submodJ modU) // mul1mx 2!(mulmxA ((submod_repr _) x)) -val_submodE.
+rewrite -(hom_mxP (submx_trans (val_submodP _) homf)) // -(val_submodJ modU) //.
+by rewrite  mul1mx 2!(mulmxA ((submod_repr _) x)) -val_submodE.
 Qed.
 
 Lemma mx_rsim_irr n1 n2 (rG1 : reprG n1) (rG2 : reprG n2) :
@@ -3943,13 +3943,13 @@ have [i simVU] := mx_JordanHolder_max compU lastU irrV.
 by exists i; apply: mx_rsim_trans simGV simVU.
 Qed.
 
-Hypothesis F'G : [char F]^'.-group G.
+Hypothesis F'G : [pchar F]^'.-group G.
 
-Lemma rsim_regular_submod :
+Lemma rsim_regular_submod_pchar :
   {U : 'M_nG & {modU : mxmodule aG U & mx_rsim rG (submod_repr modU)}}.
 Proof.
 have [V [modV eqG'V]] := rsim_regular_factmod.
-have [U modU defVU dxVU] := mx_Maschke F'G modV (submx1 V).
+have [U modU defVU dxVU] := mx_Maschke_pchar F'G modV (submx1 V).
 exists U; exists modU; apply: mx_rsim_trans eqG'V _.
 by apply: mx_rsim_factmod; rewrite ?mxdirectE /= addsmxC // addnC.
 Qed.
@@ -4162,24 +4162,27 @@ move=> ne_ij RiA RjB; apply: memmx0.
 by rewrite -(Wedderburn_annihilate ne_ij) mem_mulsmx.
 Qed.
 
-Hypothesis F'G : [char F]^'.-group G.
+Hypothesis F'G : [pchar F]^'.-group G.
 
-Lemma irr_mx_sum : (\sum_(i : sG) i = 1%:M)%MS.
-Proof. by apply: reducible_Socle1; apply: mx_Maschke. Qed.
+Lemma irr_mx_sum_pchar : (\sum_(i : sG) i = 1%:M)%MS.
+Proof. by apply: reducible_Socle1; apply: mx_Maschke_pchar. Qed.
 
-Lemma Wedderburn_sum : (\sum_i 'R_i :=: R_G)%MS.
-Proof. by apply: eqmx_trans sums_R _; rewrite /Socle irr_mx_sum mul1mx. Qed.
+Lemma Wedderburn_sum_pchar : (\sum_i 'R_i :=: R_G)%MS.
+Proof.
+by apply: eqmx_trans sums_R _; rewrite /Socle irr_mx_sum_pchar mul1mx.
+Qed.
 
 Definition Wedderburn_id i :=
   vec_mx (mxvec 1%:M *m proj_mx 'R_i (\sum_(j | j != i) 'R_j)%MS).
 
 Local Notation "''e_' i" := (Wedderburn_id i) : group_ring_scope.
 
-Lemma Wedderburn_sum_id : \sum_i 'e_i = 1%:M.
+Lemma Wedderburn_sum_id_pchar : \sum_i 'e_i = 1%:M.
 Proof.
 rewrite -linear_sum; apply: canLR mxvecK _.
 have: (1%:M \in R_G)%MS := envelop_mx1 aG.
-rewrite -Wedderburn_sum; case/(sub_dsumsmx Wedderburn_direct) => e Re -> _.
+rewrite -Wedderburn_sum_pchar.
+case/(sub_dsumsmx Wedderburn_direct) => e Re -> _.
 apply: eq_bigr => i _; have dxR := mxdirect_sumsP Wedderburn_direct i (erefl _).
 rewrite (bigD1 i) // mulmxDl proj_mx_id ?Re // proj_mx_0 ?addr0 //=.
 by rewrite summx_sub // => j ne_ji; rewrite (sumsmx_sup j) ?Re.
@@ -4188,38 +4191,38 @@ Qed.
 Lemma Wedderburn_id_mem i : ('e_i \in 'R_i)%MS.
 Proof. by rewrite vec_mxK proj_mx_sub. Qed.
 
-Lemma Wedderburn_is_id i : mxring_id 'R_i 'e_i.
+Lemma Wedderburn_is_id_pchar i : mxring_id 'R_i 'e_i.
 Proof.
 have ideRi A: (A \in 'R_i)%MS -> 'e_i *m A = A.
-  move=> RiA; rewrite -{2}[A]mul1mx -Wedderburn_sum_id mulmx_suml.
+  move=> RiA; rewrite -{2}[A]mul1mx -Wedderburn_sum_id_pchar mulmx_suml.
   rewrite (bigD1 i) //= big1 ?addr0 // => j ne_ji.
   by rewrite (Wedderburn_mulmx0 ne_ji) ?Wedderburn_id_mem.
   split=> // [||A RiA]; first 2 [exact: Wedderburn_id_mem].
   apply: contraNneq (nz_socle i) => e0.
   apply/rowV0P=> v; rewrite -mem_gring_mx -(genmxE (i *m _)) => /ideRi.
   by rewrite e0 mul0mx => /(canLR gring_mxK); rewrite linear0.
-rewrite -{2}[A]mulmx1 -Wedderburn_sum_id mulmx_sumr (bigD1 i) //=.
+rewrite -{2}[A]mulmx1 -Wedderburn_sum_id_pchar mulmx_sumr (bigD1 i) //=.
 rewrite big1 ?addr0 // => j; rewrite eq_sym => ne_ij.
 by rewrite (Wedderburn_mulmx0 ne_ij) ?Wedderburn_id_mem.
 Qed.
 
-Lemma Wedderburn_closed i : ('R_i * 'R_i = 'R_i)%MS.
+Lemma Wedderburn_closed_pchar i : ('R_i * 'R_i = 'R_i)%MS.
 Proof.
 rewrite -{3}['R_i]genmx_id -/'R_i -genmx_muls; apply/genmxP.
 have [idlRi idrRi] := andP (Wedderburn_ideal i).
 apply/andP; split.
   by apply: submx_trans idrRi; rewrite mulsmxS // genmxE submxMl.
-have [_ Ri_e ideRi _] := Wedderburn_is_id i.
+have [_ Ri_e ideRi _] := Wedderburn_is_id_pchar i.
 by apply/memmx_subP=> A RiA; rewrite -[A]ideRi ?mem_mulsmx.
 Qed.
 
-Lemma Wedderburn_is_ring i : mxring 'R_i.
+Lemma Wedderburn_is_ring_pchar i : mxring 'R_i.
 Proof.
-rewrite /mxring /left_mx_ideal Wedderburn_closed submx_refl.
-by apply/mxring_idP; exists 'e_i; apply: Wedderburn_is_id.
+rewrite /mxring /left_mx_ideal Wedderburn_closed_pchar submx_refl.
+by apply/mxring_idP; exists 'e_i; apply: Wedderburn_is_id_pchar.
 Qed.
 
-Lemma Wedderburn_min_ideal m i (E : 'A_(m, nG)) :
+Lemma Wedderburn_min_ideal_pchar m i (E : 'A_(m, nG)) :
   E != 0 -> (E <= 'R_i)%MS -> mx_ideal R_G E -> (E :=: 'R_i)%MS.
 Proof.
 move=> nzE sE_Ri /andP[idlE idrE]; apply/eqmxP; rewrite sE_Ri.
@@ -4233,7 +4236,7 @@ apply/sumsmx_subP=> j _.
 have simW := mx_iso_simple (isoW j) simSi; have [modW _ minW] := simW.
 have [{minW}dxWE | nzWE] := eqVneq (W j :&: M)%MS 0; last first.
   by rewrite (sameP capmx_idPl eqmxP) minW ?capmxSl ?capmx_module.
-have [_ Rei ideRi _] := Wedderburn_is_id i.
+have [_ Rei ideRi _] := Wedderburn_is_id_pchar i.
 have:= nzE; rewrite -submx0 => /memmx_subP[A E_A].
 rewrite -(ideRi _ (memmx_subP sE_Ri _ E_A)).
 have:= E_A; rewrite defE mem_sub_gring => /andP[R_A M_A].
@@ -4258,13 +4261,13 @@ Section IrrComponent.
 Variables (n : nat) (rG : mx_representation F G n).
 Local Notation E_G := (enveloping_algebra_mx rG).
 
-Let not_rsim_op0 (iG j : sG) A :
+Let not_rsim_op0_pchar  (iG j : sG) A :
     mx_rsim rG (socle_repr iG) -> iG != j -> (A \in 'R_j)%MS ->
   gring_op rG A = 0.
 Proof.
 case/mx_rsim_def=> f [f' _ hom_f] ne_iG_j RjA.
 transitivity (f *m in_submod _ (val_submod 1%:M *m A) *m f').
-  have{RjA}: (A \in R_G)%MS by rewrite -Wedderburn_sum (sumsmx_sup j).
+  have{RjA}: (A \in R_G)%MS by rewrite -Wedderburn_sum_pchar (sumsmx_sup j).
   case/envelop_mxP=> a ->{A}; rewrite !(linear_sum, mulmx_suml).
   by apply: eq_bigr => x Gx; rewrite 4!linearZ /= -scalemxAl -hom_f ?gring_opG.
 rewrite (_ : _ *m A = 0) ?(linear0, mul0mx) //.
@@ -4278,9 +4281,9 @@ Local Notation iG := irr_comp.
 
 Hypothesis irrG : mx_irreducible rG.
 
-Lemma rsim_irr_comp : mx_rsim rG (irr_repr iG).
+Lemma rsim_irr_comp_pchar : mx_rsim rG (irr_repr iG).
 Proof.
-have [M [modM rsimM]] := rsim_regular_submod irrG F'G.
+have [M [modM rsimM]] := rsim_regular_submod_pchar irrG F'G.
 have simM: mxsimple aG M.
   case/mx_irrP: irrG => n_gt0 minG.
   have [f def_n injf homf] := mx_rsim_sym rsimM.
@@ -4297,34 +4300,34 @@ have{modM} rsimM: mx_rsim rG (socle_repr i).
   by rewrite [component_mx _ _]PackSocleK component_mx_id.
 have [<- // | ne_i_iG] := eqVneq i iG.
 suffices {i M simM ne_i_iG rsimM}: gring_op rG 'e_iG != 0.
-  by rewrite (not_rsim_op0 rsimM ne_i_iG) ?Wedderburn_id_mem ?eqxx.
+  by rewrite (not_rsim_op0_pchar rsimM ne_i_iG) ?Wedderburn_id_mem ?eqxx.
 rewrite /iG; case: pickP => //= G0.
 suffices: rG 1%g == 0.
   by case/idPn; rewrite -mxrank_eq0 repr_mx1 mxrank1 -lt0n; case/mx_irrP: irrG.
-rewrite -gring_opG // repr_mx1 -Wedderburn_sum_id linear_sum big1 // => j _.
-by move/eqP: (G0 j).
+rewrite -gring_opG // repr_mx1 -Wedderburn_sum_id_pchar linear_sum big1 //.
+by move=> j _; move/eqP: (G0 j).
 Qed.
 
-Lemma irr_comp'_op0 j A : j != iG -> (A \in 'R_j)%MS -> gring_op rG A = 0.
-Proof. by rewrite eq_sym; apply: not_rsim_op0 rsim_irr_comp. Qed.
+Lemma irr_comp'_op0_pchar j A : j != iG -> (A \in 'R_j)%MS -> gring_op rG A = 0.
+Proof. by rewrite eq_sym; apply: not_rsim_op0_pchar rsim_irr_comp_pchar. Qed.
 
-Lemma irr_comp_envelop : ('R_iG *m lin_mx (gring_op rG) :=: E_G)%MS.
+Lemma irr_comp_envelop_pchar : ('R_iG *m lin_mx (gring_op rG) :=: E_G)%MS.
 Proof.
 apply/eqmxP/andP; split; apply/row_subP=> i.
   by rewrite row_mul mul_rV_lin gring_mxP.
 rewrite rowK /= -gring_opG ?enum_valP // -mul_vec_lin -gring_opG ?enum_valP //.
-rewrite vec_mxK /= -mulmxA mulmx_sub {i}//= -(eqmxMr _ Wedderburn_sum).
+rewrite vec_mxK /= -mulmxA mulmx_sub {i}//= -(eqmxMr _ Wedderburn_sum_pchar).
 rewrite (bigD1 iG) //= addsmxMr addsmxC [_ *m _](sub_kermxP _) ?adds0mx //=.
 apply/sumsmx_subP => j ne_j_iG; apply/memmx_subP=> A RjA; apply/sub_kermxP.
-by rewrite mul_vec_lin /= (irr_comp'_op0 ne_j_iG RjA) linear0.
+by rewrite mul_vec_lin /= (irr_comp'_op0_pchar ne_j_iG RjA) linear0.
 Qed.
 
-Lemma ker_irr_comp_op : ('R_iG :&: kermx (lin_mx (gring_op rG)))%MS = 0.
+Lemma ker_irr_comp_op_pchar : ('R_iG :&: kermx (lin_mx (gring_op rG)))%MS = 0.
 Proof.
 apply/eqP; rewrite -submx0; apply/memmx_subP=> A.
 rewrite sub_capmx /= submx0 mxvec_eq0 => /andP[R_A].
 rewrite (sameP sub_kermxP eqP) mul_vec_lin mxvec_eq0 /= => opA0.
-have [_ Re ideR _] := Wedderburn_is_id iG; rewrite -[A]ideR {ideR}//.
+have [_ Re ideR _] := Wedderburn_is_id_pchar iG; rewrite -[A]ideR {ideR}//.
 move: Re; rewrite genmxE mem_sub_gring /socle_val => /andP[Re].
 rewrite -{2}(gring_rowK Re) -submx0.
 pose simMi := socle_simple iG; have [J [M isoM ->]] := component_mx_def simMi.
@@ -4332,32 +4335,33 @@ case/sub_sumsmxP=> e ->; rewrite linear_sum mulmx_suml summx_sub // => j _.
 rewrite -(in_submodK (submxMl _ (M j))); move: (in_submod _ _) => v.
 have modMj: mxmodule aG (M j) by apply: mx_iso_module (isoM j) _; case: simMi.
 have rsimMj: mx_rsim rG (submod_repr modMj).
-  by apply: mx_rsim_trans rsim_irr_comp _; apply/mx_rsim_iso.
+  by apply: mx_rsim_trans rsim_irr_comp_pchar _; apply/mx_rsim_iso.
 have [f [f' _ hom_f]] := mx_rsim_def (mx_rsim_sym rsimMj); rewrite submx0.
 have <-: (gring_mx aG (val_submod (v *m (f *m gring_op rG A *m f')))) = 0.
   by rewrite (eqP opA0) !(mul0mx, linear0).
-have: (A \in R_G)%MS by rewrite -Wedderburn_sum (sumsmx_sup iG).
+have: (A \in R_G)%MS by rewrite -Wedderburn_sum_pchar (sumsmx_sup iG).
 case/envelop_mxP=> a ->; rewrite !(linear_sum, mulmx_suml) /=; apply/eqP.
 apply: eq_bigr=> x Gx; rewrite 3!linearZ -scalemxAl 3!linearZ /=.
 by rewrite gring_opG // -hom_f // val_submodJ // gring_mxJ.
 Qed.
 
-Lemma regular_op_inj :
+Lemma regular_op_inj_pchar :
   {in [pred A | (A \in 'R_iG)%MS] &, injective (gring_op rG)}.
 Proof.
 move=> A B RnA RnB /= eqAB; apply/eqP; rewrite -subr_eq0 -mxvec_eq0 -submx0.
-rewrite -ker_irr_comp_op sub_capmx (sameP sub_kermxP eqP) mul_vec_lin.
+rewrite -ker_irr_comp_op_pchar sub_capmx (sameP sub_kermxP eqP) mul_vec_lin.
 by rewrite 2!raddfB /= eqAB subrr linear0 addmx_sub ?eqmx_opp /=.
 Qed.
 
-Lemma rank_irr_comp : \rank 'R_iG = \rank E_G.
+Lemma rank_irr_comp_pchar : \rank 'R_iG = \rank E_G.
 Proof.
-by rewrite -irr_comp_envelop; apply/esym/mxrank_injP; rewrite ker_irr_comp_op.
+rewrite -irr_comp_envelop_pchar; apply/esym/mxrank_injP.
+by rewrite ker_irr_comp_op_pchar.
 Qed.
 
 End IrrComponent.
 
-Lemma irr_comp_rsim n1 n2 rG1 rG2 :
+Lemma irr_comp_rsim_pchar n1 n2 rG1 rG2 :
   @mx_rsim _ G n1 rG1 n2 rG2 -> irr_comp rG1 = irr_comp rG2.
 Proof.
 case=> f eq_n12; rewrite -eq_n12 in rG2 f * => inj_f hom_f.
@@ -4365,35 +4369,36 @@ rewrite /irr_comp; apply/f_equal/eq_pick => i; rewrite -!mxrank_eq0.
 (* [congr (odflt 1%irr _)] works but is very slow *)
 rewrite -(mxrankMfree _ inj_f); symmetry; rewrite -(eqmxMfull _ inj_f).
 have /envelop_mxP[e ->{i}]: ('e_i \in R_G)%MS.
-  by rewrite -Wedderburn_sum (sumsmx_sup i) ?Wedderburn_id_mem.
+  by rewrite -Wedderburn_sum_pchar (sumsmx_sup i) ?Wedderburn_id_mem.
 congr (\rank _ != _); rewrite !(mulmx_suml, linear_sum); apply: eq_bigr => x Gx.
 by rewrite 3!linearZ -scalemxAl /= !gring_opG ?hom_f.
 Qed.
 
-Lemma irr_reprK i : irr_comp (irr_repr i) = i.
+Lemma irr_reprK_pchar  i : irr_comp (irr_repr i) = i.
 Proof.
 apply/eqP; apply/component_mx_isoP; try exact: socle_simple.
-by move/mx_rsim_iso: (rsim_irr_comp (socle_irr i)); apply: mx_iso_sym.
+by move/mx_rsim_iso: (rsim_irr_comp_pchar (socle_irr i)); apply: mx_iso_sym.
 Qed.
 
-Lemma irr_repr'_op0 i j A :
+Lemma irr_repr'_op0_pchar i j A :
   j != i -> (A \in 'R_j)%MS -> gring_op (irr_repr i) A = 0.
 Proof.
-by move=> neq_ij /irr_comp'_op0->; [|apply: socle_irr|rewrite irr_reprK].
+move=> neq_ij /(irr_comp'_op0_pchar _).
+by move=> ->; [|apply: socle_irr|rewrite irr_reprK_pchar].
 Qed.
 
-Lemma op_Wedderburn_id i : gring_op (irr_repr i) 'e_i = 1%:M.
+Lemma op_Wedderburn_id_pchar i : gring_op (irr_repr i) 'e_i = 1%:M.
 Proof.
-rewrite -(gring_op1 (irr_repr i)) -Wedderburn_sum_id.
+rewrite -(gring_op1 (irr_repr i)) -Wedderburn_sum_id_pchar. 
 rewrite linear_sum (bigD1 i) //= addrC big1 ?add0r // => j neq_ji.
-exact: irr_repr'_op0 (Wedderburn_id_mem j).
+exact: irr_repr'_op0_pchar (Wedderburn_id_mem j).
 Qed.
 
-Lemma irr_comp_id (M : 'M_nG) (modM : mxmodule aG M) (iM : sG) :
+Lemma irr_comp_id_pchar (M : 'M_nG) (modM : mxmodule aG M) (iM : sG) :
   mxsimple aG M -> (M <= iM)%MS -> irr_comp (submod_repr modM) = iM.
 Proof.
-move=> simM sMiM; rewrite -[iM]irr_reprK.
-apply/esym/irr_comp_rsim/mx_rsim_iso/component_mx_iso => //.
+move=> simM sMiM; rewrite -[iM]irr_reprK_pchar.
+apply/esym/irr_comp_rsim_pchar/mx_rsim_iso/component_mx_iso => //.
 exact: socle_simple.
 Qed.
 
@@ -4406,31 +4411,31 @@ Qed.
 
 Hypothesis splitG : group_splitting_field G.
 
-Lemma rank_Wedderburn_subring i : \rank 'R_i = ('n_i ^ 2)%N.
+Lemma rank_Wedderburn_subring_pchar i : \rank 'R_i = ('n_i ^ 2)%N.
 Proof.
-apply/eqP; rewrite -{1}[i]irr_reprK; have irrSi := socle_irr i.
-by case/andP: (splitG irrSi) => _; rewrite rank_irr_comp.
+apply/eqP; rewrite -{1}[i]irr_reprK_pchar; have irrSi := socle_irr i.
+by case/andP: (splitG irrSi) => _; rewrite rank_irr_comp_pchar.
 Qed.
 
-Lemma sum_irr_degree : (\sum_i 'n_i ^ 2 = nG)%N.
+Lemma sum_irr_degree_pchar : (\sum_i 'n_i ^ 2 = nG)%N.
 Proof.
 apply: etrans (eqnP gring_free).
-rewrite -Wedderburn_sum (mxdirectP Wedderburn_direct) /=.
-by apply: eq_bigr => i _; rewrite rank_Wedderburn_subring.
+rewrite -Wedderburn_sum_pchar (mxdirectP Wedderburn_direct) /=.
+by apply: eq_bigr => i _; rewrite rank_Wedderburn_subring_pchar.
 Qed.
 
-Lemma irr_mx_mult i : socle_mult i = 'n_i.
+Lemma irr_mx_mult_pchar i : socle_mult i = 'n_i.
 Proof.
 rewrite /socle_mult -(mxrankMfree _ gring_free) -genmxE.
-by rewrite rank_Wedderburn_subring mulKn ?irr_degree_gt0.
+by rewrite rank_Wedderburn_subring_pchar mulKn ?irr_degree_gt0.
 Qed.
 
-Lemma mxtrace_regular :
+Lemma mxtrace_regular_pchar :
   {in G, forall x, \tr (aG x) = \sum_i \tr (socle_repr i x) *+ 'n_i}.
 Proof.
-move=> x Gx; have soc1: (Socle sG :=: 1%:M)%MS by rewrite -irr_mx_sum.
+move=> x Gx; have soc1: (Socle sG :=: 1%:M)%MS by rewrite -irr_mx_sum_pchar.
 rewrite -(mxtrace_submod1 (Socle_module sG) soc1) // mxtrace_Socle //.
-by apply: eq_bigr => i _; rewrite irr_mx_mult.
+by apply: eq_bigr => i _; rewrite irr_mx_mult_pchar.
 Qed.
 
 Definition linear_irr := [set i | 'n_i == 1].
@@ -4438,16 +4443,17 @@ Definition linear_irr := [set i | 'n_i == 1].
 Lemma irr_degree_abelian : abelian G -> forall i, 'n_i = 1.
 Proof. by move=> cGG i; apply: mxsimple_abelian_linear (socle_simple i). Qed.
 
-Lemma linear_irr_comp i : 'n_i = 1 -> (i :=: socle_base i)%MS.
+Lemma linear_irr_comp_pchar i : 'n_i = 1 -> (i :=: socle_base i)%MS.
 Proof.
 move=> ni1; apply/eqmxP; rewrite andbC -mxrank_leqif_eq -/'n_i.
-  by rewrite -(mxrankMfree _ gring_free) -genmxE rank_Wedderburn_subring ni1.
+  rewrite -(mxrankMfree _ gring_free) -genmxE.
+  by rewrite rank_Wedderburn_subring_pchar ni1.
 exact: component_mx_id (socle_simple i).
 Qed.
 
-Lemma Wedderburn_subring_center i : ('Z('R_i) :=: mxvec 'e_i)%MS.
+Lemma Wedderburn_subring_center_pchar i : ('Z('R_i) :=: mxvec 'e_i)%MS.
 Proof.
-have [nz_e Re ideR idRe] := Wedderburn_is_id i.
+have [nz_e Re ideR idRe] := Wedderburn_is_id_pchar i.
 have Ze: (mxvec 'e_i <= 'Z('R_i))%MS.
   rewrite sub_capmx [(_ <= _)%MS]Re.
   by apply/cent_mxP=> A R_A; rewrite ideR // idRe.
@@ -4457,43 +4463,45 @@ apply/eqmxP; rewrite andbC -(geq_leqif (mxrank_leqif_eq Ze)).
 have ->: \rank (mxvec 'e_i) = (0 + 1)%N.
   by apply/eqP; rewrite eqn_leq rank_leq_row lt0n mxrank_eq0 mxvec_eq0.
 rewrite -(mxrank_mul_ker _ (lin_mx (gring_op rG))) addnC leq_add //.
-  rewrite leqn0 mxrank_eq0 -submx0 -(ker_irr_comp_op irrG) capmxS //.
-  by rewrite irr_reprK capmxSl.
+  rewrite leqn0 mxrank_eq0 -submx0 -(ker_irr_comp_op_pchar irrG) capmxS //.
+  by rewrite irr_reprK_pchar capmxSl.
 apply: leq_trans (mxrankS _) (rank_leq_row (mxvec 1%:M)).
 apply/memmx_subP=> Ar; case/submxP=> a ->{Ar}.
 rewrite mulmxA mul_rV_lin /=; set A := vec_mx _.
 rewrite memmx1 (mx_abs_irr_cent_scalar absG) // -memmx_cent_envelop.
-apply/cent_mxP=> Br; rewrite -(irr_comp_envelop irrG) irr_reprK.
+apply/cent_mxP=> Br; rewrite -(irr_comp_envelop_pchar irrG) irr_reprK_pchar.
 case/submxP=> b /(canRL mxvecK) ->{Br}; rewrite mulmxA mx_rV_lin /=.
 set B := vec_mx _; have RiB: (B \in 'R_i)%MS by rewrite vec_mxK submxMl.
-have sRiR: ('R_i <= R_G)%MS by rewrite -Wedderburn_sum (sumsmx_sup i).
+have sRiR: ('R_i <= R_G)%MS by rewrite -Wedderburn_sum_pchar (sumsmx_sup i).
 have: (A \in 'Z('R_i))%MS by rewrite vec_mxK submxMl.
 rewrite sub_capmx => /andP[RiA /cent_mxP cRiA].
 by rewrite -!gring_opM ?(memmx_subP sRiR) 1?cRiA.
 Qed.
 
-Lemma Wedderburn_center :
+Lemma Wedderburn_center_pchar :
   ('Z(R_G) :=: \matrix_(i < #|sG|) mxvec 'e_(enum_val i))%MS.
 Proof.
-have:= mxdirect_sums_center Wedderburn_sum Wedderburn_direct Wedderburn_ideal.
+have:= mxdirect_sums_center
+  Wedderburn_sum_pchar Wedderburn_direct Wedderburn_ideal.
 move/eqmx_trans; apply; apply/eqmxP/andP; split.
-  apply/sumsmx_subP=> i _; rewrite Wedderburn_subring_center.
+  apply/sumsmx_subP=> i _; rewrite Wedderburn_subring_center_pchar.
   by apply: (eq_row_sub (enum_rank i)); rewrite rowK enum_rankK.
-apply/row_subP=> i; rewrite rowK -Wedderburn_subring_center.
+apply/row_subP=> i; rewrite rowK -Wedderburn_subring_center_pchar.
 by rewrite (sumsmx_sup (enum_val i)).
 Qed.
 
-Lemma card_irr : #|sG| = tG.
+Lemma card_irr_pchar : #|sG| = tG.
 Proof.
 rewrite -(eqnP classg_base_free) classg_base_center.
-have:= mxdirect_sums_center Wedderburn_sum Wedderburn_direct Wedderburn_ideal.
+have:= mxdirect_sums_center
+  Wedderburn_sum_pchar Wedderburn_direct Wedderburn_ideal.
 move->; rewrite (mxdirectP _) /=; last first.
   apply/mxdirect_sumsP=> i _; apply/eqP; rewrite -submx0.
   rewrite -{2}(mxdirect_sumsP Wedderburn_direct i) // capmxS ?capmxSl //=.
   by apply/sumsmx_subP=> j neji; rewrite (sumsmx_sup j) ?capmxSl.
 rewrite -sum1_card; apply: eq_bigr => i _; apply/eqP.
-rewrite Wedderburn_subring_center eqn_leq rank_leq_row lt0n mxrank_eq0.
-by rewrite andbT mxvec_eq0; case: (Wedderburn_is_id i).
+rewrite Wedderburn_subring_center_pchar eqn_leq rank_leq_row lt0n mxrank_eq0.
+by rewrite andbT mxvec_eq0; case: (Wedderburn_is_id_pchar i).
 Qed.
 
 Section CenterMode.
@@ -4556,22 +4564,22 @@ Section LinearIrr.
 Variables (gT : finGroupType) (G : {group gT}).
 
 Lemma card_linear_irr (sG : irrType G) :
-    [char F]^'.-group G -> group_splitting_field G ->
+    [pchar F]^'.-group G -> group_splitting_field G ->
   #|linear_irr sG| = #|G : G^`(1)|%g.
 Proof.
 move=> F'G splitG; apply/eqP.
 wlog sGq: / irrType (G / G^`(1))%G by apply: socle_exists.
 have [_ nG'G] := andP (der_normal 1 G); apply/eqP; rewrite -card_quotient //.
 have cGqGq: abelian (G / G^`(1))%g by apply: sub_der1_abelian.
-have F'Gq: [char F]^'.-group (G / G^`(1))%g by apply: morphim_pgroup.
+have F'Gq: [pchar F]^'.-group (G / G^`(1))%g by apply: morphim_pgroup.
 have splitGq: group_splitting_field (G / G^`(1))%G.
   exact: quotient_splitting_field.
-rewrite -(sum_irr_degree sGq) // -sum1_card.
+rewrite -(sum_irr_degree_pchar sGq) // -sum1_card.
 pose rG (j : sGq) := morphim_repr (socle_repr j) nG'G.
 have irrG j: mx_irreducible (rG j) by apply/morphim_mx_irr; apply: socle_irr.
 rewrite (reindex (fun j => irr_comp sG (rG j))) /=.
   apply: eq_big => [j | j _]; last by rewrite irr_degree_abelian.
-  have [_ lin_j _ _] := rsim_irr_comp sG F'G (irrG j).
+  have [_ lin_j _ _] := rsim_irr_comp_pchar sG F'G (irrG j).
   by rewrite inE -lin_j -irr_degreeE irr_degree_abelian.
 pose sGlin := {i | i \in linear_irr sG}.
 have sG'k (i : sGlin) : G^`(1)%g \subset rker (irr_repr (val i)).
@@ -4581,13 +4589,14 @@ have irrGq u: mx_irreducible (quo_repr (sG'k u) nG'G).
   by apply/quo_mx_irr; apply: socle_irr.
 exists (fun i => oapp h' [1 sGq]%irr (insub i)) => [j | i] lin_i.
   rewrite (insubT [in _] lin_i) /=; apply/esym/eqP/socle_rsimP.
-  apply: mx_rsim_trans (rsim_irr_comp sGq F'Gq (irrGq _)).
-  have [g lin_g inj_g hom_g] := rsim_irr_comp sG F'G (irrG j).
+  apply: mx_rsim_trans (rsim_irr_comp_pchar sGq F'Gq (irrGq _)).
+  have [g lin_g inj_g hom_g] := rsim_irr_comp_pchar sG F'G (irrG j).
   exists g => [||G'x]; last 1 [case/morphimP=> x _ Gx ->] || by [].
   by rewrite quo_repr_coset ?hom_g.
 rewrite (insubT (mem _) lin_i) /=; apply/esym/eqP/socle_rsimP.
-set u := Sub i lin_i; apply: mx_rsim_trans (rsim_irr_comp sG F'G (irrG _)).
-have [g lin_g inj_g hom_g] := rsim_irr_comp sGq F'Gq (irrGq u).
+set u := Sub i lin_i.
+apply: mx_rsim_trans (rsim_irr_comp_pchar sG F'G (irrG _)).
+have [g lin_g inj_g hom_g] := rsim_irr_comp_pchar sGq F'Gq (irrGq u).
 exists g => [||x Gx]; last 1 [have:= hom_g (coset _ x)] || by [].
 by rewrite quo_repr_coset; first by apply; rewrite mem_quotient.
 Qed.
@@ -4619,8 +4628,8 @@ apply: linear_mx_abs_irr; apply/eqP; rewrite eq_sym -linM.
 by case/mx_irrP: irrG => _; apply; rewrite // -mxrank_eq0 linM.
 Qed.
 
-Lemma cycle_repr_structure x (sG : irrType G) :
-    G :=: <[x]> -> [char F]^'.-group G -> group_splitting_field G ->
+Lemma cycle_repr_structure_pchar x (sG : irrType G) :
+    G :=: <[x]> -> [pchar F]^'.-group G -> group_splitting_field G ->
   exists2 w : F, #|G|.-primitive_root w &
   exists iphi : 'I_#|G| -> sG,
   [/\ bijective iphi,
@@ -4631,15 +4640,15 @@ Proof.
 move=> defG; rewrite {defG}(group_inj defG) -/#[x] in sG * => F'X splitF.
 have Xx := cycle_id x; have cXX := cycle_abelian x.
 have card_sG: #|sG| = #[x].
-  by rewrite card_irr //; apply/eqP; rewrite -card_classes_abelian.
+  by rewrite card_irr_pchar //; apply/eqP; rewrite -card_classes_abelian.
 have linX := irr_degree_abelian splitF cXX (_ : sG).
 pose r (W : sG) := irr_mode W x.
 have scalX W: irr_repr W x = (r W)%:M.
   by apply: irr_center_scalar; rewrite ?(center_idP _).
 have inj_r: injective r.
-  move=> V W eqVW; rewrite -(irr_reprK F'X V) -(irr_reprK F'X W).
+  move=> V W eqVW; rewrite -(irr_reprK_pchar F'X V) -(irr_reprK_pchar F'X W).
   move: (irr_repr V) (irr_repr W) (scalX V) (scalX W).
-  rewrite !linX {}eqVW => rV rW <- rWx; apply: irr_comp_rsim => //.
+  rewrite !linX {}eqVW => rV rW <- rWx; apply: irr_comp_rsim_pchar => //.
   exists 1%:M; rewrite ?row_free_unit ?unitmx1 // => xk; case/cycleP=> k ->{xk}.
   by rewrite mulmx1 mul1mx !repr_mxX // rWx.
 have rx1 W: r W ^+ #[x] = 1.
@@ -4661,13 +4670,13 @@ split=> // [|i]; last by rewrite scalX r_iphi.
 by exists iphi' => // W; rewrite /iphi iinv_f.
 Qed.
 
-Lemma splitting_cyclic_primitive_root :
-    cyclic G -> [char F]^'.-group G -> group_splitting_field G ->
+Lemma splitting_cyclic_primitive_root_pchar :
+    cyclic G -> [pchar F]^'.-group G -> group_splitting_field G ->
   classically {z : F | #|G|.-primitive_root z}.
 Proof.
 case/cyclicP=> x defG F'G splitF; case=> // IH.
 wlog sG: / irrType G by apply: socle_exists.
-have [w prim_w _] := cycle_repr_structure sG defG F'G splitF.
+have [w prim_w _] := cycle_repr_structure_pchar sG defG F'G splitF.
 by apply: IH; exists w.
 Qed.
 
@@ -4675,15 +4684,92 @@ End LinearIrr.
 
 End FieldRepr.
 
+#[deprecated(since="mathcomp 2.4.0", note="Use mx_Maschke_pchar instead.")]
+Notation mx_Maschke := (mx_Maschke_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use rsim_regular_submod_pchar instead.")]
+Notation rsim_regular_submod := (rsim_regular_submod_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use irr_mx_sum_pchar instead.")]
+Notation irr_mx_sum := (irr_mx_sum_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use Wedderburn_sum_pchar instead.")]
+Notation Wedderburn_sum := (Wedderburn_sum_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use Wedderburn_sum_id_pchar instead.")]
+Notation Wedderburn_sum_id := (Wedderburn_sum_id_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use Wedderburn_is_id_pchar instead.")]
+Notation Wedderburn_is_id:= (Wedderburn_is_id_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use Wedderburn_closed_pchar instead.")]
+Notation Wedderburn_closed := (Wedderburn_closed_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use Wedderburn_is_ring_pchar instead.")]
+Notation Wedderburn_is_ring := (Wedderburn_is_ring_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use Wedderburn_min_ideal_pchar instead.")]
+Notation Wedderburn_min_ideal := (Wedderburn_min_ideal_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use rsim_irr_comp_pchar instead.")]
+Notation rsim_irr_comp := (rsim_irr_comp_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use irr_comp'_op0_pchar instead.")]
+Notation irr_comp'_op0 := (irr_comp'_op0_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use irr_comp_envelop_pchar instead.")]
+Notation irr_comp_envelop := (irr_comp_envelop_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use ker_irr_comp_op_pchar instead.")]
+Notation ker_irr_comp_op := (ker_irr_comp_op_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use regular_op_inj_pchar instead.")]
+Notation regular_op_inj := (regular_op_inj_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use rank_irr_comp_pchar instead.")]
+Notation rank_irr_comp := (rank_irr_comp_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use irr_comp_rsim_pchar instead.")]
+Notation irr_comp_rsim := (irr_comp_rsim_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use irr_reprK_pchar instead.")]
+Notation irr_reprK := (irr_reprK_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use irr_repr'_op0_pchar instead.")]
+Notation irr_repr'_op0 := (irr_repr'_op0_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use op_Wedderburn_id_pchar instead.")]
+Notation op_Wedderburn_id := (op_Wedderburn_id_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use irr_comp_id_pchar instead.")]
+Notation irr_comp_id := (irr_comp_id_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use rank_Wedderburn_subring_pchar instead.")]
+Notation rank_Wedderburn_subring := (rank_Wedderburn_subring_pchar)
+  (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use sum_irr_degree_pchar instead.")]
+Notation sum_irr_degree := (sum_irr_degree_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use irr_mx_mult_pchar instead.")]
+Notation irr_mx_mult := (irr_mx_mult_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use mxtrace_regular_pchar instead.")]
+Notation mxtrace_regular := (mxtrace_regular_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use linear_irr_comp_pchar instead.")]
+Notation linear_irr_comp := (linear_irr_comp_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use Wedderburn_subring_center_pchar instead.")]
+Notation Wedderburn_subring_center := (Wedderburn_subring_center_pchar)
+  (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use Wedderburn_center_pchar instead.")]
+Notation Wedderburn_center := (Wedderburn_center_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use card_irr_pchar instead.")]
+Notation card_irr := (card_irr_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use cycle_repr_structure_pchar instead.")]
+Notation cycle_repr_structure := (cycle_repr_structure_pchar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0",
+  note="Use splitting_cyclic_primitive_root_pchar instead.")]
+Notation splitting_cyclic_primitive_root :=
+  (splitting_cyclic_primitive_root_pchar) (only parsing).
+
 Arguments rfix_mx {F gT G%_g n%_N} rG H%_g.
 Arguments gset_mx F {gT} G%_g A%_g.
 Arguments classg_base F {gT} G%_g _%_g : extra scopes.
 Arguments irrType F {gT} G%_g.
-
 Arguments mxmoduleP {F gT G n rG m U}.
 Arguments envelop_mxP {F gT G n rG A}.
 Arguments hom_mxP {F gT G n rG m f W}.
-Arguments mx_Maschke [F gT G n] rG _ [U].
+Arguments mx_Maschke_pchar [F gT G n] rG _ [U].
 Arguments rfix_mxP {F gT G n rG m W}.
 Arguments cyclic_mxP {F gT G n rG u v}.
 Arguments annihilator_mxP {F gT G n rG u A}.

--- a/doc/changelog/03-renamed/1311-deprecate_char.md
+++ b/doc/changelog/03-renamed/1311-deprecate_char.md
@@ -1,0 +1,146 @@
+- in `intdiv.v`
+  + `dvdz_charf` -> `dvdz_pcharf`
+
+- in `poly.v`
+	+ `char_poly` -> `pchar_poly`
+	+ `prim_root_charF` -> `prim_root_pcharF`
+	+ `char_prim_root` -> `pchar_prim_root`
+
+- in `qpoly.v`
+	+ `char_qpoly` -> `pchar_qpoly`
+
+- in `sesquilinear.v`
+	+ `is_symplectic` -> `is_psymplectic`
+	+ `is_orthogonal` -> `is_porthogonal`
+
+- in `ssralg.v`
+	+ `char` -> `pchar`
+	+ `[char _]` -> `[pchar _]`
+	+ `has_char0` -> `has_pchar0`
+	+ `Frobenius_aut` -> `pFrobenius_aut`
+	+ `charf0` -> `pcharf0`
+	+ `charf_prime` -> `pcharf_prime`
+	+ `mulrn_char` -> `mulrn_pchar`
+	+ `natr_mod_char` -> `natr_mod_pchar`
+	+ `dvdn_charf` -> `dvdn_pcharf`
+	+ `charf_eq` -> `pcharf_eq`
+	+ `bin_lt_charf_0` -> `bin_lt_pcharf_0`
+	+ `Frobenius_autE` -> `pFrobenius_autE`
+	+ `Frobenius_aut0` -> `pFrobenius_aut0`
+	+ `Frobenius_aut1` -> `pFrobenius_aut1`
+	+ `Frobenius_autMn` -> `pFrobenius_autMn`
+	+ `Frobenius_aut_nat` -> `pFrobenius_aut_nat`
+	+ `Frobenius_autM_comm` -> `pFrobenius_autM_comm`
+	+ `Frobenius_autX` -> `pFrobenius_autX`
+	+ `addrr_char2` -> `addrr_pchar2`
+	+ `Frobenius_autN` -> `pFrobenius_autN`
+	+ `Frobenius_autB_comm` -> `pFrobenius_autB_comm`
+	+ `exprNn_char` -> `exprNn_pchar`
+	+ `oppr_char2` -> `oppr_pchar2`
+	+ `subr_char2` -> `subr_pchar2`
+	+ `addrK_char2` -> `addrK_pchar2`
+	+ `rmorph_char` -> `rmorph_pchar`
+	+ `Frobenius_aut_is_semi_additive` -> `pFrobenius_aut_is_semi_additive`
+	+ `Frobenius_aut_is_multiplicative` -> `pFrobenius_aut_is_multiplicative`
+	+ `exprDn_char` -> `exprDn_pchar`
+	+ `natf_neq0` -> `natf_neq0_pchar`
+	+ `natf0_char` -> `natf0_pchar`
+	+ `charf'_nat` -> `pcharf'_nat`
+	+ `charf0P` -> `pcharf0P`
+	+ `char0_natf_div` -> `pchar0_natf_div`
+	+ `fmorph_char` -> `fmorph_pchar`
+	+ `char_lalg` -> `pchar_lalg`
+
+- in `ssrint.v`
+	+ `Frobenius_autMz` -> `pFrobenius_autMz`
+	+ `Frobenius_aut_int` -> `pFrobenius_aut_int`
+
+- in `ssrnum.v`
+	+ `char_num` -> `pchar_num`
+
+- in `zmodp.v`
+	+ `char_Zp` -> `pchar_Zp`
+	+ `char_Fp` -> `pchar_Fp`
+	+ `char_Fp_0` -> `pchar_Fp_0`
+
+- in `classfun.v`
+	+ `algC'G` -> `algC'G_pchar`
+
+- in `mxabelem.v`
+	+ `rfix_pgroup_char` -> `rfix_pgroup_pchar`
+	+ `pcore_sub_rstab_mxsimple` -> `pcore_sub_rstab_mxsimple_pchar`
+	+ `pcore_sub_rker_mx_irr` -> `pcore_sub_rker_mx_irr_pchar`
+	+ `pcore_faithful_mx_irr` -> `pcore_faithful_mx_irr_pchar`
+	+ `extraspecial_repr_structure` -> `extraspecial_repr_structure_pchar`
+	+ `faithful_repr_extraspecial` -> `faithful_repr_extraspecial_pchar`
+
+- in `mxrepresentation.v`
+	+ `mx_Maschke` -> `mx_Maschke_pchar`
+	+ `rsim_regular_submod` -> `rsim_regular_submod_pchar`
+	+ `irr_mx_sum` -> `irr_mx_sum_pchar`
+	+ `Wedderburn_sum` -> `Wedderburn_sum_pchar`
+	+ `Wedderburn_sum_id` -> `Wedderburn_sum_id_pchar`
+	+ `Wedderburn_is_id` -> `Wedderburn_is_id_pchar`
+	+ `Wedderburn_closed` -> `Wedderburn_closed_pchar`
+	+ `Wedderburn_is_ring` -> `Wedderburn_is_ring_pchar`
+	+ `Wedderburn_min_ideal` -> `Wedderburn_min_ideal_pchar`
+	+ `not_rsim_op0` -> `not_rsim_op0_pchar`
+	+ `rsim_irr_comp` -> `rsim_irr_comp_pchar`
+	+ `irr_comp'_op0` -> `irr_comp'_op0_pchar`
+	+ `irr_comp_envelop` -> `irr_comp_envelop_pchar`
+	+ `ker_irr_comp_op` -> `ker_irr_comp_op_pchar`
+	+ `regular_op_inj` -> `regular_op_inj_pchar`
+	+ `rank_irr_comp` -> `rank_irr_comp_pchar`
+	+ `irr_comp_rsim` -> `irr_comp_rsim_pchar`
+	+ `irr_reprK` -> `irr_reprK_pchar`
+	+ `irr_repr'_op0` -> `irr_repr'_op0_pchar`
+	+ `op_Wedderburn_id` -> `op_Wedderburn_id_pchar`
+	+ `irr_comp_id` -> `irr_comp_id_pchar`
+	+ `rank_Wedderburn_subring` -> `rank_Wedderburn_subring_pchar`
+	+ `sum_irr_degree` -> `sum_irr_degree_pchar`
+	+ `irr_mx_mult` -> `irr_mx_mult_pchar`
+	+ `mxtrace_regular` -> `mxtrace_regular_pchar`
+	+ `linear_irr_comp` -> `linear_irr_comp_pchar`
+	+ `Wedderburn_subring_center` -> `Wedderburn_subring_center_pchar`
+	+ `Wedderburn_center` -> `Wedderburn_center_pchar`
+	+ `card_irr` -> `card_irr_pchar`
+	+ `cycle_repr_structure` -> `cycle_repr_structure_pchar`
+	+ `splitting_cyclic_primitive_root` -> `splitting_cyclic_primitive_root_pchar`
+	
+- in `algC.v`
+	+ `Cchar` -> `Cpchar`
+
+- in `finfield.v`
+	+ `finCharP` -> `finPcharP`
+	+ `card_finCharP` -> `card_finPcharP`
+	+ `PrimeCharType` -> `pPrimeCharType`
+	+ `primeChar_scale` -> `pprimeChar_scale`
+	+ `primeChar_scaleA` -> `pprimeChar_scaleA`
+	+ `primeChar_scale1` -> `pprimeChar_scale1`
+	+ `primeChar_scaleDr` -> `pprimeChar_scaleDr`
+	+ `primeChar_scaleDl` -> `pprimeChar_scaleDl`
+	+ `primeChar_scaleAl` -> `pprimeChar_scaleAl`
+	+ `primeChar_scaleAr` -> `pprimeChar_scaleAr`
+	+ `primeChar_abelem` -> `pprimeChar_abelem`
+	+ `primeChar_pgroup` -> `pprimeChar_pgroup`
+	+ `order_primeChar` -> `order_pprimeChar`
+	+ `card_primeChar` -> `card_pprimeChar`
+	+ `primeChar_vectAxiom` -> `pprimeChar_vectAxiom`
+	+ `primeChar_dimf` -> `pprimeChar_dimf`
+	+ `PrimePowerField` -> pPrimePowerField`
+	+ `FinDomainSplittingFieldType` -> `FinDomainSplittingFieldType_pchar`
+
+- in `separable.v`
+	+ `char0_PET` -> `pchar0_PET`
+	+ `separablePn` -> `separablePn_pchar`
+	+ `separable_exponent` -> `separable_exponent_pchar`
+	+ `charf0_separable` -> `pcharf0_separable`
+	+ `charf_p_separable` -> `pcharf_p_separable`
+	+ `charf_n_separable` -> `pcharf_n_separable`
+	+ `purely_inseparable_elementP` -> `purely_inseparable_elementP_pchar`
+
+- in `abelian.v`
+	+ `fin_lmod_char_abelem` -> `fin_lmod_pchar_abelem`
+	+ `fin_lmod_char_abelem` -> `fin_lmod_pchar_abelem`
+    (`#1311 <https://github.com/coq/stdlib/pull/1311>`_,
+    by Tragicus).

--- a/field/algC.v
+++ b/field/algC.v
@@ -72,10 +72,10 @@ HB.builders Context L of isComplex L.
 
 Lemma nz2: 2 != 0 :> L.
 Proof.
-  apply/eqP=> char2; apply: conj_nt => e; apply/eqP/idPn=> eJ.
+  apply/eqP=> pchar2; apply: conj_nt => e; apply/eqP/idPn=> eJ.
   have opp_id x: - x = x :> L.
-    by apply/esym/eqP; rewrite -addr_eq0 -mulr2n -mulr_natl char2 mul0r.
-  have{} char2: 2%N \in [char L] by apply/eqP.
+    by apply/esym/eqP; rewrite -addr_eq0 -mulr2n -mulr_natl pchar2 mul0r.
+  have{} pchar2: 2%N \in [pchar L] by apply/eqP.
   without loss{eJ} eJ: e / conj e = e + 1.
     move/(_ (e / (e + conj e))); apply.
     rewrite fmorph_div rmorphD /= conjK -{1}[conj e](addNKr e) mulrDl.
@@ -86,7 +86,7 @@ Proof.
     by rewrite Dw !big_ord_recl big_ord0 /= mulr1 mulN1r addr0 subrK.
   pose b := w + conj w; have bJ: conj b = b by rewrite rmorphD /= conjK addrC.
   have Db2: b ^+ 2 + b = a.
-    rewrite -Frobenius_autE // rmorphD addrACA Dw /= Frobenius_autE -rmorphXn.
+    rewrite -pFrobenius_autE // rmorphD addrACA Dw /= pFrobenius_autE -rmorphXn.
     by rewrite -rmorphD Dw rmorphM /= aJ eJ -mulrDl -{1}[e]opp_id addKr mul1r.
   have /eqP[] := oner_eq0 L; apply: (addrI b); rewrite addr0 -{2}bJ.
   have: (b + e) * (b + conj e) == 0.
@@ -622,7 +622,7 @@ Let intr_inj_ZtoC := (intr_inj : injective ZtoC).
 Definition eqC_nat n p : (n%:R == p%:R :> algC) = (n == p) := eqr_nat _ n p.
 Definition leC_nat n p : (n%:R <= p%:R :> algC) = (n <= p)%N := ler_nat _ n p.
 Definition ltC_nat n p : (n%:R < p%:R :> algC) = (n < p)%N := ltr_nat _ n p.
-Definition Cchar : [char algC] =i pred0 := @char_num _.
+Definition Cpchar : [pchar algC] =i pred0 := @pchar_num _.
 
 (* This can be used in the converse direction to evaluate assertions over     *)
 (* manifest rationals, such as 3^-1 + 7%:%^-1 < 2%:%^-1 :> algC.              *)
@@ -932,6 +932,10 @@ Qed.
 End AutC.
 
 End AlgebraicsTheory.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use Cpchar instead.")]
+Notation Cchar := (Cpchar) (only parsing).
+
 #[global] Hint Resolve Crat0 Crat1 dvdC0 dvdC_refl eqCmod_refl eqCmodm0 : core.
 
 Local Notation "p ^^ f" := (map_poly f p)

--- a/field/algebraics_fundamentals.v
+++ b/field/algebraics_fundamentals.v
@@ -268,9 +268,9 @@ have [C [/= QtoC algC]] := countable_algebraic_closure rat.
 exists C; have [i Di2] := GRing.imaginary_exists C.
 pose Qfield := fieldExtType rat.
 pose Cmorph (L : Qfield) := {rmorphism L -> C}.
-have charQ (L : Qfield): [char L] =i pred0 := ftrans (char_lalg L) (char_num _).
+have pcharQ (L : Qfield): [pchar L] =i pred0 := ftrans (pchar_lalg L) (pchar_num _).
 have sepQ  (L : Qfield) (K E : {subfield L}): separable K E.
-  by apply/separableP=> u _; apply: charf0_separable.
+  by apply/separableP=> u _; apply: pcharf0_separable.
 pose genQfield z L := {LtoC : Cmorph L & {u | LtoC u = z & <<1; u>> = fullv}}.
 have /all_tag[Q /all_tag[ofQ genQz]] z: {Qz : Qfield & genQfield z Qz}.
   have [|p [/monic_neq0 nzp pz0 irr_p]] := minPoly_decidable_closure _ (algC z).
@@ -293,7 +293,7 @@ have PET2 x y: {z | gen z x & gen z y}.
   suffices [[[p q] z] []]: {w | Gxy w} by exists z; [exists p | exists q].
   apply/sig_eqW; have /integral_algebraic[px nz_px pxx0] := algC x.
   have /integral_algebraic[py nz_py pyy0] := algC y.
-  have [n [[p Dx] [q Dy]]] := char0_PET nz_px pxx0 nz_py pyy0 (char_num _).
+  have [n [[p Dx] [q Dy]]] := pchar0_PET nz_px pxx0 nz_py pyy0 (pchar_num _).
   by exists (p, q, y *+ n - x); congr (_, _).
 have gen_inQ z x: gen z x -> {u | ofQ z u = x}.
   have [u Dz _] := genQz z => /sig_eqW[q ->].
@@ -797,7 +797,7 @@ have /all_sig[n_ FTA] z: {n | z \in sQ (z_ n)}.
     rewrite adjoin_degreeE -iPG -dim_fixed_galois // -defQw; congr (\dim_Cn _).
     apply/esym/eqP; rewrite eqEsubv adjoinSl ?sub1v //=; apply/FadjoinP.
     by rewrite memv_adjoin /= defQw -galois_connection.
-  have nz2: 2 != 0 :> Qt by move/charf0P: (charQ (Q t)) => ->.
+  have nz2: 2 != 0 :> Qt by move/pcharf0P: (pcharQ (Q t)) => ->.
   without loss{deg_w} [C'w Cw2]: w Rz_w / w \notin Cn /\ w ^+ 2 \in Cn.
     pose p := minPoly Cn w; pose v := p`_1 / 2.
     have /polyOverP Cp: p \is a polyOver Cn := minPolyOver Cn w.
@@ -891,5 +891,5 @@ exists conjRM => [z | /(_ i)/eqP/idPn[]] /=.
   by have [n [/conjE-> /(conjK (n_ z))->]] := maxn3 (n_ (conj z)) (n_ z) 0.
 rewrite /conj/conj_ cj_i rmorphN inQ_K // eq_sym -addr_eq0 -mulr2n -mulr_natl.
 rewrite mulf_neq0 ?(memPnC (R'i 0)) ?(rpred0 (sQC _)) //.
-by have /charf0P-> := ftrans (fmorph_char QtoC) (char_num _).
+by have /pcharf0P-> := ftrans (fmorph_pchar QtoC) (pchar_num _).
 Qed.

--- a/field/algnum.v
+++ b/field/algnum.v
@@ -98,8 +98,8 @@ suffices /sig_eqW[[n [|px [|pz []]]]// [Dpx Dpz]]:
   by rewrite map_comp_poly horner_comp -Dpz.
 have [rx nz_rx rx0] := r_exists x.
 have [rz nz_rz rz0] := r_exists (- z).
-have char0_Q: [char rat] =i pred0 by apply: char_num.
-have [n [[pz Dpz] [px Dpx]]] := char0_PET nz_rz rz0 nz_rx rx0 char0_Q.
+have pchar0_Q: [pchar rat] =i pred0 by apply: pchar_num.
+have [n [[pz Dpz] [px Dpx]]] := pchar0_PET nz_rz rz0 nz_rx rx0 pchar0_Q.
 by exists (n, [:: px; - pz]); rewrite /= !raddfN hornerN -[z]opprK Dpz Dpx.
 Qed.
 

--- a/field/cyclotomic.v
+++ b/field/cyclotomic.v
@@ -269,10 +269,10 @@ have [|k_gt1] := leqP k 1; last have [p p_pr /dvdnP[k1 Dk]] := pdivP k_gt1.
   rewrite -(size_map_inj_poly (can_inj intCK)) // -Df -Dpf.
   by rewrite -(subnKC g_gt1) -(subnKC (size_minCpoly z)) !addnS.
 move: cokn; rewrite Dk coprimeMl => /andP[cok1n].
-rewrite prime_coprime // (dvdn_charf (char_Fp p_pr)) => /co_fg {co_fg}.
-have charFpX: p \in [char {poly 'F_p}] by rewrite (rmorph_char polyC) ?char_Fp.
-rewrite -(coprimep_pexpr _ _ (prime_gt0 p_pr)) -(Frobenius_autE charFpX).
-rewrite -[g]comp_polyXr map_comp_poly -horner_map /= Frobenius_autE -rmorphXn.
+rewrite prime_coprime // (dvdn_pcharf (pchar_Fp p_pr)) => /co_fg {co_fg}.
+have pcharFpX: p \in [pchar {poly 'F_p}] by rewrite (rmorph_pchar polyC) ?pchar_Fp.
+rewrite -(coprimep_pexpr _ _ (prime_gt0 p_pr)) -(pFrobenius_autE pcharFpX).
+rewrite -[g]comp_polyXr map_comp_poly -horner_map /= pFrobenius_autE -rmorphXn.
 rewrite -!map_poly_comp (@eq_map_poly _ _ _ (polyC \o *~%R 1)); last first.
   by move=> a; rewrite /= !rmorph_int.
 rewrite map_poly_comp -[_.[_]]map_comp_poly /= => co_fg.

--- a/field/finfield.v
+++ b/field/finfield.v
@@ -25,8 +25,8 @@ From mathcomp Require ssrnum ssrint archimedean algC cyclotomic.
 (*                              etc structures (including FinFieldExtType     *)
 (*                              above) for abstract vectType, falgType and    *)
 (*                              fieldExtType over a finFieldType              *)
-(*      PrimeCharType charRp == the carrier of a nzRingType R such that       *)
-(*                              charRp : p \in [char R] holds. This type has  *)
+(*    pPrimeCharType pcharRp == the carrier of a nzRingType R such that       *)
+(*                              pcharRp : p \in [pchar R] holds. This type has*)
 (*                              canonical nzRingType, ..., fieldType          *)
 (*                              structures compatible with those of R, as well*)
 (*                              as canonical lmodType 'F_p, ..., algType 'F_p *)
@@ -49,7 +49,7 @@ From mathcomp Require ssrnum ssrint archimedean algC cyclotomic.
 (*                              finDomain_fieldP domR to prove commutativity  *)
 (*                              and field axioms (the former is Wedderburn's  *)
 (*                              little theorem).                              *)
-(* FinDomainSplittingFieldType domR charRp == a splittingFieldType structure  *)
+(* FinDomainSplittingFieldType domR pcharRp == a splittingFieldType structure *)
 (*                              that repackages the two constructions above   *)
 (******************************************************************************)
 
@@ -110,20 +110,20 @@ move/all_roots_prod_XsubC->; last by rewrite uniq_rootsE enum_uniq.
 by apply/allP=> x _; rewrite rootE !hornerE expf_card subrr.
 Qed.
 
-Lemma finCharP : {p | prime p & p \in [char F]}.
+Lemma finPcharP : {p | prime p & p \in [pchar F]}.
 Proof.
 pose e := exponent [set: F]; have e_gt0: e > 0 by apply: exponent_gt0.
 have: e%:R == 0 :> F by rewrite -zmodXgE expg_exponent // inE.
-by case/natf0_char/sigW=> // p charFp; exists p; rewrite ?(charf_prime charFp).
+by case/natf0_pchar/sigW=> // p pcharFp; exists p; rewrite ?(pcharf_prime pcharFp).
 Qed.
 
 Lemma finField_is_abelem : is_abelem [set: F].
 Proof.
-have [p pr_p charFp] := finCharP.
-by apply/is_abelemP; exists p; last apply: fin_ring_char_abelem.
+have [p pr_p pcharFp] := finPcharP.
+by apply/is_abelemP; exists p; last apply: fin_ring_pchar_abelem.
 Qed.
 
-Lemma card_finCharP p n : #|F| = (p ^ n)%N -> prime p -> p \in [char F].
+Lemma card_finPcharP p n : #|F| = (p ^ n)%N -> prime p -> p \in [pchar F].
 Proof.
 move=> oF pr_p; rewrite inE pr_p -order_dvdn.
 rewrite (abelem_order_p finField_is_abelem) ?inE ?oner_neq0 //=.
@@ -132,6 +132,11 @@ by rewrite cardsT oF -(prednK n_gt0) pdiv_pfactor.
 Qed.
 
 End FinField.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use finPcharP instead.")]
+Notation finCharP := (finPcharP) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use card_finPcharP instead.")]
+Notation card_finCharP := (card_finPcharP) (only parsing).
 
 Section CardVspace.
 
@@ -219,126 +224,126 @@ Section PrimeCharRing.
 
 Variable R0 : nzRingType.
 
-Definition PrimeCharType of p \in [char R0] : predArgType := R0.
+Definition pPrimeCharType of p \in [pchar R0] : predArgType := R0.
 
-Hypothesis charRp : p \in [char R0].
-Local Notation R := (PrimeCharType charRp).
+Hypothesis pcharRp : p \in [pchar R0].
+Local Notation R := (pPrimeCharType pcharRp).
 Implicit Types (a b : 'F_p) (x y : R).
 
 HB.instance Definition _ := GRing.NzRing.on R.
 
-Definition primeChar_scale a x := a%:R * x.
-Local Infix "*p:" := primeChar_scale (at level 40).
+Definition pprimeChar_scale a x := a%:R * x.
+Local Infix "*p':" := pprimeChar_scale (at level 40).
 
 Let natrFp n : (inZp n : 'F_p)%:R = n%:R :> R.
 Proof.
-rewrite [in RHS](divn_eq n p) natrD mulrnA (mulrn_char charRp) add0r.
-by rewrite /= (Fp_cast (charf_prime charRp)).
+rewrite [in RHS](divn_eq n p) natrD mulrnA (mulrn_pchar pcharRp) add0r.
+by rewrite /= (Fp_cast (pcharf_prime pcharRp)).
 Qed.
 
-Lemma primeChar_scaleA a b x : a *p: (b *p: x) = (a * b) *p: x.
-Proof. by rewrite /primeChar_scale mulrA -natrM natrFp. Qed.
+Lemma pprimeChar_scaleA a b x : a *p': (b *p': x) = (a * b) *p': x.
+Proof. by rewrite /pprimeChar_scale mulrA -natrM natrFp. Qed.
 
-Lemma primeChar_scale1 : left_id 1 primeChar_scale.
-Proof. by move=> x; rewrite /primeChar_scale mul1r. Qed.
+Lemma pprimeChar_scale1 : left_id 1 pprimeChar_scale.
+Proof. by move=> x; rewrite /pprimeChar_scale mul1r. Qed.
 
-Lemma primeChar_scaleDr : right_distributive primeChar_scale +%R.
-Proof. by move=> a x y /=; rewrite /primeChar_scale mulrDr. Qed.
+Lemma pprimeChar_scaleDr : right_distributive pprimeChar_scale +%R.
+Proof. by move=> a x y /=; rewrite /pprimeChar_scale mulrDr. Qed.
 
-Lemma primeChar_scaleDl x : {morph primeChar_scale^~ x: a b / a + b}.
-Proof. by move=> a b; rewrite /primeChar_scale natrFp natrD mulrDl. Qed.
+Lemma pprimeChar_scaleDl x : {morph pprimeChar_scale^~ x: a b / a + b}.
+Proof. by move=> a b; rewrite /pprimeChar_scale natrFp natrD mulrDl. Qed.
 
 HB.instance Definition _ := GRing.Zmodule_isLmodule.Build 'F_p R
-  primeChar_scaleA primeChar_scale1 primeChar_scaleDr primeChar_scaleDl.
+  pprimeChar_scaleA pprimeChar_scale1 pprimeChar_scaleDr pprimeChar_scaleDl.
 
-Lemma primeChar_scaleAl (a : 'F_p) (u v : R) :  a *: (u * v) = (a *: u) * v.
+Lemma pprimeChar_scaleAl (a : 'F_p) (u v : R) :  a *: (u * v) = (a *: u) * v.
 Proof. by apply: mulrA. Qed.
 
 HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build 'F_p R
-  primeChar_scaleAl.
+  pprimeChar_scaleAl.
 
-Lemma primeChar_scaleAr (a : 'F_p) (x y : R) : a *: (x * y) = x * (a *: y).
+Lemma pprimeChar_scaleAr (a : 'F_p) (x y : R) : a *: (x * y) = x * (a *: y).
 Proof. by rewrite ![a *: _]mulr_natl mulrnAr. Qed.
 
 HB.instance Definition _ := GRing.Lalgebra_isAlgebra.Build 'F_p R
-  primeChar_scaleAr.
+  pprimeChar_scaleAr.
 
 End PrimeCharRing.
 
-Local Notation type := @PrimeCharType.
+Local Notation type := @pPrimeCharType.
 
 (* TODO: automatize parameter inference to do all of these *)
-HB.instance Definition _ (R : unitRingType) charRp :=
-  GRing.UnitRing.on (type R charRp).
-HB.instance Definition _ (R : comNzRingType) charRp :=
-  GRing.ComNzRing.on (type R charRp).
-HB.instance Definition _ (R : comUnitRingType) charRp :=
-  GRing.ComUnitRing.on (type R charRp).
-HB.instance Definition _ (R : idomainType) charRp :=
-  GRing.IntegralDomain.on (type R charRp).
-HB.instance Definition _ (R : fieldType) charRp :=
-  GRing.Field.on (type R charRp).
+HB.instance Definition _ (R : unitRingType) pcharRp :=
+  GRing.UnitRing.on (type R pcharRp).
+HB.instance Definition _ (R : comNzRingType) pcharRp :=
+  GRing.ComNzRing.on (type R pcharRp).
+HB.instance Definition _ (R : comUnitRingType) pcharRp :=
+  GRing.ComUnitRing.on (type R pcharRp).
+HB.instance Definition _ (R : idomainType) pcharRp :=
+  GRing.IntegralDomain.on (type R pcharRp).
+HB.instance Definition _ (R : fieldType) pcharRp :=
+  GRing.Field.on (type R pcharRp).
 
 Section FinNzRing.
 
-Variables (R0 : finNzRingType) (charRp : p \in [char R0]).
-Local Notation R := (type _ charRp).
+Variables (R0 : finNzRingType) (pcharRp : p \in [pchar R0]).
+Local Notation R := (type _ pcharRp).
 
 HB.instance Definition _ := FinGroup.on R.
 
-Let pr_p : prime p. Proof. exact: charf_prime charRp. Qed.
+Let pr_p : prime p. Proof. exact: pcharf_prime pcharRp. Qed.
 
-Lemma primeChar_abelem : p.-abelem [set: R].
+Lemma pprimeChar_abelem : p.-abelem [set: R].
 Proof. exact: fin_Fp_lmod_abelem. Qed.
 
-Lemma primeChar_pgroup : p.-group [set: R].
-Proof. by case/and3P: primeChar_abelem. Qed.
+Lemma pprimeChar_pgroup : p.-group [set: R].
+Proof. by case/and3P: pprimeChar_abelem. Qed.
 
-Lemma order_primeChar x : x != 0 :> R -> #[x]%g = p.
-Proof. by apply: (abelem_order_p primeChar_abelem); rewrite inE. Qed.
+Lemma order_pprimeChar x : x != 0 :> R -> #[x]%g = p.
+Proof. by apply: (abelem_order_p pprimeChar_abelem); rewrite inE. Qed.
 
 Let n := logn p #|R|.
 
-Lemma card_primeChar : #|R| = (p ^ n)%N.
-Proof. by rewrite /n -cardsT {1}(card_pgroup primeChar_pgroup). Qed.
+Lemma card_pprimeChar : #|R| = (p ^ n)%N.
+Proof. by rewrite /n -cardsT {1}(card_pgroup pprimeChar_pgroup). Qed.
 
-Lemma primeChar_vectAxiom : Vector.axiom n R.
+Lemma pprimeChar_vectAxiom : Vector.axiom n R.
 Proof.
 have /isog_isom/=[f /isomP[injf im_f]]: [set: R] \isog [set: 'rV['F_p]_n].
   rewrite (@isog_abelem_card _ _ p) fin_Fp_lmod_abelem //=.
-  by rewrite !cardsT card_primeChar card_mx mul1n card_Fp.
+  by rewrite !cardsT card_pprimeChar card_mx mul1n card_Fp.
 exists f; last by exists (invm injf) => x; rewrite ?invmE ?invmK ?im_f ?inE.
 move=> a x y; rewrite [a *: _]mulr_natl morphM ?morphX ?inE // zmodXgE.
 by congr (_ + _); rewrite -scaler_nat natr_Zp.
 Qed.
 
 HB.instance Definition _ := Lmodule_hasFinDim.Build 'F_p R
-  primeChar_vectAxiom.
+  pprimeChar_vectAxiom.
 
-Lemma primeChar_dimf : \dim {: R : vectType 'F_p } = n.
+Lemma pprimeChar_dimf : \dim {: R : vectType 'F_p } = n.
 Proof. by rewrite dimvf. Qed.
 
 End FinNzRing.
 
-HB.instance Definition _ (R : finUnitRingType) charRp :=
-  FinRing.UnitRing.on (type R charRp).
+HB.instance Definition _ (R : finUnitRingType) pcharRp :=
+  FinRing.UnitRing.on (type R pcharRp).
 #[warning="-HB.no-new-instance"]
-HB.instance Definition _ (R : finUnitRingType) charRp :=
-  FinRing.UnitAlgebra.on (type R charRp).
+HB.instance Definition _ (R : finUnitRingType) pcharRp :=
+  FinRing.UnitAlgebra.on (type R pcharRp).
 #[warning="-HB.no-new-instance"]
-HB.instance Definition _ (R : finUnitRingType) charRp :=
-  Falgebra.on (type R charRp).
-HB.instance Definition _ (R : finComNzRingType) charRp :=
-  FinRing.ComNzRing.on (type R charRp).
-HB.instance Definition _ (R : finComUnitRingType) charRp :=
-  FinRing.ComUnitRing.on (type R charRp).
-HB.instance Definition _ (R : finIdomainType) charRp :=
-  FinRing.IntegralDomain.on (type R charRp).
+HB.instance Definition _ (R : finUnitRingType) pcharRp :=
+  Falgebra.on (type R pcharRp).
+HB.instance Definition _ (R : finComNzRingType) pcharRp :=
+  FinRing.ComNzRing.on (type R pcharRp).
+HB.instance Definition _ (R : finComUnitRingType) pcharRp :=
+  FinRing.ComUnitRing.on (type R pcharRp).
+HB.instance Definition _ (R : finIdomainType) pcharRp :=
+  FinRing.IntegralDomain.on (type R pcharRp).
 
 Section FinField.
 
-Variables (F0 : finFieldType) (charFp : p \in [char F0]).
-Local Notation F := (type _ charFp).
+Variables (F0 : finFieldType) (pcharFp : p \in [pchar F0]).
+Local Notation F := (type _ pcharFp).
 
 HB.instance Definition _ := Finite.on F.
 HB.instance Definition _ := SplittingField.copy F (finvect_type F).
@@ -346,6 +351,36 @@ HB.instance Definition _ := SplittingField.copy F (finvect_type F).
 End FinField.
 
 End PrimeChar.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pPrimeCharType instead.")]
+Notation PrimeCharType := (pPrimeCharType) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_scale instead.")]
+Notation primeChar_scale := (pprimeChar_scale) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_scaleA instead.")]
+Notation primeChar_scaleA := (pprimeChar_scaleA) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_scale1 instead.")]
+Notation primeChar_scale1 := (pprimeChar_scale1) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_scaleDr instead.")]
+Notation primeChar_scaleDr := (pprimeChar_scaleDr) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_scaleDl instead.")]
+Notation primeChar_scaleDl := (pprimeChar_scaleDl) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_scaleAl instead.")]
+Notation primeChar_scaleAl := (pprimeChar_scaleAl) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_scaleAr instead.")]
+Notation primeChar_scaleAr := (pprimeChar_scaleAr) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_abelem instead.")]
+Notation primeChar_abelem := (pprimeChar_abelem) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_pgroup instead.")]
+Notation primeChar_pgroup := (pprimeChar_pgroup) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use order_pprimeChar instead.")]
+Notation order_primeChar := (order_pprimeChar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use card_pprimeChar instead.")]
+Notation card_primeChar := (card_pprimeChar) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_vectAxiom instead.")]
+Notation primeChar_vectAxiom := (pprimeChar_vectAxiom) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use pprimeChar_dimf instead.")]
+Notation primeChar_dimf := (pprimeChar_dimf) (only parsing).
+
 
 Section FinSplittingField.
 
@@ -399,9 +434,9 @@ have idfP x: reflect (f x = x) (x \in 1%VS).
   by rewrite root_prod_XsubC => /mapP[a]; exists a.
 have fA : additive f.
   rewrite /f => x y; rewrite ?exprMn ?expr1n //.
-  have [p _ charFp] := finCharP F; rewrite (card_primeChar charFp).
+  have [p _ pcharFp] := finPcharP F; rewrite (card_pprimeChar pcharFp).
   elim: (logn _ _) => // n IHn; rewrite expnSr !exprM {}IHn.
-  by rewrite -(char_lalg L) in charFp; rewrite -Frobenius_autE rmorphB.
+  by rewrite -(pchar_lalg L) in pcharFp; rewrite -pFrobenius_autE rmorphB.
 have fM : multiplicative f.
   by rewrite /f; split=> [x y|]; rewrite ?exprMn ?expr1n //.
 have fZ: scalable f.
@@ -544,8 +579,8 @@ exists (x%:A :: zs); rewrite big_cons; set rhs := _ * _.
 by rewrite Dp mulrC [_^%:A]rmorphM /= mapXsubC /= eqp_mull.
 Qed.
 
-Lemma PrimePowerField p k (m := (p ^ k)%N) :
-  prime p -> 0 < k -> {Fm : finFieldType | p \in [char Fm] & #|Fm| = m}.
+Lemma pPrimePowerField p k (m := (p ^ k)%N) :
+  prime p -> 0 < k -> {Fm : finFieldType | p \in [pchar Fm] & #|Fm| = m}.
 Proof.
 move=> pr_p k_gt0; have m_gt1: m > 1 by rewrite (ltn_exp2l 0) ?prime_gt1.
 have m_gt0 := ltnW m_gt1; have m1_gt0: m.-1 > 0 by rewrite -ltnS prednK.
@@ -554,7 +589,7 @@ pose q := 'X^m - 'X; have Dq R: q R = ('X^m.-1 - 1) * ('X - 0).
 have /FinSplittingFieldFor[/= L splitLq]: q 'F_p != 0.
   by rewrite Dq monic_neq0 ?rpredM ?monicXsubC ?monicXnsubC.
 rewrite [_^%:A]rmorphB rmorphXn /= map_polyX -/(q L) in splitLq.
-have charL: p \in [char L] by rewrite char_lalg char_Fp.
+have pcharL: p \in [pchar L] by rewrite pchar_lalg pchar_Fp.
 pose Fm := FinFieldExtType L; exists Fm => //.
 have /finField_galois_generator[/= a _ Da]: (1 <= {:L})%VS by apply: sub1v.
 pose Em := fixedSpace (a ^+ k)%g; rewrite card_Fp //= dimv1 expn1 in Da.
@@ -563,7 +598,7 @@ have Uzs: uniq zs.
   rewrite -separable_prod_XsubC -(eqp_separable DqL) Dq separable_root andbC.
   rewrite /root !hornerE subr_eq0 eq_sym expr0n gtn_eqF ?oner_eq0 //=.
   rewrite cyclotomic.separable_Xn_sub_1 // -subn1 natrB // subr_eq0.
-  by rewrite natrX charf0 // expr0n gtn_eqF // eq_sym oner_eq0.
+  by rewrite natrX pcharf0 // expr0n gtn_eqF // eq_sym oner_eq0.
 suffices /eq_card->: Fm =i zs.
   apply: succn_inj; rewrite (card_uniqP _) //= -(size_prod_XsubC _ id).
   by rewrite -(eqp_size DqL) size_polyDl size_polyXn // size_polyN size_polyX.
@@ -578,6 +613,9 @@ by rewrite subv_add sub1v; apply/span_subvP=> z; rewrite in_zs.
 Qed.
 
 End FinFieldExists.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pPrimePowerField instead.")]
+Notation PrimePowerField := (pPrimePowerField) (only parsing).
 
 Section FinDomain.
 
@@ -602,14 +640,14 @@ Qed.
 Theorem finDomain_mulrC : @commutative R R *%R.
 Proof.
 have fieldR := finDomain_field.
-have [p p_pr charRp]: exists2 p, prime p & p \in [char R].
+have [p p_pr pcharRp]: exists2 p, prime p & p \in [pchar R].
   have [e /prod_prime_decomp->]: {e | (e > 0)%N & e%:R == 0 :> R}.
     by exists #|[set: R]%G|; rewrite // -order_dvdn order_dvdG ?inE.
   rewrite big_seq; elim/big_rec: _ => [|[p m] /= n]; first by rewrite oner_eq0.
   case/mem_prime_decomp=> p_pr _ _ IHn.
   elim: m => [|m IHm]; rewrite ?mul1n {IHn}// expnS -mulnA natrM.
   by case/eqP/domR/orP=> //; exists p; last apply/andP.
-pose Rp := PrimeCharType charRp; pose L : {vspace Rp} := fullv.
+pose Rp := pPrimeCharType pcharRp; pose L : {vspace Rp} := fullv.
 pose G := [set: {unit R}]; pose ofG : {unit R} -> Rp := val.
 pose projG (E : {vspace Rp}) := [preim ofG of E].
 have inG t nzt: Sub t (finDomain_field nzt) \in G by rewrite inE.
@@ -701,7 +739,10 @@ Definition FinDomainFieldType : finFieldType :=
  let fC := GRing.UnitRing_isField.Build iR finDomain_field in
  HB.pack iR fC.
 
-Definition FinDomainSplittingFieldType p (charRp : p \in [char R]) :=
-  SplittingField.clone 'F_p R (@PrimeCharType p FinDomainFieldType charRp).
+Definition FinDomainSplittingFieldType_pchar p (pcharRp : p \in [pchar R]) :=
+  SplittingField.clone 'F_p R (@pPrimeCharType p FinDomainFieldType pcharRp).
 
 End FinDomain.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use FinDomainSplittingFieldType_pchar  instead.")]
+Notation FinDomainSplittingFieldType := (FinDomainSplittingFieldType_pchar) (only parsing).

--- a/field/separable.v
+++ b/field/separable.v
@@ -16,7 +16,7 @@ From mathcomp Require Import fieldext.
 (*         separable K E <=> every member of E is separable over K.           *)
 (* separable_generator K E == some x \in E that generates the largest         *)
 (*                           subfield K[x] that is separable over K.          *)
-(* purely_inseparable_element K x <=> there is a [char L].-nat n such that    *)
+(* purely_inseparable_element K x <=> there is a [pchar L].-nat n such that    *)
 (*                           x ^+ n \in K.                                    *)
 (* purely_inseparable K E <=> every member of E is purely inseparable over K. *)
 (*                                                                            *)
@@ -248,11 +248,11 @@ exists (- (r3`_0 / r3`_1)); rewrite [kappa _]rmorphN fmorph_div -!coef_map Dr3.
 by rewrite !coefZ polyseqXsubC mulr1 mulrC mulKf ?opprK.
 Qed.
 
-Lemma char0_PET (q : {poly F}) :
-    q != 0 -> root (q ^ iota) y -> [char F] =i pred0 ->
+Lemma pchar0_PET (q : {poly F}) :
+    q != 0 -> root (q ^ iota) y -> [pchar F] =i pred0 ->
   exists n, let z := y *+ n - x in inFz z x /\ inFz z y.
 Proof.
-move=> nz_q qy_0 /charf0P charF0.
+move=> nz_q qy_0 /pcharf0P pcharF0.
 without loss{nz_q} sep_q: q qy_0 / separable_poly q.
   move=> IHq; apply: IHq (make_separable nz_q).
   have /dvdpP[q1 Dq] := dvdp_gcdl q q^`().
@@ -264,7 +264,7 @@ without loss{nz_q} sep_q: q qy_0 / separable_poly q.
   rewrite Dq rmorphM /= gcdp_map -(eqp_dvdr _ (gcdp_mul2l _ _ _)) -deriv_map Dr.
   rewrite dvdp_gcd derivM deriv_exp derivXsubC mul1r !mulrA dvdp_mulIr /=.
   rewrite mulrDr mulrA dvdp_addr ?dvdp_mulIr // exprS -scaler_nat -!scalerAr.
-  rewrite dvdpZr -?(rmorph_nat iota) ?fmorph_eq0 ?charF0 //.
+  rewrite dvdpZr -?(rmorph_nat iota) ?fmorph_eq0 ?pcharF0 //.
   rewrite mulrA dvdp_mul2r ?expf_neq0 ?polyXsubC_eq0 //.
   by rewrite Gauss_dvdpl ?dvdp_XsubCl // coprimep_sym coprimep_XsubC.
 have [r nz_r PETxy] := large_field_PET qy_0 sep_q.
@@ -273,12 +273,15 @@ have /(max_ring_poly_roots nz_r)/=/implyP: uniq_roots ts.
   rewrite uniq_rootsE mkseq_uniq // => m n eq_mn; apply/eqP; rewrite eqn_leq.
   wlog suffices: m n eq_mn / m <= n by move=> IHmn; rewrite !IHmn.
   move/fmorph_inj/eqP: eq_mn; rewrite -subr_eq0 leqNgt; apply: contraL => lt_mn.
-  by rewrite -natrB ?(ltnW lt_mn) // charF0 -lt0n subn_gt0.
+  by rewrite -natrB ?(ltnW lt_mn) // pcharF0 -lt0n subn_gt0.
 rewrite size_mkseq ltnn implybF all_map => /allPn[n _ /= /PETxy].
 by rewrite rmorph_nat mulr_natl; exists n.
 Qed.
 
 End InfinitePrimitiveElementTheorem.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use pchar0_PET instead.")]
+Notation char0_PET := (pchar0_PET) (only parsing).
 
 Section Separable.
 
@@ -399,30 +402,30 @@ rewrite dvdp_gcd dvdpp /= => /(dvdp_leq nzPx')/leq_trans/(_ (size_poly _ _)).
 by rewrite size_minPoly ltnn.
 Qed.
 
-Lemma separablePn :
-  reflect (exists2 p, p \in [char L] &
+Lemma separablePn_pchar :
+  reflect (exists2 p, p \in [pchar L] &
             exists2 g, g \is a polyOver K & minPoly K x = g \Po 'X^p)
           (~~ separable_element K x).
 Proof.
 rewrite separable_nz_der negbK; set f := minPoly K x.
 apply: (iffP eqP) => [f'0 | [p Hp [g _ ->]]]; last first.
-  by rewrite deriv_comp derivXn -scaler_nat (charf0 Hp) scale0r mulr0.
+  by rewrite deriv_comp derivXn -scaler_nat (pcharf0 Hp) scale0r mulr0.
 pose n := adjoin_degree K x; have sz_f: size f = n.+1 := size_minPoly K x.
 have fn1: f`_n = 1 by rewrite -(monicP (monic_minPoly K x)) lead_coefE sz_f.
 have dimKx: (adjoin_degree K x)%:R == 0 :> L.
   by rewrite -(coef0 _ n.-1) -f'0 coef_deriv fn1.
-have /natf0_char[// | p charLp] := dimKx.
-have /dvdnP[r Dn]: (p %| n)%N by rewrite (dvdn_charf charLp).
+have /natf0_pchar[// | p pcharLp] := dimKx.
+have /dvdnP[r Dn]: (p %| n)%N by rewrite (dvdn_pcharf pcharLp).
 exists p => //; exists (\poly_(i < r.+1) f`_(i * p)).
   by apply: polyOver_poly => i _; rewrite (polyOverP _) ?minPolyOver.
 rewrite comp_polyE size_poly_eq -?Dn ?fn1 ?oner_eq0 //.
-have pr_p := charf_prime charLp; have p_gt0 := prime_gt0 pr_p.
+have pr_p := pcharf_prime pcharLp; have p_gt0 := prime_gt0 pr_p.
 apply/polyP=> i; rewrite coef_sum.
 have [[{}i ->] | p'i] := altP (@dvdnP p i); last first.
   rewrite big1 => [|j _]; last first.
     rewrite coefZ -exprM coefXn [_ == _](contraNF _ p'i) ?mulr0 // => /eqP->.
     by rewrite dvdn_mulr.
-  rewrite (dvdn_charf charLp) in p'i; apply: mulfI p'i _ _ _.
+  rewrite (dvdn_pcharf pcharLp) in p'i; apply: mulfI p'i _ _ _.
   by rewrite mulr0 mulr_natl; case: i => // i; rewrite -coef_deriv f'0 coef0.
 have [ltri | leir] := leqP r.+1 i.
   rewrite nth_default ?sz_f ?Dn ?ltn_pmul2r ?big1 // => j _.
@@ -563,6 +566,9 @@ Qed.
 
 End SeparableElement.
 
+#[deprecated(since="mathcomp 2.4.0", note="Use separablePn_pchar instead.")]
+Notation separablePn := (separablePn_pchar) (only parsing).
+
 Arguments separable_elementP {K x}.
 
 Lemma separable_elementS K E x :
@@ -597,15 +603,15 @@ rewrite (Derivation_separable derDx sepKx) -/Dx_p Dx_p_0 ?polyOver_comp //.
 by rewrite add0r mulrCA Dx_p_0 ?minPolyOver ?oppr0 ?mul0r.
 Qed.
 
-Lemma separable_exponent K x :
-  exists n, [char L].-nat n && separable_element K (x ^+ n).
+Lemma separable_exponent_pchar K x :
+  exists n, [pchar L].-nat n && separable_element K (x ^+ n).
 Proof.
 pose d := adjoin_degree K x; move: {2}d.+1 (ltnSn d) => n.
 elim: n => // n IHn in x @d *; rewrite ltnS => le_d_n.
-have [[p charLp]|] := altP (separablePn K x); last by rewrite negbK; exists 1.
-case=> g Kg defKx; have p_pr := charf_prime charLp.
-suffices /IHn[m /andP[charLm sepKxpm]]: adjoin_degree K (x ^+ p) < n.
-  by exists (p * m)%N; rewrite pnatM pnatE // charLp charLm exprM.
+have [[p pcharLp]|] := altP (separablePn_pchar K x); last by rewrite negbK; exists 1.
+case=> g Kg defKx; have p_pr := pcharf_prime pcharLp.
+suffices /IHn[m /andP[pcharLm sepKxpm]]: adjoin_degree K (x ^+ p) < n.
+  by exists (p * m)%N; rewrite pnatM pnatE // pcharLp pcharLm exprM.
 apply: leq_trans le_d_n; rewrite -ltnS -!size_minPoly.
 have nzKx: minPoly K x != 0 by rewrite monic_neq0 ?monic_minPoly.
 have nzg: g != 0 by apply: contra_eqN defKx => /eqP->; rewrite comp_poly0.
@@ -617,18 +623,24 @@ apply: contra_eqT (size_minPoly K x); rewrite defKx -leqNgt => /size1_polyC->.
 by rewrite comp_polyC size_polyC; case: (_ != 0).
 Qed.
 
-Lemma charf0_separable K : [char L] =i pred0 -> forall x, separable_element K x.
+#[deprecated(since="mathcomp 2.4.0", note="Use separable_exponent_pchar instead.")]
+Notation separable_exponent := (separable_exponent_pchar) (only parsing).
+
+Lemma pcharf0_separable K : [pchar L] =i pred0 -> forall x, separable_element K x.
 Proof.
-move=> charL0 x; have [n /andP[charLn]] := separable_exponent K x.
-by rewrite (pnat_1 charLn (sub_in_pnat _ charLn)) // => p _; rewrite charL0.
+move=> pcharL0 x; have [n /andP[pcharLn]] := separable_exponent_pchar K x.
+by rewrite (pnat_1 pcharLn (sub_in_pnat _ pcharLn)) // => p _; rewrite pcharL0.
 Qed.
 
-Lemma charf_p_separable K x e p :
-  p \in [char L] -> separable_element K x = (x \in <<K; x ^+ (p ^ e.+1)>>%VS).
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf0_separable instead.")]
+Notation charf0_separable := (pcharf0_separable) (only parsing).
+
+Lemma pcharf_p_separable K x e p :
+  p \in [pchar L] -> separable_element K x = (x \in <<K; x ^+ (p ^ e.+1)>>%VS).
 Proof.
-move=> charLp; apply/idP/idP=> [sepKx | /Fadjoin_poly_eq]; last first.
+move=> pcharLp; apply/idP/idP=> [sepKx | /Fadjoin_poly_eq]; last first.
   set m := p ^ _; set f := Fadjoin_poly K _ x => Dx; apply/separable_elementP.
-  have mL0: m%:R = 0 :> L by apply/eqP; rewrite -(dvdn_charf charLp) dvdn_exp.
+  have mL0: m%:R = 0 :> L by apply/eqP; rewrite -(dvdn_pcharf pcharLp) dvdn_exp.
   exists ('X - (f \Po 'X^m)); split.
   - by rewrite rpredB ?polyOver_comp ?rpredX ?polyOverX ?Fadjoin_polyOver.
   - by rewrite rootE !hornerE horner_comp hornerXn Dx subrr.
@@ -644,8 +656,8 @@ have [K'g]: g \is a polyOver K' /\ q \is a polyOver K'.
   by rewrite minPolyOver rpredB ?rpredX ?polyOverX // polyOverC memv_adjoin.
 have /dvdpP[c Dq]: 'X - x%:P %| q by rewrite dvdp_XsubCl root_minPoly.
 have co_c_g: coprimep c g.
-  have charPp: p \in [char {poly L}] := rmorph_char polyC charLp.
-  rewrite /g polyC_exp -!(Frobenius_autE charPp) -rmorphB coprimep_expr //.
+  have pcharPp: p \in [pchar {poly L}] := rmorph_pchar polyC pcharLp.
+  rewrite /g polyC_exp -!(pFrobenius_autE pcharPp) -rmorphB coprimep_expr //.
   have: separable_poly q := separable_elementS sKK' sepKx.
   by rewrite Dq separable_mul => /and3P[].
 have{g K'g co_c_g} /size_poly1P[a nz_a Dc]: size c == 1.
@@ -656,35 +668,44 @@ rewrite {q}Dq {c}Dc mulrBr -rmorphM -rmorphN -cons_poly_def qualifE /=.
 by rewrite polyseq_cons !polyseqC nz_a /= rpredN andbCA => /and3P[/fpredMl->].
 Qed.
 
-Lemma charf_n_separable K x n :
-  [char L].-nat n -> 1 < n -> separable_element K x = (x \in <<K; x ^+ n>>%VS).
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf_p_separable instead.")]
+Notation charf_p_separable := (pcharf_p_separable) (only parsing).
+
+Lemma pcharf_n_separable K x n :
+  [pchar L].-nat n -> 1 < n -> separable_element K x = (x \in <<K; x ^+ n>>%VS).
 Proof.
-rewrite -pi_pdiv; set p := pdiv n => charLn pi_n_p.
-have charLp: p \in [char L] := pnatPpi charLn pi_n_p.
-have <-: (n`_p)%N = n by rewrite -(eq_partn n (charf_eq charLp)) part_pnat_id.
-by rewrite p_part lognE -mem_primes pi_n_p -charf_p_separable.
+rewrite -pi_pdiv; set p := pdiv n => pcharLn pi_n_p.
+have pcharLp: p \in [pchar L] := pnatPpi pcharLn pi_n_p.
+have <-: (n`_p)%N = n by rewrite -(eq_partn n (pcharf_eq pcharLp)) part_pnat_id.
+by rewrite p_part lognE -mem_primes pi_n_p -pcharf_p_separable.
 Qed.
 
-Definition purely_inseparable_element U x :=
-  x ^+ ex_minn (separable_exponent <<U>> x) \in U.
+#[deprecated(since="mathcomp 2.4.0", note="Use pcharf_n_separable instead.")]
+Notation charf_n_separable := (pcharf_n_separable) (only parsing).
 
-Lemma purely_inseparable_elementP {K x} :
-  reflect (exists2 n, [char L].-nat n & x ^+ n \in K)
+Definition purely_inseparable_element U x :=
+  x ^+ ex_minn (separable_exponent_pchar <<U>> x) \in U.
+
+Lemma purely_inseparable_elementP_pchar {K x} :
+  reflect (exists2 n, [pchar L].-nat n & x ^+ n \in K)
           (purely_inseparable_element K x).
 Proof.
 rewrite /purely_inseparable_element.
-case: ex_minnP => n /andP[charLn /=]; rewrite subfield_closed => sepKxn min_xn.
-apply: (iffP idP) => [Kxn | [m charLm Kxm]]; first by exists n.
-have{min_xn}: n <= m by rewrite min_xn ?charLm ?base_separable.
+case: ex_minnP => n /andP[pcharLn /=]; rewrite subfield_closed => sepKxn min_xn.
+apply: (iffP idP) => [Kxn | [m pcharLm Kxm]]; first by exists n.
+have{min_xn}: n <= m by rewrite min_xn ?pcharLm ?base_separable.
 rewrite leq_eqVlt => /predU1P[-> // | ltnm]; pose p := pdiv m.
-have m_gt1: 1 < m by have [/leq_ltn_trans->] := andP charLn.
-have charLp: p \in [char L] by rewrite (pnatPpi charLm) ?pi_pdiv.
+have m_gt1: 1 < m by have [/leq_ltn_trans->] := andP pcharLn.
+have pcharLp: p \in [pchar L] by rewrite (pnatPpi pcharLm) ?pi_pdiv.
 have [/p_natP[em Dm] /p_natP[en Dn]]: p.-nat m /\ p.-nat n.
-  by rewrite -!(eq_pnat _ (charf_eq charLp)).
+  by rewrite -!(eq_pnat _ (pcharf_eq pcharLp)).
 rewrite Dn Dm ltn_exp2l ?prime_gt1 ?pdiv_prime // in ltnm.
 rewrite -(Fadjoin_idP Kxm) Dm -(subnKC ltnm) addSnnS expnD exprM -Dn.
-by rewrite -charf_p_separable.
+by rewrite -pcharf_p_separable.
 Qed.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use purely_inseparable_elementP_pchar instead.")]
+Notation purely_inseparable_elementP := (purely_inseparable_elementP_pchar) (only parsing).
 
 Lemma separable_inseparable_element K x :
   separable_element K x && purely_inseparable_element K x = (x \in K).
@@ -701,8 +722,8 @@ Lemma sub_inseparable K E x :
     (K <= E)%VS -> purely_inseparable_element K x ->
  purely_inseparable_element E x.
 Proof.
-move/subvP=> sKE /purely_inseparable_elementP[n charLn /sKE Exn].
-by apply/purely_inseparable_elementP; exists n.
+move/subvP=> sKE /purely_inseparable_elementP_pchar[n pcharLn /sKE Exn].
+by apply/purely_inseparable_elementP_pchar; exists n.
 Qed.
 
 Section PrimitiveElementTheorem.
@@ -822,15 +843,15 @@ Lemma strong_Primitive_Element_Theorem K x y :
   exists2 z : L, (<< <<K; y>>; x>> = <<K; z>>)%VS
                & separable_element K x -> separable_element K y.
 Proof.
-move=> sepKx_y; have [n /andP[charLn sepKyn]] := separable_exponent K y.
+move=> sepKx_y; have [n /andP[pcharLn sepKyn]] := separable_exponent_pchar K y.
 have adjK_C z t: (<<<<K; z>>; t>> = <<<<K; t>>; z>>)%VS.
   by rewrite !agenv_add_id -!addvA (addvC <[_]>%VS).
 have [z defKz] := Primitive_Element_Theorem x sepKyn.
 exists z => [|/adjoin_separable->]; rewrite ?sepKx_y // -defKz.
-have [|n_gt1|-> //] := ltngtP n 1; first by case: (n) charLn.
+have [|n_gt1|-> //] := ltngtP n 1; first by case: (n) pcharLn.
 apply/eqP; rewrite !(adjK_C _ x) eqEsubv; apply/andP.
 split; apply/FadjoinP/andP; rewrite subv_adjoin ?rpredX ?memv_adjoin //=.
-by rewrite -charf_n_separable ?sepKx_y.
+by rewrite -pcharf_n_separable ?sepKx_y.
 Qed.
 
 Definition separable U W : bool :=
@@ -862,10 +883,10 @@ Lemma inseparable_add K x y :
     purely_inseparable_element K x -> purely_inseparable_element K y ->
   purely_inseparable_element K (x + y).
 Proof.
-have insepP := purely_inseparable_elementP.
-move=> /insepP[n charLn Kxn] /insepP[m charLm Kym]; apply/insepP.
-have charLnm: [char L].-nat (n * m)%N by rewrite pnatM charLn.
-by exists (n * m)%N; rewrite ?exprDn_char // {2}mulnC !exprM memvD // rpredX.
+have insepP := purely_inseparable_elementP_pchar.
+move=> /insepP[n pcharLn Kxn] /insepP[m pcharLm Kym]; apply/insepP.
+have pcharLnm: [pchar L].-nat (n * m)%N by rewrite pnatM pcharLn.
+by exists (n * m)%N; rewrite ?exprDn_pchar // {2}mulnC !exprM memvD // rpredX.
 Qed.
 
 Lemma inseparable_sum I r (P : pred I) (v_ : I -> L) K :
@@ -892,8 +913,8 @@ Proof.
 apply/(iffP idP)=> [/allP|] sep'K_E; last by apply/allP=> x /vbasis_mem/sep'K_E.
 move=> y /coord_vbasis->; apply/inseparable_sum=> i _.
 have: purely_inseparable_element K (vbasis E)`_i by apply/sep'K_E/memt_nth.
-case/purely_inseparable_elementP=> n charLn K_Ein.
-by apply/purely_inseparable_elementP; exists n; rewrite // exprZn rpredZ.
+case/purely_inseparable_elementP_pchar=> n pcharLn K_Ein.
+by apply/purely_inseparable_elementP_pchar; exists n; rewrite // exprZn rpredZ.
 Qed.
 
 Lemma adjoin_separable_eq K x : separable_element K x = separable K <<K; x>>%VS.
@@ -907,7 +928,7 @@ without loss sKE: K / (K <= E)%VS.
   exists x; first by split; last exact/(separable_elementS _ sepKEx)/capvSl.
   apply/purely_inseparableP=> y /sep'KExE; apply: sub_inseparable.
   exact/adjoinSl/capvSl.
-pose E_ i := (vbasis E)`_i; pose fP i := separable_exponent K (E_ i).
+pose E_ i := (vbasis E)`_i; pose fP i := separable_exponent_pchar K (E_ i).
 pose f i := E_ i ^+ ex_minn (fP i); pose s := mkseq f (\dim E).
 pose K' := <<K & s>>%VS.
 have sepKs: all (separable_element K) s.
@@ -928,7 +949,7 @@ have [x sepKx defKx]: {x | x \in E /\ separable_element K x & K' = <<K; x>>%VS}.
   apply: adjoin_separable sepKy _; apply: adjoin_separableP Kyt_z.
   exact: separable_elementS (subv_adjoin K y) sepKt.
 exists x; rewrite // -defKx; apply/(all_nthP 0)=> i; rewrite size_tuple => ltiE.
-apply/purely_inseparable_elementP.
+apply/purely_inseparable_elementP_pchar.
 exists (ex_minn (fP i)); first by case: ex_minnP => n /andP[].
 by apply/seqv_sub_adjoin/map_f; rewrite mem_iota.
 Qed.
@@ -1004,17 +1025,17 @@ Lemma purely_inseparable_trans M K E :
   purely_inseparable K M -> purely_inseparable M E -> purely_inseparable K E.
 Proof.
 have insepP := purely_inseparableP => /insepP insepK_M /insepP insepM_E.
-have insepPe := purely_inseparable_elementP.
-apply/insepP=> x /insepM_E/insepPe[n charLn /insepK_M/insepPe[m charLm Kxnm]].
-by apply/insepPe; exists (n * m)%N; rewrite ?exprM // pnatM charLn charLm.
+have insepPe := purely_inseparable_elementP_pchar.
+apply/insepP=> x /insepM_E/insepPe[n pcharLn /insepK_M/insepPe[m pcharLm Kxnm]].
+by apply/insepPe; exists (n * m)%N; rewrite ?exprM // pnatM pcharLn pcharLm.
 Qed.
 
 End Separable.
 
 Arguments separable_elementP {F L K x}.
-Arguments separablePn {F L K x}.
+Arguments separablePn_pchar {F L K x}.
 Arguments Derivation_separableP {F L K x}.
 Arguments adjoin_separableP {F L K x}.
-Arguments purely_inseparable_elementP {F L K x}.
+Arguments purely_inseparable_elementP_pchar {F L K x}.
 Arguments separableP {F L K E}.
 Arguments purely_inseparableP {F L K E}.

--- a/solvable/abelian.v
+++ b/solvable/abelian.v
@@ -2160,8 +2160,8 @@ Section FimModAbelem.
 
 Import GRing.Theory FinRing.Theory.
 
-Lemma fin_lmod_char_abelem p (R : nzRingType) (V : finLmodType R):
-  p \in [char R]%R -> p.-abelem [set: V].
+Lemma fin_lmod_pchar_abelem p (R : nzRingType) (V : finLmodType R):
+  p \in [pchar R]%R -> p.-abelem [set: V].
 Proof.
 case/andP=> p_pr /eqP-pR0; apply/abelemP=> //.
 by split=> [|v _]; rewrite ?zmod_abelian // zmodXgE -scaler_nat pR0 scale0r.
@@ -2169,10 +2169,15 @@ Qed.
 
 Lemma fin_Fp_lmod_abelem p (V : finLmodType 'F_p) :
   prime p -> p.-abelem [set: V].
-Proof. by move/char_Fp/fin_lmod_char_abelem->. Qed.
+Proof. by move/pchar_Fp/fin_lmod_pchar_abelem->. Qed.
 
-Lemma fin_ring_char_abelem p (R : finNzRingType) :
-  p \in [char R]%R -> p.-abelem [set: R].
-Proof. exact: fin_lmod_char_abelem R^o. Qed.
+Lemma fin_ring_pchar_abelem p (R : finNzRingType) :
+  p \in [pchar R]%R -> p.-abelem [set: R].
+Proof. exact: fin_lmod_pchar_abelem R^o. Qed.
 
 End FimModAbelem.
+
+#[deprecated(since="mathcomp 2.4.0", note="Use fin_lmod_pchar_abelem instead.")]
+Notation fin_lmod_char_abelem := (fin_lmod_pchar_abelem) (only parsing).
+#[deprecated(since="mathcomp 2.4.0", note="Use fin_ring_pchar_abelem instead.")]
+Notation fin_ring_char_abelem := (fin_ring_pchar_abelem) (only parsing).

--- a/solvable/extraspecial.v
+++ b/solvable/extraspecial.v
@@ -138,7 +138,7 @@ rewrite [@gtype _]unlock; apply: intro_isoGrp => [|rT H].
   have def_zi i: z ^+ i = sdpair1 actp (i%:R, 0)%R.  (* FIXME: had to explicitly give actp (instead of _) *)
     rewrite def_z -morphX ?inE //; congr (sdpair1 _ _).
     by apply/eqP; rewrite /eq_op /= !morphX ?inE ?expg1n ?andbT //=.
-  rewrite def_xi def_yi char_Zp ?morph1 //.
+  rewrite def_xi def_yi pchar_Zp ?morph1 //.
   rewrite def_z -morphR ?inE // !commgEl -sdpair_act ?inE //= mulr0 addr0.
   rewrite mulVg -[_ * _]/(_ , _) /= !invg1 mulg1 !mul1g mulVg morph1 !andbT.
   have Gx: x \in G by rewrite -cycle_subG joing_subl.

--- a/solvable/extremal.v
+++ b/solvable/extremal.v
@@ -351,10 +351,10 @@ have [ms0 os0]: m s0 = (p ^ n).+1%:R /\ #[s0] = p.
     by rewrite bin2odd // mulnAC dvdn_mulr.
   have [[|d]] := m_se (n - e0.+1)%N; first by rewrite mod0n modn_small.
   move/eqP; rewrite -/s0 eqn_mod_dvd ?subn1 //=; case/dvdnP=> f -> {d}.
-  rewrite subnK // mulSn -mulnA -expnS -addSn natrD natrM -oG char_Zp //.
+  rewrite subnK // mulSn -mulnA -expnS -addSn natrD natrM -oG pchar_Zp //.
   rewrite mulr0 addr0 => m_s0; split => //.
   have [d _] := m_se (n - e0)%N; rewrite -subnSK // expnSr expgM -/s0.
-  rewrite addSn subnK // -oG  mulrS natrM char_Zp // {d}mulr0 addr0.
+  rewrite addSn subnK // -oG  mulrS natrM pchar_Zp // {d}mulr0 addr0.
   move/eqP; rewrite -m1 (inj_in_eq inj_m) ?group1 ?groupX // -order_dvdn.
   move/min_p; rewrite order_eq1; case/predU1P=> [s0_1 | ]; last by move/eqP.
   move/eqP: m_s0; rewrite eq_sym s0_1 m1 -subr_eq0 mulrSr addrK -val_eqE /=.
@@ -386,7 +386,7 @@ rewrite {+}/e0 p2 subn1 /= in s0 os0 ms0 os ms G4 defS1 lt_e0_n *.
 rewrite G4; exists s; split=> //; last first.
   exists s0; split; rewrite ?groupX //; apply/eqP; rewrite mM ?groupX //.
   rewrite ms0 mt eq_sym mulrN1 -subr_eq0 opprK -natrD -addSnnS.
-  by rewrite prednK ?expn_gt0 // addnn -mul2n -expnS -p2 -oG char_Zp.
+  by rewrite prednK ?expn_gt0 // addnn -mul2n -expnS -p2 -oG pchar_Zp.
 suffices TIst: <[s]> :&: <[t]> = 1.
   rewrite dprodE //; last by rewrite (sub_abelian_cent2 cAA) ?cycle_subG.
   apply/eqP; rewrite eqEcard mulG_subG !cycle_subG As At oA.


### PR DESCRIPTION
##### Motivation for this change
https://github.com/math-comp/math-comp/pull/1308 is not backwards compatible, so I assume we need to rename the whole world first.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
