### PR TITLE
Rename Num.trunc to Num.truncn

### DIFF
--- a/algebra/polydiv.v
+++ b/algebra/polydiv.v
@@ -2666,7 +2666,7 @@ Proof. by rewrite divpD mulpK. Qed.
 
 Lemma divpp : d %/ d = 1. Proof. by rewrite -[d in d %/ _]mul1r mulpK. Qed.
 
-Lemma leq_trunc_divp m : size (m %/ d * d) <= size m.
+Lemma leq_divMp m : size (m %/ d * d) <= size m.
 Proof.
 case: (eqVneq d 0) ulcd => [->|dn0 _]; first by rewrite lead_coef0 unitr0.
 have [->|q0] := eqVneq (m %/ d) 0; first by rewrite mul0r size_poly0 leq0n.
@@ -2713,6 +2713,9 @@ Lemma modp_mul p q : (p * (q %% d)) %% d = (p * q) %% d.
 Proof. by rewrite [q in RHS]divp_eq mulrDr modpD mulrA modp_mull add0r. Qed.
 
 End UnitDivisor.
+
+#[deprecated(since="mathcomp 2.4.0", note="Renamed to leq_divMp.")]
+Notation leq_trunc_divp := leq_divMp.
 
 Section MoreUnitDivisor.
 
@@ -2986,10 +2989,10 @@ Proof.
 by move=> dn0; apply: IdomainUnit.divpp; rewrite unitfE lead_coef_eq0.
 Qed.
 
-Lemma leq_trunc_divp d m : size (m %/ d * d) <= size m.
+Lemma leq_divMp d m : size (m %/ d * d) <= size m.
 Proof.
 have [-> | dn0] := eqVneq d 0; first by rewrite mulr0 size_poly0.
-by apply: IdomainUnit.leq_trunc_divp; rewrite unitfE lead_coef_eq0.
+by apply: IdomainUnit.leq_divMp; rewrite unitfE lead_coef_eq0.
 Qed.
 
 Lemma divpK d p : d %| p -> p %/ d * d = p.
@@ -3343,6 +3346,9 @@ Proof. by rewrite /gdcop gdcop_rec_map !size_map_poly. Qed.
 End FieldMap.
 
 End FieldDivision.
+
+#[deprecated(since="mathcomp 2.4.0", note="Renamed to leq_divMp.")]
+Notation leq_trunc_divp := leq_divMp.
 
 End Field.
 

--- a/algebra/rat.v
+++ b/algebra/rat.v
@@ -764,21 +764,21 @@ Section ratArchimedean.
 
 Implicit Types x : rat.
 
-Let trunc x : nat := if 0 <= x then (`|numq x| %/ `|denq x|)%N else 0%N.
+Let truncn x : nat := if 0 <= x then (`|numq x| %/ `|denq x|)%N else 0%N.
 
-Lemma truncP x :
-  if 0 <= x then (trunc x)%:R <= x < (trunc x).+1%:R else trunc x == 0%N.
+Lemma truncnP x :
+  if 0 <= x then (truncn x)%:R <= x < (truncn x).+1%:R else truncn x == 0%N.
 Proof.
-rewrite /trunc -numq_ge0; case: (ratP x) => -[] //= n d _.
+rewrite /truncn -numq_ge0; case: (ratP x) => -[] //= n d _.
 rewrite ler_pdivlMr ?ltr_pdivrMr ?ltr0z // -!natrM ler_nat ltr_nat.
 by rewrite leq_divM ltn_ceil.
 Qed.
 
 Let is_nat x := (0 <= x) && (denq x == 1).
 
-Lemma is_natE x : is_nat x = ((trunc x)%:R == x).
+Lemma is_natE x : is_nat x = ((truncn x)%:R == x).
 Proof.
-rewrite /is_nat /trunc -numq_ge0 !rat_eq; case: (ratP x) => -[] //= n d pnd.
+rewrite /is_nat /truncn -numq_ge0 !rat_eq; case: (ratP x) => -[] //= n d pnd.
 rewrite pmulrn numq_int denq_int mulr1 -PoszM !eqz_nat -dvdn_eq.
 apply/eqP/idP => [->|/dvdnP[k nE]] //.
 by move/eqP: pnd; rewrite nE gcdnC gcdnMl.
