### PR TITLE
Unify redundant factories in `ssralg.v`

### DIFF
--- a/algebra/poly.v
+++ b/algebra/poly.v
@@ -2693,7 +2693,7 @@ apply/polyP=> i; rewrite coefM coefMr.
 by apply: eq_bigr => j _; rewrite mulrC.
 Qed.
 
-HB.instance Definition _ := GRing.PzSemiRing_hasCommutativeMul.Build {poly R}
+HB.instance Definition _ := GRing.SemiRing_hasCommutativeMul.Build {poly R}
   poly_mul_comm.
 HB.instance Definition _ :=
   GRing.LSemiAlgebra_isComSemiAlgebra.Build R {poly R}.

--- a/algebra/qpoly.v
+++ b/algebra/qpoly.v
@@ -680,11 +680,11 @@ Proof. by apply/val_eqP; rewrite /= -scalerAl rmodpZ // monic_mk_monic. Qed.
 Fact qpoly_scaleAr a p q : qpoly_scale a (p * q) = p * (qpoly_scale a q).
 Proof. by apply/val_eqP; rewrite /= -scalerAr rmodpZ // monic_mk_monic. Qed.
 
-HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build A {poly__ A}
+HB.instance Definition _ := GRing.LSemiModule_isLSemiAlgebra.Build A {poly__ A}
   qpoly_scaleAl.
 HB.instance Definition _ := GRing.NzLalgebra.on {poly %/ h}.
 
-HB.instance Definition _ := GRing.Lalgebra_isAlgebra.Build A {poly__ A}
+HB.instance Definition _ := GRing.LSemiAlgebra_isSemiAlgebra.Build A {poly__ A}
   qpoly_scaleAr.
 HB.instance Definition _ := GRing.NzAlgebra.on {poly %/ h}.
 

--- a/algebra/ssralg.v
+++ b/algebra/ssralg.v
@@ -437,7 +437,6 @@ From mathcomp Require Export nmodule.
 (*                           combinations (a *: u + v in S when u, v in S)    *)
 (*        submod_closed S <-> collective predicate S is closed under lmodType *)
 (*                           operations (0 and a *: u + v in S)               *)
-(* [SubZmodule_isSubLmodule of V by <:] ==                                    *)
 (* [SubChoice_isSubLmodule of V by <:] == mixin axiom for a subType of an     *)
 (*                           lmodType                                         *)
 (*                                                                            *)
@@ -474,7 +473,6 @@ From mathcomp Require Export nmodule.
 (*                           a pzSemiAlgType                                  *)
 (*                                                                            *)
 (*  * PzAlgebra (ring with scaling that associates both left and right):      *)
-(* [SubLalgebra_isSubAlgebra of V by <:] ==                                   *)
 (* [SubChoice_isSubPzAlgebra of V by <:] == mixin axiom for a subType of a    *)
 (*                           pzAlgType                                        *)
 (*                                                                            *)
@@ -2063,6 +2061,16 @@ HB.mixin Record LSemiModule_isLSemiAlgebra R V
   of PzSemiRing V & LSemiModule R V := {
   scalerAl : forall (a : R) (u v : V), a *: (u * v) = (a *: u) * v
 }.
+
+Module Lmodule_isLalgebra.
+#[deprecated(since="mathcomp 2.6.0", use=LSemiModule_isLSemiAlgebra.Build)]
+Notation Build R V := (LSemiModule_isLSemiAlgebra.Build R V) (only parsing).
+End Lmodule_isLalgebra.
+
+#[deprecated(since="mathcomp 2.6.0", use=LSemiModule_isLSemiAlgebra)]
+Notation Lmodule_isLalgebra R V :=
+  (LSemiModule_isLSemiAlgebra R V) (only parsing).
+
 #[short(type="pzLSemiAlgType")]
 HB.structure Definition PzLSemiAlgebra R :=
   {A of LSemiModule R A & PzSemiRing A & LSemiModule_isLSemiAlgebra R A}.
@@ -2125,16 +2133,6 @@ Notation on R := (NzLalgebra.on R) (only parsing).
 #[deprecated(since="mathcomp 2.6.0", use=NzLalgebra.copy)]
 Notation copy T U := (NzLalgebra.copy T U) (only parsing).
 End Lalgebra.
-
-HB.factory Record Lmodule_isLalgebra R V of PzRing V & Lmodule R V := {
-  scalerAl : forall (a : R) (u v : V), a *: (u * v) = (a *: u) * v
-}.
-
-HB.builders Context R V of Lmodule_isLalgebra R V.
-
-HB.instance Definition _ := LSemiModule_isLSemiAlgebra.Build R V scalerAl.
-
-HB.end.
 
 (* Regular ring algebra tag. *)
 Definition regular R : Type := R.
@@ -2916,22 +2914,40 @@ Proof. by rewrite linearZ /= rmorph1. Qed.
 
 End LRMorphismTheory.
 
