### PR TITLE
Add (real_)distr_max_min

### DIFF
--- a/algebra/num_theory/numdomain.v
+++ b/algebra/num_theory/numdomain.v
@@ -1833,6 +1833,10 @@ Proof. by rewrite -[x + y]addr_min_max addrK. Qed.
 Lemma maxr_to_min x y : max x y = x + y - min x y.
 Proof. by rewrite -[x + y]addr_max_min addrK. Qed.
 
+Lemma real_distr_max_min :
+  {in real &, forall x y, `|x - y| = max x y - min x y}.
+Proof. by move=> x y x_real y_real; case: real_leP. Qed.
+
 Lemma real_oppr_max : {in real &, {morph -%R : x y / max x y >-> min x y : R}}.
 Proof.
 by move=> x y xr yr; rewrite !(fun_if, if_arg) ltrN2; case: real_ltgtP => // ->.
@@ -2940,6 +2944,9 @@ Lemma leif_AGM2_scaled x y : x * y *+ 4 <= (x + y) ^+ 2 ?= iff (x == y).
 Proof. exact: real_leif_AGM2_scaled. Qed.
 
 Section MinMax.
+
+Lemma distr_max_min x y : `|x - y| = max x y - min x y.
+Proof. exact: real_distr_max_min. Qed.
 
 Lemma oppr_max : {morph -%R : x y / max x y >-> min x y : R}.
 Proof. by move=> x y; apply: real_oppr_max. Qed.

--- a/algebra/num_theory/numfield.v
+++ b/algebra/num_theory/numfield.v
@@ -462,26 +462,20 @@ Variables F : realFieldType.
 Implicit Type x y : F.
 
 Lemma leif_mean_square x y : x * y <= (x ^+ 2 + y ^+ 2) / 2 ?= iff (x == y).
-Proof. by apply: real_leif_mean_square; apply: num_real. Qed.
+Proof. exact: real_leif_mean_square. Qed.
 
 Lemma leif_AGM2 x y : x * y <= ((x + y) / 2)^+ 2 ?= iff (x == y).
-Proof. by apply: real_leif_AGM2; apply: num_real. Qed.
+Proof. exact: real_leif_AGM2. Qed.
 
-Section MinMax.
-
-Lemma maxr_absE x y : Num.max x y = (x + y + `|x - y|) / 2.
+Lemma maxr_absE x y : max x y = (x + y + `|x - y|) / 2.
 Proof.
-apply: canRL (mulfK _) _ => //; rewrite ?pnatr_eq0// mulr_natr addrC.
-by case: lerP => _; first rewrite [x + y]addrC; rewrite subrKA.
+by rewrite addrC -[x + y]addr_min_max distr_max_min subrKA mulrDl -splitr.
 Qed.
 
-Lemma minr_absE x y : Num.min x y = (x + y - `|x - y|) / 2.
+Lemma minr_absE x y : min x y = (x + y - `|x - y|) / 2.
 Proof.
-apply: (addrI (Num.max x y)); rewrite addr_max_min maxr_absE.
-by rewrite -mulrDl addrCA addrK mulrDl -splitr.
+by rewrite addrC -[x + y]addr_max_min distr_max_min opprB subrKA mulrDl -splitr.
 Qed.
-
-End MinMax.
 
 End RealField.
 

--- a/doc/changelog/01-added/1500-distr_max_min.md
+++ b/doc/changelog/01-added/1500-distr_max_min.md
@@ -1,0 +1,3 @@
+- in `numdomain.v`
+  + Lemmas `real_distr_max_min` and `distr_max_min`
+    ([#1500](https://github.com/math-comp/math-comp/pull/1500)).


### PR DESCRIPTION
##### Motivation for this change

These lemmas simplify the proofs of `minr_absE` and `maxr_absE`.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
