### PR TITLE
Export le_val in Order.Theory

### DIFF
--- a/doc/changelog/01-added/1353-le_val.md
+++ b/doc/changelog/01-added/1353-le_val.md
@@ -1,0 +1,5 @@
+- in `order.v`
+  + export `le_val` in `Order.SubPOrderTheory` (included in
+    `Order.Theory`) to avoid being forced to type `Order.le_val`
+    ([#1353](https://github.com/math-comp/math-comp/pull/1353),
+    by Pierre Roux).

--- a/ssreflect/order.v
+++ b/ssreflect/order.v
@@ -6261,7 +6261,7 @@ End LatticePred.
 
 HB.mixin Record isSubPOrder d (T : porderType d) (S : pred T) d' U
     of SubType T S U & POrder d' U := {
-  le_val : {mono (val : U -> T) : x y / x <= y};
+  le_val_subproof : {mono (val : U -> T) : x y / x <= y};
 }.
 
 #[short(type="subPOrder")]
@@ -6273,6 +6273,7 @@ Section SubPOrderTheory.
 Context (d : disp_t) (T : porderType d) (S : pred T).
 Context (d' : disp_t) (U : SubPOrder.type S d').
 Local Notation val := (val : U -> T).
+Lemma le_val : {mono val : x y / x <= y}. Proof. exact: le_val_subproof. Qed.
 #[deprecated(since="mathcomp 2.3.0", note="Use le_val instead.")]
 Lemma leEsub x y : (x <= y) = (val x <= val y). Proof. by rewrite le_val. Qed.
 Lemma lt_val : {mono val : x y / x < y}.
@@ -6283,6 +6284,7 @@ Lemma le_wval : {homo val : x y / x <= y}. Proof. exact/mono2W/le_val. Qed.
 Lemma lt_wval : {homo val : x y / x < y}. Proof. exact/mono2W/lt_val. Qed.
 HB.instance Definition _ := isOrderMorphism.Build d' U d T val le_wval.
 End SubPOrderTheory.
+Arguments le_val {d T S d' U} x y.
 Arguments lt_val {d T S d' U} x y.
 Arguments le_wval {d T S d' U} x y.
 Arguments lt_wval {d T S d' U} x y.


### PR DESCRIPTION
##### Motivation for this change

Not having to type `Order.le_val` in contexts where `lt_val` works.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