-HB.mixin Record PzSemiRing_hasCommutativeMul R of PzSemiRing R := {
+HB.mixin Record SemiRing_hasCommutativeMul R of PzSemiRing R := {
   mulrC : commutative (@mul R)
 }.
 
-Module SemiRing_hasCommutativeMul.
-#[deprecated(since="mathcomp 2.4.0", use=PzSemiRing_hasCommutativeMul.Build)]
-Notation Build R := (PzSemiRing_hasCommutativeMul.Build R) (only parsing).
-End SemiRing_hasCommutativeMul.
+Module PzSemiRing_hasCommutativeMul.
+#[deprecated(since="mathcomp 2.6.0", use=SemiRing_hasCommutativeMul.Build)]
+Notation Build R := (SemiRing_hasCommutativeMul.Build R) (only parsing).
+End PzSemiRing_hasCommutativeMul.
 
-#[deprecated(since="mathcomp 2.4.0", use=PzSemiRing_hasCommutativeMul)]
-Notation SemiRing_hasCommutativeMul R :=
-  (PzSemiRing_hasCommutativeMul R) (only parsing).
+#[deprecated(since="mathcomp 2.6.0", use=SemiRing_hasCommutativeMul)]
+Notation PzSemiRing_hasCommutativeMul R :=
+  (SemiRing_hasCommutativeMul R) (only parsing).
+
+Module Ring_hasCommutativeMul.
+#[deprecated(since="mathcomp 2.4.0", use=SemiRing_hasCommutativeMul.Build)]
+Notation Build R := (SemiRing_hasCommutativeMul.Build R) (only parsing).
+End Ring_hasCommutativeMul.
+
+#[deprecated(since="mathcomp 2.4.0", use=SemiRing_hasCommutativeMul)]
+Notation Ring_hasCommutativeMul R :=
+  (SemiRing_hasCommutativeMul R) (only parsing).
+
+Module PzRing_hasCommutativeMul.
+#[deprecated(since="mathcomp 2.6.0", use=SemiRing_hasCommutativeMul.Build)]
+Notation Build R := (SemiRing_hasCommutativeMul.Build R) (only parsing).
+End PzRing_hasCommutativeMul.
+
+#[deprecated(since="mathcomp 2.6.0", use=SemiRing_hasCommutativeMul)]
+Notation PzRing_hasCommutativeMul R :=
+  (SemiRing_hasCommutativeMul R) (only parsing).
 
 #[short(type="comPzSemiRingType")]
 HB.structure Definition ComPzSemiRing :=
-  {R of PzSemiRing R & PzSemiRing_hasCommutativeMul R}.
+  {R of PzSemiRing R & SemiRing_hasCommutativeMul R}.
 
 Module ComPzSemiRingExports.
 Bind Scope ring_scope with ComPzSemiRing.sort.
@@ -2955,12 +2971,12 @@ HB.builders Context R of Nmodule_isComPzSemiRing R.
   Proof. by move=> x; rewrite mulrC mul0r. Qed.
   HB.instance Definition _ := Nmodule_isPzSemiRing.Build R
     mulrA mul1r mulr1 mulrDl mulrDr mul0r mulr0.
-  HB.instance Definition _ := PzSemiRing_hasCommutativeMul.Build R mulrC.
+  HB.instance Definition _ := SemiRing_hasCommutativeMul.Build R mulrC.
 HB.end.
 
 #[short(type="comNzSemiRingType")]
 HB.structure Definition ComNzSemiRing :=
-  {R of NzSemiRing R & PzSemiRing_hasCommutativeMul R}.
+  {R of NzSemiRing R & SemiRing_hasCommutativeMul R}.
 
 #[deprecated(since="mathcomp 2.4.0", use=ComNzSemiRing)]
 Notation ComSemiRing R := (ComNzSemiRing R) (only parsing).
@@ -3107,23 +3123,6 @@ End ComNzSemiRingTheory.
 #[short(type="comPzRingType")]
 HB.structure Definition ComPzRing := {R of PzRing R & ComPzSemiRing R}.
 
-HB.factory Record PzRing_hasCommutativeMul R of PzRing R := {
-  mulrC : commutative (@mul R)
-}.
-
-Module Ring_hasCommutativeMul.
-#[deprecated(since="mathcomp 2.4.0", use=PzRing_hasCommutativeMul.Build)]
-Notation Build R := (PzRing_hasCommutativeMul.Build R) (only parsing).
-End Ring_hasCommutativeMul.
-
-#[deprecated(since="mathcomp 2.4.0", use=PzRing_hasCommutativeMul)]
-Notation Ring_hasCommutativeMul R :=
-  (PzRing_hasCommutativeMul R) (only parsing).
-
-HB.builders Context R of PzRing_hasCommutativeMul R.
-HB.instance Definition _ := PzSemiRing_hasCommutativeMul.Build R mulrC.
-HB.end.
-
 HB.factory Record Zmodule_isComPzRing R of Zmodule R := {
   one : R;
   mul : R -> R -> R;
@@ -3138,7 +3137,7 @@ HB.builders Context R of Zmodule_isComPzRing R.
   Definition mulrDr := Monoid.mulC_dist mulrC mulrDl.
   HB.instance Definition _ := Zmodule_isPzRing.Build R
     mulrA mul1r mulr1 mulrDl mulrDr.
-  HB.instance Definition _ := PzRing_hasCommutativeMul.Build R mulrC.
+  HB.instance Definition _ := SemiRing_hasCommutativeMul.Build R mulrC.
 HB.end.
 
 Module ComPzRingExports.
@@ -3227,6 +3226,16 @@ End ComPzRingTheory.
 HB.mixin Record LSemiAlgebra_isSemiAlgebra R V of PzLSemiAlgebra R V := {
   scalerAr : forall k (x y : V), k *: (x * y) = x * (k *: y);
 }.
+
+Module Lalgebra_isAlgebra.
+#[deprecated(since="mathcomp 2.6.0", use=LSemiAlgebra_isSemiAlgebra.Build)]
+Notation Build R V := (LSemiAlgebra_isSemiAlgebra.Build R V) (only parsing).
+End Lalgebra_isAlgebra.
+
+#[deprecated(since="mathcomp 2.6.0", use=LSemiAlgebra_isSemiAlgebra)]
+Notation Lalgebra_isAlgebra R V :=
+  (LSemiAlgebra_isSemiAlgebra R V) (only parsing).
+
 #[short(type="pzSemiAlgType")]
 HB.structure Definition PzSemiAlgebra (R : pzSemiRingType) :=
   {A of LSemiAlgebra_isSemiAlgebra R A & PzLSemiAlgebra R A}.
@@ -3257,6 +3266,16 @@ End SemiAlgebra.
 
 HB.factory Record LSemiAlgebra_isComSemiAlgebra R V
   of ComPzSemiRing V & PzLSemiAlgebra R V := {}.
+
+Module Lalgebra_isComAlgebra.
+#[deprecated(since="mathcomp 2.6.0", use=LSemiAlgebra_isComSemiAlgebra.Build)]
+Notation Build R V := (LSemiAlgebra_isComSemiAlgebra.Build R V) (only parsing).
+End Lalgebra_isComAlgebra.
+
+#[deprecated(since="mathcomp 2.6.0", use=LSemiAlgebra_isComSemiAlgebra)]
+Notation Lalgebra_isComAlgebra R V :=
+  (LSemiAlgebra_isComSemiAlgebra R V) (only parsing).
+
 HB.builders Context R V of LSemiAlgebra_isComSemiAlgebra R V.
 
 Lemma scalarAr k (x y : V) : k *: (x * y) = x * (k *: y).
@@ -3305,19 +3324,6 @@ Notation on R := (NzAlgebra.on R) (only parsing).
 Notation copy T U := (NzAlgebra.copy T U) (only parsing).
 End Algebra.
 
-HB.factory Record Lalgebra_isAlgebra (R : pzRingType) V of PzLalgebra R V := {
-  scalerAr : forall k (x y : V), k *: (x * y) = x * (k *: y);
-}.
-HB.builders Context R V of Lalgebra_isAlgebra R V.
-HB.instance Definition _ := LSemiAlgebra_isSemiAlgebra.Build R V scalerAr.
-HB.end.
-
-HB.factory Record Lalgebra_isComAlgebra R V of ComPzRing V & PzLalgebra R V :=
-  {}.
-HB.builders Context R V of Lalgebra_isComAlgebra R V.
-HB.instance Definition _ := LSemiAlgebra_isComSemiAlgebra.Build R V.
-HB.end.
-
 #[short(type="comPzSemiAlgType")]
 HB.structure Definition ComPzSemiAlgebra (R : pzSemiRingType) :=
   {V of ComPzSemiRing V & PzSemiAlgebra R V}.
@@ -3351,7 +3357,7 @@ End ComSemiAlgebra.
 Section SemiAlgebraTheory.
 #[export]
 HB.instance Definition _ (R : comPzSemiRingType) :=
-  PzSemiRing_hasCommutativeMul.Build R^c (fun _ _ => mulrC _ _).
+  SemiRing_hasCommutativeMul.Build R^c (fun _ _ => mulrC _ _).
 #[export]
 HB.instance Definition _ (R : comPzSemiRingType) := ComPzSemiRing.on R^o.
 #[export]
@@ -5798,13 +5804,14 @@ HB.end.
 HB.structure Definition SubComPzSemiRing (R : pzSemiRingType) S :=
   {U of SubPzSemiRing R S U & ComPzSemiRing U}.
 
-HB.factory Record SubPzSemiRing_isSubComPzSemiRing (R : comPzSemiRingType) S U
+(* This Factory should automatically subsume the non-zero and non-semi cases *)
+HB.factory Record SubSemiRing_isSubComSemiRing (R : comPzSemiRingType) S U
     of SubPzSemiRing R S U := {}.
 
-HB.builders Context R S U of SubPzSemiRing_isSubComPzSemiRing R S U.
+HB.builders Context R S U of SubSemiRing_isSubComSemiRing R S U.
 Lemma mulrC : @commutative U U *%R.
 Proof. by move=> x y; apply: val_inj; rewrite !rmorphM mulrC. Qed.
-HB.instance Definition _ := PzSemiRing_hasCommutativeMul.Build U mulrC.
+HB.instance Definition _ := SemiRing_hasCommutativeMul.Build U mulrC.
 HB.end.
 
 #[short(type="subComNzSemiRingType")]
@@ -5822,23 +5829,6 @@ Notation on R := (SubComNzSemiRing.on R) (only parsing).
 #[deprecated(since="mathcomp 2.4.0", use=SubComNzSemiRing.copy)]
 Notation copy T U := (SubComNzSemiRing.copy T U) (only parsing).
 End SubComSemiRing.
-
-HB.factory Record SubNzSemiRing_isSubComNzSemiRing (R : comNzSemiRingType) S U
-    of SubNzSemiRing R S U := {}.
-
-Module SubSemiRing_isSubComSemiRing.
-#[deprecated(since="mathcomp 2.4.0", use=SubNzSemiRing_isSubComNzSemiRing.Build)]
-Notation Build R S U :=
-  (SubNzSemiRing_isSubComNzSemiRing.Build R S U) (only parsing).
-End SubSemiRing_isSubComSemiRing.
-
-#[deprecated(since="mathcomp 2.4.0", use=SubNzSemiRing_isSubComNzSemiRing)]
-Notation SubSemiRing_isSubComSemiRing R S U :=
-  (SubNzSemiRing_isSubComNzSemiRing R S U) (only parsing).
-
-HB.builders Context R S U of SubNzSemiRing_isSubComNzSemiRing R S U.
-HB.instance Definition _ := SubPzSemiRing_isSubComPzSemiRing.Build R S U.
-HB.end.
 
 #[short(type="subPzRingType")]
 HB.structure Definition SubPzRing (R : pzRingType) (S : pred R) :=
@@ -5893,13 +5883,6 @@ HB.end.
 HB.structure Definition SubComPzRing (R : pzRingType) S :=
   {U of SubPzRing R S U & ComPzRing U}.
 
-HB.factory Record SubPzRing_isSubComPzRing (R : comPzRingType) S U
-    of SubPzRing R S U := {}.
-
-HB.builders Context R S U of SubPzRing_isSubComPzRing R S U.
-HB.instance Definition _ := SubPzSemiRing_isSubComPzSemiRing.Build R S U.
-HB.end.
-
 #[short(type="subComNzRingType")]
 HB.structure Definition SubComNzRing (R : nzRingType) S :=
   {U of SubNzRing R S U & ComNzRing U}.
@@ -5915,22 +5898,6 @@ Notation on R := (SubComNzRing.on R) (only parsing).
 #[deprecated(since="mathcomp 2.4.0", use=SubComNzRing.copy)]
 Notation copy T U := (SubComNzRing.copy T U) (only parsing).
 End SubComRing.
-
-HB.factory Record SubNzRing_isSubComNzRing (R : comNzRingType) S U
-    of SubNzRing R S U := {}.
-
-Module SubRing_isSubComRing.
-#[deprecated(since="mathcomp 2.4.0", use=SubNzRing_isSubComNzRing.Build)]
-Notation Build R S U := (SubNzRing_isSubComNzRing.Build R S U) (only parsing).
-End SubRing_isSubComRing.
-
-#[deprecated(since="mathcomp 2.4.0", use=SubNzRing_isSubComNzRing)]
-Notation SubRing_isSubComRing R S U :=
-  (SubNzRing_isSubComNzRing R S U) (only parsing).
-
-HB.builders Context R S U of SubNzRing_isSubComNzRing R S U.
-HB.instance Definition _ := SubPzRing_isSubComPzRing.Build R S U.
-HB.end.
 
 HB.mixin Record isSubLSemiModule (R : pzSemiRingType) (V : lSemiModType R)
   (S : pred V) W of SubNmodule V S W & LSemiModule R W := {
@@ -5994,16 +5961,6 @@ HB.instance Definition _ := Nmodule_isLSemiModule.Build R W
 
 Fact valZ : scalable (val : W -> _). Proof. by move=> k w; rewrite SubK. Qed.
 HB.instance Definition _ := isSubLSemiModule.Build R V S W valZ.
-HB.end.
-
-HB.factory Record SubZmodule_isSubLmodule (R : pzRingType) (V : lmodType R) S W
-    of SubZmodule V S W := {
-  subsemimod_closed_subproof : subsemimod_closed S
-}.
-
-HB.builders Context R V S W of SubZmodule_isSubLmodule R V S W.
-HB.instance Definition _ := SubNmodule_isSubLSemiModule.Build R V S W
-  subsemimod_closed_subproof.
 HB.end.
 
 #[short(type="subPzLSemiAlgType")]
@@ -6116,13 +6073,6 @@ HB.builders Context R V S W of SubLSemiAlgebra_isSubSemiAlgebra R V S W.
 Lemma scalerAr (k : R) (x y : W) : k *: (x * y) = x * (k *: y).
 Proof. by apply: val_inj; rewrite !(linearZ, rmorphM)/= linearZ scalerAr. Qed.
 HB.instance Definition _ := LSemiAlgebra_isSemiAlgebra.Build R W scalerAr.
-HB.end.
-
-HB.factory Record SubLalgebra_isSubAlgebra (R : pzRingType)
-    (V : pzAlgType R) S W of @SubPzLalgebra R V S W := {}.
-
-HB.builders Context R V S W of SubLalgebra_isSubAlgebra R V S W.
-HB.instance Definition _ := SubLSemiAlgebra_isSubSemiAlgebra.Build R V S W.
 HB.end.
 
 #[short(type="subUnitRingType")]
@@ -6238,7 +6188,7 @@ HB.factory Record SubChoice_isSubComPzSemiRing (R : comPzSemiRingType) S U
 HB.builders Context R S U of SubChoice_isSubComPzSemiRing R S U.
 HB.instance Definition _ := SubChoice_isSubPzSemiRing.Build R S U
   semiring_closed_subproof.
-HB.instance Definition _ := SubPzSemiRing_isSubComPzSemiRing.Build R S U.
+HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
 HB.end.
 
 HB.factory Record SubChoice_isSubComNzSemiRing (R : comNzSemiRingType) S U
@@ -6302,7 +6252,7 @@ HB.factory Record SubChoice_isSubComPzRing (R : comPzRingType) S U
 HB.builders Context R S U of SubChoice_isSubComPzRing R S U.
 HB.instance Definition _ := SubChoice_isSubPzRing.Build R S U
   subring_closed_subproof.
-HB.instance Definition _ := SubPzRing_isSubComPzRing.Build R S U.
+HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
 HB.end.
 
 HB.factory Record SubChoice_isSubComNzRing (R : comNzRingType) S U
@@ -6345,7 +6295,7 @@ HB.factory Record SubChoice_isSubLmodule (R : pzRingType) (V : lmodType R) S W
 HB.builders Context R V S W of SubChoice_isSubLmodule R V S W.
 HB.instance Definition _ := SubChoice_isSubZmodule.Build V S W
   (subsemimod_closedB subsemimod_closed_subproof).
-HB.instance Definition _ := SubZmodule_isSubLmodule.Build R V S W
+HB.instance Definition _ := SubNmodule_isSubLSemiModule.Build R V S W
   subsemimod_closed_subproof.
 HB.end.
 
@@ -6382,7 +6332,7 @@ HB.factory Record SubChoice_isSubPzLalgebra
 HB.builders Context R A S W of SubChoice_isSubPzLalgebra R A S W.
 HB.instance Definition _ := SubChoice_isSubPzRing.Build A S W
   (subsemialg_closedBM subsemialg_closed_subproof).
-HB.instance Definition _ := SubZmodule_isSubLmodule.Build R A S W
+HB.instance Definition _ := SubNmodule_isSubLSemiModule.Build R A S W
   (subsemialg_closedZ subsemialg_closed_subproof).
 HB.instance Definition _ := SubRing_SubLmodule_isSubLalgebra.Build R A S W.
 HB.end.
@@ -6428,7 +6378,7 @@ HB.factory Record SubChoice_isSubPzAlgebra
 HB.builders Context R A S W of SubChoice_isSubPzAlgebra R A S W.
 HB.instance Definition _ := SubChoice_isSubPzLalgebra.Build R A S W
   subsemialg_closed_subproof.
-HB.instance Definition _ := SubLalgebra_isSubAlgebra.Build R A S W.
+HB.instance Definition _ := SubLSemiAlgebra_isSubSemiAlgebra.Build R A S W.
 HB.end.
 
 HB.factory Record SubChoice_isSubNzAlgebra
@@ -6499,15 +6449,39 @@ Notation "[ 'SubChoice_isSubSemiRing' 'of' U 'by' <: ]" :=
   (SubChoice_isSubNzSemiRing.Build _ _ U (semiringClosedP _))
   (format "[ 'SubChoice_isSubSemiRing'  'of'  U  'by'  <: ]")
   : form_scope.
+Notation "[ 'SubSemiRing_isSubComSemiRing' 'of' U 'by' <: ]" :=
+  (SubSemiRing_isSubComSemiRing.Build _ _ U)
+  (format "[ 'SubSemiRing_isSubComSemiRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.6.0",
+        note="Use [ SubSemiRing_isSubComSemiRing of U by <: ] instead.")]
+Notation "[ 'SubPzSemiRing_isSubComPzSemiRing' 'of' U 'by' <: ]" :=
+  (SubSemiRing_isSubComSemiRing.Build _ _ U)
+  (format "[ 'SubPzSemiRing_isSubComPzSemiRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.6.0",
+        note="Use [ SubSemiRing_isSubComSemiRing of U by <: ] instead.")]
 Notation "[ 'SubNzSemiRing_isSubComNzSemiRing' 'of' U 'by' <: ]" :=
-  (SubNzSemiRing_isSubComNzSemiRing.Build _ _ U)
+  (SubSemiRing_isSubComSemiRing.Build _ _ U)
   (format "[ 'SubNzSemiRing_isSubComNzSemiRing'  'of'  U  'by'  <: ]")
   : form_scope.
 #[deprecated(since="mathcomp 2.4.0",
-        note="Use [ SubNzSemiRing_isSubComNzSemiRing of U by <: ] instead.")]
-Notation "[ 'SubSemiRing_isSubComSemiRing' 'of' U 'by' <: ]" :=
-  (SubNzSemiRing_isSubComNzSemiRing.Build _ _ U)
-  (format "[ 'SubSemiRing_isSubComSemiRing'  'of'  U  'by'  <: ]")
+             note="Use [ SubSemiRing_isSubComSemiRing of U by <: ] instead.")]
+Notation "[ 'SubRing_isSubComRing' 'of' U 'by' <: ]" :=
+  (SubSemiRing_isSubComSemiRing.Build _ _ U)
+  (format "[ 'SubRing_isSubComRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.6.0",
+             note="Use [ SubSemiRing_isSubComSemiRing of U by <: ] instead.")]
+Notation "[ 'SubPzRing_isSubComPzRing' 'of' U 'by' <: ]" :=
+  (SubSemiRing_isSubComSemiRing.Build _ _ U)
+  (format "[ 'SubPzRing_isSubComPzRing'  'of'  U  'by'  <: ]")
+  : form_scope.
+#[deprecated(since="mathcomp 2.6.0",
+             note="Use [ SubSemiRing_isSubComSemiRing of U by <: ] instead.")]
+Notation "[ 'SubNzRing_isSubComNzRing' 'of' U 'by' <: ]" :=
+  (SubSemiRing_isSubComSemiRing.Build _ _ U)
+  (format "[ 'SubNzRing_isSubComNzRing'  'of'  U  'by'  <: ]")
   : form_scope.
 Notation "[ 'SubChoice_isSubComNzSemiRing' 'of' U 'by' <: ]" :=
   (SubChoice_isSubComNzSemiRing.Build _ _ U (semiringClosedP _))
