### PR TITLE
Add `subsemialg_closed` and `sub(L)SemiAlgType` factories

### DIFF
--- a/doc/changelog/01-added/1476-semi_closed.md
+++ b/doc/changelog/01-added/1476-semi_closed.md
@@ -1,0 +1,11 @@
+- in `ssralg.v`
+  + Definition `subsemialg_closed`
+  + Factories `isSubSemiAlgClosed`, `SubPzSemiRing_isNonZero`,
+    `SubChoice_isSubLSemiAlgebra`, `SubChoice_isSubSemiAlgebra`
+  + Lemmas/coercions `subsemialg_closedZ`, `subsemialg_closedM`,
+    `subalg_closed_semi`
+  + Lemmas `subsemimod_closed_submod`, `subsemimod_closedB`,
+    `subsemialg_closed_subalg`, `subsemialg_closedBM`,
+    `subsemialgClosedP`
+    ([#1476](https://github.com/math-comp/math-comp/pull/1476),
+    fixes [#1387](https://github.com/math-comp/math-comp/issues/1387)).

--- a/doc/changelog/02-changed/1476-semi_closed.md
+++ b/doc/changelog/02-changed/1476-semi_closed.md
@@ -1,0 +1,8 @@
+- in `ssralg.v`
+  + Factories `isSubmodClosed`, `SubNmodule_isSubLSemiModule`,
+    `SubZmodule_isSubLmodule`, `SubChoice_isSubLmodule` generalized
+    to take `subsemimod_closed` instead of `submod_closed`
+  + Factories `isSubalgClosed`, `SubChoice_isSubLalgebra`,
+    `SubChoice_isSubAlgebra` generalized to take `subsemialg_closed`
+    instead of `subalg_closed`
+    ([#1476](https://github.com/math-comp/math-comp/pull/1476)).


### PR DESCRIPTION
##### Motivation for this change

Also, `sub(mod|alg)_closed` are equivalent to `subsemi(mod|alg)_closed` given that the additive inverse exists, and there are coercions from the former to the latter. So, all factories that take these closedness properties now take the latter (the "semi" one), and this change should be backward compatible.

Closes #1387

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
