### PR TITLE
Fingroup on to of monoid

### DIFF
--- a/algebra/matrix.v
+++ b/algebra/matrix.v
@@ -197,7 +197,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 Import GRing.Theory.
 Local Open Scope ring_scope.
 

--- a/algebra/mxalgebra.v
+++ b/algebra/mxalgebra.v
@@ -138,7 +138,7 @@ Unset Printing Implicit Defensive.
 
 Declare Scope matrix_set_scope.
 
-Import GroupScope.
+Local Open Scope group_scope.
 Import GRing.Theory.
 Local Open Scope ring_scope.
 

--- a/algebra/zmodp.v
+++ b/algebra/zmodp.v
@@ -182,7 +182,7 @@ apply: val_inj => /=; elim: n => [|n IHn]; first by rewrite muln0 modn_small.
 by rewrite !GRing.mulrS /= IHn modnDmr mulnS.
 Qed.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Lemma Zp_mulgC : @commutative 'I_p _ mulg.
 Proof. exact: Zp_addC. Qed.
@@ -263,7 +263,7 @@ Proof. by rewrite Zp_nat valZpK. Qed.
 Lemma natr_negZp (x : 'I_p) : (- x)%:R = - x.
 Proof. by apply: val_inj; rewrite /= Zp_nat /= modn_mod. Qed.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Lemma unit_Zp_mulgC : @commutative {unit 'I_p} _ mulg.
 Proof. by move=> u v; apply: val_inj; rewrite /= GRing.mulrC. Qed.

--- a/boot/monoid.v
+++ b/boot/monoid.v
@@ -193,6 +193,8 @@ End ClosedPredicates.
 
 End MagmaTheory.
 
+Prenex Implicits commute.
+
 HB.mixin Record Magma_isSemigroup G of Magma G := {
   mulgA : associative (@mul G)
 }.
@@ -252,6 +254,8 @@ Section baseUMagmaTheory.
 
 Variable G : baseUMagmaType.
 Implicit Types x : G.
+
+Lemma expgnE x n : x ^+ n = iterop n mul x 1. Proof. by []. Qed.
 Lemma expg0 x : x ^+ 0 = 1. Proof. by []. Qed.
 Lemma expg1 x : x ^+ 1 = x. Proof. by []. Qed.
 Lemma expg2 x : x ^+ 2 = x * x. Proof. by []. Qed.
@@ -310,6 +314,8 @@ Proof. by rewrite /commute mulg1 mul1g. Qed.
 
 End UMagmaTheory.
 
+#[global] Hint Resolve commute1 : core.
+
 #[short(type="monoidType")]
 HB.structure Definition Monoid := {G of Magma_isUMagma G & Semigroup G}.
 
@@ -361,17 +367,11 @@ Section MonoidTheory.
 Variable G : monoidType.
 Implicit Types x y : G.
 
-Lemma expgSr x n : x ^+ n.+1 = x ^+ n * x.
-Proof.
-elim: n => [|n IHn]; first by rewrite mul1g.
-by rewrite expgS [in LHS]IHn expgS mulgA.
-Qed.
-
 Lemma expgnDr x m n : x ^+ (m + n) = x ^+ m * x ^+ n.
-Proof.
-elim: m => [|m IHm]; first by rewrite mul1g.
-by rewrite 2!expgS IHm mulgA.
-Qed.
+Proof. by elim: m => [|m IHm]; rewrite ?mul1g // !expgS IHm mulgA. Qed.
+
+Lemma expgSr x n : x ^+ n.+1 = x ^+ n * x.
+Proof. by rewrite -addn1 expgnDr expg1. Qed.
 
 Lemma expgnA x m n : x ^+ (m * n) = x ^+ m ^+ n.
 Proof. by rewrite mulnC; elim: n => //= n IHn; rewrite expgS expgnDr IHn. Qed.
@@ -446,14 +446,129 @@ HB.structure Definition BaseGroup := {G of hasInv G & BaseUMagma G}.
 
 Bind Scope group_scope with BaseGroup.sort.
 
-HB.mixin Record Monoid_isGroup G of BaseGroup G := {
+Local Notation "x ^-1" := (inv x) : group_scope. Local Notation "x / y" := (x * y^-1) : group_scope.
+Local Notation "x ^- n" := ((x ^+ n)^-1) : group_scope.
+
+Definition conjg (G : baseGroupType) (x y : G) := y^-1 * (x * y).
+Local Notation "x ^ y" := (conjg x y) : group_scope.
+
+Definition commg (G : baseGroupType) (x y : G) := x^-1 * (conjg x y).
+Local Notation "[ ~ x1 , x2 , .. , xn ]" := (commg .. (commg x1 x2) .. xn)
+  : group_scope.
+
+HB.mixin Record Monoid_isStarMonoid G of BaseGroup G := {
+  invgK : involutive (@inv G);
+  invgM : {morph @inv G : x y / x * y >-> y * x}
+}.
+
+#[short(type="starMonoidType")]
+HB.structure Definition StarMonoid :=
+  { G of Monoid_isStarMonoid G & Monoid G & BaseGroup G }.
+
+Prenex Implicits invgK.
+
+Bind Scope group_scope with StarMonoid.sort.
+
+HB.factory Record isStarMonoid G of Choice G := {
+  mul : G -> G -> G;
+  one : G;
+  inv : G -> G;
+  mulgA : associative mul;
+  mul1g : left_id one mul;
+  invgK : involutive inv;
+  invgM : {morph inv : x y / mul x y >-> mul y x}
+}.
+
+HB.builders Context G of isStarMonoid G.
+
+Lemma invg1 : inv one = one.
+Proof.
+by apply: (can_inj invgK); rewrite -{1}[inv one]mul1g invgM invgK mul1g.
+Qed.
+
+Lemma mulg1 : right_id one mul.
+Proof. by move=> x; apply: (can_inj invgK); rewrite invgM invg1 mul1g. Qed.
+
+HB.instance Definition _ := isMonoid.Build G mulgA mul1g mulg1.
+HB.instance Definition _ := hasInv.Build G inv.
+HB.instance Definition _ := Monoid_isStarMonoid.Build G invgK invgM.
+
+HB.end.
+
+Section StarMonoidTheory.
+Variable G : starMonoidType.
+Implicit Types x y z : G.
+
+Lemma invg_inj : injective (@inv G). Proof. exact: can_inj invgK. Qed.
+
+Lemma invg1 : 1^-1 = 1 :> G.
+Proof. by apply: invg_inj; rewrite -{1}[1^-1]mul1g invgM invgK mul1g. Qed.
+
+Lemma invgF x y : (x / y)^-1 = y / x.
+Proof. by rewrite invgM invgK. Qed.
+
+Lemma prodgV I r (P : pred I) (E : I -> G) :
+  \prod_(i <- r | P i) (E i)^-1 = (\prod_(i <- rev r | P i) E i)^-1.
+Proof.
+elim: r => [|x r IHr]; first by rewrite !big_nil invg1.
+rewrite big_cons rev_cons big_rcons/= IHr.
+by case: ifP => _; rewrite ?mulg1// invgM.
+Qed.
+
+Lemma eqg_inv x y : (x^-1 == y^-1) = (x == y).
+Proof. exact: can_eq invgK x y. Qed.
+
+Lemma eqg_invLR x y : (x^-1 == y) = (x == y^-1).
+Proof. exact: inv_eq invgK x y. Qed.
+
+Lemma invg_eq1 x : (x^-1 == 1) = (x == 1).
+Proof. by rewrite eqg_invLR invg1. Qed.
+
+Lemma expVgn x n : x^-1 ^+ n = x ^- n.
+Proof. by elim: n => [|n IHn]; rewrite ?invg1 // expgSr expgS invgM IHn. Qed.
+
+Lemma conjgE x y : x ^ y = y^-1 * (x * y). Proof. by []. Qed.
+
+Lemma commgEl x y : [~ x, y] = x^-1 * x ^ y. Proof. by []. Qed.
+
+Lemma commgEr x y : [~ x, y] = y^-1 ^ x * y.
+Proof. by rewrite -!mulgA. Qed.
+
+End StarMonoidTheory.
+
+Arguments invg_inj {G} [x1 x2].
+
+HB.mixin Record StarMonoid_isGroup G of BaseGroup G := {
   mulVg : left_inverse one inv (@mul G);
-  mulgV : right_inverse one inv (@mul G)
 }.
 
 #[short(type="groupType")]
 HB.structure Definition Group :=
-  {G of Monoid_isGroup G & BaseGroup G & Monoid G}.
+  {G of StarMonoid_isGroup G & BaseGroup G & StarMonoid G}.
+
+HB.factory Record Monoid_isGroup G of Monoid G & BaseGroup G := {
+  mulVg : left_inverse one inv (@mul G);
+  mulgV : right_inverse one inv (@mul G);
+}.
+
+HB.builders Context G of Monoid_isGroup G.
+
+Fact invgK : involutive (@inv G).
+Proof. by move=> x; rewrite -[LHS]mul1g -(mulgV x) -mulgA mulgV mulg1. Qed.
+
+Fact mulKg : @left_loop G G inv *%g.
+Proof. by move=> x y; rewrite [LHS]mulgA mulVg mul1g. Qed.
+
+Fact invgM : {morph inv : x y / x * y >-> y * x : G}.
+Proof.
+move=> x y; apply: (can_inj (mulKg (x * y))).
+by rewrite [LHS]mulgV [RHS]mulgA -(mulgA x) mulgV mulg1 mulgV.
+Qed.
+
+HB.instance Definition _ := Monoid_isStarMonoid.Build G invgK invgM.
+HB.instance Definition _ := StarMonoid_isGroup.Build G mulVg.
+
+HB.end.
 
 HB.factory Record isGroup G of Choice G := {
   one : G;
@@ -478,21 +593,13 @@ HB.end.
 
 Bind Scope group_scope with Group.sort.
 
-Local Notation "x ^-1" := (inv x) : group_scope.
-Local Notation "x / y" := (x * y^-1) : group_scope.
-Local Notation "x ^- n" := ((x ^+ n)^-1) : group_scope.
-
-Definition conjg (G : groupType) (x y : G) := y^-1 * (x * y).
-Local Notation "x ^ y" := (conjg x y) : group_scope.
-
-Definition commg (G : groupType) (x y : G) := x^-1 * (conjg x y).
-Local Notation "[~ x , y ]" := (commg x y) : group_scope.
-
 Section GroupTheory.
 Variable G : groupType.
 Implicit Types x y : G.
 
-Definition divgg := @mulgV G.
+Lemma mulgV : right_inverse one inv (@mul G).
+Proof. by move=> x; rewrite -{1}(invgK x) mulVg. Qed.
+Definition divgg := mulgV.
 
 Lemma mulKg : @left_loop G G (@inv G) *%g.
 Proof. by move=> x y; rewrite mulgA mulVg mul1g. Qed.
@@ -513,41 +620,15 @@ Proof. by move=> x; apply: can_inj (mulKg x). Qed.
 Lemma mulIg : @left_injective G G G *%g.
 Proof. by move=> x; apply: can_inj (mulgK x). Qed.
 
-Lemma invgK : @involutive G (@inv G).
-Proof. by move=> x; rewrite -[LHS](mulVKg x) divgg mulg1. Qed.
-
-Lemma invg_inj : @injective G G (@inv G).
-Proof. exact: inv_inj invgK. Qed.
-
 Lemma divgI : @right_injective G G G (fun x y => x / y).
 Proof. by move=> x y z /mulgI/invg_inj. Qed.
 
 Lemma divIg : @left_injective G G G (fun x y => x / y).
 Proof. by move=> x y z /mulIg. Qed.
 
-Lemma invg1 : 1 ^-1 = 1 :> G.
-Proof. by rewrite -[LHS]mul1g divgg. Qed.
-
-Lemma invg_eq1 x : (x ^-1 == 1) = (x == 1).
-Proof. by rewrite (inv_eq invgK) invg1. Qed.
-
 Lemma divg1 x : x / 1 = x. Proof. by rewrite invg1 mulg1. Qed.
 
 Lemma div1g x : 1 / x = x^-1. Proof. by rewrite mul1g. Qed.
-
-Lemma invgF x y : (x / y)^-1 = y / x.
-Proof. by apply/(canRL (mulgK x))/(@divIg y); rewrite -mulgA mulVg divgg. Qed.
-
-Lemma invgM : {morph (@inv G): x y / x * y >-> y * x : G}.
-Proof. by move=> x y; rewrite -[y in LHS]invgK invgF. Qed.
-
-Lemma prodgV I r (P : pred I) (E : I -> G) :
-  \prod_(i <- r | P i) (E i)^-1 = (\prod_(i <- rev r | P i) E i)^-1.
-Proof.
-elim: r => [|x r IHr]; first by rewrite !big_nil invg1.
-rewrite big_cons rev_cons big_rcons/= IHr.
-by case: ifP => _; rewrite ?mulg1// invgM.
-Qed.
 
 Lemma divKg x y : commute x y -> x / (x / y) = y.
 Proof. by move=> xyC; rewrite invgF mulgA xyC mulgK. Qed.
@@ -574,28 +655,14 @@ Proof. by rewrite divg_eq mul1g. Qed.
 Lemma mulg_eq1 x y : (x * y == 1) = (x == y^-1).
 Proof. by rewrite -[y in LHS]invgK divg_eq1. Qed.
 
-Lemma eqg_inv x y : (x^-1 == y^-1) = (x == y).
-Proof. exact: can_eq invgK x y. Qed.
-
-Lemma eqg_invLR x y : (x^-1 == y) = (x == y^-1).
-Proof. exact: inv_eq invgK x y. Qed.
-
 Lemma commuteV x y : commute x y -> commute x y^-1.
 Proof. by move=> cxy; apply: (@mulIg y); rewrite mulgVK -mulgA cxy mulKg. Qed.
-
-Lemma expVgn x n : (x^-1) ^+ n = x ^- n.
-Proof.
-apply/esym/mulg1_eq; rewrite -expgMn; first by rewrite divgg expg1n.
-exact/commuteV.
-Qed.
 
 Lemma expgnFr x m n : n <= m -> x ^+ (m - n) = x ^+ m / x ^+ n.
 Proof. by move=> lenm; rewrite -[in RHS](subnK lenm) expgnDr mulgK. Qed.
 
 Lemma expgnFl x y n : commute x y -> (x / y) ^+ n = x ^+ n / y ^+ n.
 Proof. by move=> xyC; rewrite expgMn 1?expVgn; last exact/commuteV. Qed.
-
-Lemma conjgE x y : x ^ y = y^-1 * (x * y). Proof. by []. Qed.
 
 Lemma conjgC x y : x * y = y * x ^ y.
 Proof. by rewrite mulVKg. Qed.
@@ -636,10 +703,11 @@ Proof. by move=> y; apply: can_inj (conjgK y). Qed.
 Lemma conjg_eq1 x y : (x ^ y == 1) = (x == 1).
 Proof. by rewrite (can2_eq (conjgK _) (conjgKV _)) conj1g. Qed.
 
-Lemma commgEl x y : [~ x, y] = x^-1 * x ^ y. Proof. by []. Qed.
-
-Lemma commgEr x y : [~ x, y] = y^-1 ^ x * y.
-Proof. by rewrite -!mulgA. Qed.
+Lemma conjg_prod I r (P : pred I) (F : I -> G) z :
+  (\prod_(i <- r | P i) F i) ^ z = \prod_(i <- r | P i) (F i ^ z).
+Proof.
+by apply: (big_morph ((@conjg G)^~ z)) => [x y|]; rewrite ?conj1g ?conjMg.
+Qed.
 
 Lemma commgC x y : x * y = y * x * [~ x, y].
 Proof. by rewrite -mulgA !mulVKg. Qed.
@@ -703,6 +771,20 @@ Qed.
 End ClosedPredicates.
 
 End GroupTheory.
+
+#[global] Hint Rewrite @mulg1 @mul1g invg1 @mulVg mulgV (@invgK) mulgK mulgVK
+             @invgM @mulgA : gsimpl.
+
+Ltac gsimpl := autorewrite with gsimpl; try done.
+
+Definition gsimp := (@mulg1, @mul1g, (@invg1, @invgK), (@mulgV, @mulVg)).
+Definition gnorm := (gsimp, (@mulgK, @mulgVK, (@mulgA, @invgM))).
+
+Arguments mulgI [G].
+Arguments mulIg [G].
+Arguments conjg_inj {G} x [x1 x2].
+Arguments commgP {G x y}.
+Arguments conjg_fixP {G x y}.
 
 (* Morphism hierarchy. *)
 
@@ -1133,12 +1215,48 @@ HB.instance Definition _ := hasInv.Build H invH.
 
 Lemma mulVg : left_inverse 1%g invH *%g.
 Proof. by move=> x; apply/val_inj; rewrite valM SubK mulVg val1. Qed.
-Lemma mulgV : right_inverse 1%g invH *%g.
-Proof. by move=> x; apply/val_inj; rewrite valM SubK mulgV val1. Qed. 
 
-HB.instance Definition _ := Monoid_isGroup.Build H mulVg mulgV.
+HB.instance Definition _ := StarMonoid_isGroup.Build H mulVg.
 
 HB.end.
+
+Prenex Implicits mul inv natexp conjg commg.
+
+Notation "*%g" := (@mul _) : function_scope.
+Notation "x * y" := (mul x y) : group_scope.
+Notation "1" := (@one _) : group_scope.
+Notation "s `_ i" := (nth 1 s i) : group_scope.
+Notation "\prod_ ( i <- r | P ) F" :=
+  (\big[*%g/1]_(i <- r | P%B) F%g) : group_scope.
+Notation "\prod_ ( i <- r ) F" :=
+  (\big[*%g/1]_(i <- r) F%g) : group_scope.
+Notation "\prod_ ( m <= i < n | P ) F" :=
+  (\big[*%g/1]_(m <= i < n | P%B) F%g) : group_scope.
+Notation "\prod_ ( m <= i < n ) F" :=
+  (\big[*%g/1]_(m <= i < n) F%g) : group_scope.
+Notation "\prod_ ( i | P ) F" :=
+  (\big[*%g/1]_(i | P%B) F%g) : group_scope.
+Notation "\prod_ i F" :=
+  (\big[*%g/1]_i F%g) : group_scope.
+Notation "\prod_ ( i : t | P ) F" :=
+  (\big[*%g/1]_(i : t | P%B) F%g) (only parsing) : group_scope.
+Notation "\prod_ ( i : t ) F" :=
+  (\big[*%g/1]_(i : t) F%g) (only parsing) : group_scope.
+Notation "\prod_ ( i < n | P ) F" :=
+  (\big[*%g/1]_(i < n | P%B) F%g) : group_scope.
+Notation "\prod_ ( i < n ) F" :=
+  (\big[*%g/1]_(i < n) F%g) : group_scope.
+Notation "\prod_ ( i 'in' A | P ) F" :=
+  (\big[*%g/1]_(i in A | P%B) F%g) : group_scope.
+Notation "\prod_ ( i 'in' A ) F" :=
+  (\big[*%g/1]_(i in A) F%g) : group_scope.
+Notation "x ^+ n" := (natexp x n) : group_scope.
+Notation "x ^-1" := (inv x) : group_scope.
+Notation "x / y" := (x * y^-1) : group_scope.
+Notation "x ^- n" := ((x ^+ n)^-1) : group_scope.
+Notation "x ^ y" := (conjg x y) : group_scope.
+Notation "[ ~ x1 , x2 , .. , xn ]" := (commg .. (commg x1 x2) .. xn)
+  : group_scope.
 
 (* Lifting Structure from the codomain of finfuns. *)
 Section FinFunMagma.

--- a/character/character.v
+++ b/character/character.v
@@ -68,7 +68,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.TTheory GroupScope GRing.Theory Num.Theory.
+Local Open Scope group_scope.
+Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
 Section AlgC.

--- a/character/classfun.v
+++ b/character/classfun.v
@@ -94,7 +94,8 @@ Unset Printing Implicit Defensive.
 
 Declare Scope cfun_scope.
 
-Import Order.TTheory GroupScope GRing.Theory Num.Theory.
+Local Open Scope group_scope.
+Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 Delimit Scope cfun_scope with CF.
 

--- a/character/inertia.v
+++ b/character/inertia.v
@@ -49,7 +49,7 @@ Fact cfConjg_subproof :
 Proof.
 apply: intro_class_fun => [x z _ Gz | x notGx].
   have [nGy | _] := ifP; last by rewrite cfunJgen.
-  by rewrite -conjgM conjgC conjgM cfunJgen // memJ_norm ?groupV.
+  by rewrite -conjgM conjgC conjgM [LHS]cfunJgen // memJ_norm ?groupV.
 by rewrite cfun0gen //; case: ifP => // nGy; rewrite memJ_norm ?groupV.
 Qed.
 Definition cfConjg := Cfun 1 cfConjg_subproof.

--- a/character/inertia.v
+++ b/character/inertia.v
@@ -14,7 +14,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.TTheory GroupScope GRing.Theory Num.Theory.
+Local Open Scope group_scope.
+Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
 (******************************************************************************)

--- a/character/integral_char.v
+++ b/character/integral_char.v
@@ -440,7 +440,7 @@ have inj_lambda: {in 'Z(G) &, injective lambda}.
   apply/eqP; transitivity ('Res['Z('chi_i)%CF] 'chi_i (x^-1 * y)%g).
     by rewrite cfResE ?cfcenter_sub // groupM ?groupV.
   rewrite Dlambda !cfunE lin_charM ?groupV // -eq_xy -lin_charM ?groupV //.
-  by rewrite mulrC mulVg lin_char1 ?mul1r.
+  by rewrite mulrC mulVg [X in X * _]lin_char1 ?mul1r.
 rewrite unfold_in -if_neg irr1_neq0 Cint_rat_Aint //.
   by rewrite rpred_div ?rpred_nat // rpred_nat_num ?Cnat_irr1.
 rewrite (cfcenter_fful_irr fful) nCdivE natf_indexg ?center_sub //=.
@@ -468,7 +468,7 @@ transitivity ('chi_i x * 'chi_i (x^-1)%g *+ #|h x|); last first.
       exists (x ^ v)%g (z * z1)%g; rewrite ?imset_f ?groupM //.
       by rewrite conjMg -mulgA /(z ^ v)%g cGz // mulKg.
     exists ((x * z) ^ v)%g (z^-1 * z1)%g; rewrite ?imset_f ?groupM ?groupV //.
-    by rewrite conjMg -mulgA /(z ^ v)%g cGz // mulKg mulKVg.
+    by rewrite conjMg -[RHS]mulgA /(z ^ v)%g cGz // mulKg mulKVg.
   rewrite !irr_inv DchiZ ?groupJ ?cfunJ // rmorphM mulrACA -!normCK -exprMn.
   by rewrite (normC_lin_char lin_lambda) ?mulr1 //= cfcenter_fful_irr.
 rewrite mulrAC -natrM mulr_natl; congr (_ *+ _).

--- a/character/integral_char.v
+++ b/character/integral_char.v
@@ -35,7 +35,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.TTheory GroupScope GRing.Theory Num.Theory.
+Local Open Scope group_scope.
+Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
 Lemma group_num_field_exists (gT : finGroupType) (G : {group gT}) :

--- a/character/mxabelem.v
+++ b/character/mxabelem.v
@@ -50,7 +50,8 @@ Unset Printing Implicit Defensive.
 
 Declare Scope abelem_scope.
 
-Import GroupScope GRing.Theory FinRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory FinRing.Theory.
 Local Open Scope ring_scope.
 
 (* Special results for representations on a finite field. In this case, the   *)

--- a/character/mxrepresentation.v
+++ b/character/mxrepresentation.v
@@ -286,7 +286,8 @@ Unset Printing Implicit Defensive.
 Declare Scope irrType_scope.
 Declare Scope group_ring_scope.
 
-Import GroupScope GRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory.
 Local Open Scope ring_scope.
 
 Reserved Notation "''n_' i" (at level 8, i at level 2, format "''n_' i").

--- a/character/vcharacter.v
+++ b/character/vcharacter.v
@@ -41,7 +41,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.TTheory GroupScope GRing.Theory Num.Theory.
+Local Open Scope group_scope.
+Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
 Section Basics.

--- a/field/algebraics_fundamentals.v
+++ b/field/algebraics_fundamentals.v
@@ -113,7 +113,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.TTheory GroupScope GRing.Theory Num.Theory.
+Local Open Scope group_scope.
+Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
 Local Notation "p ^ f" := (map_poly f p) : ring_scope.

--- a/field/finfield.v
+++ b/field/finfield.v
@@ -57,7 +57,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope GRing.Theory FinRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory FinRing.Theory.
 Local Open Scope ring_scope.
 
 Section FinNzRing.

--- a/field/galois.v
+++ b/field/galois.v
@@ -41,7 +41,8 @@ Unset Printing Implicit Defensive.
 Reserved Notation "''Gal' ( A / B )"
   (A at level 35, format "''Gal' ( A  /  B )").
 
-Import GroupScope GRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory.
 Local Open Scope ring_scope.
 
 Section SplittingFieldFor.

--- a/fingroup/action.v
+++ b/fingroup/action.v
@@ -125,7 +125,7 @@ Unset Printing Implicit Defensive.
 Declare Scope action_scope.
 Declare Scope groupAction_scope.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section ActionDef.
 

--- a/fingroup/automorphism.v
+++ b/fingroup/automorphism.v
@@ -32,7 +32,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 (***********************************************************************)
 (* A group automorphism, defined as a permutation on a subset of a     *)

--- a/fingroup/fingroup.v
+++ b/fingroup/fingroup.v
@@ -37,7 +37,7 @@ From mathcomp Require Export monoid.
 (*      group_scope (delimiter %g) for point operations and set constructs.   *)
 (*      Group_scope (delimiter %G) for explicit {group gT} structures.        *)
 (* These scopes should not be opened globally, although group_scope is often  *)
-(* opened locally in group-theory files (via Import GroupScope).              *)
+(* opened locally in group-theory files.                                      *)
 (*   As {group gT} is both a subtype and an interface structure for {set gT}, *)
 (* the fact that a given G : {set gT} is a group can (and usually should) be  *)
 (* inferred by type inference with canonical structures. This means that all  *)
@@ -139,9 +139,6 @@ Declare Scope Group_scope.
 
 Delimit Scope Group_scope with G.
 
-(* This module can be imported to open the scope for group element *)
-(* operations locally to a file, without exporting the Open to     *)
-(* clients of that file (as Open would do).                        *)
 Module GroupScope.
 Open Scope group_scope.
 End GroupScope.
@@ -181,49 +178,28 @@ Reserved Notation "[ 'min' A 'of' G | gP & gQ ]"
 Reserved Notation "[ 'min' G | gP & gQ ]"
   (format "[ '[hv' 'min'  G '/ '  |  gP '/ '  &  gQ ']' ]").
 
-(* We split the group axiomatisation in two. We define a  *)
-(* class of "base groups", which are basically monoids    *)
-(* with an involutive antimorphism, from which we derive  *)
-(* the class of groups proper. This allows us to reuse    *)
-(* much of the group notation and algebraic axioms for    *)
-(* group subsets, by defining a base group class on them. *)
-(*   We use class/mixins here rather than telescopes to   *)
-(* be able to interoperate with the type coercions.       *)
-(* Another potential benefit (not exploited here) would   *)
-(* be to define a class for infinite groups, which could  *)
-(* share all of the algebraic laws.                       *)
+Module isMulBaseGroup.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.isStarMonoid.Build instead.")]
+Notation Build G := (isStarMonoid.Build G) (only parsing).
+End isMulBaseGroup.
 
-HB.mixin Record isMulBaseGroup G := {
-  mulg_subdef : G -> G -> G;
-  oneg_subdef : G;
-  invg_subdef : G -> G;
-  mulgA_subproof : associative mulg_subdef ;
-  mul1g_subproof : left_id oneg_subdef  mulg_subdef ;
-  invgK_subproof : involutive invg_subdef ;
-  invMg_subproof : {morph invg_subdef  : x y / mulg_subdef  x y >-> mulg_subdef  y x}
-}.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.isStarMonoid instead.")]
+Notation isMulBaseGroup G := (isStarMonoid G) (only parsing).
 
-(* We want to use sort as a coercion class, both to infer         *)
-(* argument scopes properly, and to allow groups and cosets to    *)
-(* coerce to the base group of group subsets.                     *)
-(*   However, the return type of group operations should NOT be a *)
-(* coercion class, since this would trump the real (head-normal)  *)
-(* coercion class for concrete group types, thus spoiling the     *)
-(* coercion of A * B to pred_sort in x \in A * B, or rho * tau to *)
-(* ffun and Funclass in (rho * tau) x, when rho tau : perm T.     *)
-(*   Therefore we define an alias of sort for argument types, and *)
-(* make it the default coercion FinGroup.base_type >-> Sortclass  *)
-(* so that arguments of a functions whose parameters are of type, *)
-(* say, gT : finGroupType, can be coerced to the coercion class   *)
-(* of arg_sort. Care should be taken, however, to declare the     *)
-(* return type of functions and operators as FinGroup.sort gT     *)
-(* rather than gT, e.g., mulg : gT -> gT -> FinGroup.sort gT.     *)
-(* Note that since we do this here and in quotient.v for all the  *)
-(* basic functions, the inferred return type should generally be  *)
-(* correct.                                                       *)
+Module BaseFinGroup_isGroup.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.StarMonoid_isGroup.Build instead.")]
+Notation Build G := (StarMonoid_isGroup.Build G) (only parsing).
+End BaseFinGroup_isGroup.
+
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.StarMonoid_isGroup instead.")]
+Notation BaseFinGroup_isGroup G := (StarMonoid_isGroup G) (only parsing).
 
 #[arg_sort, short(type="baseFinGroupType")]
-HB.structure Definition BaseFinGroup := { G of isMulBaseGroup G & Finite G }.
+HB.structure Definition BaseFinGroup := { G of StarMonoid G & Finite G }.
 
 Module BaseFinGroupExports.
 Bind Scope group_scope with BaseFinGroup.arg_sort.
@@ -231,72 +207,65 @@ Bind Scope group_scope with BaseFinGroup.sort.
 End BaseFinGroupExports.
 HB.export BaseFinGroupExports.
 
-Module Notations.
-Section ElementOps.
-
-Variable T : baseFinGroupType.
-Notation rT := (BaseFinGroup.sort T).
-
-Definition oneg : rT := Eval unfold oneg_subdef in @oneg_subdef T.
-Definition mulg : T -> T -> rT := Eval unfold mulg_subdef in @mulg_subdef T.
-Definition invg : T -> rT := Eval unfold invg_subdef in @invg_subdef T.
-Definition expgn (x : T) n : rT := iterop n mulg x oneg.
-
-End ElementOps.
-Arguments expgn : simpl never.
-
-Notation "1" := (@oneg _) : group_scope.
-Notation "x1 * x2" := (mulg x1 x2) : group_scope.
-Notation "x ^-1" := (invg x) : group_scope.
-Notation "x ^+ n" := (expgn x n) : group_scope.
-Notation "x ^- n" := (x ^+ n)^-1 : group_scope.
-End Notations.
-HB.export Notations.
-
-HB.mixin Record BaseFinGroup_isGroup G of BaseFinGroup G := {
-  mulVg_subproof : left_inverse (@oneg G) (@invg _) (@mulg _)
-}.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.one instead.")]
+Notation oneg := one (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mul instead.")]
+Notation mulg := mul (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.inv instead.")]
+Notation invg := inv (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.natexp instead.")]
+Notation expgn := natexp (only parsing).
 
 #[short(type="finGroupType")]
 HB.structure Definition FinGroup :=
-  { G of BaseFinGroup_isGroup G & BaseFinGroup G }.
+  { G of Group G & Finite G }.
 
 Module FinGroupExports.
 Bind Scope group_scope with FinGroup.sort.
 End FinGroupExports.
 HB.export FinGroupExports.
 
-HB.factory Record isMulGroup G of Finite G := {
-  mulg : G -> G -> G;
-  oneg : G;
-  invg : G -> G;
-  mulgA : associative mulg;
-  mul1g : left_id oneg mulg;
-  mulVg : left_inverse oneg invg mulg;
+HB.factory Record Finite_isGroup G of Finite G := {
+  mul : G -> G -> G;
+  one : G;
+  inv : G -> G;
+  mulgA : associative mul;
+  mul1g : left_id one mul;
+  mulVg : left_inverse one inv mul;
 }.
 
-HB.builders Context G of isMulGroup G.
+Module isMulGroup.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Finite_isGroup.Build instead.")]
+Notation Build G := (Finite_isGroup.Build G) (only parsing).
+End isMulGroup.
 
-Notation "1" := oneg.
-Infix "*" := mulg.
-Notation "x ^-1" := (invg x).
+HB.builders Context G of Finite_isGroup G.
 
-Lemma mk_invgK : involutive invg.
+Notation "1" := one.
+Infix "*" := mul.
+Notation "x ^-1" := (inv x).
+
+Lemma invgK : involutive inv.
 Proof.
 have mulV21 x: x^-1^-1 * 1 = x by rewrite -(mulVg x) mulgA mulVg mul1g.
 by move=> x; rewrite -[_ ^-1]mulV21 -(mul1g 1) mulgA !mulV21.
 Qed.
 
-Lemma mk_invMg : {morph invg : x y / x * y >-> y * x}.
+Lemma invMg : {morph inv : x y / x * y >-> y * x}.
 Proof.
-have mulgV x: x * x^-1 = 1 by rewrite -{1}[x]mk_invgK mulVg.
+have mulgV x: x * x^-1 = 1 by rewrite -{1}[x]invgK mulVg.
 move=> x y /=; rewrite -[y^-1 * _]mul1g -(mulVg (x * y)) -2!mulgA (mulgA y).
 by rewrite mulgV mul1g mulgV -(mulgV (x * y)) mulgA mulVg mul1g.
 Qed.
 
 HB.instance Definition _ :=
-  isMulBaseGroup.Build G mulgA mul1g mk_invgK mk_invMg.
-HB.instance Definition _ := BaseFinGroup_isGroup.Build G mulVg.
+  isStarMonoid.Build G mulgA mul1g invgK invMg.
+HB.instance Definition _ := StarMonoid_isGroup.Build G mulVg.
 
 HB.end.
 
@@ -304,282 +273,216 @@ HB.end.
 HB.instance Definition _ (T : baseFinGroupType) :
     Finite (BaseFinGroup.arg_sort T) := Finite.class T.
 
-(* Arguments of conjg are restricted to true groups to avoid an *)
-(* improper interpretation of A ^ B with A and B sets, namely:  *)
-(*       {x^-1 * (y * z) | y \in A, x, z \in B}                 *)
-Definition conjg (T : finGroupType) (x y : T) := y^-1 * (x * y).
-Notation "x1 ^ x2" := (conjg x1 x2) : group_scope.
-
-Definition commg (T : finGroupType) (x y : T) := x^-1 * x ^ y.
-Notation "[ ~ x1 , x2 , .. , xn ]" := (commg .. (commg x1 x2) .. xn)
-  : group_scope.
-
-Prenex Implicits mulg invg expgn conjg commg.
-
-Notation "\prod_ ( i <- r | P ) F" :=
-  (\big[mulg/1]_(i <- r | P%B) F%g) : group_scope.
-Notation "\prod_ ( i <- r ) F" :=
-  (\big[mulg/1]_(i <- r) F%g) : group_scope.
-Notation "\prod_ ( m <= i < n | P ) F" :=
-  (\big[mulg/1]_(m <= i < n | P%B) F%g) : group_scope.
-Notation "\prod_ ( m <= i < n ) F" :=
-  (\big[mulg/1]_(m <= i < n) F%g) : group_scope.
-Notation "\prod_ ( i | P ) F" :=
-  (\big[mulg/1]_(i | P%B) F%g) : group_scope.
-Notation "\prod_ i F" :=
-  (\big[mulg/1]_i F%g) : group_scope.
-Notation "\prod_ ( i : t | P ) F" :=
-  (\big[mulg/1]_(i : t | P%B) F%g) (only parsing) : group_scope.
-Notation "\prod_ ( i : t ) F" :=
-  (\big[mulg/1]_(i : t) F%g) (only parsing) : group_scope.
-Notation "\prod_ ( i < n | P ) F" :=
-  (\big[mulg/1]_(i < n | P%B) F%g) : group_scope.
-Notation "\prod_ ( i < n ) F" :=
-  (\big[mulg/1]_(i < n) F%g) : group_scope.
-Notation "\prod_ ( i 'in' A | P ) F" :=
-  (\big[mulg/1]_(i in A | P%B) F%g) : group_scope.
-Notation "\prod_ ( i 'in' A ) F" :=
-  (\big[mulg/1]_(i in A) F%g) : group_scope.
-
-Section PreGroupIdentities.
-
-Variable T : baseFinGroupType.
-Implicit Types x y z : T.
-Local Notation mulgT := (@mulg T).
-
-Lemma mulgA : associative mulgT.  Proof. exact: mulgA_subproof. Qed.
-Lemma mul1g : left_id 1 mulgT.  Proof. exact: mul1g_subproof. Qed.
-Lemma invgK : @involutive T invg. Proof. exact: invgK_subproof. Qed.
-Lemma invMg x y : (x * y)^-1 = y^-1 * x^-1. Proof. exact: invMg_subproof. Qed.
-
-Lemma invg_inj : @injective T T invg. Proof. exact: can_inj invgK. Qed.
-
-Lemma eq_invg_sym x y : (x^-1 == y) = (x == y^-1).
-Proof. by apply: (inv_eq invgK). Qed.
-
-Lemma invg1 : 1^-1 = 1 :> T.
-Proof. by apply: invg_inj; rewrite -{1}[1^-1]mul1g invMg invgK mul1g. Qed.
-
-Lemma eq_invg1 x : (x^-1 == 1) = (x == 1).
-Proof. by rewrite eq_invg_sym invg1. Qed.
-
-Lemma mulg1 : right_id 1 mulgT.
-Proof. by move=> x; apply: invg_inj; rewrite invMg invg1 mul1g. Qed.
-
-HB.instance Definition _ := Monoid.isLaw.Build T 1 mulgT mulgA mul1g mulg1.
-
-Lemma expgnE x n : x ^+ n = iterop n mulg x 1. Proof. by []. Qed.
-
-Lemma expg0 x : x ^+ 0 = 1. Proof. by []. Qed.
-Lemma expg1 x : x ^+ 1 = x. Proof. by []. Qed.
-
-Lemma expgS x n : x ^+ n.+1 = x * x ^+ n.
-Proof. by case: n => //; rewrite mulg1. Qed.
-
-Lemma expg1n n : 1 ^+ n = 1 :> T.
-Proof. by elim: n => // n IHn; rewrite expgS mul1g. Qed.
-
-Lemma expgD x n m : x ^+ (n + m) = x ^+ n * x ^+ m.
-Proof. by elim: n => [|n IHn]; rewrite ?mul1g // !expgS IHn mulgA. Qed.
-
-Lemma expgSr x n : x ^+ n.+1 = x ^+ n * x.
-Proof. by rewrite -addn1 expgD expg1. Qed.
-
-Lemma expgM x n m : x ^+ (n * m) = x ^+ n ^+ m.
-Proof.
-elim: m => [|m IHm]; first by rewrite muln0 expg0.
-by rewrite mulnS expgD IHm expgS.
-Qed.
-
-Lemma expgAC x m n : x ^+ m ^+ n = x ^+ n ^+ m.
-Proof. by rewrite -!expgM mulnC. Qed.
-
-Definition commute x y := x * y = y * x.
-
-Lemma commute_refl x : commute x x.
-Proof. by []. Qed.
-
-Lemma commute_sym x y : commute x y -> commute y x.
-Proof. by []. Qed.
-
-Lemma commute1 x : commute x 1.
-Proof. by rewrite /commute mulg1 mul1g. Qed.
-
-Lemma commuteM x y z : commute x y ->  commute x z ->  commute x (y * z).
-Proof. by move=> cxy cxz; rewrite /commute -mulgA -cxz !mulgA cxy. Qed.
-
-Lemma commuteX x y n : commute x y ->  commute x (y ^+ n).
-Proof.
-by move=> cxy; case: n; [apply: commute1 | elim=> // n; apply: commuteM].
-Qed.
-
-Lemma commuteX2 x y m n : commute x y -> commute (x ^+ m) (y ^+ n).
-Proof. by move=> cxy; apply/commuteX/commute_sym/commuteX. Qed.
-
-Lemma expgVn x n : x^-1 ^+ n = x ^- n.
-Proof. by elim: n => [|n IHn]; rewrite ?invg1 // expgSr expgS invMg IHn. Qed.
-
-Lemma expgMn x y n : commute x y -> (x * y) ^+ n  = x ^+ n * y ^+ n.
-Proof.
-move=> cxy; elim: n => [|n IHn]; first by rewrite mulg1.
-by rewrite !expgS IHn -mulgA (mulgA y) (commuteX _ (commute_sym cxy)) !mulgA.
-Qed.
-
-End PreGroupIdentities.
-
-#[global] Hint Resolve commute1 : core.
-Arguments invg_inj {T} [x1 x2].
-Prenex Implicits commute invgK.
-
-Section GroupIdentities.
-
-Variable T : finGroupType.
-Implicit Types x y z : T.
-Local Notation mulgT := (@mulg T).
-
-Lemma mulVg : left_inverse 1 invg mulgT. Proof. exact: mulVg_subproof. Qed.
-
-Lemma mulgV : right_inverse 1 invg mulgT.
-Proof. by move=> x; rewrite -{1}(invgK x) mulVg. Qed.
-
-Lemma mulKg : left_loop invg mulgT.
-Proof. by move=> x y; rewrite mulgA mulVg mul1g. Qed.
-
-Lemma mulKVg : rev_left_loop invg mulgT.
-Proof. by move=> x y; rewrite mulgA mulgV mul1g. Qed.
-
-Lemma mulgI : right_injective mulgT.
-Proof. by move=> x; apply: can_inj (mulKg x). Qed.
-
-Lemma mulgK : right_loop invg mulgT.
-Proof. by move=> x y; rewrite -mulgA mulgV mulg1. Qed.
-
-Lemma mulgKV : rev_right_loop invg mulgT.
-Proof. by move=> x y; rewrite -mulgA mulVg mulg1. Qed.
-
-Lemma mulIg : left_injective mulgT.
-Proof. by move=> x; apply: can_inj (mulgK x). Qed.
-
-Lemma eq_invg_mul x y : (x^-1 == y :> T) = (x * y == 1 :> T).
-Proof. by rewrite -(inj_eq (@mulgI x)) mulgV eq_sym. Qed.
-
-Lemma eq_mulgV1 x y : (x == y) = (x * y^-1 == 1 :> T).
-Proof. by rewrite -(inj_eq invg_inj) eq_invg_mul. Qed.
-
-Lemma eq_mulVg1 x y : (x == y) = (x^-1 * y == 1 :> T).
-Proof. by rewrite -eq_invg_mul invgK. Qed.
-
-Lemma commuteV x y : commute x y -> commute x y^-1.
-Proof. by move=> cxy; apply: (@mulIg y); rewrite mulgKV -mulgA cxy mulKg. Qed.
-
-Lemma conjgE x y : x ^ y = y^-1 * (x * y). Proof. by []. Qed.
-
-Lemma conjgC x y : x * y = y * x ^ y.
-Proof. by rewrite mulKVg. Qed.
-
-Lemma conjgCV x y : x * y = y ^ x^-1 * x.
-Proof. by rewrite -mulgA mulgKV invgK. Qed.
-
-Lemma conjg1 x : x ^ 1 = x.
-Proof. by rewrite conjgE commute1 mulKg. Qed.
-
-Lemma conj1g x : 1 ^ x = 1.
-Proof. by rewrite conjgE mul1g mulVg. Qed.
-
-Lemma conjMg x y z : (x * y) ^ z = x ^ z * y ^ z.
-Proof. by rewrite !conjgE !mulgA mulgK. Qed.
-
-Lemma conjgM x y z : x ^ (y * z) = (x ^ y) ^ z.
-Proof. by rewrite !conjgE invMg !mulgA. Qed.
-
-Lemma conjVg x y : x^-1 ^ y = (x ^ y)^-1.
-Proof. by rewrite !conjgE !invMg invgK mulgA. Qed.
-
-Lemma conjJg x y z : (x ^ y) ^ z = (x ^ z) ^ y ^ z.
-Proof. by rewrite 2!conjMg conjVg. Qed.
-
-Lemma conjXg x y n : (x ^+ n) ^ y = (x ^ y) ^+ n.
-Proof. by elim: n => [|n IHn]; rewrite ?conj1g // !expgS conjMg IHn. Qed.
-
-Lemma conjgK : @right_loop T T invg conjg.
-Proof. by move=> y x; rewrite -conjgM mulgV conjg1. Qed.
-
-Lemma conjgKV : @rev_right_loop T T invg conjg.
-Proof. by move=> y x; rewrite -conjgM mulVg conjg1. Qed.
-
-Lemma conjg_inj : @left_injective T T T conjg.
-Proof. by move=> y; apply: can_inj (conjgK y). Qed.
-
-Lemma conjg_eq1 x y : (x ^ y == 1) = (x == 1).
-Proof. by rewrite (canF_eq (conjgK _)) conj1g. Qed.
-
-Lemma conjg_prod I r (P : pred I) F z :
-  (\prod_(i <- r | P i) F i) ^ z = \prod_(i <- r | P i) (F i ^ z).
-Proof.
-by apply: (big_morph (conjg^~ z)) => [x y|]; rewrite ?conj1g ?conjMg.
-Qed.
-
-Lemma commgEl x y : [~ x, y] = x^-1 * x ^ y. Proof. by []. Qed.
-
-Lemma commgEr x y : [~ x, y] = y^-1 ^ x * y.
-Proof. by rewrite -!mulgA. Qed.
-
-Lemma commgC x y : x * y = y * x * [~ x, y].
-Proof. by rewrite -mulgA !mulKVg. Qed.
-
-Lemma commgCV x y : x * y = [~ x^-1, y^-1] * (y * x).
-Proof. by rewrite commgEl !mulgA !invgK !mulgKV. Qed.
-
-Lemma conjRg x y z : [~ x, y] ^ z = [~ x ^ z, y ^ z].
-Proof. by rewrite !conjMg !conjVg. Qed.
-
-Lemma invg_comm x y : [~ x, y]^-1 = [~ y, x].
-Proof. by rewrite commgEr conjVg invMg invgK. Qed.
-
-Lemma commgP x y : reflect (commute x y) ([~ x, y] == 1 :> T).
-Proof. by rewrite [[~ x, y]]mulgA -invMg -eq_mulVg1 eq_sym; apply: eqP. Qed.
-
-Lemma conjg_fixP x y : reflect (x ^ y = x) ([~ x, y] == 1 :> T).
-Proof. by rewrite -eq_mulVg1 eq_sym; apply: eqP. Qed.
-
-Lemma commg1_sym x y : ([~ x, y] == 1 :> T) = ([~ y, x] == 1 :> T).
-Proof. by rewrite -invg_comm (inv_eq invgK) invg1. Qed.
-
-Lemma commg1 x : [~ x, 1] = 1.
-Proof. exact/eqP/commgP. Qed.
-
-Lemma comm1g x : [~ 1, x] = 1.
-Proof. by rewrite -invg_comm commg1 invg1. Qed.
-
-Lemma commgg x : [~ x, x] = 1.
-Proof. exact/eqP/commgP. Qed.
-
-Lemma commgXg x n : [~ x, x ^+ n] = 1.
-Proof. exact/eqP/commgP/commuteX. Qed.
-
-Lemma commgVg x : [~ x, x^-1] = 1.
-Proof. exact/eqP/commgP/commuteV. Qed.
-
-Lemma commgXVg x n : [~ x, x ^- n] = 1.
-Proof. exact/eqP/commgP/commuteV/commuteX. Qed.
-
-(* Other commg identities should slot in here. *)
-
-End GroupIdentities.
-
-#[global] Hint Rewrite mulg1 @mul1g invg1 @mulVg mulgV (@invgK) mulgK mulgKV
-             @invMg @mulgA : gsimpl.
-
-Ltac gsimpl := autorewrite with gsimpl; try done.
-
-Definition gsimp := (@mulg1, @mul1g, (@invg1, @invgK), (@mulgV, @mulVg)).
-Definition gnorm := (gsimp, (@mulgK, @mulgKV, (@mulgA, @invMg))).
-
-Arguments mulgI [T].
-Arguments mulIg [T].
-Arguments conjg_inj {T} x [x1 x2].
-Arguments commgP {T x y}.
-Arguments conjg_fixP {T x y}.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjg instead.")]
+Notation conjg := conjg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commg instead.")]
+Notation commg := commg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mulgA instead.")]
+Notation mulgA := mulgA (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mul1g instead.")]
+Notation mul1g := mul1g (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.invgK instead.")]
+Notation invgK := invgK (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.invgM instead.")]
+Notation invMg := invgM (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.invg_inj instead.")]
+Notation invg_inj := invg_inj (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.eqg_invLR instead.")]
+Notation eq_invg_sym := eqg_invLR (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.invg1 instead.")]
+Notation invg1 := invg1 (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.invg_eq1 instead.")]
+Notation eq_invg1 := invg_eq1 (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mulg1 instead.")]
+Notation mulg1 := mulg1 (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.expgnE instead.")]
+Notation expgnE := expgnE (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.expg0 instead.")]
+Notation expg0 := expg0 (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.expg1 instead.")]
+Notation expg1 := expg1 (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.expg1n instead.")]
+Notation expg1n := expg1n (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.expgnDr instead.")]
+Notation expgD := expgnDr (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.expgSr instead.")]
+Notation expgSr := expgSr (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.expgnA instead.")]
+Notation expgM := expgnA (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.expgnAC instead.")]
+Notation expgAC := expgnAC (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commute instead.")]
+Notation commute := commute (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commute_refl instead.")]
+Notation commute_refl := commute_refl (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commute_sym instead.")]
+Notation commute_sym := commute_sym (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commute1 instead.")]
+Notation commute1 := commute1 (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commuteM instead.")]
+Notation commuteM := commuteM (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commuteX instead.")]
+Notation commuteX := commuteX (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commuteX2 instead.")]
+Notation commuteX2 := commuteX2 (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.expVgn instead.")]
+Notation expgVn := expVgn (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.expgMn instead.")]
+Notation expgMn := expgMn (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mulVg instead.")]
+Notation mulVg := mulVg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mulgV instead.")]
+Notation mulgV := mulgV (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mulKg instead.")]
+Notation mulKg := mulKg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mulVKg instead.")]
+Notation mulKVg := mulVKg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mulgI instead.")]
+Notation mulgI := mulgI (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mulgK instead.")]
+Notation mulgK := mulgK (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mulgVK instead.")]
+Notation mulgKV := mulgVK (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.mulg_eq1 instead.")]
+Lemma eq_invg_mul (T : finGroupType) x y : (x^-1 == y :> T) = (x * y == 1).
+Proof. by rewrite mulg_eq1 eqg_invLR. Qed.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.divg_eq1 instead.")]
+Lemma eq_mulgV1 (T : finGroupType) x y : (x == y) = (x * y^-1 == 1 :> T).
+Proof. exact/esym/divg_eq1. Qed.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.divg_eq1 instead.")]
+Lemma eq_mulVg1 (T : finGroupType) x y : (x == y) = (x^-1 * y == 1 :> T).
+Proof. by rewrite mulg_eq1 eqg_inv. Qed.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commuteV instead.")]
+Notation commuteV := commuteV (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjgE instead.")]
+Notation conjgE := conjgE (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjgC instead.")]
+Notation conjgC := conjgC (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjgCV instead.")]
+Notation conjgCV := conjgCV (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjg1 instead.")]
+Notation conjg1 := conjg1 (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conj1g instead.")]
+Notation conj1g := conj1g (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjMg instead.")]
+Notation conjMg := conjMg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjgM instead.")]
+Notation conjgM := conjgM (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjVg instead.")]
+Notation conjVg := conjVg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjJg instead.")]
+Notation conjJg := conjJg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjXg instead.")]
+Notation conjXg := conjXg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjgK instead.")]
+Notation conjgK := conjgK (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjgKV instead.")]
+Notation conjgKV := conjgKV (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjg_inj instead.")]
+Notation conjg_inj := conjg_inj (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjg_eq1 instead.")]
+Notation conjg_eq1 := conjg_eq1 (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjg_prod instead.")]
+Notation conjg_prod := conjg_prod (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commgEl instead.")]
+Notation commgEl := commgEl (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commgEr instead.")]
+Notation commgEr := commgEr (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commgC instead.")]
+Notation commgC := commgC (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commgCV instead.")]
+Notation commgCV := commgCV (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjRg instead.")]
+Notation conjRg := conjRg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.invgR instead.")]
+Notation invg_comm := invgR (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commgP instead.")]
+Notation commgP := commgP (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.conjg_fixP instead.")]
+Notation conjg_fixP := conjg_fixP (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commg1_sym instead.")]
+Notation commg1_sym := commg1_sym (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commg1 instead.")]
+Notation commg1 := commg1 (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.comm1g instead.")]
+Notation comm1g := comm1g (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commgg instead.")]
+Notation commgg := commgg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commgXg instead.")]
+Notation commgXg := commgXg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commgVg instead.")]
+Notation commgVg := commgVg (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.commgXVg instead.")]
+Notation commgXVg := commgXVg (only parsing).
 
 Section Repr.
 (* Plucking a set representative. *)
@@ -672,6 +575,11 @@ End GroupSetBaseGroupSig.
 
 Module MakeGroupSetBaseGroup (Gset_base : GroupSetBaseGroupSig).
 Identity Coercion of_sort : Gset_base.sort >-> BaseFinGroup.arg_sort.
+Definition of_sort_magma (gT : baseFinGroupType) (G : Gset_base.sort gT) := G : Magma.sort {set gT}.
+Coercion of_sort_magma : Gset_base.sort >-> Magma.sort.
+
+Definition of_sort_baseGroup (gT : baseFinGroupType) (G : Gset_base.sort gT) := G : BaseGroup.sort {set gT}.
+Coercion of_sort_baseGroup : Gset_base.sort >-> BaseGroup.sort.
 End MakeGroupSetBaseGroup.
 
 Module Export GroupSetBaseGroup := MakeGroupSetBaseGroup GroupSet.
@@ -1336,10 +1244,10 @@ Proof. by move=> G1; rewrite card_le1_trivg ?G1. Qed.
 Lemma mulG_subl A : A \subset A * G.
 Proof. exact: mulg_subl group1. Qed.
 
-Lemma mulG_subr A : A \subset ((G : {set gT}) * A ).
+Lemma mulG_subr A : A \subset (G * A).
 Proof. exact: mulg_subr group1. Qed.
 
-Lemma mulGid : (G : {set gT}) * G = G.
+Lemma mulGid : G * G = G :> {set gT}.
 Proof.
 by apply/eqP; rewrite eqEsubset mulG_subr andbT; case/andP: (valP G).
 Qed.
@@ -1412,7 +1320,8 @@ Proof. by move=> G_P; elim/big_ind: _ => //; apply: groupM. Qed.
 
 (* Inverse is an anti-morphism. *)
 
-Lemma invGid : G^-1 = G. Proof. by apply/setP=> x; rewrite inE groupV. Qed.
+Lemma invGid : G^-1 = G :> {set gT}.
+Proof. by apply/setP=> x; rewrite inE groupV. Qed.
 
 Lemma inv_subG A : (A^-1 \subset G) = (A \subset G).
 Proof. by rewrite -{1}invGid invSg. Qed.
@@ -1697,16 +1606,16 @@ Proof. by move/(congr1 (setU 1)); rewrite !setD1K. Qed.
 Lemma invMG G H : (G * H)^-1 = H * G.
 Proof. by rewrite invMg !invGid. Qed.
 
-Lemma mulSGid G H : H \subset G -> H * G = G.
+Lemma mulSGid G H : H \subset G -> H * G = G :> {set gT}.
 Proof. exact: mulSgGid (group1 H). Qed.
 
-Lemma mulGSid G H : H \subset G -> G * H = G.
+Lemma mulGSid G H : H \subset G -> G * H = G :> {set gT}.
 Proof. exact: mulGSgid (group1 H). Qed.
 
-Lemma mulGidPl G H : reflect (G * H = G) (H \subset G).
+Lemma mulGidPl G H : reflect (G * H = G :> {set gT}) (H \subset G).
 Proof. by apply: (iffP idP) => [|<-]; [apply: mulGSid | apply: mulG_subr]. Qed.
 
-Lemma mulGidPr G H : reflect (G * H = H) (G \subset H).
+Lemma mulGidPr G H : reflect (G * H = H :> {set gT}) (G \subset H).
 Proof. by apply: (iffP idP) => [|<-]; [apply: mulSGid | apply: mulG_subl]. Qed.
 
 Lemma comm_group_setP G H : reflect (commute G H) (group_set (G * H)).
@@ -2763,7 +2672,8 @@ Proof. by move=> cGH; apply: norm_joinEr (cents_norm cGH). Qed.
 Lemma centJ A x : 'C(A :^ x) = 'C(A) :^ x.
 Proof.
 apply/setP=> y; rewrite mem_conjg; apply/centP/centP=> cAy z Az.
-  by apply: (conjg_inj x); rewrite 2!conjMg conjgKV cAy ?memJ_conjg.
+  apply: (conjg_inj x).
+  by rewrite conjMg [in RHS]conjMg conjgKV cAy ?memJ_conjg.
 by apply: (conjg_inj x^-1); rewrite 2!conjMg cAy -?mem_conjg.
 Qed.
 

--- a/fingroup/fingroup.v
+++ b/fingroup/fingroup.v
@@ -139,10 +139,11 @@ Declare Scope Group_scope.
 
 Delimit Scope Group_scope with G.
 
+(* FIXME: Do we have a way to deprecate this? *)
 Module GroupScope.
 Open Scope group_scope.
 End GroupScope.
-Import GroupScope.
+Local Open Scope group_scope.
 
 (* These are the operation notations introduced by this file. *)
 Reserved Notation "[ ~ x1 , x2 , .. , xn ]"

--- a/fingroup/fingroup.v
+++ b/fingroup/fingroup.v
@@ -199,8 +199,34 @@ End BaseFinGroup_isGroup.
              note="Use Algebra.StarMonoid_isGroup instead.")]
 Notation BaseFinGroup_isGroup G := (StarMonoid_isGroup G) (only parsing).
 
-#[arg_sort, short(type="baseFinGroupType")]
-HB.structure Definition BaseFinGroup := { G of StarMonoid G & Finite G }.
+#[arg_sort, short(type="finStarMonoidType")]
+HB.structure Definition FinStarMonoid := { G of StarMonoid G & Finite G }.
+
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.finStarMonoidType instead.")]
+Notation baseFinGroupType := finStarMonoidType (only parsing).
+
+Module BaseFinGroup.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.FinStarMonoid.sort instead.")]
+Notation sort := (FinStarMonoid.sort) (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.FinStarMonoid.arg_sort instead.")]
+Notation arg_sort := (FinStarMonoid.arg_sort) (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.FinStarMonoid.on instead.")]
+Notation on M := (FinStarMonoid.on M) (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.FinStarMonoid.copy instead.")]
+Notation copy M N := (FinStarMonoid.copy M N) (only parsing).
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Algebra.FinStarMonoid.clone instead.")]
+Notation clone M N := (FinStarMonoid.clone M N) (only parsing).
+End BaseFinGroup.
+
+#[deprecated(since="mathcomp 2.4.0",
+             note="Use FinStarMonoid instead.")]
+Notation BaseFinGroup R := (FinStarMonoid R) (only parsing).
 
 Module BaseFinGroupExports.
 Bind Scope group_scope with BaseFinGroup.arg_sort.
@@ -244,6 +270,9 @@ Module isMulGroup.
              note="Use Finite_isGroup.Build instead.")]
 Notation Build G := (Finite_isGroup.Build G) (only parsing).
 End isMulGroup.
+#[deprecated(since="mathcomp 2.5.0",
+             note="Use Finite_isGroup instead.")]
+Notation isMulGroup G := (Finite_isGroup G) (only parsing).
 
 HB.builders Context G of Finite_isGroup G.
 
@@ -570,20 +599,36 @@ Definition sort (gT : baseFinGroupType) := {set gT}.
 End GroupSet.
 Identity Coercion GroupSet_of_sort : GroupSet.sort >-> set_of.
 
-Module Type GroupSetBaseGroupSig.
+Module Type GroupSetBaseFinGroupSig.
 Definition sort (gT : baseFinGroupType) := BaseFinGroup.arg_sort {set gT}.
+End GroupSetBaseFinGroupSig.
+
+Module MakeGroupSetBaseFinGroup (Gset_base : GroupSetBaseFinGroupSig).
+Identity Coercion of_sort : Gset_base.sort >-> BaseFinGroup.arg_sort.
+End MakeGroupSetBaseFinGroup.
+
+Module Export GroupSetBaseFinGroup := MakeGroupSetBaseFinGroup GroupSet.
+
+Module Type GroupSetMagmaSig.
+Definition sort (gT : baseFinGroupType) := Magma.sort {set gT}.
+End GroupSetMagmaSig.
+
+Module MakeGroupSetMagma (Gset_base : GroupSetMagmaSig).
+Identity Coercion of_sort : Gset_base.sort >-> Magma.sort.
+End MakeGroupSetMagma.
+
+Module Export GroupSetMagma := MakeGroupSetMagma GroupSet.
+
+Module Type GroupSetBaseGroupSig.
+Definition sort (gT : baseFinGroupType) := BaseGroup.sort {set gT}.
 End GroupSetBaseGroupSig.
 
 Module MakeGroupSetBaseGroup (Gset_base : GroupSetBaseGroupSig).
-Identity Coercion of_sort : Gset_base.sort >-> BaseFinGroup.arg_sort.
-Definition of_sort_magma (gT : baseFinGroupType) (G : Gset_base.sort gT) := G : Magma.sort {set gT}.
-Coercion of_sort_magma : Gset_base.sort >-> Magma.sort.
-
-Definition of_sort_baseGroup (gT : baseFinGroupType) (G : Gset_base.sort gT) := G : BaseGroup.sort {set gT}.
-Coercion of_sort_baseGroup : Gset_base.sort >-> BaseGroup.sort.
+Identity Coercion of_sort : Gset_base.sort >-> BaseGroup.sort.
 End MakeGroupSetBaseGroup.
 
 Module Export GroupSetBaseGroup := MakeGroupSetBaseGroup GroupSet.
+
 HB.instance Definition _ gT : Finite (GroupSet.sort gT) :=
    Finite.class {set gT}.
 
@@ -1248,7 +1293,7 @@ Proof. exact: mulg_subl group1. Qed.
 Lemma mulG_subr A : A \subset (G * A).
 Proof. exact: mulg_subr group1. Qed.
 
-Lemma mulGid : G * G = G :> {set gT}.
+Lemma mulGid : G * G = G.
 Proof.
 by apply/eqP; rewrite eqEsubset mulG_subr andbT; case/andP: (valP G).
 Qed.
@@ -1321,7 +1366,7 @@ Proof. by move=> G_P; elim/big_ind: _ => //; apply: groupM. Qed.
 
 (* Inverse is an anti-morphism. *)
 
-Lemma invGid : G^-1 = G :> {set gT}.
+Lemma invGid : G^-1 = G.
 Proof. by apply/setP=> x; rewrite inE groupV. Qed.
 
 Lemma inv_subG A : (A^-1 \subset G) = (A \subset G).
@@ -1607,16 +1652,16 @@ Proof. by move/(congr1 (setU 1)); rewrite !setD1K. Qed.
 Lemma invMG G H : (G * H)^-1 = H * G.
 Proof. by rewrite invMg !invGid. Qed.
 
-Lemma mulSGid G H : H \subset G -> H * G = G :> {set gT}.
+Lemma mulSGid G H : H \subset G -> H * G = G.
 Proof. exact: mulSgGid (group1 H). Qed.
 
-Lemma mulGSid G H : H \subset G -> G * H = G :> {set gT}.
+Lemma mulGSid G H : H \subset G -> G * H = G.
 Proof. exact: mulGSgid (group1 H). Qed.
 
-Lemma mulGidPl G H : reflect (G * H = G :> {set gT}) (H \subset G).
+Lemma mulGidPl G H : reflect (G * H = G) (H \subset G).
 Proof. by apply: (iffP idP) => [|<-]; [apply: mulGSid | apply: mulG_subr]. Qed.
 
-Lemma mulGidPr G H : reflect (G * H = H :> {set gT}) (G \subset H).
+Lemma mulGidPr G H : reflect (G * H = H) (G \subset H).
 Proof. by apply: (iffP idP) => [|<-]; [apply: mulSGid | apply: mulG_subl]. Qed.
 
 Lemma comm_group_setP G H : reflect (commute G H) (group_set (G * H)).

--- a/fingroup/gproduct.v
+++ b/fingroup/gproduct.v
@@ -275,8 +275,9 @@ Hypothesis complH_K : H \in [complements to K in G].
 Lemma remgrM : K <| G -> {in G &, {morph remgr K H : x y / x * y}}.
 Proof.
 case/normalP=> _; case/complP: complH_K => tiKH <- nK_KH x y KHx KHy.
-rewrite {1}(divgr_eq K H y) mulgA (conjgCV x) {2}(divgr_eq K H x) -2!mulgA.
-rewrite mulgA remgrMid //; last by rewrite groupMl mem_remgr.
+rewrite {1}(divgr_eq K H y) mulgA (conjgCV x) {2}(divgr_eq K H x) -mulgA.
+rewrite -[X in _ * X]mulgA mulgA remgrMid //; last first.
+  by rewrite groupMl mem_remgr.
 by rewrite groupMl !(=^~ mem_conjg, nK_KH, mem_divgr).
 Qed.
 
@@ -1026,20 +1027,20 @@ Definition pairg1 x : gT1 * gT2 := (x, 1).
 Definition pair1g x : gT1 * gT2 := (1, x).
 
 Lemma pairg1_morphM : {morph pairg1 : x y / x * y}.
-Proof. by move=> x y /=; rewrite {2}/mulg /= /extprod_mulg /= mul1g. Qed.
+Proof. by move=> x y /=; rewrite {2}/mulg /= /mul_pair/= mul1g. Qed.
 
 Canonical pairg1_morphism := @Morphism _ _ setT _ (in2W pairg1_morphM).
 
 Lemma pair1g_morphM : {morph pair1g : x y / x * y}.
-Proof. by move=> x y /=; rewrite {2}/mulg /= /extprod_mulg /= mul1g. Qed.
+Proof. by move=> x y /=; rewrite {2}/mulg /= /mul_pair/= mul1g. Qed.
 
 Canonical pair1g_morphism := @Morphism _ _ setT _ (in2W pair1g_morphM).
 
 Lemma fst_morphM : {morph (@fst gT1 gT2) : x y / x * y}.
-Proof. by move=> x y. Qed.
+Proof. by []. Qed.
 
 Lemma snd_morphM : {morph (@snd gT1 gT2) : x y / x * y}.
-Proof. by move=> x y. Qed.
+Proof. by []. Qed.
 
 Canonical fst_morphism := @Morphism _ _ setT _ (in2W fst_morphM).
 
@@ -1085,7 +1086,7 @@ apply/imset2P/andP=> [[[x1 u1] [v1 y1]] | [Hx Hy]].
   rewrite !inE /= => /andP[Hx1 /eqP->] /andP[/eqP-> Hx] [-> ->].
   by rewrite mulg1 mul1g.
 exists (x, 1 : gT2) (1 : gT1, y); rewrite ?inE ?Hx ?eqxx //.
-by rewrite /mulg /= /extprod_mulg /= mulg1 mul1g.
+by rewrite /mulg /= /mul_pair /= mulg1 mul1g.
 Qed.
 
 Lemma setX_dprod (H1 : {group gT1}) (H2 : {group gT2}) :
@@ -1883,7 +1884,7 @@ apply: (iffP misomP) => [[pM /isomP[injf /= <-]] | ].
 case/dprodP=> _ defG cH12 trH12.
 have fM: morphic (setX H1 H2) mulgm.
   apply/morphicP=> [[x1 x2] [y1 y2] /setXP[_ Hx2] /setXP[Hy1 _]].
-  by rewrite /= mulgA -(mulgA x1) -(centsP cH12 x2) ?mulgA.
+  by rewrite /= mulgA -(mulgA x1) -(centsP cH12 x2 _ y1) ?mulgA//.
 exists fM; apply/isomP; split; last by rewrite morphimEsub //= imset_mulgm.
 apply/subsetP=> [[x1 x2]]; rewrite !inE /= andbC -eq_invg_mul.
 case: eqP => //= <-; rewrite groupV -in_setI trH12 => /set1P->.

--- a/fingroup/gproduct.v
+++ b/fingroup/gproduct.v
@@ -59,7 +59,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Defs.
 

--- a/fingroup/morphism.v
+++ b/fingroup/morphism.v
@@ -65,7 +65,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Reserved Notation "x \isog y" (at level 70).
 

--- a/fingroup/perm.v
+++ b/fingroup/perm.v
@@ -40,7 +40,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section PermDefSection.
 

--- a/fingroup/presentation.v
+++ b/fingroup/presentation.v
@@ -55,7 +55,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Module Presentation.
 

--- a/fingroup/quotient.v
+++ b/fingroup/quotient.v
@@ -24,7 +24,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Cosets.
 

--- a/solvable/abelian.v
+++ b/solvable/abelian.v
@@ -292,7 +292,7 @@ Lemma pi_of_exponent G : \pi(exponent G) = \pi(G).
 Proof. by rewrite /pi_of primes_exponent. Qed.
 
 Lemma partn_exponentS pi H G :
-  H \subset G -> #|G|`_pi %| #|H| -> (exponent H)`_pi = (exponent G)`_pi.
+  H \subset G -> #|G|`_pi %| #|H| -> ((exponent H)`_pi = (exponent G)`_pi)%N.
 Proof.
 move=> sHG Gpi_dvd_H; apply/eqP; rewrite eqn_dvd.
 rewrite partn_dvd ?exponentS ?exponent_gt0 //=; apply/dvdn_partP=> // p.
@@ -312,7 +312,7 @@ rewrite (bigD1 (y ^ z))  ?(subsetP sPH) -?cycle_subG ?cycleJ //=.
 by rewrite orderJ part_pnat_id ?dvdn_lcml // (pi_pnat p_y).
 Qed.
 
-Lemma exponent_Hall pi G H : pi.-Hall(G) H -> exponent H = (exponent G)`_pi.
+Lemma exponent_Hall pi G H : pi.-Hall(G) H -> exponent H = ((exponent G)`_pi)%N.
 Proof.
 move=> hallH; have [sHG piH _] := and3P hallH.
 rewrite -(partn_exponentS sHG) -?(card_Hall hallH) ?part_pnat_id //.

--- a/solvable/abelian.v
+++ b/solvable/abelian.v
@@ -70,7 +70,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section AbelianDefs.
 

--- a/solvable/alt.v
+++ b/solvable/alt.v
@@ -19,7 +19,8 @@ Unset Printing Implicit Defensive.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
-Import GroupScope GRing.
+Local Open Scope group_scope.
+Import GRing.
 
 HB.instance Definition _ := isMulGroup.Build bool addbA addFb addbb.
 

--- a/solvable/burnside_app.v
+++ b/solvable/burnside_app.v
@@ -12,7 +12,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Lemma burnside_formula : forall (gT : finGroupType) s (G : {group gT}),
    uniq s -> s =i G ->

--- a/solvable/center.v
+++ b/solvable/center.v
@@ -40,7 +40,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Defs.
 

--- a/solvable/commutator.v
+++ b/solvable/commutator.v
@@ -73,11 +73,12 @@ Proof. by rewrite commgMJ conjg_mulR mulgA. Qed.
 
 Lemma Hall_Witt_identity x y z :
   [~ x, y^-1, z] ^ y * [~ y, z^-1, x] ^ z * [~ z, x^-1, y] ^ x = 1.
-Proof. (* gsimpl *)
+Proof.
+  (* gsimpl *)
 pose a x y z : gT := x * z * y ^ x.
 suffices{x y z} hw_aux x y z: [~ x, y^-1, z] ^ y = (a x y z)^-1 * (a y z x).
-  by rewrite !hw_aux 2!mulgA !mulgK mulVg.
-by rewrite commgEr conjMg -conjgM -conjg_Rmul 2!invMg conjgE !mulgA.
+  by rewrite !hw_aux; move: a {hw_aux} => a; rewrite 2!mulgA !mulgK mulVg.
+by rewrite commgEr conjMg -conjgM -conjg_Rmul conjgE !invMg !mulgA.
 Qed.
 
 (* the following properties are useful for studying p-groups of class 2 *)
@@ -279,8 +280,8 @@ Lemma commgAC G x y z : x \in G -> y \in G -> z \in G ->
 Proof.
 move=> Gx Gy Gz cyz /centsP cRxG; pose cx' u := [~ x^-1, u].
 have xR3 u v: [~ x, u, v] = x^-1 * (cx' u * cx' v) * x ^ (u * v).
-  rewrite mulgA -conjg_mulR conjVg [cx' v]commgEl mulgA -invMg.
-  by rewrite -mulgA conjgM -conjMg -!commgEl.
+  rewrite [X in X * _]mulgA -conjg_mulR conjVg [cx' v]commgEl.
+  by rewrite [X in X * _]mulgA -invMg -mulgA conjgM -conjMg -!commgEl.
 suffices RxGcx' u: u \in G -> cx' u \in [~: [set x], G].
   by rewrite !xR3 {}cyz; congr (_ * _ * _); rewrite cRxG ?RxGcx'.
 move=> Gu; suffices/groupMl <-: [~ x, u] ^ x^-1 \in [~: [set x], G].
@@ -296,7 +297,7 @@ Proof.
 move=> nGH /centsP cKH nKG; rewrite commGC gen_subG centsC.
 apply/centsP=> x Kx _ /imset2P[y z Hy Gz ->]; red.
 rewrite mulgA -[x * _]cKH ?groupV // -!mulgA; congr (_ * _).
-rewrite (mulgA x) (conjgC x) (conjgCV z) 3!mulgA; congr (_ * _).
+rewrite (mulgA x) (conjgC x) (conjgCV z) 2!mulgA [in RHS]mulgA; congr (_ * _).
 by rewrite -2!mulgA (cKH y) // -mem_conjg (normsP nKG).
 Qed.
 

--- a/solvable/commutator.v
+++ b/solvable/commutator.v
@@ -22,7 +22,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Definition derived_at n (gT : finGroupType) (A : {set gT}) :=
   iter n (fun B => [~: B, B]) A.

--- a/solvable/cyclic.v
+++ b/solvable/cyclic.v
@@ -137,7 +137,7 @@ Lemma cycleMsub a b :
 Proof.
 move=> cab co_ab; apply/subsetP=> _ /cycleP[k ->].
 apply/cycleP; exists (chinese #[a] #[b] k 0); symmetry.
-rewrite expgMn // -expg_mod_order chinese_modl // expg_mod_order.
+rewrite expgMn // -[in LHS]expg_mod_order chinese_modl // expg_mod_order.
 by rewrite /chinese addn0 -mulnA mulnCA expgM expg_order expg1n mulg1.
 Qed.
 
@@ -848,7 +848,7 @@ Lemma has_prim_root_subproof (F : fieldType) (n : nat) (rs : seq F)
     (sG_Vg : left_inverse sG_1 sG_V sG_M) :
   has n.-primitive_root rs.
 Proof.
-pose ssMG : isMulGroup (seq_sub rs) := isMulGroup.Build (seq_sub rs) sG_Ag sG_1g sG_Vg.
+pose ssMG : Finite_isGroup (seq_sub rs) := isMulGroup.Build (seq_sub rs) sG_Ag sG_1g sG_Vg.
 pose gT : finGroupType := HB.pack (seq_sub rs) ssMG.
 have /cyclicP[x gen_x]: @cyclic gT setT.
   apply: (@field_mul_group_cyclic gT [set: _] F r) => // x _.

--- a/solvable/cyclic.v
+++ b/solvable/cyclic.v
@@ -38,7 +38,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope GRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory.
 
 (***********************************************************************)
 (*  Cyclic groups.                                                     *)

--- a/solvable/extraspecial.v
+++ b/solvable/extraspecial.v
@@ -44,7 +44,8 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Local Notation "n %:R" := (n %:R%R).
-Import GroupScope GRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory.
 
 Reserved Notation "p ^{1+2}" (format "p ^{1+2}").
 Reserved Notation "p ^{1+2* n }" (n at level 2, format "p ^{1+2* n }").

--- a/solvable/extremal.v
+++ b/solvable/extremal.v
@@ -782,7 +782,7 @@ have sqrB i j: (u ^+ i * v ^+ j) ^+ 2 = (if odd j then v ^+ 2 else u ^+ i.*2).
   rewrite expgS; case: ifP => odd_j.
     rewrite {1}(conjgC (u ^+ i)) conjXg uvj odd_j expgVn -mulgA mulKg.
     rewrite -expgD addnn -(odd_double_half j) odd_j doubleD addnC /=.
-    by rewrite -(expg_mod _ v4) -!muln2 -mulnA modnMDl.
+    by rewrite -[LHS](expg_mod _ v4) -!muln2 -mulnA modnMDl.
   rewrite {2}(conjgC (u ^+ i)) conjXg uvj odd_j mulgA -(mulgA (u ^+ i)).
   rewrite -expgD addnn -(odd_double_half j) odd_j -2!mul2n mulnA.
   by rewrite expgM v4 expg1n mulg1 -expgD addnn.

--- a/solvable/extremal.v
+++ b/solvable/extremal.v
@@ -52,7 +52,8 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Local Notation "n %:R" := (n %:R%R).
-Import GroupScope GRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory.
 
 Reserved Notation "''Mod_' m" (at level 8, m at level 2, format "''Mod_' m").
 Reserved Notation "''D_' m" (at level 8, m at level 2, format "''D_' m").

--- a/solvable/finmodule.v
+++ b/solvable/finmodule.v
@@ -62,10 +62,14 @@ Bind Scope ring_scope with fmod_of.
 
 Section OneFinMod.
 
-(* TODO: understand why FinGroup has to be changed to BaseFinGroup here. *)
-Let f2sub (gT : finGroupType) (A : {group gT}) (abA : abelian A) :=
-  fun u : fmod_of abA => let : Fmod x Ax := u in Subg Ax : BaseFinGroup.arg_sort _.
-Local Coercion f2sub : fmod_of >-> BaseFinGroup.arg_sort.
+(* TODO: understand why FinGroup has to be changed to Magma here. *)
+Let f2sub_magma (gT : finGroupType) (A : {group gT}) (abA : abelian A) :=
+  fun u : fmod_of abA => let : Fmod x Ax := u in Subg Ax : Magma.sort _.
+Local Coercion f2sub_magma : fmod_of >-> Magma.sort.
+
+Let f2sub_baseGroup (gT : finGroupType) (A : {group gT}) (abA : abelian A) :=
+  fun u : fmod_of abA => let : Fmod x Ax := u in Subg Ax : BaseGroup.sort _.
+Local Coercion f2sub_baseGroup : fmod_of >-> BaseGroup.sort.
 
 Variables (gT : finGroupType) (A : {group gT}) (abelA : abelian A).
 Local Notation fmodA := (fmod_of abelA).
@@ -73,7 +77,7 @@ Implicit Types (x y z : gT) (u v w : fmodA).
 
 Let sub2f (s : [subg A]) := Fmod abelA (valP s).
 
-Definition fmval u := val (f2sub u).
+Definition fmval u := val (f2sub_magma u).
 #[export]
 HB.instance Definition _ := [isSub for fmval].
 Local Notation valA := (val: fmodA -> gT) (only parsing).
@@ -288,10 +292,11 @@ have actrH a x: x \in G -> (a ^@ rH x = a ^@ x)%R.
   case/rcosetP: (HrH x) => b /(fmodK abelH) <- ->; rewrite conjgM.
   by congr (_ ^ _); rewrite conjgE -fmvalN -!fmvalA (addrC a) addKr.
 have mu_Pmul x y z: x \in P -> mu (x * y) z = mu y z.
-  move=> Px; congr fmod; rewrite -mulgA !(rH_Pmul x) ?rPmul //.
+  move=> Px; congr fmod; rewrite -(mulgA x) !(rH_Pmul x) ?rPmul //.
   by rewrite -mulgA invMg -mulgA mulKg.
 have mu_Hmul x y z: x \in G -> y \in H -> mu x (y * z) = mu x z.
-  move=> Gx Hy; congr fmod; rewrite (mulgA x) (conjgCV x) -mulgA 2?rH_Hmul //.
+  move=> Gx Hy; congr fmod; rewrite (mulgA x) (conjgCV x) -(mulgA _ x).
+  rewrite rH_Hmul // [in LHS]rH_Hmul //.
   by rewrite -mem_conjg (normP _) ?nHG.
 have{mu_Hmul} nu_Hmul y z: y \in H -> nu (y * z) = nu z.
   move=> Hy; apply: eq_bigr => _ /rcosetsP[x Gx ->]; apply: mu_Hmul y z _ Hy.
@@ -302,7 +307,7 @@ have cocycle_mu: {in G & &, forall x y z,
   apply: (mulgI (rH x * rH y * rH z)).
   rewrite -(actrH _ _ Gz) addrC [in LHS]fmvalA fmvalJ ?nHG ?GrH //.
   rewrite mulgA -(mulgA _ (rH z)) -conjgC mulgA -!rHmul ?groupM //.
-  by rewrite mulgA -mulgA -2!(mulgA (rH x)) -!rHmul ?groupM.
+  by rewrite mulgA -(mulgA x) -2!(mulgA (rH x)) -!rHmul ?groupM.
 move: mu => mu in rHmul mu_Pmul cocycle_mu nu nu_Hmul.
 have{cocycle_mu} cocycle_nu: {in G &, forall y z,
   nu z + nu y ^@ z = mu y z *+ #|G : P| + nu (y * z)%g}%R.
@@ -319,8 +324,8 @@ have{cocycle_mu} cocycle_nu: {in G &, forall y z,
 move: nu => nu in nu_Hmul cocycle_nu.
 pose f x := rH x * val (nu x *+ m)%R.
 have{cocycle_nu} fM: {in G &, {morph f : x y / x * y}}.
-  move=> x y Gx Gy; rewrite /f ?rHmul // -3!mulgA; congr (_ * _).
-  rewrite (mulgA _ (rH y)) (conjgC _ (rH y)) -mulgA; congr (_ * _).
+  move=> x y Gx Gy; rewrite /f ?rHmul // -2!mulgA -[RHS]mulgA; congr (_ * _).
+  rewrite (mulgA _ (rH y)) (conjgC _ (rH y)) -[RHS]mulgA; congr (_ * _).
   rewrite -fmvalJ ?actrH ?nHG ?GrH // -!fmvalA actZr -mulrnDl.
   rewrite -(addrC (nu y)) cocycle_nu // mulrnDl !fmvalA; congr (_ * _).
   by rewrite !fmvalZ expgK ?fmodP.

--- a/solvable/finmodule.v
+++ b/solvable/finmodule.v
@@ -47,7 +47,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope GRing.Theory FinRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory FinRing.Theory.
 Local Open Scope ring_scope.
 
 Module FiniteModule.
@@ -234,7 +235,8 @@ Arguments FiniteModule.actrK {gT A abelA} x.
 Arguments FiniteModule.actrKV {gT A abelA} x.
 
 (* Still allow ring notations, but give priority to groups now. *)
-Import FiniteModule GroupScope.
+Local Open Scope group_scope.
+Import FiniteModule .
 
 Section Gaschutz.
 

--- a/solvable/frobenius.v
+++ b/solvable/frobenius.v
@@ -50,7 +50,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Definitions.
 

--- a/solvable/frobenius.v
+++ b/solvable/frobenius.v
@@ -700,7 +700,7 @@ rewrite -(cardsID 'Ldiv_n()) dvdn_addl.
   rewrite -setIA ['Ldiv_n(_)](setIidPr _) //.
   by apply/subsetP=> x; rewrite !inE -!order_dvdn; apply: dvdn_mull.
 rewrite -setIDA; set A := _ :\: _.
-have pA x: x \in A -> #[x]`_p = (n`_p * p)%N.
+have pA x: x \in A -> (#[x]`_p = n`_p * p)%N.
   rewrite !inE -!order_dvdn => /andP[xn xnp].
   rewrite !p_part // -expnSr; congr (p ^ _)%N; apply/eqP.
   rewrite eqn_leq -{1}addn1 -(pfactorK 1 pr_p) -lognM ?expn1 // mulnC.
@@ -778,11 +778,11 @@ have{def_z} zp_ya: z.`_p = y ^ a.
     by rewrite (constt1P _) ?p_eltNK ?p_elt_constt ?mulg1.
   apply: commute_sym; apply/cent1P.
   by rewrite -def_z conjgK groupMl // in Cz; apply/cent1P.
-have ozp: #[z ^ a^-1]`_p = #[y] by rewrite -order_constt consttJ zp_ya conjgK.
+have ozp: (#[z ^ a^-1]`_p)%N = #[y] by rewrite -order_constt consttJ zp_ya conjgK.
 split; rewrite zp_ya // -class_lcoset lcoset_id // eqxx andbT.
 rewrite -(conjgKV a z) !inE groupJ //= -!order_dvdn orderJ; apply/andP; split.
   apply: contra (partn_dvd p n_gt0) _.
-  by rewrite ozp -(muln1 n`_p) oy dvdn_pmul2l // dvdn1 neq_ltn lt1p orbT.
+  by rewrite ozp -(muln1 n`_p)%N oy dvdn_pmul2l // dvdn1 neq_ltn lt1p orbT.
 rewrite -(partnC p n_gt0) mulnCA mulnA -oy -(@partnC p #[_]) // ozp.
 apply dvdn_mul => //; apply: dvdn_trans (dvdn_trans n'Z (dvdn_gcdr _ _)).
 rewrite {2}/order -morphim_cycle // -quotientE card_quotient ?cycle_subG //.

--- a/solvable/gfunctor.v
+++ b/solvable/gfunctor.v
@@ -87,7 +87,7 @@ Unset Printing Implicit Defensive.
 
 Declare Scope gFun_scope.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Delimit Scope gFun_scope with gF.
 

--- a/solvable/gseries.v
+++ b/solvable/gseries.v
@@ -34,7 +34,7 @@ Unset Printing Implicit Defensive.
 
 Declare Scope group_rel_scope.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section GroupDefs.
 

--- a/solvable/hall.v
+++ b/solvable/hall.v
@@ -162,7 +162,7 @@ have sA_AG: A \subset AG := joing_subl _ _.
 have sG_AG: G \subset AG := joing_subr _ _.
 have sM_AG := subset_trans sMA sA_AG.
 have oAG: #|AG| = (#|A| * #|G|)%N by rewrite defAG coprime_cardMg 1?coprime_sym.
-have q'G: #|G|`_q = 1%N.
+have q'G: (#|G|`_q = 1)%N.
   rewrite part_p'nat ?p'natE -?prime_coprime // coprime_sym.
   have [_ _ [k oM]] := pgroup_pdiv qM ntM.
   by rewrite -(@coprime_pexpr k.+1) // -oM (coprimegS sMA).

--- a/solvable/hall.v
+++ b/solvable/hall.v
@@ -22,7 +22,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Hall.
 

--- a/solvable/jordanholder.v
+++ b/solvable/jordanholder.v
@@ -56,7 +56,7 @@ Unset Printing Implicit Defensive.
 
 Declare Scope section_scope.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Inductive section (gT : finGroupType) := GSection of {group gT} * {group gT}.
 

--- a/solvable/maximal.v
+++ b/solvable/maximal.v
@@ -44,7 +44,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Defs.
 

--- a/solvable/nilpotent.v
+++ b/solvable/nilpotent.v
@@ -30,7 +30,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section SeriesDefs.
 

--- a/solvable/pgroup.v
+++ b/solvable/pgroup.v
@@ -50,7 +50,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section PgroupDefs.
 

--- a/solvable/pgroup.v
+++ b/solvable/pgroup.v
@@ -160,7 +160,7 @@ Proof. exact: p'natEpi (cardG_gt0 G). Qed.
 Lemma pgroup_pi G : \pi(G).-group G.
 Proof. by rewrite /=; apply: pnat_pi. Qed.
 
-Lemma partG_eq1 pi G : (#|G|`_pi == 1%N) = pi^'.-group G.
+Lemma partG_eq1 pi G : (#|G|`_pi == 1)%N = pi^'.-group G.
 Proof. exact: partn_eq1 (cardG_gt0 G). Qed.
 
 Lemma pgroupP pi G :
@@ -233,7 +233,7 @@ move=> coKR pR ntR; have [p_pr _ [e oK]] := pgroup_pdiv pR ntR.
 by rewrite oK coprime_sym coprime_pexpl // prime_coprime // -p'natE in coKR.
 Qed.
 
-Lemma card_Hall pi G H : pi.-Hall(G) H -> #|H| = #|G|`_pi.
+Lemma card_Hall pi G H : pi.-Hall(G) H -> #|H| = (#|G|`_pi)%N.
 Proof.
 case/and3P=> sHG piH pi'H; rewrite -(Lagrange sHG).
 by rewrite partnM ?Lagrange // part_pnat_id ?part_p'nat ?muln1.
@@ -245,7 +245,7 @@ Proof. by case/andP. Qed.
 Lemma pHall_pgroup pi A B : pi.-Hall(A) B -> pi.-group B.
 Proof. by case/and3P. Qed.
 
-Lemma pHallP pi G H : reflect (H \subset G /\ #|H| = #|G|`_pi) (pi.-Hall(G) H).
+Lemma pHallP pi G H : reflect (H \subset G /\ #|H| = #|G|`_pi)%N (pi.-Hall(G) H).
 Proof.
 apply: (iffP idP) => [piH | [sHG oH]].
   by split; [apply: pHall_sub piH | apply: card_Hall].
@@ -253,7 +253,7 @@ rewrite /pHall sHG -divgS // /pgroup oH.
 by rewrite -{2}(@partnC pi #|G|) ?mulKn ?part_pnat.
 Qed.
 
-Lemma pHallE pi G H : pi.-Hall(G) H = (H \subset G) && (#|H| == #|G|`_pi).
+Lemma pHallE pi G H : pi.-Hall(G) H = (H \subset G) && (#|H| == #|G|`_pi)%N.
 Proof. by apply/pHallP/andP=> [] [->] /eqP. Qed.
 
 Lemma coprime_mulpG_Hall pi G K R :
@@ -504,7 +504,7 @@ Qed.
 Lemma p'_elt_constt pi x : pi^'.-elt (x * (x.`_pi)^-1).
 Proof. by rewrite -{1}(consttC pi^' x) consttNK mulgK p_elt_constt. Qed.
 
-Lemma order_constt pi (x : gT) : #[x.`_pi] = #[x]`_pi.
+Lemma order_constt pi (x : gT) : #[x.`_pi] = (#[x]`_pi)%N.
 Proof.
 rewrite -{2}(consttC pi x) orderM; [|exact: commuteX2|]; last first.
   by apply: (@pnat_coprime pi); apply: p_elt_constt.

--- a/solvable/primitive_action.v
+++ b/solvable/primitive_action.v
@@ -24,7 +24,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section PrimitiveDef.
 

--- a/solvable/sylow.v
+++ b/solvable/sylow.v
@@ -16,7 +16,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 (* The mod p lemma for the action of p-groups. *)
 Section ModP.

--- a/test_suite/imset2_gproduct.v
+++ b/test_suite/imset2_gproduct.v
@@ -2,6 +2,6 @@ From mathcomp Require Import all_boot all_fingroup.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-Import GroupScope.
+Local Open Scope group_scope.
 Open Scope group_scope.
 Check @ker_sdprodm.


### PR DESCRIPTION
##### Motivation for this change

This changes the hierarchy in `fingroup.v` so that it relies on the one in `monoid.v`.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