@@ -788,10 +788,12 @@ Lemma is_intE x : (denq x == 1) = is_nat x || is_nat (- x).
 Proof. by rewrite /is_nat denqN oppr_ge0 -andb_orl le_total. Qed.
 
 End ratArchimedean.
+#[deprecated(since="mathcomp 2.4.0", note="Renamed to truncnP.")]
+Notation truncP := truncnP.
 End ratArchimedean.
 
 HB.instance Definition _ := Num.NumDomain_isArchimedean.Build rat
-  ratArchimedean.truncP ratArchimedean.is_natE ratArchimedean.is_intE.
+  ratArchimedean.truncnP ratArchimedean.is_natE ratArchimedean.is_intE.
 
 Lemma Qint_def (x : rat) : (x \is a Num.int) = (denq x == 1). Proof. by []. Qed.
 

--- a/algebra/rat.v
+++ b/algebra/rat.v
@@ -771,7 +771,7 @@ Lemma truncP x :
 Proof.
 rewrite /trunc -numq_ge0; case: (ratP x) => -[] //= n d _.
 rewrite ler_pdivlMr ?ltr_pdivrMr ?ltr0z // -!natrM ler_nat ltr_nat.
-by rewrite leq_trunc_div ltn_ceil.
+by rewrite leq_divM ltn_ceil.
 Qed.
 
 Let is_nat x := (0 <= x) && (denq x == 1).

--- a/character/character.v
+++ b/character/character.v
@@ -846,7 +846,7 @@ Lemma char_sum_irrP {phi} :
 Proof.
 apply: (iffP idP)=> [/forallP-Nphi | [n ->]]; last first.
   by apply: rpred_sum => i _; rewrite scaler_nat rpredMn // irr_char.
-do [have [a ->] := cfun_irr_sum phi] in Nphi *; exists (Num.trunc \o a).
+do [have [a ->] := cfun_irr_sum phi] in Nphi *; exists (Num.truncn \o a).
 apply: eq_bigr => i _; congr (_ *: _); have:= eqP (Nphi i).
 by rewrite eq_sum_nth_irr coord_sum_free ?irr_free.
 Qed.
@@ -2579,7 +2579,7 @@ End DetRepr.
 
 HB.lock
 Definition cfDet (gT : finGroupType) (G : {group gT}) phi :=