@@ -6539,16 +6513,6 @@ Notation "[ 'SubChoice_isSubRing' 'of' U 'by' <: ]" :=
   (SubChoice_isSubNzRing.Build _ _ U (subringClosedP _))
   (format "[ 'SubChoice_isSubRing'  'of'  U  'by'  <: ]")
   : form_scope.
-Notation "[ 'SubNzRing_isSubComNzRing' 'of' U 'by' <: ]" :=
-  (SubNzRing_isSubComNzRing.Build _ _ U)
-  (format "[ 'SubNzRing_isSubComNzRing'  'of'  U  'by'  <: ]")
-  : form_scope.
-#[deprecated(since="mathcomp 2.4.0",
-             note="Use [ SubNzRing_isSubComNzRing of U by <: ] instead.")]
-Notation "[ 'SubRing_isSubComRing' 'of' U 'by' <: ]" :=
-  (SubNzRing_isSubComNzRing.Build _ _ U)
-  (format "[ 'SubRing_isSubComRing'  'of'  U  'by'  <: ]")
-  : form_scope.
 Notation "[ 'SubChoice_isSubComNzRing' 'of' U 'by' <: ]" :=
   (SubChoice_isSubComNzRing.Build _ _ U (subringClosedP _))
   (format "[ 'SubChoice_isSubComNzRing'  'of'  U  'by'  <: ]")
