### PR TITLE
Reduce and reorder `Require Import`s in `algebra/`

### DIFF
--- a/algebra/countalg.v
+++ b/algebra/countalg.v
@@ -2,7 +2,7 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import fintype bigop ssralg.
+From mathcomp Require Import bigop ssralg.
 
 (*****************************************************************************)
 (*     The algebraic part of the algebraic hierarchy for countable types     *)

--- a/algebra/fraction.v
+++ b/algebra/fraction.v
@@ -1,9 +1,8 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat div seq.
-From mathcomp Require Import ssrAC choice tuple bigop ssralg poly polydiv.
-From mathcomp Require Import generic_quotient.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import ssrAC ssralg generic_quotient.
 
 (******************************************************************************)
 (*                  Field of fraction of an integral domain                   *)

--- a/algebra/intdiv.v
+++ b/algebra/intdiv.v
@@ -2,9 +2,8 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
-From mathcomp Require Import div choice fintype tuple prime order.
-From mathcomp Require Import ssralg poly ssrnum ssrint matrix.
-From mathcomp Require Import polydiv perm zmodp bigop.
+From mathcomp Require Import div choice fintype tuple bigop prime order perm.
+From mathcomp Require Import ssralg poly polydiv ssrnum ssrint zmodp matrix.
 
 (******************************************************************************)
 (* This file provides various results on divisibility of integers.            *)

--- a/algebra/matrix.v
+++ b/algebra/matrix.v
@@ -1,9 +1,9 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq choice.
-From mathcomp Require Import fintype finfun finset fingroup perm order div.
-From mathcomp Require Import prime binomial ssralg countalg finalg zmodp bigop.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype finfun bigop finset order fingroup perm.
+From mathcomp Require Import ssralg countalg finalg zmodp.
 
 (******************************************************************************)
 (* Basic concrete linear algebra : definition of type for matrices, and all   *)

--- a/algebra/zmodp.v
+++ b/algebra/zmodp.v
@@ -3,7 +3,7 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool choice eqtype ssrnat seq.
 From mathcomp Require Import div fintype bigop finset prime fingroup perm.
-From mathcomp Require Import ssralg finalg countalg.
+From mathcomp Require Import ssralg countalg finalg.
 
 (******************************************************************************)
 (*  Definition of the additive group and ring Zp, represented as 'I_p         *)


### PR DESCRIPTION
##### Motivation for this change

This change removes some unnecessary libraries from `Require Import`s in `algebra/`. Most notably, the compilation of `fraction.v` does not need to wait for the compilation of `countalg.v`, `poly.v`, and `polydiv.v`.

Similarly, I found that `orderedzmod.v` does not depend on `poly.v`, but I refrained from performing this change in this PR to avoid interfering with #1338. Furthermore, only a very small part of `ssrnum.v` depends on `poly.v`: `real_closed_axiom` and three lemmas. It would be interesting to see if we can compile `alg_theory/` (#1504) and `num_theory/` in parallel by eliminating (parallelizing) the dependency path `numdomain.v` -> `poly.v` -> `countalg.v` -> `decfield.v` -> `divalg.v` -> `algebra.v`. However, we probably won't benefit from this idea when compiling the entire MathComp with `make -j`, because compiling `order.v` takes a long time, unless we split it into smaller pieces (#1508).

##### Minimal TODO list

<!-- please fill in the following checklist -->
- ~[ ] added changelog entries with `doc/changelog/make-entry.sh`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
