### PR TITLE
Explicit floor and ceil for rat

### DIFF
--- a/algebra/intdiv.v
+++ b/algebra/intdiv.v
@@ -1,10 +1,10 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq path.
-From mathcomp Require Import div choice fintype tuple finfun prime order.
-From mathcomp Require Import ssralg poly ssrnum ssrint archimedean rat matrix.
-From mathcomp Require Import polydiv perm zmodp bigop mxalgebra vector.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple prime order.
+From mathcomp Require Import ssralg poly ssrnum ssrint matrix.
+From mathcomp Require Import polydiv perm zmodp bigop.
 
 (******************************************************************************)
 (* This file provides various results on divisibility of integers.            *)
@@ -36,9 +36,6 @@ From mathcomp Require Import polydiv perm zmodp bigop mxalgebra vector.
 (*                 coefficient of p.                                          *)
 (* zprimitive p == the primitive part of p : {poly int}, i.e., p divided by   *)
 (*                 its contents.                                              *)
-(* inIntSpan X v <-> v is an integral linear combination of elements of       *)
-(*                 X : seq V, where V is a zmodType. We prove that this is a  *)
-(*                 decidable property for Q-vector spaces.                    *)
 (* int_Smith_normal_form :: a theorem asserting the existence of the Smith    *)
 (*                 normal form for integer matrices.                          *)
 (* Note that many of the concepts and results in this file could and perhaps  *)
@@ -456,16 +453,6 @@ Lemma divzDr m n d :
   (d %| n)%Z -> ((m + n) %/ d)%Z = (m %/ d)%Z + (n %/ d)%Z.
 Proof. by move=> dv_n; rewrite addrC divzDl // addrC. Qed.
 
-Lemma Qint_dvdz (m d : int) : (d %| m)%Z -> (m%:~R / d%:~R : rat) \is a Num.int.
-Proof.
-case/dvdzP=> z ->; rewrite rmorphM /=; have [->|dn0] := eqVneq d 0.
-  by rewrite mulr0 mul0r.
-by rewrite mulfK ?intr_eq0.
-Qed.
-
-Lemma Qnat_dvd (m d : nat) : (d %| m)%N -> (m%:R / d%:R : rat) \is a Num.nat.
-Proof. by move=> h; rewrite natrEint divr_ge0 ?ler0n // !pmulrn Qint_dvdz. Qed.
-
 Lemma dvdz_charf (R : nzRingType) p : p \in [char R] ->
   forall n : int, (p %| n)%Z = (n%:~R == 0 :> R).
 Proof.
@@ -504,7 +491,7 @@ Proof. by rewrite -!(gcdzC n) gcdz_modr. Qed.
 
 Lemma gcdzMDl q m n : gcdz m (q * m + n) = gcdz m n.
 Proof. by rewrite -gcdz_modr modzMDl gcdz_modr. Qed.
- 
+
 Lemma gcdzDl m n : gcdz m (m + n) = gcdz m n.
 Proof. by rewrite -{2}(mul1r m) gcdzMDl. Qed.
 
@@ -882,60 +869,6 @@ exists (zcontents q *: zprimitive r); rewrite -scalerAr.
 by rewrite -zprimitiveM mulrC -Dpr zprimitiveZ // -zpolyEprim.
 Qed.
 
