### PR TITLE
Add `hide` constant, `[hide]`, `[let]`, `[fix]`, `[cofix]` ltac views

### DIFF
--- a/boot/ssreflect.v
+++ b/boot/ssreflect.v
@@ -7,3 +7,59 @@ Global Set Bullet Behavior "None".
 
 #[deprecated(since="mathcomp 2.3.0", note="Use `Arguments def : simpl never` instead (should work fine since Coq 8.18).")]
 Notation nosimpl t := (nosimpl t).
+
+(**
+  Additions to be ported to Corelib ssreflect:
+      hide t == t, but hide t displays as <hidden>
+     hideT t == t, but both hideT t and its inferred type display as <hidden>
+  New ltac views:
+      => /#[#hide#]#     := insert hide in the type of the top assumption (and
+                        its body if it is a 'let'), so it displays as <hidden>.
+      => /#[#let#]#      := if the type (or body) of the top assumption is a
+                        'let', make that 'let' the top assumption, e.g.,
+                      turn (let n := 1 in m < half n) -> G
+                      into let n := 1 in m < half n -> G
+      => /#[#fix#]#      := names a 'fix' expression f in the goal G(f), by 
+                        replacing the goal with let fx := hide f in G(fx),
+                        where fx is a fresh variable, and hide f displays
+                        as <hidden>.    
+      => /#[#cofix#]#    := similarly, names a 'cofix' expression in the goal.
+            
+**)
+Definition hide {T} t : T := t.
+Notation hideT := (@hide (hide _)) (only parsing).
+Notation "<hidden >" := (hide _)
+  (at level 0, format "<hidden >", only printing) : ssr_scope.
+
+Notation "'[' 'hide' ']'" := (ltac:(
+  move; lazymatch goal with
+    | |- forall x : ?A, ?G =>      change (forall x : hide A, G)
+    | |- let x : ?A := ?a in ?G => change (let x : hide A := @hide A a in G)
+    | _ => fail "[hide] : no top assumption"
+  end)) (at level 0, only parsing) : ssripat_scope.
+
+Notation "'[' 'let' ']'" := (ltac:(
+  move; lazymatch goal with
+    | |- forall (H : let x : ?A := ?a in ?T), ?G =>
+      change (let x : A := a in forall H : T, G)
+    | |- let H : (let x : ?A := ?a in ?T) := ?t in ?G =>
+      change (let x : A := a in let H : T := t in G)
+    | |- let H : ?T := (let x : ?A := ?a in ?t) in ?G =>
+      change (let x : A := a in let H : T := t in G)
+    | _ => fail "[let]: top assumption type or body is not a 'let'"
+  end)) (at level 0, only parsing) : ssripat_scope.
+
+Notation "'[' 'fix' ']'" := (ltac:(
+  match goal with
+  | |- context [?t] =>
+    is_fix t; let f := fresh "fix" in set f := t; move: @f => /[hide]
+  | _ => fail 1 "[fix]: no visible 'fix' in goal"
+  end)) (at level 0, only parsing) : ssripat_scope.
+
+Notation "'[' 'cofix' ']'" := (ltac:(
+  match goal with
+  | |- context [?t] =>
+    is_cofix t; let z := fresh "cofix" in set z := t; move: @z => /[hide]
+  | _ => fail 1 "[cofix]: no visible 'cofix' in goal"
+  end)) (at level 0, only parsing) : ssripat_scope.
+

--- a/doc/changelog/01-added/1440-new-ltac-views.md
+++ b/doc/changelog/01-added/1440-new-ltac-views.md
@@ -1,0 +1,4 @@
+- in `boot/ssreflect.v`
+  + Definition `hide`, Notation `hideT`
+  + Ltac (view) Notations `[hide]`, `[let]`, `[fix]`, and `[cofix]`
+    ([#1440](https://github.com/math-comp/math-comp/pull/1440)).


### PR DESCRIPTION
 - add `hide`, an identity function that displays as `<hidden>`, similarly to `abstract`, but without the number tag.
 - Notation `hideT := @hide (hide _)` similarly hides both a value and its type.
 - add `[hide]`, an ltac view that insert `hide` in the top assumption.
 - add `[let]`, an ltac view that extrudes a `let` from the top assumption.
 - add `[fix]` and `[cofix]`,  ltac views that name a `fix` (resp. `cofix`) expression in the goal

##### Motivation for this change

- `hide` and `hideT` provide means to preserve readability of the displayed proof context, by suppressing the display of large terms, such as `HB`-generated classes or signatures, `let fix`  subexpressions, or `have @` proof terms.
- `[hide]` makes it possible to insert `hide` after the fact in a local assumption, e.g.,
    `pose x := biguglyterm; move/[hide] in x`
or `have @ := HB.pack_for cType myT (@Tfactory.build myT op _ _ _) => /[hide]mkTc.
- `[let]` makes it possible to extend to the proof context a `let` local to the proof assumption. Use cases for this include the `let` in the induction hypothesis generated by `elim: s @x =>`, and in the statement of steps asserting the existence of some packed class, e.g.,
  `have [? /[let]Tr PTr]: {cT | let Tr := MyClass.Pack cT in ... Tr ...}.`
  Note that capturing this sort of statement would otherwise require the definition of a bespoke `Variant`.
- `[fix]` facilitates proving properties of functions with an embedded `let fix`, e.g., `algebra.polydiv.gcdp`, providing means to name the "general recursive" form of the function on the fly, without crowding the proof context with the actual definition of the function. This obviates the need to declare a vernacular-level `Fixpoint` for the general recursive case.
- `[cofix]` provides similar function for embedded `cofix`, although these are not used in `mathcomp`.

Note that this PR only provides the new functionality, and does not use it to refactor the rest of the library, deferring it to later maintenance.
Implementation note: when the top assumption is a `let`,`[let]` extracts a `let` from either the type (preferably) or the body of the top assumption, but not both, because the pattern for tht case makes Ltac emit a "variable conflict" warning at every point of use.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`
- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
