### PR TITLE
lsubmx0 and rsubmx0 lemmas

### DIFF
--- a/algebra/matrix.v
+++ b/algebra/matrix.v
@@ -821,7 +821,13 @@ Proof.
 move=> eqAB; move: (congr1 usubmx eqAB) (congr1 dsubmx eqAB).
 by rewrite !(col_mxKu, col_mxKd).
 Qed.
+  
+Lemma lsubmx_const (r : R) : lsubmx (const_mx r : 'M_(m, n1 + n2)) = const_mx r.
+Proof. by apply/matrixP => i j; rewrite !mxE. Qed.
 
+Lemma rsubmx_const (r : R) : rsubmx (const_mx r : 'M_(m, n1 + n2)) = const_mx r.
+Proof. by apply/matrixP => i j; rewrite !mxE. Qed.
+  
 Lemma row_mx_const a : row_mx (const_mx a) (const_mx a) = const_mx a.
 Proof. by split_mxE. Qed.
 

--- a/doc/changelog/01-added/1442-patch-1.md
+++ b/doc/changelog/01-added/1442-patch-1.md
@@ -1,0 +1,3 @@
+- in `matrix.v`
+  + lemmas `lsubmx_const` and `rsubmx_const`
+    ([#1442](https://github.com/math-comp/math-comp/pull/1442)).


### PR DESCRIPTION
##### Motivation for this change
When working with partitioned matrices (lsubmx, rsubmx), especially in the context of ODEs, we often want to prove that a quantity vanishes at equilibrium points. 
If the full matrix is zero, then both left and right submatrices are also zero. 
These lemmas make such reasoning immediate.  

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
