### PR TITLE
Performance patch

### DIFF
--- a/mathcomp/algebra/mxpoly.v
+++ b/mathcomp/algebra/mxpoly.v
@@ -1113,9 +1113,9 @@ suffices [m [X [[u [_ Du]] idealM]]]: exists m,
   have: (\det B *: (u *m X^T)) 0 0 == 0.
     rewrite scalemxAr -linearZ -mul_mx_scalar -mul_mx_adj mulmxA XB0 /=.
     by rewrite mul0mx trmx0 mulmx0 mxE.
-  rewrite mxE -Du mulr1 rootE -horner_evalE -!det_map_mx; congr (\det _ == 0).
-  rewrite !raddfB /= !map_scalar_mx /= map_polyX horner_evalE hornerX.
-  by apply/matrixP=> i j; rewrite !mxE map_polyC /horner_eval hornerC.
+  rewrite mxE -Du mulr1 rootE -horner_evalE -2!det_map_mx; congr (\det _ == 0).
+  rewrite raddfB/= map_scalar_mx; apply/matrixP=> i j.
+  by rewrite !mxE raddfB raddfMn/= map_polyX map_polyC /horner_eval !hornerE.
 pose gen1 x E y := exists2 r, pXin E r & y = r.[x]; pose gen := foldr gen1 memR.
 have gen1S (E : K -> Prop) x y: E 0 -> E y -> gen1 x E y.
   by exists y%:P => [i|]; rewrite ?hornerC ?coefC //; case: ifP.
@@ -1889,7 +1889,9 @@ apply/(codiagonalizable_on _ mxdirect_eigenspaces) => // i/=.
     by rewrite thinmx0 sub0mx.
   by rewrite comm_mx_stable_eigenspace.
 rewrite codiagonalizable1.