@@ -6567,8 +6531,10 @@ Notation "[ 'SubChoice_isSubLSemiModule' 'of' U 'by' <: ]" :=
   (SubChoice_isSubLSemiModule.Build _ _ _ U (subsemimodClosedP _))
   (format "[ 'SubChoice_isSubLSemiModule'  'of'  U  'by'  <: ]")
   : form_scope.
+#[deprecated(since="mathcomp 2.6.0",
+        note="Use [ SubNmodule_isSubLSemiModule of U by <: ] instead.")]
 Notation "[ 'SubZmodule_isSubLmodule' 'of' U 'by' <: ]" :=
-  (SubZmodule_isSubLmodule.Build _ _ _ U (subsemimodClosedP _))
+  (SubNmodule_isSubLSemiModule.Build _ _ _ U (subsemimodClosedP _))
   (format "[ 'SubZmodule_isSubLmodule'  'of'  U  'by'  <: ]")
   : form_scope.
 Notation "[ 'SubChoice_isSubLmodule' 'of' U 'by' <: ]" :=
@@ -6599,8 +6565,10 @@ Notation "[ 'SubLSemiAlgebra_isSubSemiAlgebra' 'of' U 'by' <: ]" :=
   (SubLSemiAlgebra_isSubSemiAlgebra.Build _ _ _ U)
   (format "[ 'SubLSemiAlgebra_isSubSemiAlgebra'  'of'  U  'by'  <: ]")
   : form_scope.
