### PR TITLE
remove attribution from make-entry

### DIFF
--- a/doc/changelog/make-entry.sh
+++ b/doc/changelog/make-entry.sh
@@ -18,13 +18,13 @@ printf "Fixes? (space separated list of bug numbers)\n"
 read -r fixes_list
 
 fixes_string="$(echo $fixes_list | sed 's/ /~    and /g; s,\([0-9][0-9]*\),[#\1](https://github.com/math-comp/math-comp/issues/\1),g' | tr '~' '\n')"
-if [ ! -z "$fixes_string" ]; then fixes_string="$(printf '\n    fixes %s,' "$fixes_string")"; fi
+if [ ! -z "$fixes_string" ]; then fixes_string="$(printf ',\n    fixes %s' "$fixes_string")"; fi
 
 # shellcheck disable=SC2016
 # the ` are regular strings, this is intended
 # use %s for the leading - to avoid looking like an option (not sure
 # if necessary but doesn't hurt)
-printf '%s in `%s`\n  + Describe your change here but do not end with a period\n    for instance: lemmas `lem1`, `lem2` and `lem3`\n    ([#%s](https://github.com/math-comp/math-comp/pull/%s),%s\n    by %s).\n' - "$in_file" "$PR" "$PR" "$fixes_string" "$(git config user.name)" > "$where"
+printf '%s in `%s`\n  + Describe your change here but do not end with a period\n    for instance: lemmas `lem1`, `lem2` and `lem3`\n    ([#%s](https://github.com/math-comp/math-comp/pull/%s)%s).\n' - "$in_file" "$PR" "$PR" "$fixes_string" > "$where"
 
 printf 'Name of created changelog file:\n'
 printf '%s\n' "$where"


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).