### PR TITLE
Adding (count|fin)Pz(Semi)?Ring

### DIFF
--- a/algebra/countalg.v
+++ b/algebra/countalg.v
@@ -11,9 +11,13 @@ From mathcomp Require Import fintype bigop ssralg.
 (* not cover the left module / algebra interfaces, providing only            *)
 (*          countNmodType == countable nmodType interface                    *)
 (*          countZmodType == countable zmodType interface                    *)
+(*    countPzSemiRingType == countable pzSemiRingType interface              *)
 (*    countNzSemiRingType == countable nzSemiRingType interface              *)
+(*        countPzRingType == countable pzRingType interface                  *)
 (*        countNzRingType == countable nzRingType interface                  *)
+(* countComPzSemiRingType == countable comPzSemiRingType interface           *)
 (* countComNzSemiRingType == countable comNzSemiRingType interface           *)
+(*     countComPzRingType == countable comPzRingType interface               *)
 (*     countComNzRingType == countable comNzRingType interface               *)
 (*      countUnitRingType == countable unitRingType interface                *)
 (*   countComUnitRingType == countable comUnitRingType interface             *)
@@ -43,6 +47,9 @@ HB.structure Definition Nmodule := {M of GRing.Nmodule M & Countable M}.
 #[short(type="countZmodType")]
 HB.structure Definition Zmodule := {M of GRing.Zmodule M & Countable M}.
 
+#[short(type="countPzSemiRingType")]
+HB.structure Definition PzSemiRing := {R of GRing.PzSemiRing R & Countable R}.
+
 #[short(type="countNzSemiRingType")]
 HB.structure Definition NzSemiRing := {R of GRing.NzSemiRing R & Countable R}.
 
@@ -61,6 +68,9 @@ Notation on R := (NzSemiRing.on R) (only parsing).
              note="Use CountRing.NzSemiRing.copy instead.")]
 Notation copy T U := (NzSemiRing.copy T U) (only parsing).
 End SemiRing.
+
+#[short(type="countPzRingType")]
+HB.structure Definition PzRing := {R of GRing.PzRing R & Countable R}.
 
 #[short(type="countNzRingType")]
 HB.structure Definition NzRing := {R of GRing.NzRing R & Countable R}.
@@ -81,6 +91,10 @@ Notation on R := (NzRing.on R) (only parsing).
 Notation copy T U := (NzRing.copy T U) (only parsing).
 End Ring.
 
+#[short(type="countComPzSemiRingType")]
+HB.structure Definition ComPzSemiRing :=
+  {R of GRing.ComPzSemiRing R & Countable R}.
+
 #[short(type="countComNzSemiRingType")]
 HB.structure Definition ComNzSemiRing :=
   {R of GRing.ComNzSemiRing R & Countable R}.
@@ -100,6 +114,9 @@ Notation on R := (ComNzSemiRing.on R) (only parsing).
              note="Use CountRing.ComNzSemiRing.copy instead.")]
 Notation copy T U := (ComNzSemiRing.copy T U) (only parsing).
 End ComSemiRing.
+
+#[short(type="countComPzRingType")]
+HB.structure Definition ComPzRing := {R of GRing.ComPzRing R & Countable R}.
 
 #[short(type="countComNzRingType")]
 HB.structure Definition ComNzRing := {R of GRing.ComNzRing R & Countable R}.
@@ -140,14 +157,26 @@ HB.structure Definition DecidableField :=
 #[short(type="countClosedFieldType")]
 HB.structure Definition ClosedField := {R of GRing.ClosedField R & Countable R}.
 
-#[export]
+Module ReguralExports.
+HB.instance Definition _ (R : countType) := Countable.on R^o.
 HB.instance Definition _ (R : countNmodType) := Nmodule.on R^o.
-#[export]
 HB.instance Definition _ (R : countZmodType) := Zmodule.on R^o.
-#[export]
+HB.instance Definition _ (R : countPzSemiRingType) := PzSemiRing.on R^o.
 HB.instance Definition _ (R : countNzSemiRingType) := NzSemiRing.on R^o.
-#[export]
+HB.instance Definition _ (R : countPzRingType) := PzRing.on R^o.
 HB.instance Definition _ (R : countNzRingType) := NzRing.on R^o.
+HB.instance Definition _ (R : countComPzSemiRingType) := ComPzSemiRing.on R^o.
+HB.instance Definition _ (R : countComNzSemiRingType) := ComNzSemiRing.on R^o.
+HB.instance Definition _ (R : countComPzRingType) := ComPzRing.on R^o.
+HB.instance Definition _ (R : countComNzRingType) := ComNzRing.on R^o.
+HB.instance Definition _ (R : countUnitRingType) := UnitRing.on R^o.
+HB.instance Definition _ (R : countComUnitRingType) := ComUnitRing.on R^o.
+HB.instance Definition _ (R : countIdomainType) := IntegralDomain.on R^o.
+HB.instance Definition _ (R : countFieldType) := Field.on R^o.
+HB.instance Definition _ (R : countDecFieldType) := DecidableField.on R^o.
+HB.instance Definition _ (R : countClosedFieldType) := ClosedField.on R^o.
+End ReguralExports.
+HB.export ReguralExports.
 
 End CountRing.
 

--- a/algebra/finalg.v
+++ b/algebra/finalg.v
@@ -12,9 +12,10 @@ From mathcomp Require Import ssralg countalg.
 (* allows type inference to function properly on expressions that mix        *)
 (* combinatorial and algebraic operators, e.g., [set x + y | x in A, y in A].*)
 (*                                                                           *)
