### PR TITLE
Introduce proper (semi)vector space structures to fix the ring and algebra instances on `'End(vT)`

### DIFF
--- a/doc/changelog/01-added/1492-nzvector.md
+++ b/doc/changelog/01-added/1492-nzvector.md
@@ -1,0 +1,14 @@
+- in `vector.v`
+  + proper (semi-)vector space structures `nzSemiVectType` and `nzVectType`
+  + mixin `SemiVector_isProper`
+  + lemma `dim_gt0`
+  + canonical `nzSemiVectType` (resp. `nzVectType`) on `R^o` for any
+    `nzSemiRingType` (resp. `nzRingType) `R`
+    ([#1492](https://github.com/math-comp/math-comp/pull/1492),
+    fixes [#1470](https://github.com/math-comp/math-comp/issues/1470)).
+
+- in `falgebra.v`
+  + factory `UnitAlgebra_isFalgebra` for deriving a `falgType R` instance of a
+    type that is canonically a `vectType R` and a `unitAlgType R`
+    ([#1492](https://github.com/math-comp/math-comp/pull/1492),
+    fixes [#1470](https://github.com/math-comp/math-comp/issues/1470)).

--- a/doc/changelog/02-changed/1492-nzvector.md
+++ b/doc/changelog/02-changed/1492-nzvector.md
@@ -1,0 +1,10 @@
+- in `vector.v`
+  + The non-zero (semi)ring and (semi)algebra structures on `'End(vT)` are now
+    canonical
+    ([#1492](https://github.com/math-comp/math-comp/pull/1492),
+    fixes [#1470](https://github.com/math-comp/math-comp/issues/1470)).
+
+- in `falgebra.v`
+  + `falgType` now inherits from `nzVectType`
+    ([#1492](https://github.com/math-comp/math-comp/pull/1492),
+    fixes [#1470](https://github.com/math-comp/math-comp/issues/1470)).

--- a/doc/changelog/05-deprecated/1492-nzvector.md
+++ b/doc/changelog/05-deprecated/1492-nzvector.md
@@ -1,0 +1,12 @@
+- in `vector.v`
+  + `lfun_comp_nzRingType`
+  + `lfun_nzRingType`
+  + `lfun_lalgType`
+  + `lfun_algType`
+    ([#1492](https://github.com/math-comp/math-comp/pull/1492),
+    fixes [#1470](https://github.com/math-comp/math-comp/issues/1470)).
+
+- in `falgebra.v`
+  + lemma `FalgType_proper`, use `dim_gt0` instead
+    ([#1492](https://github.com/math-comp/math-comp/pull/1492),
+    fixes [#1470](https://github.com/math-comp/math-comp/issues/1470)).

--- a/field/fieldext.v
+++ b/field/fieldext.v
@@ -668,6 +668,7 @@ by apply/forall_inP; move/directv_sum_unique: dxSbL => <- //; apply/eqP/v2rK.
 Qed.
 
 HB.instance Definition _ := fieldOver_vectMixin.
+HB.instance Definition _ := UnitAlgebra_isFalgebra.Build K_F L_F.
 
 Implicit Types (V : {vspace L}) (E : {subfield L}).
 
@@ -814,6 +815,7 @@ by rewrite !coord_sum_free ?(basis_free (vbasisP _)).
 Qed.
 
 HB.instance Definition _ := baseField_vectMixin.
+HB.instance Definition _ := UnitAlgebra_isFalgebra.Build F0 L0.
 
 Let F0ZEZ a x v : a *: ((x *: v : L) : L0)  = (a *: x) *: v.
 Proof. by rewrite [a *: _]scalerA -scalerAl mul1r. Qed.
@@ -1295,7 +1297,9 @@ by move/eqP/(can_inj rVpolyK).
 Qed.
 
 Definition SubfxVect := Lmodule_hasFinDim.Build _ subFExtend min_subfx_vect.
-Definition SubFieldExtType : fieldExtType F := HB.pack subFExtend SubfxVect.
+Definition SubVectType : vectType F := HB.pack subFExtend SubfxVect.
+Definition SubFieldExtType : fieldExtType F :=
+  HB.pack subFExtend SubfxVect (UnitAlgebra_isFalgebra.Build F SubVectType).
 
 End Irreducible.
 
@@ -1362,7 +1366,8 @@ have unitM : GRing.ComUnitRing_isField cuL.
   suffices: x * toL u.2 = 1 by exists (toL u.2); rewrite mulrC.
   apply: toPinj; rewrite !toL_K -upq1 modp_mul modpD mulrC.
   by rewrite modp_mull add0r.
-pose feL : fieldExtType F := HB.pack vL cuL unitM.
+pose feL : fieldExtType F :=
+  HB.pack vL cuL unitM (UnitAlgebra_isFalgebra.Build F cuL).
 exists feL; first by rewrite dimvf; apply: mul1n.
 exists toPF.
 have tol_lin: linear toL by move=> a q1 q2; rewrite -linearP -modpZl -modpD.
@@ -1420,7 +1425,8 @@ Qed.
 (*   suffices: x * toL u.2 = 1 by exists (toL u.2); rewrite mulrC. *)
 (*   congr (poly_rV _); rewrite toL_K modp_mul mulrC (canRL (addKr _) upq1). *)
 (*   by rewrite -mulNr modp_addl_mul_small ?size_poly1. *)
-(* pose feL : fieldExtType F := HB.pack vL cuL unitM. *)
+(* pose feL : fieldExtType F := *)
+(*   HB.pack vL cuL unitM (UnitAlgebra_isFalgebra.Build F cuL). *)
 (* exists feL; first by rewrite dimvf; apply: mul1n. *)
 (* pose z : vL := toL 'X; set iota := in_alg _. *)
 (* have q_z q: rVpoly (map_poly iota q).[z] = q %% p. *)

--- a/field/finfield.v
+++ b/field/finfield.v
@@ -326,6 +326,8 @@ End FinNzRing.
 
 HB.instance Definition _ (R : finUnitRingType) pcharRp :=
   FinRing.UnitRing.on (type R pcharRp).
+HB.instance Definition _ (R : finUnitRingType) pcharRp :=
+  UnitAlgebra_isFalgebra.Build 'F_p (type R pcharRp).
 HB.instance Definition _ (R : finComNzRingType) pcharRp :=
   FinRing.ComNzRing.on (type R pcharRp).
 HB.instance Definition _ (R : finComUnitRingType) pcharRp :=

--- a/field/qfpoly.v
+++ b/field/qfpoly.v
@@ -113,6 +113,7 @@ HB.instance Definition _ := GRing.ComUnitRing_isField.Build {poly %/ h with hI}
 
 HB.instance Definition _ := GRing.UnitAlgebra.on {poly %/ h with hI}.
 HB.instance Definition _ := Vector.on {poly %/ h with hI}.
+HB.instance Definition _ := UnitAlgebra_isFalgebra.Build R {poly %/ h with hI}.
 
 End Field.
 


### PR DESCRIPTION
##### Motivation for this change

Closes #1470

- The first commit makes the potentially-zero instances canonical, by taking advantage of recently-introduced structures.
- The second commit makes the non-zero instances canonical, by introducing non-zero (semi)vector space structures.

The question is whether we want these non-zero (semi)vector space structures or not.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
