### PR TITLE
Change coq/stdlib to math-comp/math-comp in changelog

### DIFF
--- a/doc/changelog/01-added/1198-abel-b-solvable.md
+++ b/doc/changelog/01-added/1198-abel-b-solvable.md
@@ -1,19 +1,19 @@
 - in `zmodp.v`
   + lemmas `gen_tperm_step`, `perm_addr1X`, `gen_tpermn_circular_shift`
-    ([#1198](https://github.com/coq/stdlib/pull/1198),
+    ([#1198](https://github.com/math-comp/math-comp/pull/1198),
     by Tragicus).
 
 - in `cyclic.v`
   + lemmas `eq_expg_ord`, `expgD_Zp`
-    ([#1198](https://github.com/coq/stdlib/pull/1198),
+    ([#1198](https://github.com/math-comp/math-comp/pull/1198),
     by Tragicus).
 
 - in `nilpotent.v`
   + lemma `setXn_sol`
-    ([#1198](https://github.com/coq/stdlib/pull/1198),
+    ([#1198](https://github.com/math-comp/math-comp/pull/1198),
     by Tragicus).
 
 - in `alt.v`
   + lemmas `gen_tperm_circular_shift`, `solvable_AltF`, `solvable_SymF`
-    ([#1198](https://github.com/coq/stdlib/pull/1198),
+    ([#1198](https://github.com/math-comp/math-comp/pull/1198),
     by Tragicus).

--- a/doc/changelog/01-added/1298-separate_changelog.md
+++ b/doc/changelog/01-added/1298-separate_changelog.md
@@ -3,5 +3,5 @@
     `\max^d_<range> e`, `\min^p_<range> e`, `\max^p_<range> e`,
     `\min^sp_<range> e`, `\max^sp_<range> e`, `\meet^l_<range> e`,
     `\join^l_<range> e`, `\min^l_<range> e`, `\max^l_<range> e`
-    ([#1298](https://github.com/coq/stdlib/pull/1298),
+    ([#1298](https://github.com/math-comp/math-comp/pull/1298),
     by Quentin Vermande).

--- a/doc/changelog/01-added/1318-ntherror.md
+++ b/doc/changelog/01-added/1318-ntherror.md
@@ -3,10 +3,10 @@
     `onthTE`, `onthNE`, `onth_default`, `onth_cat`, `onth_nseq`, `eq_onthP`,
     `eq_from_onth`, `eq_from_onth_le`, `onth_map`, `inj_onth_map`, `onthP`,
     `onthPn`, and `onth_inj`.
-    ([#1318](https://github.com/coq/stdlib/pull/1318),
+    ([#1318](https://github.com/math-comp/math-comp/pull/1318),
     by Cyril Cohen, KimayaBedarkar, Pierre Roux, and Quentin Vermande).
 
 - in `tuple.v`
   + new lemma `tnth_onth`
-    ([#1318](https://github.com/coq/stdlib/pull/1318),
+    ([#1318](https://github.com/math-comp/math-comp/pull/1318),
     by Cyril Cohen).

--- a/doc/changelog/01-added/1319-pzring.md
+++ b/doc/changelog/01-added/1319-pzring.md
@@ -21,5 +21,5 @@
   + factories `SubPzRing_isSubComPzRing`, `SubChoice_isSubPzSemiRing`,
     `SubChoice_isSubComPzSemiRing`, `SubChoice_isSubPzRing`,
     `SubChoice_isSubComPzRing`
-    ([#1319](https://github.com/coq/stdlib/pull/1319),
+    ([#1319](https://github.com/math-comp/math-comp/pull/1319),
     by Tragicus).

--- a/doc/changelog/01-added/1333-seminorm.md
+++ b/doc/changelog/01-added/1333-seminorm.md
@@ -1,8 +1,8 @@
 - in `ssrnum.v`
   + Mixin `Zmodule_isSemiNormed` and class `SemiNormedZmodule` with
     associated structure `semiNormedZmodType`.
-    ([#1333](https://github.com/coq/stdlib/pull/1333),
+    ([#1333](https://github.com/math-comp/math-comp/pull/1333),
     by Alessandro Bruni and Cyril Cohen).
   + lemmas `gtr0_norm_neq0`, and `gtr0_norm_eq0F`
-    ([#1333](https://github.com/coq/stdlib/pull/1333),
+    ([#1333](https://github.com/math-comp/math-comp/pull/1333),
     by Alessandro Bruni and Cyril Cohen).

--- a/doc/changelog/01-added/1343-no-stdlib.md
+++ b/doc/changelog/01-added/1343-no-stdlib.md
@@ -1,4 +1,4 @@
 - in `ssrnat.v`
   + definition `N_eqb`
-    ([#1343](https://github.com/coq/stdlib/pull/1343),
+    ([#1343](https://github.com/math-comp/math-comp/pull/1343),
     by Pierre Roux).

--- a/doc/changelog/02-changed/1314-separate_changelog.md
+++ b/doc/changelog/02-changed/1314-separate_changelog.md
@@ -1,9 +1,9 @@
 - in `sesquilinear.v`
   + notations `_ ^ _` and `_ ^t _` are now in the dedicated scope `sesquilinear_scope`.
-  ([#1314](https://github.com/coq/stdlib/pull/1314),
+  ([#1314](https://github.com/math-comp/math-comp/pull/1314),
   by Cyril Cohen).
 
 - in `spectral.v`
   + notations `_ ^t*` is now in the dedicated scope `sesquilinear_scope`.
-  ([#1314](https://github.com/coq/stdlib/pull/1314),
+  ([#1314](https://github.com/math-comp/math-comp/pull/1314),
   by Cyril Cohen).

--- a/doc/changelog/02-changed/1319-pzring.md
+++ b/doc/changelog/02-changed/1319-pzring.md
@@ -78,7 +78,7 @@
   + `exprBn`, `subrXX`, `sqrrB`, `subr_sqr`, `subr_sqrDB`,
     `scale_is_scalable`, `scale_fun_is_scalable`, `comRingMixin`,
     `ffun_mulC`, `pair_mulC` generalized to `comPzRingType`
-    ([#1319](https://github.com/coq/stdlib/pull/1319),
+    ([#1319](https://github.com/math-comp/math-comp/pull/1319),
      by Tragicus).
 		
 - in `ssrint.v`
@@ -88,5 +88,5 @@
     `rmorph_int`, `linearMn`, `commrMz`, `commr_int`, `sumMz`,
     `prodMz`, `intr_sign`, `rpred_int`, `rpredZint` generalized to
     `pzRingType`
-    ([#1319](https://github.com/coq/stdlib/pull/1319),
+    ([#1319](https://github.com/math-comp/math-comp/pull/1319),
      by Tragicus).

--- a/doc/changelog/02-changed/1333-seminorm.md
+++ b/doc/changelog/02-changed/1333-seminorm.md
@@ -1,12 +1,12 @@
 - in `ssrnum.v`
   + Mixin `Zmodule_isNormed` is now a factory building a
     `SemiNormedZmodule` and a `SemiNormedZmodule_isPositiveDefinite`.
-    ([#1333](https://github.com/coq/stdlib/pull/1333),
+    ([#1333](https://github.com/math-comp/math-comp/pull/1333),
     by  Alessandro Bruni and Cyril Cohen).
   + Generalized lemmas from the theory of `normedZmodType` to
     `semiNormedZmodType`: `normr0`, `distrC`, `normr_id`, and
     `normr_ge0`, `normr_real`, `ler_norm_sum`, `ler_normB`,
     `ler_distD`, `lerB_normD`, `lerB_dist`, `ler_dist_dist`,
     `ler_dist_normD`, `ler_nnorml`, `ltr_nnorml`, `lter_nnormr`.
-    ([#1333](https://github.com/coq/stdlib/pull/1333),
+    ([#1333](https://github.com/math-comp/math-comp/pull/1333),
     by Alessandro Bruni and Cyril Cohen).

--- a/doc/changelog/02-changed/1343-no-stdlib.md
+++ b/doc/changelog/02-changed/1343-no-stdlib.md
@@ -2,5 +2,5 @@
   + lemma `eq_binP` changed from Stdlib's `N.eqb` to new `N_eqb`
   + eqtype instance on `nat` changed from Stdlib's `N.eqb`
     to new `N_eqb`
-    ([#1343](https://github.com/coq/stdlib/pull/1343),
+    ([#1343](https://github.com/math-comp/math-comp/pull/1343),
     by Pierre Roux).

--- a/doc/changelog/03-renamed/1300-eqfun.md
+++ b/doc/changelog/03-renamed/1300-eqfun.md
@@ -4,5 +4,5 @@
 	+ `eqrel` now has type
 			`forall [C] [B : C -> Type] [A : forall c, B c -> Type]
 				(f g : forall c b, A c b), Prop`
-    (`#1300 <https://github.com/coq/stdlib/pull/1300>`_,
+    (`#1300 <https://github.com/math-comp/math-comp/pull/1300>`_,
     by Tragicus).

--- a/doc/changelog/03-renamed/1306-separate_changelog.md
+++ b/doc/changelog/03-renamed/1306-separate_changelog.md
@@ -28,13 +28,13 @@
   + `subComSemiRingType` -> `subComNzSemiRingType`
   + `subRingType` -> `nzSubRingType`
   + ``subComNzRingType` -> `subComNzRingType`
-  ([#1306](https://github.com/coq/stdlib/pull/1306),
+  ([#1306](https://github.com/math-comp/math-comp/pull/1306),
   by Quentin Vermande).
 
 - in `ring_quotient.v`
   + `isRingQuotient` -> `isNzRingQuotient`
   + `ringQuotType` -> `nzRingQuotType`
-  ([#1306](https://github.com/coq/stdlib/pull/1306),
+  ([#1306](https://github.com/math-comp/math-comp/pull/1306),
   by Quentin Vermande).
 
 - in `finalg.v`
@@ -44,7 +44,7 @@
   + `finComSemiRingType` -> `finComNzSemiRingType`
   + `finComRingType` -> `finComNzRingType`
   + `card_finRing_gt1` -> `card_finNzRing_gt1`
-  ([#1306](https://github.com/coq/stdlib/pull/1306),
+  ([#1306](https://github.com/math-comp/math-comp/pull/1306),
   by Quentin Vermande).
 
 - in `countalg.v`
@@ -52,5 +52,5 @@
   + `countRingType` -> `countNzRingType`
   + `countComSemiRingType` -> `countComNzSemiRingType`
   + `countComRingType` -> `countComNzRingType`
-  ([#1306](https://github.com/coq/stdlib/pull/1306),
+  ([#1306](https://github.com/math-comp/math-comp/pull/1306),
   by Quentin Vermande).

--- a/doc/changelog/03-renamed/1315-separate_changelog.md
+++ b/doc/changelog/03-renamed/1315-separate_changelog.md
@@ -3,5 +3,5 @@
   + `size_add` -> `size_polyD`
   + `size_addl` -> `size_polyDl`
   + `size_mul_leq` -> `size_polyM_leq`
-  ([#1315](https://github.com/coq/stdlib/pull/1315),
+  ([#1315](https://github.com/math-comp/math-comp/pull/1315),
   by Reynald Affeldt).

--- a/doc/changelog/04-removed/1319-pzring.md
+++ b/doc/changelog/04-removed/1319-pzring.md
@@ -1,5 +1,5 @@
 - in `ssralg.v`
   + mixin `NzSemiRing_hasCommutativeMul`
   + factory `NzRing_hasCommutativeMul`
-    ([#1319](https://github.com/coq/stdlib/pull/1319),
+    ([#1319](https://github.com/math-comp/math-comp/pull/1319),
     by Tragicus).

--- a/doc/changelog/04-removed/1343-no-stdlib.md
+++ b/doc/changelog/04-removed/1343-no-stdlib.md
@@ -8,11 +8,11 @@
   + definition `extend_number` (was a coercion)
   + tactic `nat_litteral`
   + ring instance for `nat` (use algebra-tactics instead)
-    ([#1343](https://github.com/coq/stdlib/pull/1343),
+    ([#1343](https://github.com/math-comp/math-comp/pull/1343),
     by Pierre Roux).
 
 - in `rat.v`
   + lemmas `rat_ring_theory` and `rat_field_theory`
   + ring and field instances for `rat` (use algebra-tactics instead)
-    ([#1343](https://github.com/coq/stdlib/pull/1343),
+    ([#1343](https://github.com/math-comp/math-comp/pull/1343),
     by Pierre Roux).

--- a/doc/changelog/05-deprecated/1324-separate_changelog.md
+++ b/doc/changelog/05-deprecated/1324-separate_changelog.md
@@ -1,4 +1,4 @@
 - in `ssrnum.v`
   + lemma `pmulrn_rgt0`
-    ([#1324](https://github.com/coq/stdlib/pull/1324),
+    ([#1324](https://github.com/math-comp/math-comp/pull/1324),
     by Reynald Affeldt).

--- a/doc/changelog/README.md
+++ b/doc/changelog/README.md
@@ -28,9 +28,9 @@ Here is a summary of the structure of a changelog entry in
 - in `SomeFile.v`
 
   + lemmas `lem1`, `lem2` and `lem3`
-  (`#PRNUM <https://github.com/coq/stdlib/pull/PRNUM>`_,
-  [fixes `#ISSUE1 <https://github.com/coq/stdlib/issues/ISSUE1>`_
-  [ and `#ISSUE2 <https://github.com/coq/stdlib/issues/ISSUE2>`_],]
+  (`#PRNUM <https://github.com/math-comp/math-comp/pull/PRNUM>`_,
+  [fixes `#ISSUE1 <https://github.com/math-comp/math-comp/issues/ISSUE1>`_
+  [ and `#ISSUE2 <https://github.com/math-comp/math-comp/issues/ISSUE2>`_],]
   by Full Name[, with help / review of Full Name]).
 ```
 

--- a/doc/changelog/make-entry.sh
+++ b/doc/changelog/make-entry.sh
@@ -17,14 +17,14 @@ read -r in_file
 printf "Fixes? (space separated list of bug numbers)\n"
 read -r fixes_list
 
-fixes_string="$(echo $fixes_list | sed 's/ /~    and /g; s,\([0-9][0-9]*\),[#\1](https://github.com/coq/stdlib/issues/\1),g' | tr '~' '\n')"
+fixes_string="$(echo $fixes_list | sed 's/ /~    and /g; s,\([0-9][0-9]*\),[#\1](https://github.com/math-comp/math-comp/issues/\1),g' | tr '~' '\n')"
 if [ ! -z "$fixes_string" ]; then fixes_string="$(printf '\n    fixes %s,' "$fixes_string")"; fi
 
 # shellcheck disable=SC2016
 # the ` are regular strings, this is intended
 # use %s for the leading - to avoid looking like an option (not sure
 # if necessary but doesn't hurt)
-printf '%s in `%s`\n  + Describe your change here but do not end with a period\n    for instance: lemmas `lem1`, `lem2` and `lem3`\n    ([#%s](https://github.com/coq/stdlib/pull/%s),%s\n    by %s).\n' - "$in_file" "$PR" "$PR" "$fixes_string" "$(git config user.name)" > "$where"
+printf '%s in `%s`\n  + Describe your change here but do not end with a period\n    for instance: lemmas `lem1`, `lem2` and `lem3`\n    ([#%s](https://github.com/math-comp/math-comp/pull/%s),%s\n    by %s).\n' - "$in_file" "$PR" "$PR" "$fixes_string" "$(git config user.name)" > "$where"
 
 printf 'Name of created changelog file:\n'
 printf '%s\n' "$where"


### PR DESCRIPTION
##### Motivation for this change

The changelog script automatically puts links to the `coq/stdlib` repository.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
