### PR TITLE
Generalize rmorph_comm and some semilinear function instances to the "potentially-zero" case

### DIFF
--- a/algebra/ssralg.v
+++ b/algebra/ssralg.v
@@ -2961,6 +2961,28 @@ Proof. by rewrite exprDn_comm //; apply: mulrC. Qed.
 Lemma sqrrD x y : (x + y) ^+ 2 = x ^+ 2 + x * y *+ 2 + y ^+ 2.
 Proof. by rewrite exprDn !big_ord_recr big_ord0 /= add0r mulr1 mul1r. Qed.
 
+Lemma rmorph_comm (S : pzSemiRingType) (f : {rmorphism R -> S}) x y :
+  comm (f x) (f y).
+Proof. by red; rewrite -!rmorphM mulrC. Qed.
+
+Section ScaleLinear.
+
+Variables (U V : lSemiModType R) (b : R) (f : {linear U -> V}).
+
+Lemma scale_is_scalable : scalable ( *:%R b : V -> V).
+Proof. by move=> a v /=; rewrite !scalerA mulrC. Qed.
+#[export]
+HB.instance Definition _ :=
+  isScalable.Build R V V *:%R ( *:%R b) scale_is_scalable.
+
+Lemma scale_fun_is_scalable : scalable (b \*: f).
+Proof. by move=> a v /=; rewrite !linearZ. Qed.
+#[export]
+HB.instance Definition _ :=
+  isScalable.Build R U V *:%R (b \*: f) scale_fun_is_scalable.
+
+End ScaleLinear.
+
 End ComSemiRingTheory.
 
 (* FIXME: Generalize to `comPzSemiRingType` ? *)
@@ -2999,29 +3021,6 @@ have pcharRp: p \in pchar R by rewrite (pnatPpi pcharRn) ?pi_pdiv.
 have{pcharRn} /p_natP[e ->]: p.-nat n by rewrite -(eq_pnat _ (pcharf_eq pcharRp)).
 by elim: e => // e IHe; rewrite !expnSr !exprM IHe -pFrobenius_autE rmorphD.
 Qed.
-
-(* FIXME: Generalize to `comPzSemiRingType` ? *)
-Lemma rmorph_comm (S : nzSemiRingType) (f : {rmorphism R -> S}) x y :
-  comm (f x) (f y).
-Proof. by red; rewrite -!rmorphM mulrC. Qed.
-
-Section ScaleLinear.
-
-Variables (U V : lSemiModType R) (b : R) (f : {linear U -> V}).
-
-Lemma scale_is_scalable : scalable ( *:%R b : V -> V).
-Proof. by move=> a v /=; rewrite !scalerA mulrC. Qed.
-#[export]
-HB.instance Definition _ :=
-  isScalable.Build R V V *:%R ( *:%R b) scale_is_scalable.
-
-Lemma scale_fun_is_scalable : scalable (b \*: f).
-Proof. by move=> a v /=; rewrite !linearZ. Qed.
-#[export]
-HB.instance Definition _ :=
-  isScalable.Build R U V *:%R (b \*: f) scale_fun_is_scalable.
-
-End ScaleLinear.
 
 End ComNzSemiRingTheory.
 

--- a/doc/changelog/02-changed/1467-scalelinear.md
+++ b/doc/changelog/02-changed/1467-scalelinear.md
@@ -1,0 +1,6 @@
+- in `ssralg.v`
+  + `rmorph_comm` generalized to the "potentially-zero" case, i.e.,
+    `comPzSemiRingType` and `pzSemiRingType`
+  + The semilinear function instances on `GRing.scale` and `GRing.scale_fun`
+    generalized to `comPzSemiRingType`
+    ([#1467](https://github.com/math-comp/math-comp/pull/1467)).


### PR DESCRIPTION
##### Motivation for this change

Generalization of the scalars of vector spaces to potentially-zero rings (#1464) requires the generalization of the semilinear function instance on `GRing.scalar`. I'm opening this as a separate PR since it is rather trivial compared to the rest of #1464.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