+#[deprecated(since="mathcomp 2.6.0",
+        note="Use [ SubLSemiAlgebra_isSubSemiAlgebra of U by <: ] instead.")]
 Notation "[ 'SubLalgebra_isSubAlgebra' 'of' U 'by' <: ]" :=
-  (SubLalgebra_isSubAlgebra.Build _ _ _ U)
+  (SubLSemiAlgebra_isSubSemiAlgebra.Build _ _ _ U)
   (format "[ 'SubLalgebra_isSubAlgebra'  'of'  U  'by'  <: ]")
   : form_scope.
 Notation "[ 'SubChoice_isSubPzLSemiAlgebra' 'of' U 'by' <: ]" :=
@@ -7616,7 +7584,7 @@ Proof. by move=> f1 f2; apply/ffunP=> i; rewrite !ffunE mulrC. Qed.
 (* TODO_HB
 #[export]
 HB.instance Definition _ :=
-  Ring_hasCommutativeMul.Build (ffun_ring _ a) ffun_mulC.
+  SemiRing_hasCommutativeMul.Build (ffun_ring _ a) ffun_mulC.
 *)
 
 End FinFunComRing.
@@ -7718,7 +7686,7 @@ Fact pair_mulC : commutative (@mul_pair R1 R2).
 Proof. by move=> x y; congr (_, _); apply: mulrC. Qed.
 
 #[export]