-  \prod_i detRepr 'Chi_i ^+ Num.trunc '[phi, 'chi[G]_i].
+  \prod_i detRepr 'Chi_i ^+ Num.truncn '[phi, 'chi[G]_i].
 Canonical cfDet_unlockable := Unlockable cfDet.unlock.
 
 Section DetOrder.
@@ -2595,11 +2595,11 @@ Lemma cfDetD :
   {in character &, {morph cfDet : phi psi / phi + psi >-> phi * psi}}.
 Proof.
 move=> phi psi Nphi Npsi; rewrite unlock /= -big_split; apply: eq_bigr => i _ /=.
-by rewrite -exprD cfdotDl truncD ?nnegrE ?natr_ge0 // Cnat_cfdot_char_irr.
+by rewrite -exprD cfdotDl truncnD ?nnegrE ?natr_ge0 // Cnat_cfdot_char_irr.
 Qed.
 
 Lemma cfDet0 : cfDet 0 = 1.
-Proof. by rewrite unlock big1 // => i _; rewrite cfdot0l trunc0. Qed.
+Proof. by rewrite unlock big1 // => i _; rewrite cfdot0l truncn0. Qed.
 
 Lemma cfDetMn k :
   {in character, {morph cfDet : phi / phi *+ k >-> phi ^+ k}}.
@@ -2695,7 +2695,7 @@ Qed.
 
 Lemma cfDet_mul_lin gT (G : {group gT}) (lambda phi : 'CF(G)) :
     lambda \is a linear_char -> phi \is a character ->
-  cfDet (lambda * phi) = lambda ^+ Num.trunc (phi 1%g) * cfDet phi.
+  cfDet (lambda * phi) = lambda ^+ Num.truncn (phi 1%g) * cfDet phi.
 Proof.
 case/andP=> /char_reprP[[n1 rG1] ->] /= n1_1 /char_reprP[[n2 rG2] ->] /=.
 do [rewrite !cfRepr1 pnatr_eq1 natrK; move/eqP] in n1_1 *.

--- a/character/inertia.v
+++ b/character/inertia.v
@@ -1130,8 +1130,8 @@ have nsKT_G: K :&: T <| G.
   exact: subset_trans (der1_min nLK abKbar) (sub_Inertia _ sLK).
 have [e DthL]: exists e, 'Res theta = e%:R *: \sum_(xi <- (phi ^: K)%CF) xi.
   rewrite (Clifford_Res_sum_cfclass nsLK sLp0) -/phi; set e := '[_, _].
-  exists (Num.trunc e).
-  by rewrite truncK ?Cnat_cfdot_char ?cfRes_char ?irr_char.
+  exists (Num.truncn e).
+  by rewrite truncnK ?Cnat_cfdot_char ?cfRes_char ?irr_char.
 have [defKT | ltKT_K] := eqVneq (K :&: T) K; last first.
   have defKT: K :&: T = L.
     apply: maxL; last by rewrite subsetI sLK sub_Inertia.
@@ -1239,8 +1239,8 @@ have [t sGt] := constt_cfInd_irr s (normal_sub nsNG); exists t.
 have [e DtN]: exists e, 'Res 'chi_t = e%:R *: 'chi_s.
   rewrite constt_Ind_Res in sGt.
   rewrite (Clifford_Res_sum_cfclass nsNG sGt) cfclass_invariant // big_seq1.
-  set e := '[_, _]; exists (Num.trunc e).
-  by rewrite truncK ?Cnat_cfdot_char ?cfRes_char ?irr_char.
+  set e := '[_, _]; exists (Num.truncn e).
+  by rewrite truncnK ?Cnat_cfdot_char ?cfRes_char ?irr_char.
 have [/irrWnorm/eqP | [c injc DtNc]] := cfRes_prime_irr_cases t nsNG iGN pr_p.
   rewrite DtN cfnormZ cfnorm_irr normr_nat mulr1 -natrX pnatr_eq1.
   by rewrite muln_eq1 andbb => /eqP->; rewrite scale1r.
@@ -1260,14 +1260,14 @@ Qed.
 (* This is Isaacs, Lemma (6.24). *)
 Lemma extend_to_cfdet G N s c0 u :
     let theta := 'chi_s in let lambda := cfDet theta in let mu := 'chi_u in
-    N <| G -> coprime #|G : N| (Num.trunc (theta 1%g)) ->
+    N <| G -> coprime #|G : N| (Num.truncn (theta 1%g)) ->
     'Res[N, G] 'chi_c0 = theta -> 'Res[N, G] mu = lambda ->
   exists2 c, 'Res 'chi_c = theta /\ cfDet 'chi_c = mu
           & forall c1, 'Res 'chi_c1 = theta -> cfDet 'chi_c1 = mu -> c1 = c.
 Proof.
-move=> theta lambda mu nsNG; set e := #|G : N|; set f := Num.trunc _.
+move=> theta lambda mu nsNG; set e := #|G : N|; set f := Num.truncn _.
 set eta := 'chi_c0 => co_e_f etaNth muNlam; have [sNG nNG] := andP nsNG.
-have fE: f%:R = theta 1%g by rewrite truncK ?Cnat_irr1.
+have fE: f%:R = theta 1%g by rewrite truncnK ?Cnat_irr1.
 pose nu := cfDet eta; have lin_nu: nu \is a linear_char := cfDet_lin_char _.
 have nuNlam: 'Res nu = lambda by rewrite -cfDetRes ?irr_char ?etaNth.
 have lin_lam: lambda \is a linear_char := cfDet_lin_char _.
@@ -1317,11 +1317,11 @@ Qed.
 (* This is Isaacs, Theorem (6.25). *)
 Theorem solvable_irr_extendible_from_det G N s (theta := 'chi[N]_s) :
     N <| G -> solvable (G / N) ->
-    G \subset 'I[theta] -> coprime #|G : N| (Num.trunc (theta 1%g)) ->
+    G \subset 'I[theta] -> coprime #|G : N| (Num.truncn (theta 1%g)) ->
   [exists c, 'Res 'chi[G]_c == theta]
     = [exists u, 'Res 'chi[G]_u == cfDet theta].
 Proof.
-set e := #|G : N|; set f := Num.trunc _ => nsNG solG IGtheta co_e_f.
+set e := #|G : N|; set f := Num.truncn _ => nsNG solG IGtheta co_e_f.
 apply/exists_eqP/exists_eqP=> [[c cNth] | [u uNdth]].
   have /lin_char_irr/irrP[u Du] := cfDet_lin_char 'chi_c.
   by exists u; rewrite -Du -cfDetRes ?irr_char ?cNth.
@@ -1423,8 +1423,8 @@ have [c vGc co_p_f]: exists2 c, c \in irr_constt nuG & ~~ (p %| 'chi_c 1%g)%C.
   rewrite sum_cfunE rpred_sum // => i /p_dv_v1 p_dv_chi1i.
   rewrite cfunE dvdC_mull // intr_nat //.
   by rewrite Cnat_cfdot_char ?cfInd_char ?irr_char.
-pose f := Num.trunc ('chi_c 1%g); pose b := (egcdn f m).1.
-have fK: f%:R = 'chi_c 1%g by rewrite truncK ?Cnat_irr1.
+pose f := Num.truncn ('chi_c 1%g); pose b := (egcdn f m).1.
+have fK: f%:R = 'chi_c 1%g by rewrite truncnK ?Cnat_irr1.
 have fb_mod_m: f * b = 1 %[mod m].
   have co_m_f: coprime m f.
     by rewrite (pnat_coprime p_m) ?p'natE // -dvdC_nat CdivE fK.
@@ -1510,13 +1510,13 @@ Qed.
 (* This is Isaacs, Corollary (6.28). *)
 Corollary extend_solvable_coprime_irr G N t (theta := 'chi[N]_t) :
     N <| G -> solvable (G / N) -> G \subset 'I[theta] ->
-    coprime #|G : N| ('o(theta)%CF * Num.trunc (theta 1%g)) ->
+    coprime #|G : N| ('o(theta)%CF * Num.truncn (theta 1%g)) ->
   exists c, [/\ 'Res 'chi[G]_c = theta, 'o('chi_c)%CF = 'o(theta)%CF
               & forall d,
                   'Res 'chi_d = theta -> coprime #|G : N| 'o('chi_d)%CF ->
                 d = c].
 Proof.
-set e := #|G : N|; set f := Num.trunc _ => nsNG solG IGtheta.
+set e := #|G : N|; set f := Num.truncn _ => nsNG solG IGtheta.
 rewrite coprimeMr => /andP[co_e_th co_e_f].
 have [sNG nNG] := andP nsNG; pose lambda := cfDet theta.
 have lin_lam: lambda \is a linear_char := cfDet_lin_char theta.

--- a/character/integral_char.v
+++ b/character/integral_char.v
@@ -262,12 +262,12 @@ Qed.
 
 (* This is Isaacs, Theorem (3.8). *)
 Theorem coprime_degree_support_cfcenter g :
-    coprime (Num.trunc ('chi_i 1%g)) #|g ^: G| -> g \notin ('Z('chi_i))%CF ->
+    coprime (Num.truncn ('chi_i 1%g)) #|g ^: G| -> g \notin ('Z('chi_i))%CF ->
   'chi_i g = 0.
 Proof.
-set m := Num.trunc _ => co_m_gG notZg.
+set m := Num.truncn _ => co_m_gG notZg.
 have [Gg | /cfun0-> //] := boolP (g \in G).
-have Dm: 'chi_i 1%g = m%:R by rewrite truncK ?Cnat_irr1.
+have Dm: 'chi_i 1%g = m%:R by rewrite truncnK ?Cnat_irr1.
 have m_gt0: (0 < m)%N by rewrite -ltC_nat -Dm irr1_gt0.
 have nz_m: m%:R != 0 :> algC by rewrite pnatr_eq0 -lt0n.
 pose alpha := 'chi_i g / m%:R.
@@ -571,7 +571,7 @@ Qed.
 
 (* This is Isaacs, Theorem (3.13). *)
 Theorem faithful_degree_p_part gT (p : nat) (G P : {group gT}) i :
-    cfaithful 'chi[G]_i -> p.-nat (Num.trunc ('chi_i 1%g)) ->
+    cfaithful 'chi[G]_i -> p.-nat (Num.truncn ('chi_i 1%g)) ->
     p.-Sylow(G) P -> abelian P ->
   'chi_i 1%g = (#|G : 'Z(G)|`_p)%:R.
 Proof.

--- a/field/algC.v
+++ b/field/algC.v
@@ -271,7 +271,7 @@ Parameter conjMixin : Num.ClosedField type.
 Parameter isCountable : Countable type.
 
 (* Note that this cannot be included in conjMixin since a few proofs
-   depend from nat_num being definitionally equal to (trunc x)%:R == x *)
+   depend from nat_num being definitionally equal to (truncn x)%:R == x *)
 Axiom archimedean : Num.archimedean_axiom (Num.ClosedField.Pack conjMixin).
 
 Axiom algebraic : integralRange (@ratr (Num.ClosedField.Pack conjMixin)).

--- a/ssreflect/div.v
+++ b/ssreflect/div.v
@@ -137,15 +137,18 @@ Proof. by case: d => // d; rewrite modn_def; case: edivnP. Qed.
 Lemma ltn_pmod m d : 0 < d -> m %% d < d.
 Proof. by rewrite ltn_mod. Qed.
 
-Lemma leq_trunc_div m d : m %/ d * d <= m.
+Lemma leq_divM m d : m %/ d * d <= m.
 Proof. by rewrite [leqRHS](divn_eq m d) leq_addr. Qed.
+
+#[deprecated(since="mathcomp 2.4.0", note="Renamed to leq_divM.")]
+Notation leq_trunc_div := leq_divM.
 
 Lemma leq_mod m d : m %% d <= m.
 Proof. by rewrite [leqRHS](divn_eq m d) leq_addl. Qed.
 
 Lemma leq_div m d : m %/ d <= m.
 Proof.
-by case: d => // d; apply: leq_trans (leq_pmulr _ _) (leq_trunc_div _ _).
+by case: d => // d; apply: leq_trans (leq_pmulr _ _) (leq_divM _ _).
 Qed.
 
 Lemma ltn_ceil m d : 0 < d -> m < (m %/ d).+1 * d.
@@ -158,7 +161,7 @@ Proof.
 move=> d_gt0; apply/idP/idP.
   by rewrite -(leq_pmul2r d_gt0); apply: leq_trans (ltn_ceil _ _).
 rewrite !ltnNge -(@leq_pmul2r d n) //; apply: contra => le_nd_floor.
-exact: leq_trans le_nd_floor (leq_trunc_div _ _).
+exact: leq_trans le_nd_floor (leq_divM _ _).
 Qed.
 
 Lemma leq_divRL m n d : d > 0 -> (m <= n %/ d) = (m * d <= n).
@@ -179,7 +182,7 @@ Qed.
 Lemma leq_div2l m d e : 0 < d -> d <= e -> m %/ e <= m %/ d.
 Proof.
 move/leq_divRL=> -> le_de.
-by apply: leq_trans (leq_trunc_div m e); apply: leq_mul.
+by apply: leq_trans (leq_divM m e); apply: leq_mul.
 Qed.
 
 Lemma edivnD m n d (offset := m %% d + n %% d >= d) : 0 < d ->


### PR DESCRIPTION
##### Motivation for this change

To avoid confusion with mathematical truncation which rather seem to be a rounding towards 0 (of type `_ -> int` then), as decided during last sharing day.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
