### PR TITLE
Generalize the `SemiGroup` instances on `*%g` and  `+%R` to `semigroupType` and `addSemigroupType`

### DIFF
--- a/boot/monoid.v
+++ b/boot/monoid.v
@@ -223,6 +223,9 @@ Section SemigroupTheory.
 Variable G : semigroupType.
 Implicit Types x y : G.
 
+#[export]
+HB.instance Definition _ := SemiGroup.isLaw.Build G *%g mulgA.
+
 Lemma commuteM x y z : commute x y -> commute x z -> commute x (y * z).
 Proof. by move=> cxy cxz; rewrite /commute -mulgA -cxz !mulgA cxy. Qed.
 
@@ -361,7 +364,8 @@ HB.instance Definition _ := Magma_isUMagma.Build G mul1g mulg1.
 HB.end.
 
 #[export]
-HB.instance Definition _ (G : monoidType) := Monoid.isLaw.Build G 1 *%g mulgA mul1g mulg1.
+HB.instance Definition _ (G : monoidType) :=
+  Monoid.isMonoidLaw.Build G 1 *%g mul1g mulg1.
 
 Bind Scope group_scope with Monoid.sort.
 

--- a/doc/changelog/02-changed/1507-addr_semigroup.md
+++ b/doc/changelog/02-changed/1507-addr_semigroup.md
@@ -1,0 +1,7 @@
+- in `monoid.v`
+  + the `SemiGroup.law` instance on `*%g` generalized to `semigroupType`
+    ([#1507](https://github.com/math-comp/math-comp/pull/1507)).
+
+- in `nmodule.v`
+  + the `SemiGroup.com_law` instance on `+%R` generalized to `addSemigroupType`
+    ([#1507](https://github.com/math-comp/math-comp/pull/1507)).


### PR DESCRIPTION
##### Motivation for this change

Some `bigop` lemmas should apply to any `semigroupType` (resp. `addSemigroupType`) that has no `1%g` (resp. `0%R`).

##### Overlay PRs

- https://github.com/affeldt-aist/infotheo/pull/198

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