-HB.instance Definition _ := PzSemiRing_hasCommutativeMul.Build (R1 * R2)%type
+HB.instance Definition _ := SemiRing_hasCommutativeMul.Build (R1 * R2)%type
   pair_mulC.
 
 End PairComSemiRing.

--- a/algebra/vector.v
+++ b/algebra/vector.v
@@ -1813,13 +1813,15 @@ Definition lfun_nzRingType : nzRingType := lfun_comp_nzRingType^c.
 #[deprecated(since="mathcomp 2.4.0", use=lfun_nzRingType)]
 Notation lfun_ringType := (lfun_nzRingType) (only parsing).
 
-Definition lfun_lalgMixin := GRing.Lmodule_isLalgebra.Build R lfun_nzRingType
-  (fun k x y => comp_lfunZr k y x).
+Definition lfun_lalgMixin :=
+  GRing.LSemiModule_isLSemiAlgebra.Build R lfun_nzRingType
+    (fun k x y => comp_lfunZr k y x).
 Definition lfun_lalgType : nzLalgType R :=
   HB.pack 'End(vT) lfun_nzRingType lfun_lalgMixin.
 
-Definition lfun_algMixin := GRing.Lalgebra_isAlgebra.Build R lfun_lalgType
-  (fun k x y => comp_lfunZl k y x).
+Definition lfun_algMixin :=
+  GRing.LSemiAlgebra_isSemiAlgebra.Build R lfun_lalgType
+    (fun k x y => comp_lfunZl k y x).
 Definition lfun_algType : nzAlgType R :=
   HB.pack 'End(vT) lfun_lalgType lfun_algMixin.
 
@@ -1967,8 +1969,7 @@ Inductive subvs_of : predArgType := Subvs u & u \in U.
 Definition vsval w : vT := let: Subvs u _ := w in u.
 HB.instance Definition _ := [isSub of subvs_of for vsval].
 HB.instance Definition _ := [Choice of subvs_of by <:].
-HB.instance Definition _ := [SubChoice_isSubZmodule of subvs_of by <:].
-HB.instance Definition _ := [SubZmodule_isSubLmodule of subvs_of by <:].
+HB.instance Definition _ := [SubChoice_isSubLmodule of subvs_of by <:].
 
 Lemma subvsP w : vsval w \in U. Proof. exact: valP. Qed.
 Lemma subvs_inj : injective vsval. Proof. exact: val_inj. Qed.

