### PR TITLE
spurious space in mktuple notation

### DIFF
--- a/ssreflect/tuple.v
+++ b/ssreflect/tuple.v
@@ -472,7 +472,7 @@ End UseFinTuple.
 
 Notation "[ 'tuple' F | i < n ]" := (mktuple (fun i : 'I_n => F))
   (at level 0, i at level 0,
-   format "[ '[hv' 'tuple'  F '/'   |  i  <  n ] ']'") : form_scope.
+   format "[ '[hv' 'tuple'  F '/'  |  i  <  n ] ']'") : form_scope.
 
 Arguments eq_mktuple {n T'} [f1] f2 eq_f12.
 


### PR DESCRIPTION
##### Motivation for this change

The mktuple notation notations displays with one extra space.

##### Minimal TODO list

<!-- please fill in the following checklist -->
~~- [ ] added changelog entries with `doc/changelog/make-entry.sh`~~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