-(*   finNmodType, finZmodType, finNzSemiRingType, finNzRingType,             *)
-(*   finComNzRingType, finComNzSemiRingType, finUnitRingType,                *)
-(*   finComUnitRingType, finIdomType, finFieldType, finLmodType,             *)
+(*   finNmodType, finZmodType, finPzSemiRingType, finNzSemiRingType,         *)
+(*   finPzRingType, finNzRingType, finComPzRingType, finComNzRingType,       *)
+(*   finComPzSemiRingType, finComNzSemiRingType, finUnitRingType,            *)
+(*   finComUnitRingType, finIdomainType, finFieldType, finLmodType,          *)
 (*   finLalgType, finAlgType, finUnitAlgType                                 *)
 (*      == the finite counterparts of nmodType, etc                          *)
 (* Note that a finFieldType is canonically decidable.                        *)
@@ -53,6 +54,9 @@ Notation "[ 'finGroupMixin' 'of' R 'for' +%R ]" :=
 End ZmoduleExports.
 HB.export ZmoduleExports.
 
+#[short(type="finPzSemiRingType")]
+HB.structure Definition PzSemiRing := {R of GRing.PzSemiRing R & Finite R}.
+
 #[short(type="finNzSemiRingType")]
 HB.structure Definition NzSemiRing := {R of GRing.NzSemiRing R & Finite R}.
 
@@ -71,6 +75,9 @@ Notation on R := (NzSemiRing.on R) (only parsing).
              note="Use FinRing.NzSemiRing.copy instead.")]
 Notation copy T U := (NzSemiRing.copy T U) (only parsing).
 End SemiRing.
+
+#[short(type="finPzRingType")]
+HB.structure Definition PzRing := {R of GRing.PzRing R & Finite R}.
 
 #[short(type="finNzRingType")]
 HB.structure Definition NzRing := {R of GRing.NzRing R & Finite R}.
@@ -91,6 +98,10 @@ Notation on R := (NzRing.on R) (only parsing).
 Notation copy T U := (NzRing.copy T U) (only parsing).
 End Ring.
 
+#[short(type="finComPzSemiRingType")]
+HB.structure Definition ComPzSemiRing :=
+  {R of GRing.ComPzSemiRing R & Finite R}.
+
 #[short(type="finComNzSemiRingType")]
 HB.structure Definition ComNzSemiRing :=
   {R of GRing.ComNzSemiRing R & Finite R}.
@@ -110,6 +121,9 @@ Notation on R := (ComNzSemiRing.on R) (only parsing).
              note="Use FinRing.ComNzSemiRing.copy instead.")]
 Notation copy T U := (ComNzSemiRing.copy T U) (only parsing).
 End ComSemiRing.
+
+#[short(type="finComPzRingType")]
+HB.structure Definition ComPzRing := {R of GRing.ComPzRing R & Finite R}.
 
 #[short(type="finComNzRingType")]
 HB.structure Definition ComNzRing := {R of GRing.ComNzRing R & Finite R}.
@@ -391,8 +405,16 @@ Coercion UnitAlgebra_to_finGroup (R : unitRingType) (M : UnitAlgebra.type R) :=
   FinGroup.clone M _.
 
 Module RegularExports.
+HB.instance Definition _ (R : finType) := Finite.on R^o.
+HB.instance Definition _ (R : finNmodType) := Nmodule.on R^o.
 HB.instance Definition _ (R : finZmodType) := Zmodule.on R^o.
+HB.instance Definition _ (R : finPzSemiRingType) := PzSemiRing.on R^o.
+HB.instance Definition _ (R : finPzRingType) := PzRing.on R^o.
+HB.instance Definition _ (R : finNzSemiRingType) := NzSemiRing.on R^o.
 HB.instance Definition _ (R : finNzRingType) := NzRing.on R^o.
+HB.instance Definition _ (R : finComPzSemiRingType) := PzSemiRing.on R^o.
+HB.instance Definition _ (R : finComPzRingType) := PzRing.on R^o.
+HB.instance Definition _ (R : finComNzSemiRingType) := NzSemiRing.on R^o.
 HB.instance Definition _ (R : finComNzRingType) := NzRing.on R^o.
 HB.instance Definition _ (R : finUnitRingType) := NzRing.on R^o.
 HB.instance Definition _ (R : finComUnitRingType) := NzRing.on R^o.

--- a/algebra/ssralg.v
+++ b/algebra/ssralg.v
@@ -4853,6 +4853,8 @@ Bind Scope ring_scope with DecidableField.sort.
 End DecFieldExports.
 HB.export DecFieldExports.
 
+#[export] HB.instance Definition _ (F : decFieldType) := DecidableField.on F^o.
+
 Section DecidableFieldTheory.
 
 Variable F : decFieldType.
@@ -5045,6 +5047,8 @@ Module ClosedFieldExports.
 Bind Scope ring_scope with ClosedField.sort.
 End ClosedFieldExports.
 HB.export ClosedFieldExports.
+
+#[export] HB.instance Definition _ (F : closedFieldType) := ClosedField.on F^o.
 
 Section ClosedFieldTheory.
 

--- a/doc/changelog/01-added/1431-finpzring.md
+++ b/doc/changelog/01-added/1431-finpzring.md
@@ -1,0 +1,9 @@
+- in `algebra/countalg.v`
+  + structures `countPzSemiRingType`, `countPzRingType`,
+    `countComPzSemiRingType`, `countPzRingType`
+    ([#1431](https://github.com/math-comp/math-comp/pull/1431)).
+
+- in `algebra/finalg.v`
+  + structures `finPzSemiRingType`, `finPzRingType`, `finComPzSemiRingType`,
+   `finPzRingType`
+    ([#1431](https://github.com/math-comp/math-comp/pull/1431)).


### PR DESCRIPTION
##### Motivation for this change

There are a few missing joins with `pz(Semi)RingType`. Adding them increases the compilation time by ~2%.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
