### PR TITLE
Fix notations using seqlexi_display

### DIFF
--- a/mathcomp/ssreflect/order.v
+++ b/mathcomp/ssreflect/order.v
@@ -7657,14 +7657,14 @@ End LexiSyntax.
 
 Module Import SeqLexiSyntax.
 
-Notation "<=^l%O" := (@le (seqlexi_display _ _) _) : function_scope.
-Notation ">=^l%O" := (@ge (seqlexi_display _ _) _) : function_scope.
-Notation ">=^l%O" := (@ge (seqlexi_display _ _) _) : function_scope.
-Notation "<^l%O" := (@lt (seqlexi_display _ _) _) : function_scope.
-Notation ">^l%O" := (@gt (seqlexi_display _ _) _) : function_scope.
-Notation "<?=^l%O" := (@leif (seqlexi_display _ _) _) : function_scope.
-Notation ">=<^l%O" := (@comparable (seqlexi_display _ _) _) : function_scope.
-Notation "><^l%O" := (fun x y => ~~ (@comparable (seqlexi_display _ _) _ x y)) :
+Notation "<=^l%O" := (@le (seqlexi_display _) _) : function_scope.
+Notation ">=^l%O" := (@ge (seqlexi_display _) _) : function_scope.
+Notation ">=^l%O" := (@ge (seqlexi_display _) _) : function_scope.
+Notation "<^l%O" := (@lt (seqlexi_display _) _) : function_scope.
+Notation ">^l%O" := (@gt (seqlexi_display _) _) : function_scope.
+Notation "<?=^l%O" := (@leif (seqlexi_display _) _) : function_scope.
+Notation ">=<^l%O" := (@comparable (seqlexi_display _) _) : function_scope.
+Notation "><^l%O" := (fun x y => ~~ (@comparable (seqlexi_display _) _ x y)) :
   function_scope.
 
 Notation "<=^l y" := (>=^l%O y) : order_scope.
@@ -7704,8 +7704,8 @@ Notation "><^l y" := [pred x | ~~ (>=<^l%O x y)] : order_scope.
 Notation "><^l y :> T" := (><^l (y : T)) (only parsing) : order_scope.
 Notation "x ><^l y" := (~~ (><^l%O x y)) : order_scope.
 
-Notation meetlexi := (@meet (seqlexi_display _ _) _).
-Notation joinlexi := (@join (seqlexi_display _ _) _).
+Notation meetlexi := (@meet (seqlexi_display _) _).
+Notation joinlexi := (@join (seqlexi_display _) _).
 
 Notation "x `&^l` y" :=  (meetlexi x y) : order_scope.
 Notation "x `|^l` y" := (joinlexi x y) : order_scope.


### PR DESCRIPTION
##### Motivation for this change

As revealed in [this Zulip thread](https://coq.zulipchat.com/#narrow/channel/283123-math-comp-private/topic/Syntax.20for.20lexicographic.20order/near/493348463), the notations in `order.v` using `seqlexi_display` are broken because they expect the latter to take two arguments.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
