### PR TITLE
depend on rocq-hierarchy-builder if available

### DIFF
--- a/rocq-mathcomp-ssreflect.opam
+++ b/rocq-mathcomp-ssreflect.opam
@@ -14,7 +14,8 @@ depends: [
   | "rocq-core" {>= "9.0" | = "dev"})
   # Please keep the "dev" above as it is required for the coq-dev Docker images
   "elpi" {>= "1.17.0"}
-  "coq-hierarchy-builder" { >= "1.7.0"}
+  ("coq-hierarchy-builder" { >= "1.7.0"}
+  | "rocq-hierarchy-builder" { >= "1.9.0" | = "dev" })
 ]
 
 tags: [


### PR DESCRIPTION
##### Motivation for this change

changes the constraints so that the Coq compatibility shim is not required if the `rocq-*` packages are selected

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
