### PR TITLE
Add semi-vector spaces

### DIFF
--- a/doc/changelog/01-added/1464-semi-vector.md
+++ b/doc/changelog/01-added/1464-semi-vector.md
@@ -1,0 +1,9 @@
+- in `vector.v`
+  + Semi-vector space structure `semiVectType` over a `nzSemiRingType` that
+    generalizes `vectType` to the case where there is no additive inverse
+  + `LSemiModule_hasFinDim` mixin of semi-vector spaces
+  + `semivector_axiom_def` (`SemiVector.axiom`) axiom of semi-vector spaces
+  + `semiVectType` instances on matrices, `regular`, `prod`, `{ffun I -> vT}`,
+    that generalize the corresponding `vectType` instances to the case where
+    there is no additive inverse
+    ([#1464](https://github.com/math-comp/math-comp/pull/1464)).

--- a/doc/changelog/02-changed/1464-semi-vector.md
+++ b/doc/changelog/02-changed/1464-semi-vector.md
@@ -1,0 +1,13 @@
+- in `vector.v`
+  + Semilinear function instance on `fun_of_lfun` generalized to `semiVectType`
+  + `subType`, `eqType`, `subEqType`, `choiceType`, `subChoiceType`, `nmodType`,
+    `lSemiModType`, and `semiVectType` instances on `'Hom(aT, rT)` generalized
+    to `semiVectType`
+  + Definitions `dim`, `hom`, `fun_of_lfun_def`, `fun_of_lfun`, `linfun_def`,
+    `linfun`, `id_lfun`, `comp_lfun` generalized to `semiVectType`
+  + Lemmas `lfunE`, `fun_of_lfunK`, `lfunP`, `zero_lfunE`, `add_lfunE`,
+    `sum_lfunE`, `scale_lfunE`, `id_lfunE`, `comp_lfunE`, `comp_lfunA`,
+    `comp_lfun1l`, `comp_lfun1r`, `comp_lfun0l`, `comp_lfun0r`, `comp_lfunDl`,
+    `comp_lfunDr`, `comp_lfunZl`, `comp_lfunZr`, `dim_matrix` generalized to
+    `semiVectType`
+    ([#1464](https://github.com/math-comp/math-comp/pull/1464)).


### PR DESCRIPTION
##### Motivation for this change

This PR:
- ~generalizes the type parameter (scalars) of `vectType` to `pzRingType`, and~
- adds the semi-vector space structure `semiVectType` over `pzSemiRingType`.

The latter generalization unlocks some generalization in `qpoly.v`, cf. https://github.com/math-comp/math-comp/pull/1269#issuecomment-2352387057 and #1466.

Questions/remarks:
- Now it's a bit weird that ssralg does not have a semifield structure.
- ~Can we generalize the (semi)vector space structures to potentially-zero (semi)rings?~ No, we shouldn't.

##### Dependencies

- #1467

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