--- a/character/classfun.v
+++ b/character/classfun.v
@@ -314,14 +314,9 @@ HB.instance Definition _ := GRing.Zmodule_isLmodule.Build algC classfun
 
 Fact cfun_scaleAl a phi psi : a *: (phi * psi) = (a *: phi) * psi.
 Proof. by apply/cfunP=> x; rewrite !cfunE mulrA. Qed.
-Fact cfun_scaleAr a phi psi : a *: (phi * psi) = phi * (a *: psi).
-Proof. by rewrite !(mulrC phi) cfun_scaleAl. Qed.
 
-HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build algC classfun
-  cfun_scaleAl.
-
-HB.instance Definition _ := GRing.Lalgebra_isAlgebra.Build algC classfun
-  cfun_scaleAr.
+HB.instance Definition _ :=
+  GRing.LSemiModule_isComSemiAlgebra.Build algC classfun cfun_scaleAl.
 
 Section Automorphism.
 

--- a/doc/changelog/05-deprecated/1475-SubSemiRing_isSubComSemiRing.md
+++ b/doc/changelog/05-deprecated/1475-SubSemiRing_isSubComSemiRing.md
@@ -1,0 +1,21 @@
+- in `ssralg.v`
+  + factory `Lmodule_isLalgebra`, use `LSemiModule_isLSemiAlgebra` instead
+  + factory `PzSemiRing_hasCommutativeMul`, use `SemiRing_hasCommutativeMul`
+    instead
+  + factory `Ring_hasCommutativeMul`, use `SemiRing_hasCommutativeMul` instead
+  + factory `PzRing_hasCommutativeMul`, use `SemiRing_hasCommutativeMul` instead
+  + factory `Lalgebra_isAlgebra`, use `LSemiAlgebra_isSemiAlgebra` instead
+  + factory `Lalgebra_isComAlgebra`, use `LSemiAlgebra_isComSemiAlgebra` instead
+  + factory `[SubPzSemiRing_isSubComPzSemiRing of U by <:]`,
+    use `[SubSemiRing_isSubComSemiRing of U by <:]` instead
+  + factory `[SubNzSemiRing_isSubComNzSemiRing of U by <:]`,
+    use `[SubSemiRing_isSubComSemiRing of U by <:]` instead
+  + factory `[SubPzRing_isSubComPzRing of U by <:]`,
+    use `[SubSemiRing_isSubComSemiRing of U by <:]` instead
+  + factory `[SubNzRing_isSubComNzRing of U by <:]`,
+    use `[SubSemiRing_isSubComSemiRing of U by <:]` instead
+  + factory `[SubZmodule_isSubLmodule of U by <:]`,
+    use `[SubNmodule_isSubLSemiModule of U by <:]` instead
+  + factory `[SubLalgebra_isSubAlgebra of U by <:]`,
+    use `[SubLSemiAlgebra_isSubSemiAlgebra of U by <:]` instead
+    ([#1475](https://github.com/math-comp/math-comp/pull/1475)).

--- a/field/falgebra.v
+++ b/field/falgebra.v
@@ -958,22 +958,22 @@ Proof. by move=> x; apply/val_inj/algidl/(valP x). Qed.
 Fact subvs_mul1 : right_id subvs_one subvs_mul.
 Proof. by move=> x; apply/val_inj/algidr/(valP x). Qed.
 Fact subvs_mulDl : left_distributive subvs_mul +%R.
-Proof. move=> x y z; apply/val_inj/mulrDl. Qed.
+Proof. by move=> x y z; apply/val_inj/mulrDl. Qed.
 Fact subvs_mulDr : right_distributive subvs_mul +%R.
-Proof. move=> x y z; apply/val_inj/mulrDr. Qed.
+Proof. by move=> x y z; apply/val_inj/mulrDr. Qed.
 
 HB.instance Definition _ := GRing.Zmodule_isNzRing.Build (subvs_of A)
   subvs_mulA subvs_mu1l subvs_mul1 subvs_mulDl subvs_mulDr (algid_neq0 _).
 
 Lemma subvs_scaleAl k (x y : subvs_of A) : k *: (x * y) = (k *: x) * y.
 Proof. exact/val_inj/scalerAl. Qed.
-HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build K (subvs_of A)
-  subvs_scaleAl.
+HB.instance Definition _ :=
+  GRing.LSemiModule_isLSemiAlgebra.Build K (subvs_of A) subvs_scaleAl.
 
 Lemma subvs_scaleAr k (x y : subvs_of A) : k *: (x * y) = x * (k *: y).
 Proof. exact/val_inj/scalerAr. Qed.
-HB.instance Definition _ := GRing.Lalgebra_isAlgebra.Build K (subvs_of A)
-  subvs_scaleAr.
+HB.instance Definition _ :=
+  GRing.LSemiAlgebra_isSemiAlgebra.Build K (subvs_of A) subvs_scaleAr.
 
 HB.instance Definition _ := Algebra_isFalgebra.Build K (subvs_of A).
 

--- a/field/fieldext.v
+++ b/field/fieldext.v
@@ -82,7 +82,7 @@ Import GRing.Theory.
 
 #[short(type="fieldExtType")]
 HB.structure Definition FieldExt (R : nzRingType) := {T of Falgebra R T &
-  GRing.PzRing_hasCommutativeMul T & GRing.Field T}.
+  GRing.SemiRing_hasCommutativeMul T & GRing.Field T}.
 
 Module FieldExtExports.
 Bind Scope ring_scope with FieldExt.sort.
@@ -207,7 +207,7 @@ HB.instance Definition _ (K : {subfield L}) :=
    there, it is thus built only here *)
 
 HB.instance Definition _ (K : {subfield L}) :=