-Local Notation pZtoQ := (map_poly (intr : int -> rat)).
-
-Lemma size_rat_int_poly p : size (pZtoQ p) = size p.
-Proof. by apply: size_map_inj_poly; first apply: intr_inj. Qed.
-
-Lemma rat_poly_scale (p : {poly rat}) :
-  {q : {poly int} & {a | a != 0 & p = a%:~R^-1 *: pZtoQ q}}.
-Proof.
-pose a := \prod_(i < size p) denq p`_i.
-have nz_a: a != 0 by apply/prodf_neq0=> i _; apply: denq_neq0.
-exists (map_poly numq (a%:~R *: p)), a => //.
-apply: canRL (scalerK _) _; rewrite ?intr_eq0 //.
-apply/polyP=> i; rewrite !(coefZ, coef_map_id0) // numqK // Qint_def mulrC.
-have [ltip | /(nth_default 0)->] := ltnP i (size p); last by rewrite mul0r.
-by rewrite [a](bigD1 (Ordinal ltip)) // rmorphM mulrA -numqE -rmorphM denq_int.
-Qed.
-
-Lemma dvdp_rat_int p q : (pZtoQ p %| pZtoQ q) = (p %| q).
-Proof.
-apply/dvdpP/Pdiv.Idomain.dvdpP=> [[/= r1 Dq] | [[/= a r] nz_a Dq]]; last first.
-  exists (a%:~R^-1 *: pZtoQ r).
-  by rewrite -scalerAl -rmorphM -Dq /= linearZ/= scalerK ?intr_eq0.
-have [r [a nz_a Dr1]] := rat_poly_scale r1; exists (a, r) => //=.
-apply: (map_inj_poly _ _ : injective pZtoQ) => //; first exact: intr_inj.
-by rewrite linearZ /= Dq Dr1 -scalerAl -rmorphM scalerKV ?intr_eq0.
-Qed.
-
-Lemma dvdpP_rat_int p q :
-    p %| pZtoQ q ->
-  {p1 : {poly int} & {a | a != 0 & p = a *: pZtoQ p1} & {r | q = p1 * r}}.
-Proof.
-have{p} [p [a nz_a ->]] := rat_poly_scale p.
-rewrite dvdpZl ?invr_eq0 ?intr_eq0 // dvdp_rat_int => dv_p_q.
-exists (zprimitive p); last exact: dvdpP_int.
-have [-> | nz_p] := eqVneq p 0.
-  by exists 1; rewrite ?oner_eq0 // zprimitive0 map_poly0 !scaler0.
-exists ((zcontents p)%:~R / a%:~R).
-  by rewrite mulf_neq0 ?invr_eq0 ?intr_eq0 ?zcontents_eq0.
-by rewrite mulrC -scalerA -map_polyZ -zpolyEprim.
-Qed.
-
-Lemma irreducible_rat_int p :
-  irreducible_poly (pZtoQ p) <-> irreducible_poly p.
-Proof.
-rewrite /irreducible_poly size_rat_int_poly; split=> -[] p1 p_irr; split=> //.
-  move=> q q1; rewrite /eqp -!dvdp_rat_int => rq.
-  by apply/p_irr => //; rewrite size_rat_int_poly.
-move=> q + /dvdpP_rat_int [] r [] c c0 qE [] s sE.
-rewrite qE size_scale// size_rat_int_poly => r1.
-apply/(eqp_trans (eqp_scale _ c0)).
-rewrite /eqp !dvdp_rat_int; apply/p_irr => //.
-by rewrite sE dvdp_mulIl.
-Qed.
-
 End ZpolyScale.
 
 (* Integral spans. *)
@@ -1044,172 +977,4 @@ rewrite [D in _ *m D *m _](_ : _ = block_mx 1 0 0 D1); last first.
   by apply/matrixP=> i j; do 3?[rewrite ?mxE ?ord1 //=; case: splitP => ? ->].
 rewrite !mulmx_block !(mul0mx, mulmx0, addr0) !mulmx1 add0r mul1mx -Da -dM1.
 by rewrite addNKr submxK.
-Qed.
-
-Definition inIntSpan (V : zmodType) m (s : m.-tuple V) v :=
-  exists a : int ^ m, v = \sum_(i < m) s`_i *~ a i.
-
-Lemma solve_Qint_span (vT : vectType rat) m (s : m.-tuple vT) v :
-  {b : int ^ m &
-  {p : seq (int ^ m) &
-  forall a : int ^ m,
-  v = \sum_(i < m) s`_i *~ a i <->
-  exists c : seq int, a = b + \sum_(i < size p) p`_i *~ c`_i}} +
-  (~ inIntSpan s v).
-Proof.
-have s_s (i : 'I_m): s`_i \in <<s>>%VS by rewrite memv_span ?memt_nth.
-have s_Zs a: \sum_(i < m) s`_i *~ a i \in <<s>>%VS.
-  by apply/rpred_sum => i _; apply/rpredMz.
-case s_v: (v \in <<s>>%VS); last by right=> [[a Dv]]; rewrite Dv s_Zs in s_v.
-move SE : (\matrix_(i < m, j < _) coord (vbasis <<s>>) j s`_i) => S.
-move rE : (\rank S) => r; move kE : (m - r)%N => k.
-have Dm: (m = k + r)%N by rewrite -kE -rE subnK ?rank_leq_row.
-rewrite Dm in s s_s s_Zs s_v S SE rE kE *.
-move=> {Dm m}; pose m := (k + r)%N.
-have [K kerK]: {K : 'M_(k, m) | map_mx intr K == kermx S}%MS.
-  move: (mxrank_ker S); rewrite rE kE => krk.
-  pose B := row_base (kermx S); pose d := \prod_ij denq (B ij.1 ij.2).
-  exists (castmx (krk, erefl m) (map_mx numq (intr d *: B))).
-  rewrite map_castmx !eqmx_cast -map_mx_comp map_mx_id_in => [|i j]; last first.
-    rewrite mxE mulrC [d](bigD1 (i, j)) //= rmorphM mulrA.
-    by rewrite -numqE -rmorphM numq_int.
-  suff nz_d: d%:Q != 0 by rewrite !eqmx_scale // !eq_row_base andbb.
-  by rewrite intr_eq0; apply/prodf_neq0 => i _; apply: denq_neq0.
-have [L _ [G uG [D _ defK]]] := int_Smith_normal_form K.
-have {K L D defK kerK} [kerGu kerS_sub_Gu]: map_mx intr (usubmx G) *m S = 0 /\
-    (kermx S <= map_mx intr (usubmx G))%MS.
-  pose Kl : 'M[rat]_k := map_mx intr (lsubmx (K *m invmx G)).
-  have {}defK: map_mx intr K = Kl *m map_mx intr (usubmx G).
-    rewrite /Kl -map_mxM; congr map_mx.
-    rewrite -[LHS](mulmxKV uG) -{2}[G]vsubmxK -{1}[K *m _]hsubmxK.
-    rewrite mul_row_col -[RHS]addr0; congr (_ + _).
-    rewrite defK mulmxK //= -[RHS](mul0mx _ (dsubmx G)); congr (_ *m _).
-    apply/matrixP => i j; rewrite !mxE big1 //= => j1 _.
-    rewrite mxE /= eqn_leq andbC.
-    by rewrite leqNgt (leq_trans (valP j1)) ?mulr0 ?leq_addr.
-  split; last by rewrite -(eqmxP kerK); apply/submxP; exists Kl.
-  suff /row_full_inj: row_full Kl.
-    by apply; rewrite mulmx0 mulmxA (sub_kermxP _) // -(eqmxP kerK) defK.
-  rewrite /row_full eqn_leq rank_leq_row /= -{1}kE -{2}rE -(mxrank_ker S).
-  by rewrite -(eqmxP kerK) defK mxrankM_maxl.
-pose T := map_mx intr (dsubmx G) *m S.
-have defS: map_mx intr (rsubmx (invmx G)) *m T = S.
-  rewrite mulmxA -map_mxM /=; move: (mulVmx uG).
-  rewrite -{2}[G]vsubmxK -{1}[invmx G]hsubmxK mul_row_col.
-  move/(canRL (addKr _)) ->; rewrite -mulNmx raddfD /= map_mx1 map_mxM /=.
-  by rewrite mulmxDl -mulmxA kerGu mulmx0 add0r mul1mx.
-pose vv := \row_j coord (vbasis <<s>>) j v.
-have uS: row_full S.
-  apply/row_fullP; exists (\matrix_(i, j) coord s j (vbasis <<s>>)`_i).
-  apply/matrixP => j1 j2; rewrite !mxE.
-  rewrite -(coord_free _ _ (basis_free (vbasisP _))).
-  rewrite -!tnth_nth (coord_span (vbasis_mem (mem_tnth j1 _))) linear_sum.
-  by apply: eq_bigr => /= i _; rewrite -SE !mxE (tnth_nth 0) !linearZ.
-have eqST: (S :=: T)%MS by apply/eqmxP; rewrite -{1}defS !submxMl.
-case Zv: (map_mx denq (vv *m pinvmx T) == const_mx 1); last first.
-  right=> [[a Dv]]; case/eqP: Zv; apply/rowP.
-  have ->: vv = map_mx intr (\row_i a i) *m S.
-    apply/rowP => j; rewrite !mxE Dv linear_sum.
-    by apply: eq_bigr => i _; rewrite -SE -scaler_int linearZ !mxE.
-  rewrite -defS -2!mulmxA; have ->: T *m pinvmx T = 1%:M.
-    have uT: row_free T by rewrite /row_free -eqST rE.
-    by apply: (row_free_inj uT); rewrite mul1mx mulmxKpV.
-  by move=> i; rewrite mulmx1 -map_mxM 2!mxE denq_int mxE.
-pose b := map_mx numq (vv *m pinvmx T) *m dsubmx G.
-left; exists [ffun j => b 0 j], [seq [ffun j => (usubmx G) i j] | i : 'I_k].
-rewrite size_image card_ord => a; rewrite -[a](addNKr [ffun j => b 0 j]).
-move: (_ + a) => h; under eq_bigr => i _ do rewrite !ffunE mulrzDr.
-rewrite big_split /=.
-have <-: v = \sum_(i < m) s`_i *~ b 0 i.
-  transitivity (\sum_j (map_mx intr b *m S) 0 j *: (vbasis <<s>>)`_j).
-    rewrite {1}(coord_vbasis s_v); apply: eq_bigr => j _; congr (_ *: _).
-    suff ->: map_mx intr b = vv *m pinvmx T *m map_mx intr (dsubmx G).
-      by rewrite -(mulmxA _ _ S) mulmxKpV ?mxE // -eqST submx_full.
-    rewrite map_mxM /=; congr (_ *m _); apply/rowP => i; rewrite 2!mxE numqE.
-    by have /eqP/rowP/(_ i)/[!mxE] -> := Zv; rewrite mulr1.
-  rewrite (coord_vbasis (s_Zs _)); apply: eq_bigr => j _; congr (_ *: _).
-  rewrite linear_sum mxE; apply: eq_bigr => i _.
-  by rewrite -SE -scaler_int linearZ [b]lock !mxE.
-split.
-  rewrite -[LHS]addr0 => /addrI hP; pose c := \row_i h i *m lsubmx (invmx G).
-  exists [seq c 0 i | i : 'I_k]; congr (_ + _).
-  have/sub_kermxP: map_mx intr (\row_i h i) *m S = 0.
-    transitivity (\row_j coord (vbasis <<s>>) j (\sum_(i < m) s`_i *~ h i)).
-      apply/rowP => j; rewrite !mxE linear_sum; apply: eq_bigr => i _.
-      by rewrite -SE !mxE -scaler_int linearZ.
-    by apply/rowP => j; rewrite !mxE -hP linear0.
-  case/submx_trans/(_ kerS_sub_Gu)/submxP => c' /[dup].
-  move/(congr1 (mulmx^~ (map_mx intr (lsubmx (invmx G))))).
-  rewrite -mulmxA -!map_mxM [in RHS]mulmx_lsub mul_usub_mx -/c mulmxV //=.
-  rewrite scalar_mx_block -/(ulsubmx _) block_mxKul map_scalar_mx mulmx1.
-  move=> <- {c'}; rewrite -map_mxM /= => defh; apply/ffunP => j.
-  move/rowP/(_ j): defh; rewrite sum_ffunE !mxE => /intr_inj ->.
-  apply: eq_bigr => i _; rewrite ffunMzE mulrzz mulrC.
-  rewrite (nth_map i) ?size_enum_ord // nth_ord_enum ffunE.
-  by rewrite (nth_map i) ?size_enum_ord // nth_ord_enum.
-case=> c /addrI -> {h}; rewrite -[LHS]addr0; congr (_ + _).
-pose h := \row_(j < k) c`_j *m usubmx G.
-transitivity (\sum_j (map_mx intr h *m S) 0 j *: (vbasis <<s>>)`_j).
-  by rewrite map_mxM -mulmxA kerGu mulmx0 big1 // => j _; rewrite mxE scale0r.
-rewrite (coord_vbasis (s_Zs _)); apply: eq_bigr => i _; congr (_ *: _).
-rewrite linear_sum -SE mxE; apply: eq_bigr => j _.
-rewrite -scaler_int linearZ !mxE sum_ffunE; congr (_%:~R * _).
-apply: {i} eq_bigr => i _; rewrite mxE ffunMzE mulrzz mulrC.
-by rewrite (nth_map i) ?size_enum_ord // ffunE nth_ord_enum.
-Qed.
-
-Lemma dec_Qint_span (vT : vectType rat) m (s : m.-tuple vT) v :
-  decidable (inIntSpan s v).
-Proof.
-have [[b [p aP]]|] := solve_Qint_span s v; last by right.
-left; exists b; apply/(aP b); exists [::]; rewrite big1 ?addr0 // => i _.
-by rewrite nth_nil mulr0z.
-Qed.
-
-Lemma eisenstein_crit (p : nat) (q : {poly int}) : prime p -> (size q != 1)%N ->
-  ~~ (p %| lead_coef q)%Z -> ~~ (p ^+ 2 %| q`_0)%Z ->
-  (forall i, (i < (size q).-1)%N -> p %| q`_i)%Z ->
-  irreducible_poly q.
-Proof.
-move=> p_prime qN1 Ndvd_pql Ndvd_pq0 dvd_pq.
-apply/irreducible_rat_int.
-have qN0 : q != 0 by rewrite -lead_coef_eq0; apply: contraNneq Ndvd_pql => ->.
-split.
-  rewrite size_map_poly_id0 ?intr_eq0 ?lead_coef_eq0//.
-  by rewrite ltn_neqAle eq_sym qN1 size_poly_gt0.
-move=> f' +/dvdpP_rat_int[f [d dN0 feq]]; rewrite {f'}feq size_scale// => fN1.
-move=> /= [g q_eq]; rewrite q_eq (eqp_trans (eqp_scale _ _))//.
-have fN0 : f != 0 by apply: contra_neq qN0; rewrite q_eq => ->; rewrite mul0r.
-have gN0 : g != 0 by apply: contra_neq qN0; rewrite q_eq => ->; rewrite mulr0.
-rewrite size_map_poly_id0 ?intr_eq0 ?lead_coef_eq0// in fN1.
-have [/eqP/size_poly1P[c cN0 ->]|gN1] := eqVneq (size g) 1%N.
-  by rewrite mulrC mul_polyC map_polyZ/= eqp_sym eqp_scale// intr_eq0.
-have c_neq0 : (lead_coef q)%:~R != 0 :> 'F_p
-   by rewrite -(dvdz_charf (char_Fp _)).
-have : map_poly (intr : int -> 'F_p) q = (lead_coef q)%:~R *: 'X^(size q).-1.
-  apply/val_inj/(@eq_from_nth _ 0) => [|i]; rewrite size_map_poly_id0//.
-    by rewrite size_scale// size_polyXn -polySpred.
-  move=> i_small; rewrite coef_poly i_small coefZ coefXn lead_coefE.
-  move: i_small; rewrite polySpred// ltnS/=.
-  case: ltngtP => // [i_lt|->]; rewrite (mulr1, mulr0)//= => _.
-  by apply/eqP; rewrite -(dvdz_charf (char_Fp _))// dvd_pq.
-rewrite [in LHS]q_eq rmorphM/=.
-set c := (X in X *: _); set n := (_.-1).
-set pf := map_poly _ f; set pg := map_poly _ g => pfMpg.
-have dvdXn (r : {poly _}) : size r != 1%N -> r %| c *: 'X^n -> r`_0 = 0.
-  move=> rN1; rewrite (eqp_dvdr _ (eqp_scale _ _))//.
-  rewrite -['X]subr0; move=> /dvdp_exp_XsubCP[k lekn]; rewrite subr0.
-  move=> /eqpP[u /andP[u1N0 u2N0]]; have [->|k_gt0] := posnP k.
-    move=> /(congr1 (size \o val))/eqP.
-    by rewrite /= !size_scale// size_polyXn (negPf rN1).
-  move=> /(congr1 (fun p : {poly _} => p`_0))/eqP.
-  by rewrite !coefZ coefXn ltn_eqF// mulr0 mulf_eq0 (negPf u1N0) => /eqP.
-suff : ((p : int) ^+ 2 %| q`_0)%Z by rewrite (negPf Ndvd_pq0).
-have := c_neq0; rewrite q_eq coefM big_ord1.
-rewrite lead_coefM rmorphM mulf_eq0 negb_or => /andP[lpfN0 qfN0].
-have pfN1 : size pf != 1%N by rewrite size_map_poly_id0.
-have pgN1 : size pg != 1%N by rewrite size_map_poly_id0.
-have /(dvdXn _ pgN1) /eqP : pg %| c *: 'X^n by rewrite -pfMpg dvdp_mull.
-have /(dvdXn _ pfN1) /eqP : pf %| c *: 'X^n by rewrite -pfMpg dvdp_mulr.
-by rewrite !coef_map// -!(dvdz_charf (char_Fp _))//; apply: dvdz_mul.
 Qed.

--- a/algebra/rat.v
+++ b/algebra/rat.v
@@ -763,41 +763,78 @@ Proof. by case: b; rewrite ?(mul1r, mulN1r) // denqN. Qed.
 Lemma denq_norm x : denq `|x| = denq x.
 Proof. by rewrite normrEsign denq_mulr_sign. Qed.
 
+Definition floorq (x : rat) : int :=
+  if 0 <= x then (numq x %/ (denq x))%Z
+  else - ((- numq x + denq x - 1) %/ denq x)%Z.
+
+Definition ceilq (x : rat) : int :=
+  if 0 <= x then ((numq x + denq x - 1) %/ (denq x))%Z
+  else - (- numq x %/ denq x)%Z.
+
+Definition truncnq (x : rat) : nat :=
+  if 0 <= x then (`|numq x| %/ `|denq x|)%N else 0%N.
+
 Module ratArchimedean.
 Section ratArchimedean.
 
 Implicit Types x : rat.
 
-Let truncn x : nat := if 0 <= x then (`|numq x| %/ `|denq x|)%N else 0%N.
-
-Lemma truncnP x :
-  if 0 <= x then (truncn x)%:R <= x < (truncn x).+1%:R else truncn x == 0%N.
-Proof.
-rewrite /truncn -numq_ge0; case: (ratP x) => -[] //= n d _.
-rewrite ler_pdivlMr ?ltr_pdivrMr ?ltr0z // -!natrM ler_nat ltr_nat.
-by rewrite leq_divM ltn_ceil.
-Qed.
+Let is_int x := denq x == 1.
 
 Let is_nat x := (0 <= x) && (denq x == 1).
 
-Lemma is_natE x : is_nat x = ((truncn x)%:R == x).
+Lemma floorP x :
+  if x \is Num.real then (floorq x)%:~R <= x < (floorq x + 1)%:~R
+  else floorq x == 0.
 Proof.
-rewrite /is_nat /truncn -numq_ge0 !rat_eq; case: (ratP x) => -[] //= n d pnd.
-rewrite pmulrn numq_int denq_int mulr1 -PoszM !eqz_nat -dvdn_eq.
-apply/eqP/idP => [->|/dvdnP[k nE]] //.
-by move/eqP: pnd; rewrite nE gcdnC gcdnMl.
+rewrite num_real /floorq; case: (ratP x) => n d _ {x}.
+rewrite !ler_pdivlMr// mul0r ltr_pdivrMr//; case: n => n.
+  by rewrite -pmulrn ler0n -!intrM pmulrn ler_int ltr_int lez_floor ?ltz_ceil.
+rewrite NegzE mulrNz oppr_ge0 -pmulrn opprK lern0/= pmulrn -!intrM.
+rewrite [_ + 1]addrC -[1 - _]opprB !mulNr !mulrNz lerN2 ltrN2 ler_int ltr_int.
+apply/andP; split.
+- rewrite -(lerD2r (Posz d.+1 -1 + 1)) !addrA lezD1 addrK.
+  by rewrite -[X in _ * _ + X]mul1r -mulrDl ltz_ceil.
+- by rewrite mulrDl mulNr mul1r ltrBlDr -lezD1 -lerBrDr lez_floor.
 Qed.
 
-Lemma is_intE x : (denq x == 1) = is_nat x || is_nat (- x).
-Proof. by rewrite /is_nat denqN oppr_ge0 -andb_orl le_total. Qed.
+Lemma ceilP x : ceilq x = - floorq (- x).
+Proof.
+rewrite /ceilq /floorq; have [xlt0 | xgt0 |->//] := ltgtP x 0.
+- by congr (- _); rewrite oppr_ge0 (ltW xlt0) numqN denqN.
+- by rewrite oppr_ge0 leNgt xgt0/= numqN denqN !opprK.
+Qed.
+
+Lemma truncnP x : truncnq x = if floorq x is Posz n then n else 0.
+Proof.
+rewrite /truncnq /floorq; case: (ratP x) => n d _ {x} /=.
+rewrite !ler_pdivlMr// mul0r; case: n => n.
+  by rewrite -pmulrn ler0n absz_nat divz_nat.
+rewrite NegzE mulrNz oppr_ge0 -pmulrn opprK lern0/=.
+set nd := (_ %/ _)%Z; suff: 1 <= nd by case: nd => -[].
+by rewrite /nd -addrA addrCA -[X in X + _]mul1r divzMDl.
+Qed.
+
+Lemma intrP x : reflect (exists n, x = n%:~R) (is_int x).
+Proof.
+apply: (iffP idP) => [/eqP d1 | [i ->]]; [|by rewrite /is_int denq_int].
+by exists (numq x); case: (ratP x) d1 => n d _ ->; rewrite divr1.
+Qed.
+
+Lemma natrP x : reflect (exists n, x = n%:R) (is_nat x).
+Proof.
+apply: (iffP idP) => [/andP[]/[swap]/intrP[i ->]|[n ->]].
+  by rewrite ler0z; case: i => [n _|//]; exists n.
+by rewrite /is_nat pmulrn ler0z denq_int.
+Qed.
 
 End ratArchimedean.
-#[deprecated(since="mathcomp 2.4.0", note="Renamed to truncnP.")]
-Notation truncP := truncnP.
 End ratArchimedean.
 
-HB.instance Definition _ := Num.NumDomain_isArchimedean.Build rat
-  ratArchimedean.truncnP ratArchimedean.is_natE ratArchimedean.is_intE.
+HB.instance Definition _ :=
+  Num.NumDomain_hasFloorCeilTruncn.Build rat
+    ratArchimedean.floorP ratArchimedean.ceilP ratArchimedean.truncnP
+    ratArchimedean.intrP ratArchimedean.natrP.
 
 Lemma Qint_def (x : rat) : (x \is a Num.int) = (denq x == 1). Proof. by []. Qed.
 

--- a/doc/changelog/01-added/1381-floorq.md
+++ b/doc/changelog/01-added/1381-floorq.md
@@ -4,5 +4,9 @@
     `rat_poly_scale`, `dvdp_rat_int`, `dvdpP_rat_int`,
     `irreductible_rat_int`, `solve_QInt_span`, `dec_Qint_span`,
     `eisenstein_crit` (from `intdiv.v`)
+  + definitions `floorq`, `ceilq`, `truncnq`
+  + lemmas `ratArchimedean.floorP`, `ratArchimedean.ceilP`,
+    `ratArchimedean.truncnP`, `ratArchimedean.intrP`,
+    `ratArchimedean.natrP`
     ([#1381](https://github.com/math-comp/math-comp/pull/1381),
     by Pierre Roux).

--- a/doc/changelog/01-added/1381-floorq.md
+++ b/doc/changelog/01-added/1381-floorq.md
@@ -1,0 +1,8 @@
+- in `rat.v`
+  + definition `inIntSpan` (from `intdiv.v`)
+  + lemmas `Qint_dvdz`, `Qnat_dvd`, `size_rat_int_poly`,
+    `rat_poly_scale`, `dvdp_rat_int`, `dvdpP_rat_int`,
+    `irreductible_rat_int`, `solve_QInt_span`, `dec_Qint_span`,
+    `eisenstein_crit` (from `intdiv.v`)
+    ([#1381](https://github.com/math-comp/math-comp/pull/1381),
+    by Pierre Roux).

--- a/doc/changelog/02-changed/1381-floorq.md
+++ b/doc/changelog/02-changed/1381-floorq.md
@@ -1,0 +1,4 @@
+- in `rat.v`
+  + `Num.floor`, `Num.ceil` and `Num.truncn` on `rat` now compute
+    ([#1381](https://github.com/math-comp/math-comp/pull/1381), by
+    Pierre Roux).

--- a/doc/changelog/04-removed/1381-floorq.md
+++ b/doc/changelog/04-removed/1381-floorq.md
@@ -4,5 +4,7 @@
     `rat_poly_scale`, `dvdp_rat_int`, `dvdpP_rat_int`,
     `irreductible_rat_int`, `solve_QInt_span`, `dec_Qint_span`,
     `eisenstein_crit` (moved to `rat.v`)
+  + lemmas `ratArchimedean.truncnP`, `ratArchimedean.is_natE`,
+    `ratArchimedean.is_intE`
     ([#1381](https://github.com/math-comp/math-comp/pull/1381),
     by Pierre Roux).

--- a/doc/changelog/04-removed/1381-floorq.md
+++ b/doc/changelog/04-removed/1381-floorq.md
@@ -1,0 +1,8 @@
+- in `rat.v`
+  + definition `inIntSpan` (moved to `rat.v`)
+  + lemmas `Qint_dvdz`, `Qnat_dvd`, `size_rat_int_poly`,
+    `rat_poly_scale`, `dvdp_rat_int`, `dvdpP_rat_int`,
+    `irreductible_rat_int`, `solve_QInt_span`, `dec_Qint_span`,
+    `eisenstein_crit` (moved to `rat.v`)
+    ([#1381](https://github.com/math-comp/math-comp/pull/1381),
+    by Pierre Roux).


### PR DESCRIPTION
~Requires https://github.com/math-comp/math-comp/pull/1250~ (merged)

##### Motivation for this change

This enables Num.floor and Num.ceil on rat to compute.

For instance:
    
```Coq
Goal Num.ceil (4 / 3 : rat) <= 2.
by compute.
```

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