-by rewrite (@conjmx_eigenvalue _ _ _ rs`_i) ?eq_row_base ?row_base_free.
+rewrite (@conjmx_eigenvalue _ _ _ rs`_i); first exact: diagonalizable_scalar.
+  by rewrite eq_row_base.
+by rewrite row_base_free.
 Qed.
 
 Lemma diagonalizableP n' (n := n'.+1) (A : 'M[F]_n) :
@@ -1909,8 +1911,10 @@ Qed.
 Lemma diagonalizable_conj_diag m n (V : 'M[F]_(m, n)) (d : 'rV[F]_n) :
   stablemx V (diag_mx d) -> row_free V -> diagonalizable (conjmx V (diag_mx d)).
 Proof.
-case: m n => [|m] [|n] in V d * => Vd rdV; rewrite ?thinmx0//=.
-  by rewrite /row_free mxrank.unlock in rdV.
+case: m n => [|m] [|n] in V d * => Vd rdV; rewrite ?thinmx0.
+- by [].
+- by [].
+- by exfalso; move: rdV; rewrite /row_free mxrank.unlock eqxx orbT.
 apply/diagonalizableP; pose u := undup [seq d 0 i | i <- enum 'I_n.+1].
 exists u; first by rewrite undup_uniq.
 by rewrite (dvdp_trans (mxminpoly_conj (f:=diag_mx d) _ _))// mxminpoly_diag.
@@ -1944,7 +1948,7 @@ rewrite (@conjmx_eigenvalue _ _ _ rs`_i) ?eq_row_base ?row_base_free//.
 set Bs := map _ _; suff [P Punit /= PBs] : codiagonalizable Bs.
   exists P; rewrite /= ?PBs ?andbT// /(diagonalizable_for _ _).
   by rewrite conjmx_scalar ?mx_scalar_is_diag// row_free_unit.
-apply: IHk; rewrite ?size_map/= ?ltnS//; split.
+apply: IHk; rewrite ?size_map//=; split.
   apply/all_comm_mxP => _ _ /mapP[/= B BAs ->] /mapP[/= h hAs ->].
   rewrite -!conjmxM ?inE ?stablemx_row_base ?eAB ?inE ?BAs ?hAs ?orbT//.
   by rewrite (all_comm_mxP _ AsC).

--- a/mathcomp/character/character.v
+++ b/mathcomp/character/character.v
@@ -2271,7 +2271,8 @@ move=> Nchi; without loss kerH: / H \subset cfker chi.
   by apply/cfunP=> x; rewrite cfunE cfun1E mulr_natr cfunElock IHchi.
 without loss nsHG: G chi Nchi kerH / H <| G.
   move=> IHchi; have nsHN := normalSG (subset_trans kerH (cfker_sub chi)).
-  by rewrite cfQuoInorm ?(cfRes_char, IHchi) ?sub_cfker_Res // ?normal_sub.
+  rewrite cfQuoInorm//; apply/cfRes_char/IHchi => //; first exact: cfRes_char. 
+  by apply: sub_cfker_Res => //; apply: normal_sub.
 have [rG Dchi] := char_reprP Nchi; rewrite Dchi cfker_repr in kerH.
 apply/char_reprP; exists (Representation (quo_repr kerH (normal_norm nsHG))).
 apply/cfun_inP=> _ /morphimP[x nHx Gx ->]; rewrite Dchi cfQuoE ?cfker_repr //=.

--- a/mathcomp/character/classfun.v
+++ b/mathcomp/character/classfun.v
@@ -1777,7 +1777,7 @@ Lemma sub_cfker_mod (A : {set gT}) K (psi : 'CF(G / K)) :
     K <| G -> A \subset 'N(K) ->
   (A \subset cfker (psi %% K)) = (A / K \subset cfker psi)%g.
 Proof.
-by move=> nsKG nKA; rewrite -(quotientSGK nKA) ?quotient_cfker_mod ?cfker_mod.
+by move=> nsKG nKA; rewrite -(quotientSGK nKA) ?quotient_cfker_mod// cfker_mod.
 Qed.
 
 Lemma cfker_quo H phi :
@@ -1801,7 +1801,7 @@ Lemma cfResQuo H K phi :
 Proof.
 move=> kerK sKH sHG; apply/cfun_inP=> xb Hxb; rewrite cfResE ?quotientS //.
 have{xb Hxb} [x nKx Hx ->] := morphimP Hxb.
-by rewrite !cfQuoEnorm ?cfResE ?sub_cfker_Res // inE ?Hx ?(subsetP sHG).
+by rewrite !cfQuoEnorm ?cfResE// 1?inE ?Hx ?(subsetP sHG)// sub_cfker_Res.
 Qed.
 
 Lemma cfQuoInorm K phi :

--- a/mathcomp/character/inertia.v
+++ b/mathcomp/character/inertia.v
@@ -926,7 +926,8 @@ have [sHG sTG]: H \subset G /\ T \subset G by rewrite subsetIl normal_sub.
 have nsHT : H <| T := normal_Inertia theta sHG; have sHT := normal_sub nsHT.
 have AtoB_P s (psi := 'chi_s) (chi := 'Ind[G] psi): s \in calA ->
   [/\ chi \in irr G, AtoB s \in calB & '['Res psi, theta] = '['Res chi, theta]].
-- rewrite !constt_Ind_Res => sHt; have [r sGr] := constt_cfInd_irr s sTG.
+- rewrite constt_Ind_Res => sHt; have [r sGr] := constt_cfInd_irr s sTG.
+  rewrite constt_Ind_Res.
   have rTs: s \in irr_constt ('Res[T] 'chi_r) by rewrite -constt_Ind_Res.
   have NrT: 'Res[T] 'chi_r \is a character by rewrite cfRes_char ?irr_char.
   have rHt: t \in irr_constt ('Res[H] 'chi_r).

--- a/mathcomp/character/mxabelem.v
+++ b/mathcomp/character/mxabelem.v
@@ -732,13 +732,14 @@ Qed.
 
 Lemma rsim_abelem_subg : mx_rsim rHG rH.
 Proof.
-exists 1%:M => // [|x Hx]; first by rewrite row_free_unit unitmx1.
+exists 1%:M => [//| |x Hx]; first by rewrite row_free_unit unitmx1.
 by rewrite mul1mx mulmx1 eq_abelem_subg_repr.
 Qed.
 
 Lemma mxmodule_abelem_subg m (U : 'M_(m, n)) : mxmodule rHG U = mxmodule rH U.
 Proof.
-apply: eq_subset_r => x /[!inE]; apply: andb_id2l => Hx.
+apply: eq_subset_r => x.
+rewrite [LHS]inE inE; apply: andb_id2l => Hx.
 by rewrite eq_abelem_subg_repr.
 Qed.
 

--- a/mathcomp/solvable/burnside_app.v
+++ b/mathcomp/solvable/burnside_app.v
@@ -206,7 +206,7 @@ Proof. by rewrite cards2 diff_id_sh. Qed.
 Lemma group_set_iso2 : group_set isometries2.
 Proof.
 apply/group_setP; split => [|x y]; rewrite !inE ?eqxx //.
-do 2![case/orP; move/eqP->]; gsimpl; rewrite ?(eqxx, orbT) //.
+do 2![case/orP; move/eqP->]; rewrite ?(mul1g, mulg1) ?eqxx ?orbT//.
 by rewrite -/sh -{1}sh_inv mulVg eqxx.
 Qed.
 Canonical iso2_group := Group group_set_iso2.

--- a/mathcomp/solvable/extraspecial.v
+++ b/mathcomp/solvable/extraspecial.v
@@ -145,7 +145,9 @@ rewrite [@gtype _]unlock; apply: intro_isoGrp => [|rT H].
   have Gy: y \in G by rewrite -cycle_subG joing_subr.
   rewrite eqEsubset subsetT -im_sdpair mulG_subG /= -/G; apply/andP; split.
     apply/subsetP=> u /morphimP[[i j] _ _ def_u].
-    suffices ->: u = z ^+ i * x ^+ j by rewrite groupMl groupX ?groupR.
+    suffices ->: u = z ^+ i * x ^+ j. 
+      rewrite groupMl; apply/groupX; first exact: Gx.
+      by apply/groupR; first exact: Gx.
     rewrite def_zi def_xi !natr_Zp -morphM ?inE // def_u.
     by congr (sdpair1 _ (_, _)); rewrite ?mulg1 ?mul1g.
   apply/subsetP=> v /morphimP[k _ _ def_v].
@@ -607,7 +609,9 @@ have oQ: #|'Q_(2 ^ 3)| = 8 by rewrite card_quaternion.
 have pQ: 2.-group 'Q_8 by rewrite /pgroup oQ.
 case: DnQ_P => gz isoZ.
 rewrite -im_cpair cardMg_divn setI_im_cpair cpair_center_id.
-rewrite -injm_center 3?{1}card_injm ?injm_cpairg1 ?injm_cpair1g ?center_sub //.
+rewrite -injm_center//; last exact: injm_cpair1g.
+rewrite (card_injm (injm_cpairg1 _))// (card_injm (injm_cpair1g _))//.
+rewrite (card_injm (injm_cpair1g _))//; last exact: center_sub.
 rewrite oQ card_pX1p2n // (card_center_extraspecial pQ Q8_extraspecial).
 by rewrite -muln_divA // mulnC -(expnD 2 2).
 Qed.

--- a/mathcomp/solvable/extremal.v
+++ b/mathcomp/solvable/extremal.v
@@ -132,7 +132,8 @@ have def_s: aut_of = s.
   by rewrite !autmE // sb (eqP tb).
 apply: intro_isoGrp => [|gT G].
   apply/existsP; exists (sdpair1 _ b, sdpair2 _ a); rewrite /= !xpair_eqE.
-  rewrite -!morphim_cycle ?norm_joinEr ?im_sdpair ?im_sdpair_norm ?eqxx //=.
+  apply/andP; split.
+    by rewrite -!morphim_cycle ?norm_joinEr ?im_sdpair ?im_sdpair_norm ?eqxx //=.
   rewrite -!order_dvdn !order_injm ?injm_sdpair1 ?injm_sdpair2 // oa ob !dvdnn.
   by rewrite -sdpair_act // [act _ _ _]apermE /= eltm_id -morphX // -sb -def_s.
 case/existsP=> -[x y] /= /eqP[defG xq1 yp1 xy].


### PR DESCRIPTION
##### Motivation for this change

This PR saves 5% of the total compilation time by rewriting a few proofs.
Fun fact: 17% of the total compilation time is spent importing things and 25% in HB commands (not counting the HB.packs).

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