-  [SubNzRing_isSubComNzRing of subvs_of K by <:].
+  [SubSemiRing_isSubComSemiRing of subvs_of K by <:].
 HB.instance Definition _ (K : {subfield L}) :=
   [SubComUnitRing_isSubIntegralDomain of subvs_of K by <:].
 
@@ -638,14 +638,8 @@ Proof. by []. Qed.
 Fact fieldOver_scaleAl a u v : a *F: (u * v) = (a *F: u) * v.
 Proof. exact: mulrA. Qed.
 
-HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build _ L_F
-  fieldOver_scaleAl.
-
-Fact fieldOver_scaleAr a u v : a *F: (u * v) = u * (a *F: v).
-Proof. exact: mulrCA. Qed.
-
-HB.instance Definition _ := GRing.Lalgebra_isAlgebra.Build _ L_F
-  fieldOver_scaleAr.
+HB.instance Definition _ :=
+  GRing.LSemiModule_isComSemiAlgebra.Build _ L_F fieldOver_scaleAl.
 
 Fact fieldOver_vectMixin : Lmodule_hasFinDim K_F L_F.
 Proof.
@@ -791,14 +785,8 @@ Proof. by []. Qed.
 Fact baseField_scaleAl a (u v : L0) : a *F0: (u * v) = (a *F0: u) * v.
 Proof. exact: scalerAl. Qed.
 
-HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build _ L0
+HB.instance Definition _ := GRing.LSemiModule_isComSemiAlgebra.Build _ L0
   baseField_scaleAl.
-
-Fact baseField_scaleAr a u v : a *F0: (u * v) = u * (a *F0: v).
-Proof. exact: scalerAr. Qed.
-
-HB.instance Definition _ := GRing.Lalgebra_isAlgebra.Build _ L0
-  baseField_scaleAr.
 
 Let n := \dim {:F}.
 Let bF : n.-tuple F := vbasis {:F}.
@@ -1225,13 +1213,8 @@ HB.instance Definition _ := GRing.Zmodule_isLmodule.Build _ subFExtend
 
 Fact subfx_scaleAl a u v : subfx_scale a (u * v) = (subfx_scale a u) * v.
 Proof. exact: mulrA. Qed.
-HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build _ subFExtend
-  subfx_scaleAl.
-
-Fact subfx_scaleAr a u v : subfx_scale a (u * v) = u * (subfx_scale a v).
-Proof. exact: mulrCA. Qed.
-HB.instance Definition _ := GRing.Lalgebra_isAlgebra.Build _ subFExtend
-  subfx_scaleAr.
+HB.instance Definition _ :=
+  GRing.LSemiModule_isComSemiAlgebra.Build _ subFExtend subfx_scaleAl.
 
 Fact subfx_evalZ : scalable subfx_eval.
 Proof. by move=> a q; rewrite -mul_polyC rmorphM. Qed.

--- a/field/finfield.v
+++ b/field/finfield.v
@@ -255,16 +255,16 @@ Proof. by move=> a b; rewrite /pprimeChar_scale natrFp natrD mulrDl. Qed.
 HB.instance Definition _ := GRing.Zmodule_isLmodule.Build 'F_p R
   pprimeChar_scaleA pprimeChar_scale1 pprimeChar_scaleDr pprimeChar_scaleDl.
 
-Lemma pprimeChar_scaleAl (a : 'F_p) (u v : R) :  a *: (u * v) = (a *: u) * v.
+Lemma pprimeChar_scaleAl (a : 'F_p) (u v : R) : a *: (u * v) = (a *: u) * v.
 Proof. by apply: mulrA. Qed.
 
-HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build 'F_p R
+HB.instance Definition _ := GRing.LSemiModule_isLSemiAlgebra.Build 'F_p R
   pprimeChar_scaleAl.
 
 Lemma pprimeChar_scaleAr (a : 'F_p) (x y : R) : a *: (x * y) = x * (a *: y).
 Proof. by rewrite ![a *: _]mulr_natl mulrnAr. Qed.
 
-HB.instance Definition _ := GRing.Lalgebra_isAlgebra.Build 'F_p R
+HB.instance Definition _ := GRing.LSemiAlgebra_isSemiAlgebra.Build 'F_p R
   pprimeChar_scaleAr.
 
 End PrimeCharRing.
@@ -725,7 +725,7 @@ by rewrite -[aq d]expr1 -exprB ?leq_b1 ?unitfE ?rpredX.
 Qed.
 
 Definition FinDomainFieldType : finFieldType :=
- let cC := GRing.PzRing_hasCommutativeMul.Build R finDomain_mulrC in
+ let cC := GRing.SemiRing_hasCommutativeMul.Build R finDomain_mulrC in
  let cR : comUnitRingType := HB.pack R cC in
  let iC := GRing.ComUnitRing_isIntegral.Build cR domR in
  let iR : finIdomainType := HB.pack cR iC in


### PR DESCRIPTION
##### Motivation for this change

For example, `Sub(Pz|Nz)(Semi|)Ring_isSubCom(Pz|Nz)(Semi|)Ring` can be unified into the most general one (now called `SubSemiRing_isSubComSemiRing`), which should subsume all these special cases (for the same reason as https://github.com/math-comp/math-comp/pull/1462#discussion_r2359521911). If `U` is a `sub*Nz*SemiRingType`, the use of this factory should automatically find a `subCom*Nz*SemiRingType` instance.

##### Dependencies

- #1476
- #1482

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
