### PR TITLE
generalization of `subset_itv`

### DIFF
--- a/algebra/interval.v
+++ b/algebra/interval.v
@@ -329,26 +329,30 @@ Proof. by rewrite !itv_boundlr andbT. Qed.
 Lemma subitvP i1 i2 : i1 <= i2 -> {subset i1 <= i2}.
 Proof. by move=> ? ? /le_trans; exact. Qed.
 
-Lemma subset_itv (r s u v : bool) x y : r <= u -> v <= s ->
+Lemma subset_itv (x y z u : itv_bound T) : x <= y -> z <= u ->
+  {subset Interval y z <= Interval x u}.
+Proof. by move=> xy zu; apply: subitvP; rewrite subitvE xy zu. Qed.
+
+Lemma subset_itv_bound (r s u v : bool) x y : r <= u -> v <= s ->
   {subset Interval (BSide r x) (BSide s y) <= Interval (BSide u x) (BSide v y)}.
 Proof.
-by move: r s u v=> [] [] [] []// *; apply: subitvP; rewrite subitvE !bound_lexx.
+by move: r s u v=> [] [] [] []// *; apply: subset_itv; rewrite bnd_simp.
 Qed.
 
 Lemma subset_itv_oo_cc x y : {subset `]x, y[ <= `[x, y]}.
-Proof. exact: subset_itv. Qed.
+Proof. exact: subset_itv_bound. Qed.
 
 Lemma subset_itv_oo_oc x y : {subset `]x, y[ <= `]x, y]}.
-Proof. exact: subset_itv. Qed.
+Proof. exact: subset_itv_bound. Qed.
 
 Lemma subset_itv_oo_co x y : {subset `]x, y[ <= `[x, y[}.
-Proof. exact: subset_itv. Qed.
+Proof. exact: subset_itv_bound. Qed.
 
 Lemma subset_itv_oc_cc x y : {subset `]x, y] <= `[x, y]}.
-Proof. exact: subset_itv. Qed.
+Proof. exact: subset_itv_bound. Qed.
 
 Lemma subset_itv_co_cc x y : {subset `[x, y[ <= `[x, y]}.
-Proof. exact: subset_itv. Qed.
+Proof. exact: subset_itv_bound. Qed.
 
 Lemma itvxx x : `[x, x] =i pred1 x.
 Proof. by move=> y; rewrite in_itv/= -eq_le eq_sym. Qed.


### PR DESCRIPTION
##### Motivation for this change

This PR generalizes of `subset_itv`

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
