### PR TITLE
More Archimedean lemmas

### DIFF
--- a/algebra/archimedean.v
+++ b/algebra/archimedean.v
@@ -343,19 +343,19 @@ move: (ger_real lemx); rewrite realz => /real_floor_itv/andP[lefx ltxf1].
 by rewrite -!(ltr_int R) 2?(@le_lt_trans _ _ x).
 Qed.
 
-Lemma real_floor_ge_int x n : x \is real_num -> (n <= floor x) = (n%:~R <= x).
+Lemma real_floor_gez x n : x \is real_num -> (n <= floor x) = (n%:~R <= x).
 Proof.
 move=> /real_floor_itv /andP[lefx ltxf1]; apply/idP/idP => lenx.
   by apply: le_trans lefx; rewrite ler_int.
 by rewrite -ltzD1 -(ltr_int R); apply: le_lt_trans ltxf1.
 Qed.
 
-Lemma real_floor_lt_int x n : x \is real_num -> (floor x < n) = (x < n%:~R).
+Lemma real_floor_ltz x n : x \is real_num -> (floor x < n) = (x < n%:~R).
 Proof.
-by move=> ?; rewrite [RHS]real_ltNge ?realz -?real_floor_ge_int -?ltNge.
+by move=> ?; rewrite [RHS]real_ltNge ?realz -?real_floor_gez -?ltNge.
 Qed.
 
-Lemma real_floor_eq x n : x \is real_num ->
+Lemma real_eq_floor x n : x \is real_num ->
   (floor x == n) = (n%:~R <= x < (n + 1)%:~R).
 Proof.
 by move=> xr; apply/eqP/idP => [<-|]; [exact: real_floor_itv|exact: floor_def].
@@ -404,21 +404,21 @@ Lemma floorX n : {in int_num, {morph floor : x / x ^+ n}}.
 Proof. by move=> _ /intrP[m ->]; rewrite -rmorphXn !intrKfloor. Qed.
 
 Lemma real_floor_ge0 x : x \is real_num -> (0 <= floor x) = (0 <= x).
-Proof. by move=> ?; rewrite real_floor_ge_int. Qed.
+Proof. by move=> ?; rewrite real_floor_gez. Qed.
 
 Lemma floor_lt0 x : (floor x < 0) = (x < 0).
 Proof.
-case: ifP (floorP x) => [xr _ | xr /eqP <-]; first by rewrite real_floor_lt_int.
+case: ifP (floorP x) => [xr _ | xr /eqP <-]; first by rewrite real_floor_ltz.
 by rewrite ltxx; apply/esym/(contraFF _ xr)/ltr0_real.
 Qed.
 
 Lemma real_floor_le0 x : x \is real_num -> (floor x <= 0) = (x < 1).
-Proof. by move=> ?; rewrite -ltzD1 add0r real_floor_lt_int. Qed.
+Proof. by move=> ?; rewrite -ltzD1 add0r real_floor_ltz. Qed.
 
 Lemma floor_gt0 x : (floor x > 0) = (x >= 1).
 Proof.
 case: ifP (floorP x) => [xr _ | xr /eqP->].
-  by rewrite gtz0_ge1 real_floor_ge_int.
+  by rewrite gtz0_ge1 real_floor_gez.
 by rewrite ltxx; apply/esym/(contraFF _ xr)/ger1_real.
 Qed.
 
@@ -460,18 +460,15 @@ rewrite -ltrN2 -lerN2 andbC -!intrN opprD opprK ceilNfloor.
 by move=> /floor_def ->; rewrite opprK.
 Qed.
 
-Lemma real_ceil_le_int x n : x \is real_num -> (ceil x <= n) = (x <= n%:~R).
+Lemma real_ceil_lez x n : x \is real_num -> (ceil x <= n) = (x <= n%:~R).
 Proof.
-rewrite ceilNfloor lerNl -realN => /real_floor_ge_int ->.
-by rewrite intrN lerN2.
+by rewrite ceilNfloor lerNl -realN => /real_floor_gez ->; rewrite intrN lerN2.
 Qed.
 
-Lemma real_ceil_gt_int x n : x \is real_num -> (n < ceil x) = (n%:~R < x).
-Proof.
-by move=> ?; rewrite [RHS]real_ltNge ?realz -?real_ceil_le_int ?ltNge.
-Qed.
+Lemma real_ceil_gtz x n : x \is real_num -> (n < ceil x) = (n%:~R < x).
+Proof. by move=> ?; rewrite [RHS]real_ltNge ?realz -?real_ceil_lez ?ltNge. Qed.
 
-Lemma real_ceil_eq x n : x \is real_num ->
+Lemma real_eq_ceil x n : x \is real_num ->
   (ceil x == n) = ((n - 1)%:~R < x <= n%:~R).
 Proof.
 by move=> xr; apply/eqP/idP => [<-|]; [exact: real_ceil_itv|exact: ceil_def].
@@ -522,7 +519,7 @@ Lemma ceil_lt0 x : (ceil x < 0) = (x <= -1).
 Proof. by rewrite ceilNfloor oppr_lt0 floor_gt0 lerNr. Qed.
 
 Lemma real_ceil_le0 x : x \is real_num -> (ceil x <= 0) = (x <= 0).
-Proof. by move=> ?; rewrite real_ceil_le_int. Qed.
+Proof. by move=> ?; rewrite real_ceil_lez. Qed.
 
 Lemma ceil_gt0 x : (ceil x > 0) = (x > 0).
 Proof. by rewrite ceilNfloor oppr_gt0 floor_lt0 oppr_lt0. Qed.
@@ -574,27 +571,26 @@ have/truncn_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lemx; apply: ler0n.
 by rewrite -!(ltr_nat R) 2?(@le_lt_trans _ _ x).
 Qed.
 
-Lemma truncn_ge_nat x n : 0 <= x -> (n <= truncn x)%N = (n%:R <= x).
+Lemma truncn_geq x n : 0 <= x -> (n <= truncn x)%N = (n%:R <= x).
 Proof.
 move=> /truncn_itv /andP[letx ltxt1]; apply/idP/idP => lenx.
   by apply: le_trans letx; rewrite ler_nat.
 by rewrite -ltnS -(ltr_nat R); apply: le_lt_trans ltxt1.
 Qed.
 
-Lemma truncn_gt_nat x n : (n < truncn x)%N = (n.+1%:R <= x).
+Lemma truncn_gtn x n : (n < truncn x)%N = (n.+1%:R <= x).
 Proof.
-case: ifP (truncnP x) => [x0 _ | x0 /eqP->]; first by rewrite truncn_ge_nat.
+case: ifP (truncnP x) => [x0 _ | x0 /eqP->]; first by rewrite truncn_geq.
 by rewrite ltn0; apply/esym/(contraFF _ x0)/le_trans.
 Qed.
 
-Lemma truncn_lt_nat x n : 0 <= x -> (truncn x < n)%N = (x < n%:R).
-Proof. by move=> ?; rewrite real_ltNge ?ger0_real// ltnNge truncn_ge_nat. Qed.
+Lemma truncn_ltn x n : 0 <= x -> (truncn x < n)%N = (x < n%:R).
+Proof. by move=> ?; rewrite real_ltNge ?ger0_real// ltnNge truncn_geq. Qed.
 
-Lemma real_truncn_le_nat x n :
-  x \is real_num -> (truncn x <= n)%N = (x < n.+1%:R).
-Proof. by move=> ?; rewrite real_ltNge// leqNgt truncn_gt_nat. Qed.
+Lemma real_truncn_leq x n : x \is real_num -> (truncn x <= n)%N = (x < n.+1%:R).
+Proof. by move=> ?; rewrite real_ltNge// leqNgt truncn_gtn. Qed.
 
-Lemma truncn_eq x n : 0 <= x -> (truncn x == n) = (n%:R <= x < n.+1%:R).
+Lemma eq_truncn x n : 0 <= x -> (truncn x == n) = (n%:R <= x < n.+1%:R).
 Proof.
 by move=> xr; apply/eqP/idP => [<-|]; [exact: truncn_itv|exact: truncn_def].
 Qed.
@@ -628,12 +624,16 @@ Lemma truncn0 : truncn 0 = 0%N. Proof. exact: natrK 0%N. Qed.
 Lemma truncn1 : truncn 1 = 1%N. Proof. exact: natrK 1%N. Qed.
 #[local] Hint Resolve truncn0 truncn1 : core.
 
-Lemma truncnD :
+Lemma truncnDnr :
   {in nat_num & nneg_num, {morph truncn : x y / x + y >-> (x + y)%N}}.
 Proof.
 move=> _ y /natrP[n ->] y_ge0; apply: truncn_def.
 by rewrite -addnS !natrD !natrK lerD2l ltrD2l truncn_itv.
 Qed.
+
+Lemma truncnDrn :
+  {in nneg_num & nat_num, {morph truncn : x y / x + y >-> (x + y)%N}}.
+Proof. by move=> x y ? ?; rewrite addrC addnC truncnDnr. Qed.
 
 Lemma truncnM : {in nat_num &, {morph truncn : x y / x * y >-> (x * y)%N}}.
 Proof. by move=> _ _ /natrP[n1 ->] /natrP[n2 ->]; rewrite -natrM !natrK. Qed.
@@ -643,7 +643,7 @@ Proof. by move=> _ /natrP[n1 ->]; rewrite -natrX !natrK. Qed.
 
 Lemma truncn_gt0 x : (0 < truncn x)%N = (1 <= x).
 Proof.
-case: ifP (truncnP x) => [x0 | x0 /eqP<-]; first by rewrite truncn_ge_nat.
+case: ifP (truncnP x) => [x0 | x0 /eqP<-]; first by rewrite truncn_geq.
 by rewrite ltnn; apply/esym/(contraFF _ x0)/le_trans.
 Qed.
 
@@ -722,8 +722,8 @@ Notation truncK := truncnK (only parsing).
 Notation trunc0 := truncn0 (only parsing).
 #[deprecated(since="mathcomp 2.4.0", use=truncn1)]
 Notation trunc1 := truncn1 (only parsing).
-#[deprecated(since="mathcomp 2.4.0", use=truncnD)]
-Notation truncD := truncnD (only parsing).
+#[deprecated(since="mathcomp 2.4.0", use=truncnDnr)]
+Notation truncD := truncnDnr (only parsing).
 #[deprecated(since="mathcomp 2.4.0", use=truncnM)]
 Notation truncM := truncnM (only parsing).
 #[deprecated(since="mathcomp 2.4.0", use=truncnX)]
@@ -753,10 +753,35 @@ Notation natrE := natrEtruncn (only parsing).
 
 #[deprecated(since="mathcomp 2.5.0", use=le_ceil)]
 Notation le_ceil_tmp := le_ceil (only parsing).
-#[deprecated(since="mathcomp 2.5.0", use=real_floor_ge_int)]
-Notation real_floor_ge_int_tmp := real_floor_ge_int (only parsing).
-#[deprecated(since="mathcomp 2.5.0", use=real_ceil_le_int)]
-Notation real_ceil_le_int_tmp := real_ceil_le_int (only parsing).
+#[deprecated(since="mathcomp 2.5.0", use=real_floor_gez)]
+Notation real_floor_ge_int_tmp := real_floor_gez (only parsing).
+#[deprecated(since="mathcomp 2.5.0", use=real_ceil_lez)]
+Notation real_ceil_le_int_tmp := real_ceil_lez (only parsing).
+
+#[deprecated(since="mathcomp 2.7.0", use=real_floor_gez)]
+Notation real_floor_ge_int := real_floor_gez (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=real_floor_ltz)]
+Notation real_floor_lt_int := real_floor_ltz (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=real_ceil_lez)]
+Notation real_ceil_le_int := real_ceil_lez (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=real_ceil_gtz)]
+Notation real_ceil_gt_int := real_ceil_gtz (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=real_eq_floor)]
+Notation real_floor_eq := real_eq_floor (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=real_eq_ceil)]
+Notation real_ceil_eq := real_eq_ceil (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=truncn_geq)]
+Notation truncn_ge_nat := truncn_geq (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=truncn_gtn)]
+Notation truncn_gt_nat := truncn_gtn (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=truncn_ltn)]
+Notation truncn_lt_nat := truncn_ltn (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=real_truncn_leq)]
+Notation real_truncn_le_nat := real_truncn_leq (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=eq_truncn)]
+Notation truncn_eq := eq_truncn (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=truncnDnr)]
+Notation truncnD := truncnDnr (only parsing).
 
 Arguments natrK {R} _%_N.
 Arguments intrKfloor {R}.
@@ -795,8 +820,8 @@ Qed.
 Lemma truncnS_gt x : x < (truncn x).+1%:R.
 Proof. exact: real_truncnS_gt. Qed.
 
-Lemma truncn_le_nat x n : (truncn x <= n)%N = (x < n.+1%:R).
-Proof. exact: real_truncn_le_nat. Qed.
+Lemma truncn_leq x n : (truncn x <= n)%N = (x < n.+1%:R).
+Proof. exact: real_truncn_leq. Qed.
 
 Lemma floor_itv x : (floor x)%:~R <= x < (floor x + 1)%:~R.
 Proof. exact: real_floor_itv. Qed.
@@ -806,14 +831,14 @@ Lemma floor_le x : (floor x)%:~R <= x. Proof. exact: real_floor_le. Qed.
 Lemma floorD1_gt x : x < (floor x + 1)%:~R.
 Proof. exact: real_floorD1_gt. Qed.
 
-Lemma floor_ge_int x n : (n <= floor x) = (n%:~R <= x).
-Proof. exact: real_floor_ge_int. Qed.
+Lemma floor_gez x n : (n <= floor x) = (n%:~R <= x).
+Proof. exact: real_floor_gez. Qed.
 
-Lemma floor_lt_int x n : (floor x < n) = (x < n%:~R).
-Proof. exact: real_floor_lt_int. Qed.
+Lemma floor_ltz x n : (floor x < n) = (x < n%:~R).
+Proof. exact: real_floor_ltz. Qed.
 
-Lemma floor_eq x n : (floor x == n) = (n%:~R <= x < (n + 1)%:~R).
-Proof. exact: real_floor_eq. Qed.
+Lemma eq_floor x n : (floor x == n) = (n%:~R <= x < (n + 1)%:~R).
+Proof. exact: real_eq_floor. Qed.
 
 Lemma floorDzr : {in @int_num R, {morph floor : x y / x + y}}.
 Proof. by move=> x xz y; apply/real_floorDzr/num_real. Qed.
@@ -835,14 +860,14 @@ Proof. exact: real_ceilB1_lt. Qed.
 
 Lemma ceil_ge x : x <= (ceil x)%:~R. Proof. exact: real_ceil_ge. Qed.
 
-Lemma ceil_le_int x n : (ceil x <= n) = (x <= n%:~R).
-Proof. exact: real_ceil_le_int. Qed.
+Lemma ceil_lez x n : (ceil x <= n) = (x <= n%:~R).
+Proof. exact: real_ceil_lez. Qed.
 
-Lemma ceil_gt_int x n : (n < ceil x) = (n%:~R < x).
-Proof. exact: real_ceil_gt_int. Qed.
+Lemma ceil_gtz x n : (n < ceil x) = (n%:~R < x).
+Proof. exact: real_ceil_gtz. Qed.
 
-Lemma ceil_eq x n : (ceil x == n) = ((n - 1)%:~R < x <= n%:~R).
-Proof. exact: real_ceil_eq. Qed.
+Lemma eq_ceil x n : (ceil x == n) = ((n - 1)%:~R < x <= n%:~R).
+Proof. exact: real_eq_ceil. Qed.
 
 Lemma ceilDzr : {in @int_num R, {morph ceil : x y / x + y}}.
 Proof. by move=> x xz y; apply/real_ceilDzr/num_real. Qed.
@@ -870,10 +895,25 @@ Notation gt_pred_ceil := ceilB1_lt (only parsing).
 
 #[deprecated(since="mathcomp 2.5.0", use=floor_le)]
 Notation floor_le_tmp := floor_le (only parsing).
-#[deprecated(since="mathcomp 2.5.0", use=floor_ge_int)]
-Notation floor_ge_int_tmp := floor_ge_int (only parsing).
-#[deprecated(since="mathcomp 2.5.0", use=ceil_le_int)]
-Notation ceil_le_int_tmp := ceil_le_int (only parsing).
+#[deprecated(since="mathcomp 2.5.0", use=floor_gez)]
+Notation floor_ge_int_tmp := floor_gez (only parsing).
+#[deprecated(since="mathcomp 2.5.0", use=ceil_lez)]
+Notation ceil_le_int_tmp := ceil_lez (only parsing).
+
+#[deprecated(since="mathcomp 2.7.0", use=floor_gez)]
+Notation floor_ge_int := floor_gez (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=floor_ltz)]
+Notation floor_lt_int := floor_ltz (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=ceil_lez)]
+Notation ceil_le_int := ceil_lez (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=ceil_gtz)]
+Notation ceil_gt_int := ceil_gtz (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=eq_floor)]
+Notation floor_eq := eq_floor (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=eq_ceil)]
+Notation ceil_eq := eq_ceil (only parsing).
+#[deprecated(since="mathcomp 2.7.0", use=truncn_leq)]
+Notation truncn_le_nat := truncn_leq (only parsing).
 
 Section ArchiNumFieldTheory.
 

--- a/algebra/archimedean.v
+++ b/algebra/archimedean.v
@@ -53,25 +53,69 @@ Import Order.TTheory GRing.Theory Num.Theory.
 Module Num.
 Import Num.Def.
 
-HB.mixin Record NumDomain_hasFloorCeilTruncn R & Num.NumDomain R := {
+(* TODO: move to numdomain.v *)
+Section to_real.
+
+Variable (R : numDomainType).
+Implicit Types x : R.
+
+Definition to_real x : R := if x \is real_num then x else 0.
+
+Lemma to_realT x : x \is real_num -> to_real x = x.
+Proof. exact: ifT. Qed.
+
+Lemma ler_to_real : {homo to_real : x y / x <= y}.
+Proof. by move=> x y lexy; rewrite /to_real (ler_real lexy); case: ifP. Qed.
+
+Lemma to_realN x : to_real (- x) = - to_real x.
+Proof. by rewrite /to_real realN; case: ifP; rewrite // oppr0. Qed.
+
+Lemma real_to_real x : to_real x \is real_num.
+Proof. by rewrite /to_real; case: ifP. Qed.
+
+Definition to_nneg x : R := if 0 <= x then x else 0.
+
+Lemma to_nnegT x : 0 <= x -> to_nneg x = x.
+Proof. exact: ifT. Qed.
+
+Lemma ler_to_nneg : {homo to_nneg : x y / x <= y}.
+Proof.
+move=> x y lexy; rewrite /to_nneg; case: ifP => [le0x|]; last by case: ifP.
+by rewrite (le_trans le0x lexy).
+Qed.
+
+Lemma nneg_to_nneg x : to_nneg x \is nneg_num.
+Proof. by rewrite nnegrE /to_nneg; case: ifP. Qed.
+
+Lemma real_to_nneg x : to_nneg x \is real_num.
+Proof. exact/ger0_real/nneg_to_nneg. Qed.
+
+(* TOTHINK: is this the right name? *)
+Lemma to_real_le_nneg x : to_real x <= to_nneg x.
+Proof.
+by rewrite /to_real /to_nneg realE; have []//= := comparableP 0 x => /ltW.
+Qed.
+
+End to_real.
+(* /TODO *)
+
+HB.mixin Record NumDomain_hasFloorCeilTruncn_truncn_abs_floor
+  R & Num.NumDomain R := {
   floor : R -> int;
   ceil  : R -> int;
   truncn : R -> nat;
   int_num_subdef : pred R;
   nat_num_subdef : pred R;
-  floor_subproof :
-    forall x,
-      if x \is real_num then (floor x)%:~R <= x < (floor x + 1)%:~R
-      else floor x == 0;
+  floor_subproof : forall x, (floor x)%:~R <= to_real x < (floor x + 1)%:~R;
   ceil_subproof : forall x, ceil x = - floor (- x);
-  truncn_subproof : forall x, truncn x = if floor x is Posz n then n else 0;
+  truncn_subproof : forall x, truncn x = if 0 <= x then `|floor x|%N else 0%N;
   int_num_subproof : forall x, reflect (exists n, x = n%:~R) (int_num_subdef x);
   nat_num_subproof : forall x, reflect (exists n, x = n%:R) (nat_num_subdef x);
 }.
 
 #[short(type="archiNumDomainType")]
 HB.structure Definition ArchiNumDomain :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.NumDomain R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R & Num.NumDomain R }.
 
 Module ArchiNumDomainExports.
 Bind Scope ring_scope with ArchiNumDomain.sort.
@@ -80,7 +124,7 @@ HB.export ArchiNumDomainExports.
 
 #[short(type="archiNumFieldType")]
 HB.structure Definition ArchiNumField :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.NumField R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R & Num.NumField R }.
 
 Module ArchiNumFieldExports.
 Bind Scope ring_scope with ArchiNumField.sort.
@@ -89,7 +133,7 @@ HB.export ArchiNumFieldExports.
 
 #[short(type="archiClosedFieldType")]
 HB.structure Definition ArchiClosedField :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.ClosedField R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R & Num.ClosedField R }.
 
 Module ArchiClosedFieldExports.
 Bind Scope ring_scope with ArchiClosedField.sort.
@@ -98,7 +142,7 @@ HB.export ArchiClosedFieldExports.
 
 #[short(type="archiRealDomainType")]
 HB.structure Definition ArchiRealDomain :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.RealDomain R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R & Num.RealDomain R }.
 
 Module ArchiRealDomainExports.
 Bind Scope ring_scope with ArchiRealDomain.sort.
@@ -107,7 +151,7 @@ HB.export ArchiRealDomainExports.
 
 #[short(type="archiRealFieldType")]
 HB.structure Definition ArchiRealField :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.RealField R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R & Num.RealField R }.
 
 Module ArchiRealFieldExports.
 Bind Scope ring_scope with ArchiRealField.sort.
@@ -116,7 +160,8 @@ HB.export ArchiRealFieldExports.
 
 #[short(type="archiRcfType")]
 HB.structure Definition ArchiRealClosedField :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.RealClosedField R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R
+    & Num.RealClosedField R }.
 
 Module ArchiRealClosedFieldExports.
 Bind Scope ring_scope with ArchiRealClosedField.sort.
@@ -160,9 +205,13 @@ Section intArchimedean.
 
 Implicit Types n : int.
 
-Fact floor_subproof n :
-  if n \is real_num then n%:~R <= n < (n + 1)%:~R else n == 0.
-Proof. by rewrite num_real !intz ltzD1 lexx. Qed.
+Let truncz n := if n is Posz n then n else 0%N.
+
+Fact floor_subproof n : n%:~R <= to_real n < (n + 1)%:~R.
+Proof. by rewrite to_realT ?num_real// !intz ltzD1 lexx. Qed.
+
+Fact truncn_subproof n : truncz n = if 0 <= n then `|n|%N else 0%N.
+Proof. by rewrite /truncz; case: n. Qed.
 
 Fact intrP n : reflect (exists m, n = m%:~R) true.
 Proof. by apply: ReflectT; exists n; rewrite intz. Qed.
@@ -178,9 +227,10 @@ End intArchimedean.
 
 #[export]
 HB.instance Definition _ :=
-  @NumDomain_hasFloorCeilTruncn.Build int id id _ xpredT nneg_num_pred
-    intArchimedean.floor_subproof (fun=> esym (opprK _)) (fun=> erefl)
-    intArchimedean.intrP intArchimedean.natrP.
+  @NumDomain_hasFloorCeilTruncn_truncn_abs_floor.Build int
+    id id _ xpredT nneg_num_pred
+    intArchimedean.floor_subproof (fun=> esym (opprK _))
+    intArchimedean.truncn_subproof intArchimedean.intrP intArchimedean.natrP.
 
 Module Import Theory.
 Export Num.Theory.
@@ -196,19 +246,11 @@ Local Notation ceil := (@ceil R).
 Local Notation nat_num := (@Def.nat_num R).
 Local Notation int_num := (@Def.int_num R).
 
-Local Lemma floorP x :
-  if x \is real_num then (floor x)%:~R <= x < (floor x + 1)%:~R
-  else floor x == 0.
-Proof. exact: floor_subproof. Qed.
-
 Lemma floorNceil x : floor x = - ceil (- x).
 Proof. by rewrite ceil_subproof !opprK. Qed.
 
 Lemma ceilNfloor x : ceil x = - floor (- x).
 Proof. exact: ceil_subproof. Qed.
-
-Lemma truncEfloor x : truncn x = if floor x is Posz n then n else 0.
-Proof. exact: truncn_subproof. Qed.
 
 Lemma natrP x : reflect (exists n, x = n%:R) (x \is a nat_num).
 Proof. exact: nat_num_subproof. Qed.
@@ -326,46 +368,79 @@ Qed.
 
 (* floor and int_num *)
 
+Lemma to_real_floor_itv x : (floor x)%:~R <= to_real x < (floor x + 1)%:~R.
+Proof. exact: floor_subproof. Qed.
+
 Lemma real_floor_itv x :
   x \is real_num -> (floor x)%:~R <= x < (floor x + 1)%:~R.
-Proof. by case: ifP (floorP x). Qed.
+Proof. by move=> xr; have := to_real_floor_itv x; rewrite to_realT. Qed.
+
+#[deprecated(since="mathcomp 2.7.0", use=to_real_floor_itv)]
+Local Lemma floorP x :
+  if x \is real_num then (floor x)%:~R <= x < (floor x + 1)%:~R
+  else floor x == 0.
+Proof.
+have := to_real_floor_itv x; rewrite /to_real; case: ifP => //= _.
+by rewrite lerz0 ltr0z addrC ltz1D -eq_le.
+Qed.
+
+Lemma to_real_floor_le x : (floor x)%:~R <= to_real x.
+Proof. by have/andP[] := to_real_floor_itv x. Qed.
 
 Lemma real_floor_le x : x \is real_num -> (floor x)%:~R <= x.
 Proof. by case/real_floor_itv/andP. Qed.
 
+Lemma to_real_floorD1_gt x : to_real x < (floor x + 1)%:~R.
+Proof. by have/andP[] := to_real_floor_itv x. Qed.
+
 Lemma real_floorD1_gt x : x \is real_num -> x < (floor x + 1)%:~R.
 Proof. by case/real_floor_itv/andP. Qed.
 
-Lemma floor_def x m : m%:~R <= x < (m + 1)%:~R -> floor x = m.
+Lemma to_real_floor_gez x n : (n <= floor x) = (n%:~R <= to_real x).
 Proof.
-case/andP=> lemx ltxm1; apply/eqP; rewrite eq_le -!ltzD1.
-move: (ger_real lemx); rewrite realz => /real_floor_itv/andP[lefx ltxf1].
-by rewrite -!(ltr_int R) 2?(@le_lt_trans _ _ x).
+apply/idP/idP; first by rewrite -(ler_int R); apply/le_geP/to_real_floor_le.
+by rewrite -ltzD1 -(ltr_int R); apply/lt_gtP/to_real_floorD1_gt.
 Qed.
 
 Lemma real_floor_gez x n : x \is real_num -> (n <= floor x) = (n%:~R <= x).
+Proof. by rewrite to_real_floor_gez => /to_realT->. Qed.
+
+Lemma to_real_floor_ltz x n : (floor x < n) = (to_real x < n%:~R).
 Proof.
-move=> /real_floor_itv /andP[lefx ltxf1]; apply/idP/idP => lenx.
-  by apply: le_trans lefx; rewrite ler_int.
-by rewrite -ltzD1 -(ltr_int R); apply: le_lt_trans ltxf1.
+apply/idP/idP; last by rewrite -(ltr_int R); apply/le_lt_trans/to_real_floor_le.
+by rewrite -lezD1 -(ler_int R); apply/lt_ltP/to_real_floorD1_gt.
 Qed.
 
 Lemma real_floor_ltz x n : x \is real_num -> (floor x < n) = (x < n%:~R).
-Proof.
-by move=> ?; rewrite [RHS]real_ltNge ?realz -?real_floor_gez -?ltNge.
-Qed.
+Proof. by rewrite to_real_floor_ltz => /to_realT->. Qed.
+
+Lemma to_real_eq_floor x n :
+  (floor x == n) = (n%:~R <= to_real x < (n + 1)%:~R).
+Proof. by rewrite -to_real_floor_gez -to_real_floor_ltz ltzD1 andbC -eq_le. Qed.
 
 Lemma real_eq_floor x n : x \is real_num ->
   (floor x == n) = (n%:~R <= x < (n + 1)%:~R).
+Proof. by rewrite to_real_eq_floor => /to_realT->. Qed.
+
+Lemma to_real_floor_eqP x n :
+  reflect (floor x = n) (n%:~R <= to_real x < (n + 1)%:~R).
+Proof. by rewrite -to_real_eq_floor; exact/eqP. Qed.
+
+Lemma real_floor_eqP x n : x \is real_num ->
+  reflect (floor x = n) (n%:~R <= x < (n + 1)%:~R).
+Proof. by move=> /real_eq_floor <-; exact/eqP. Qed.
+
+(* TODO: rename to floor_eq *)
+Lemma floor_def x n : n%:~R <= x < (n + 1)%:~R -> floor x = n.
 Proof.
-by move=> xr; apply/eqP/idP => [<-|]; [exact: real_floor_itv|exact: floor_def].
+move=> /[dup] /andP[lenx _] ?.
+by apply/real_floor_eqP; rewrite // (ger_real lenx) realz.
 Qed.
 
 Lemma le_floor : {homo floor : x y / x <= y}.
 Proof.
-move=> x y lexy; move: (floorP x) (floorP y); rewrite (ger_real lexy).
-case: ifP => [_ /andP[lefx _] /andP[_] | _ /eqP-> /eqP-> //].
-by move=> /(le_lt_trans lexy) /(le_lt_trans lefx); rewrite ltr_int ltzD1.
+move=> x y /ler_to_real; rewrite to_real_floor_gez.
+exact/le_leP/to_real_floor_le.
 Qed.
 
 Lemma intrKfloor : cancel intr floor.
@@ -373,7 +448,7 @@ Proof. by move=> m; apply: floor_def; rewrite lexx rmorphD ltrDl ltr01. Qed.
 
 Lemma intrEfloor x : (x \is a int_num) = ((floor x)%:~R == x).
 Proof.
-by apply/intrP/eqP => [[n ->] | <-]; [rewrite intrKfloor | exists (floor x)].
+by apply/idP/eqP => [/intrP[n ->]|<-]; rewrite (intrKfloor, intr_int).
 Qed.
 
 Lemma floorK : {in int_num, cancel floor intr}.
@@ -383,14 +458,22 @@ Lemma floor0 : floor 0 = 0. Proof. exact: intrKfloor 0. Qed.
 Lemma floor1 : floor 1 = 1. Proof. exact: intrKfloor 1. Qed.
 #[local] Hint Resolve floor0 floor1 : core.
 
-Lemma real_floorDzr : {in int_num & real_num, {morph floor : x y / x + y}}.
+Lemma to_real_floorDzr x y :
+  x \is a int_num -> floor (x + to_real y) = floor x + floor y.
 Proof.
-move=> _ y /intrP[m ->] Ry; apply: floor_def.
-by rewrite -addrA 2!rmorphD /= intrKfloor lerD2l ltrD2l real_floor_itv.
+move=> /intrP[m ->]; apply: floor_def.
+by rewrite -addrA 2!rmorphD/= intrKfloor lerD2l ltrD2l to_real_floor_itv.
 Qed.
 
+Lemma real_floorDzr : {in int_num & real_num, {morph floor : x y / x + y}}.
+Proof. by move=> x y xz yr; rewrite -to_real_floorDzr// to_realT. Qed.
+
+Lemma to_real_floorDrz x y :
+  y \is a int_num -> floor (to_real x + y) = floor x + floor y.
+Proof. by move=> yz; rewrite addrC to_real_floorDzr// addrC. Qed.
+
 Lemma real_floorDrz : {in real_num & int_num, {morph floor : x y / x + y}}.
-Proof. by move=> x y xr yz; rewrite addrC real_floorDzr // addrC. Qed.
+Proof. by move=> x y xr yz; rewrite -to_real_floorDrz// to_realT. Qed.
 
 Lemma floorN : {in int_num, {morph floor : x / - x}}.
 Proof. by move=> _ /intrP[m ->]; rewrite -rmorphN !intrKfloor. Qed.
@@ -403,31 +486,32 @@ Qed.
 Lemma floorX n : {in int_num, {morph floor : x / x ^+ n}}.
 Proof. by move=> _ /intrP[m ->]; rewrite -rmorphXn !intrKfloor. Qed.
 
+Lemma to_real_floor_ge0 x : (0 <= floor x) = (0 <= to_real x).
+Proof. exact: to_real_floor_gez. Qed.
+
 Lemma real_floor_ge0 x : x \is real_num -> (0 <= floor x) = (0 <= x).
-Proof. by move=> ?; rewrite real_floor_gez. Qed.
+Proof. exact: real_floor_gez. Qed.
 
 Lemma floor_lt0 x : (floor x < 0) = (x < 0).
 Proof.
-case: ifP (floorP x) => [xr _ | xr /eqP <-]; first by rewrite real_floor_ltz.
-by rewrite ltxx; apply/esym/(contraFF _ xr)/ltr0_real.
+rewrite to_real_floor_ltz /to_real; case: ifPn => // xr.
+by rewrite ltxx; apply/esym/(contraNF _ xr)/ltr0_real.
 Qed.
 
+Lemma to_real_floor_le0 x : (floor x <= 0) = (to_real x < 1).
+Proof. by rewrite -ltzD1 add0r to_real_floor_ltz. Qed.
+
 Lemma real_floor_le0 x : x \is real_num -> (floor x <= 0) = (x < 1).
-Proof. by move=> ?; rewrite -ltzD1 add0r real_floor_ltz. Qed.
+Proof. by move=> ?; rewrite to_real_floor_le0 to_realT. Qed.
 
 Lemma floor_gt0 x : (floor x > 0) = (x >= 1).
 Proof.
-case: ifP (floorP x) => [xr _ | xr /eqP->].
-  by rewrite gtz0_ge1 real_floor_gez.
-by rewrite ltxx; apply/esym/(contraFF _ xr)/ger1_real.
+rewrite gtz0_ge1 to_real_floor_gez /to_real; case: ifPn => // xr.
+by rewrite ler10; apply/esym/(contraNF _ xr)/ger1_real.
 Qed.
 
 Lemma floor_neq0 x : (floor x != 0) = (x < 0) || (x >= 1).
-Proof.
-case: ifP (floorP x) => [xr _ | xr /eqP->]; rewrite ?eqxx/=.
-  by rewrite neq_lt floor_lt0 floor_gt0.
-by apply/esym/(contraFF _ xr) => /orP[/ltr0_real|/ger1_real].
-Qed.
+Proof. by rewrite neq_lt floor_lt0 floor_gt0. Qed.
 
 Lemma floorpK : {in polyOver int_num, cancel (map_poly floor) (map_poly intr)}.
 Proof.
@@ -442,36 +526,61 @@ Proof. by exists (map_poly floor p); rewrite floorpK. Qed.
 
 (* ceil and int_num *)
 
-Lemma real_ceil_itv x : x \is real_num -> (ceil x - 1)%:~R < x <= (ceil x)%:~R.
+Lemma to_real_ceil_itv x : (ceil x - 1)%:~R < to_real x <= (ceil x)%:~R.
 Proof.
-rewrite ceilNfloor -opprD !intrN ltrNl lerNr andbC -realN.
-exact: real_floor_itv.
+rewrite ceilNfloor -opprD !intrN ltrNl lerNr andbC -to_realN.
+by rewrite to_real_floor_itv.
 Qed.
+
+Lemma real_ceil_itv x : x \is real_num -> (ceil x - 1)%:~R < x <= (ceil x)%:~R.
+Proof. by move=> xr; have := to_real_ceil_itv x; rewrite to_realT. Qed.
+
+Lemma to_real_ceilB1_lt x : (ceil x - 1)%:~R < to_real x.
+Proof. by have/andP[] := to_real_ceil_itv x. Qed.
 
 Lemma real_ceilB1_lt x : x \is real_num -> (ceil x - 1)%:~R < x.
 Proof. by case/real_ceil_itv/andP. Qed.
 
+Lemma to_real_ceil_ge x : to_real x <= (ceil x)%:~R.
+Proof. by have/andP[] := to_real_ceil_itv x. Qed.
+
 Lemma real_ceil_ge x : x \is real_num -> x <= (ceil x)%:~R.
 Proof. by case/real_ceil_itv/andP. Qed.
 
-Lemma ceil_def x m : (m - 1)%:~R < x <= m%:~R -> ceil x = m.
-Proof.
-rewrite -ltrN2 -lerN2 andbC -!intrN opprD opprK ceilNfloor.
-by move=> /floor_def ->; rewrite opprK.
-Qed.
+Lemma to_real_ceil_lez x n : (ceil x <= n) = (to_real x <= n%:~R).
+Proof. by rewrite ceilNfloor lerNl to_real_floor_gez intrN to_realN lerN2. Qed.
 
 Lemma real_ceil_lez x n : x \is real_num -> (ceil x <= n) = (x <= n%:~R).
-Proof.
-by rewrite ceilNfloor lerNl -realN => /real_floor_gez ->; rewrite intrN lerN2.
-Qed.
+Proof. by rewrite to_real_ceil_lez => /to_realT->. Qed.
+
+Lemma to_real_ceil_gtz x n : (n < ceil x) = (n%:~R < to_real x).
+Proof. by rewrite ceilNfloor ltrNr to_real_floor_ltz to_realN intrN ltrN2. Qed.
 
 Lemma real_ceil_gtz x n : x \is real_num -> (n < ceil x) = (n%:~R < x).
-Proof. by move=> ?; rewrite [RHS]real_ltNge ?realz -?real_ceil_lez ?ltNge. Qed.
+Proof. by rewrite to_real_ceil_gtz => /to_realT->. Qed.
+
+Lemma to_real_eq_ceil x n : (ceil x == n) = ((n - 1)%:~R < to_real x <= n%:~R).
+Proof.
+by rewrite -to_real_ceil_lez -to_real_ceil_gtz ltrBlDr ltzD1 andbC -eq_le.
+Qed.
 
 Lemma real_eq_ceil x n : x \is real_num ->
   (ceil x == n) = ((n - 1)%:~R < x <= n%:~R).
+Proof. by rewrite to_real_eq_ceil => /to_realT->. Qed.
+
+Lemma to_real_ceil_eqP x n :
+  reflect (ceil x = n) ((n - 1)%:~R < to_real x <= n%:~R).
+Proof. by rewrite -to_real_eq_ceil; exact/eqP. Qed.
+
+Lemma real_ceil_eqP x n : x \is real_num ->
+  reflect (ceil x = n) ((n - 1)%:~R < x <= n%:~R).
+Proof. by move=> /real_eq_ceil<-; exact/eqP. Qed.
+
+(* TODO: rename to ceil_eq *)
+Lemma ceil_def x n : (n - 1)%:~R < x <= n%:~R -> ceil x = n.
 Proof.
-by move=> xr; apply/eqP/idP => [<-|]; [exact: real_ceil_itv|exact: ceil_def].
+move=> /[dup] /andP[_ lexn] ?.
+by apply/real_ceil_eqP; rewrite // (ler_real lexn) realz.
 Qed.
 
 Lemma le_ceil : {homo ceil : x y / x <= y}.
@@ -490,14 +599,22 @@ Lemma ceil0 : ceil 0 = 0. Proof. exact: intrKceil 0. Qed.
 Lemma ceil1 : ceil 1 = 1. Proof. exact: intrKceil 1. Qed.
 #[local] Hint Resolve ceil0 ceil1 : core.
 
-Lemma real_ceilDzr : {in int_num & real_num, {morph ceil : x y / x + y}}.
+Lemma to_real_ceilDzr x y :
+  x \is a int_num -> ceil (x + to_real y) = ceil x + ceil y.
 Proof.
-move=> x y x_int y_real.
-by rewrite ceilNfloor opprD real_floorDzr ?rpredN // opprD -!ceilNfloor.
+move=> xz; rewrite ceilNfloor opprD -to_realN.
+by rewrite to_real_floorDzr 1?rpredN// opprD -!ceilNfloor.
 Qed.
 
+Lemma real_ceilDzr : {in int_num & real_num, {morph ceil : x y / x + y}}.
+Proof. by move=> x y xz yr; rewrite -to_real_ceilDzr// to_realT. Qed.
+
+Lemma to_real_ceilDrz x y :
+  y \is a int_num -> ceil (to_real x + y) = ceil x + ceil y.
+Proof. by move=> yz; rewrite addrC to_real_ceilDzr// addrC. Qed.
+
 Lemma real_ceilDrz : {in real_num & int_num, {morph ceil : x y / x + y}}.
-Proof. by move=> x y xr yz; rewrite addrC real_ceilDzr // addrC. Qed.
+Proof. by move=> x y xr yz; rewrite -to_real_ceilDrz// to_realT. Qed.
 
 Lemma ceilN : {in int_num, {morph ceil : x / - x}}.
 Proof. by move=> ? ?; rewrite !ceilNfloor !opprK floorN. Qed.
@@ -510,97 +627,146 @@ Qed.
 Lemma ceilX n : {in int_num, {morph ceil : x / x ^+ n}}.
 Proof. by move=> _ /intrP[m ->]; rewrite -rmorphXn !intrKceil. Qed.
 
-Lemma real_ceil_ge0 x : x \is real_num -> (0 <= ceil x) = (-1 < x).
-Proof.
-by move=> ?; rewrite ceilNfloor oppr_ge0 real_floor_le0 ?realN 1?ltrNl.
-Qed.
+Lemma to_real_ceil_ge0 x : (0 <= ceil x) = (- 1 < to_real x).
+Proof. by rewrite ceilNfloor oppr_ge0 to_real_floor_le0 to_realN ltrNl. Qed.
 
-Lemma ceil_lt0 x : (ceil x < 0) = (x <= -1).
+Lemma real_ceil_ge0 x : x \is real_num -> (0 <= ceil x) = (- 1 < x).
+Proof. by rewrite to_real_ceil_ge0 => /to_realT->. Qed.
+
+Lemma ceil_lt0 x : (ceil x < 0) = (x <= - 1).
 Proof. by rewrite ceilNfloor oppr_lt0 floor_gt0 lerNr. Qed.
 
+Lemma to_real_ceil_le0 x : (ceil x <= 0) = (to_real x <= 0).
+Proof. exact: to_real_ceil_lez. Qed.
+
 Lemma real_ceil_le0 x : x \is real_num -> (ceil x <= 0) = (x <= 0).
-Proof. by move=> ?; rewrite real_ceil_lez. Qed.
+Proof. exact: real_ceil_lez. Qed.
 
 Lemma ceil_gt0 x : (ceil x > 0) = (x > 0).
 Proof. by rewrite ceilNfloor oppr_gt0 floor_lt0 oppr_lt0. Qed.
 
-Lemma ceil_neq0 x : (ceil x != 0) = (x <= -1) || (x > 0).
-Proof. by rewrite ceilNfloor oppr_eq0 floor_neq0 oppr_lt0 lerNr orbC. Qed.
+Lemma ceil_neq0 x : (ceil x != 0) = (x <= - 1) || (x > 0).
+Proof. by rewrite neq_lt ceil_lt0 ceil_gt0. Qed.
+
+(* TODO: *)
+(* Lemma to_real_ceil_floor x : ceil x = floor x + (to_real x \isn't a int_num). *)
 
 Lemma real_ceil_floor x : x \is real_num ->
   ceil x = floor x + (x \isn't a int_num).
 Proof.
 case Ix: (x \is a int_num) => Rx /=.
   by apply/eqP; rewrite addr0 ceilNfloor eqr_oppLR floorN.
-apply/ceil_def; rewrite addrK; move: (real_floor_itv Rx).
-by rewrite le_eqVlt -intrEfloor Ix /= => /andP[-> /ltW].
+apply/to_real_ceil_eqP; rewrite addrK; have := to_real_floor_itv x.
+by rewrite to_realT// le_eqVlt -intrEfloor Ix /= => /andP[-> /ltW].
 Qed.
 
 (* Relating Cnat and oldCnat. *)
 
 Lemma truncn_floor x : truncn x = if 0 <= x then `|floor x|%N else 0%N.
+Proof. exact: truncn_subproof. Qed.
+
+Lemma truncEfloor x : truncn x = if floor x is Posz n then n else 0.
 Proof.
-move: (floorP x); rewrite truncEfloor realE.
-have [/le_floor|_]/= := boolP (0 <= x); first by rewrite floor0; case: floor.
-by case: ifP => [/le_floor|_ /eqP->//]; rewrite floor0; case: floor => [[]|].
+move: (to_real_floor_le0 x) (to_real_floor_ge0 x).
+rewrite truncn_floor /to_real realE; have []//= := comparableP 0 x.
+- by move=> /ltW ->; case: floor.
+- by case: comparableP => //; case: floor.
+- by rewrite ltr01 lexx; case: floor => [[]|].
+- by move=> <-; rewrite ltr01 lexx; case: floor.
 Qed.
 
 (* trunc and nat_num *)
 
-Local Lemma truncnP x :
-  if 0 <= x then (truncn x)%:R <= x < (truncn x).+1%:R else truncn x == 0%N.
+Lemma to_nneg_truncn_itv x : (truncn x)%:R <= to_nneg x < (truncn x).+1%:R.
 Proof.
-rewrite truncn_floor.
-case: (boolP (0 <= x)) => //= /[dup] /le_floor + /ger0_real/real_floor_itv.
-by rewrite floor0; case: (floor x) => // n _; rewrite absz_nat addrC -intS.
+rewrite truncn_floor /to_nneg; case: ifP => le0x; last by rewrite lexx ltr01.
+rewrite 2!pmulrn intS addrC gez0_abs.
+  by rewrite real_floor_ge0// ger0_real.
+by rewrite real_floor_itv// ger0_real.
 Qed.
 
 Lemma truncn_itv x : 0 <= x -> (truncn x)%:R <= x < (truncn x).+1%:R.
-Proof. by move=> x_ge0; move: (truncnP x); rewrite x_ge0. Qed.
+Proof. by move=> le0x; have := to_nneg_truncn_itv x; rewrite to_nnegT. Qed.
+
+#[deprecated(since="mathcomp 2.7.0", use=to_nneg_truncn_itv)]
+Local Lemma truncnP x :
+  if 0 <= x then (truncn x)%:R <= x < (truncn x).+1%:R else truncn x == 0%N.
+Proof.
+have := to_nneg_truncn_itv x; rewrite /to_nneg.
+by case: ifP; last by rewrite lern0 => _ /andP[].
+Qed.
+
+Lemma to_nneg_truncn_le x : (truncn x)%:R <= to_nneg x.
+Proof. by have/andP[] := to_nneg_truncn_itv x. Qed.
 
 Lemma truncn_le x : ((truncn x)%:R <= x) = (0 <= x).
-Proof. by case: ifP (truncnP x) => [+ /andP[] | + /eqP->//]. Qed.
+Proof. by apply/idP/idP => [|/truncn_itv /andP[] //]; exact: le_trans. Qed.
+
+Lemma to_nneg_truncnS_gt x : to_nneg x < (truncn x).+1%:R.
+Proof. by have/andP[] := to_nneg_truncn_itv x. Qed.
+
+Lemma to_real_truncnS_gt x : to_real x < (truncn x).+1%:R.
+Proof. by apply/le_lt_trans/to_real_le_nneg: (to_nneg_truncnS_gt x). Qed.
 
 Lemma real_truncnS_gt x : x \is real_num -> x < (truncn x).+1%:R.
-Proof. by move/real_ge0P => [/truncn_itv/andP[]|/lt_le_trans->]. Qed.
+Proof. by move=> xr; have := to_real_truncnS_gt x; rewrite to_realT. Qed.
 
-Lemma truncn_def x n : n%:R <= x < n.+1%:R -> truncn x = n.
+Lemma to_nneg_truncn_geq x n : (n <= truncn x)%N = (n%:R <= to_nneg x).
 Proof.
-case/andP=> lemx ltxm1; apply/eqP; rewrite eqn_leq -ltnS -[(n <= _)%N]ltnS.
-have/truncn_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lemx; apply: ler0n.
-by rewrite -!(ltr_nat R) 2?(@le_lt_trans _ _ x).
+apply/idP/idP => lenx.
+  by apply: le_trans (to_nneg_truncn_le x); rewrite ler_nat.
+by rewrite -ltnS -(ltr_nat R); apply: le_lt_trans (to_nneg_truncnS_gt x).
 Qed.
 
 Lemma truncn_geq x n : 0 <= x -> (n <= truncn x)%N = (n%:R <= x).
-Proof.
-move=> /truncn_itv /andP[letx ltxt1]; apply/idP/idP => lenx.
-  by apply: le_trans letx; rewrite ler_nat.
-by rewrite -ltnS -(ltr_nat R); apply: le_lt_trans ltxt1.
-Qed.
+Proof. by rewrite to_nneg_truncn_geq => /to_nnegT->. Qed.
 
 Lemma truncn_gtn x n : (n < truncn x)%N = (n.+1%:R <= x).
 Proof.
-case: ifP (truncnP x) => [x0 _ | x0 /eqP->]; first by rewrite truncn_geq.
-by rewrite ltn0; apply/esym/(contraFF _ x0)/le_trans.
+rewrite to_nneg_truncn_geq /to_nneg; case: ifPn => // x0.
+by rewrite lern0/=; apply/esym/(contraNF _ x0)/le_trans.
 Qed.
 
+Lemma to_nneg_truncn_ltn x n : (truncn x < n)%N = (to_nneg x < n%:R).
+Proof. by rewrite ltnNge to_nneg_truncn_geq -real_ltNge// real_to_nneg. Qed.
+
 Lemma truncn_ltn x n : 0 <= x -> (truncn x < n)%N = (x < n%:R).
-Proof. by move=> ?; rewrite real_ltNge ?ger0_real// ltnNge truncn_geq. Qed.
+Proof. by rewrite to_nneg_truncn_ltn => /to_nnegT->. Qed.
+
+Lemma to_real_truncn_leq x n : (truncn x <= n)%N = (to_real x < n.+1%:R).
+Proof.
+rewrite -ltnS to_nneg_truncn_ltn /to_real /to_nneg realE.
+by have []//= := comparableP 0 x; rewrite ltr0Sn => /lt_le_trans->.
+Qed.
 
 Lemma real_truncn_leq x n : x \is real_num -> (truncn x <= n)%N = (x < n.+1%:R).
-Proof. by move=> ?; rewrite real_ltNge// leqNgt truncn_gtn. Qed.
+Proof. by rewrite to_real_truncn_leq => /to_realT->. Qed.
+
+Lemma to_nneg_eq_truncn x n : (truncn x == n) = (n%:R <= to_nneg x < n.+1%:R).
+Proof.
+by rewrite -to_nneg_truncn_geq -to_nneg_truncn_ltn ltnS -eqn_leq eq_sym.
+Qed.
 
 Lemma eq_truncn x n : 0 <= x -> (truncn x == n) = (n%:R <= x < n.+1%:R).
+Proof. by rewrite to_nneg_eq_truncn => /to_nnegT->. Qed.
+
+Lemma to_nneg_truncn_eqP x n :
+  reflect (truncn x = n) (n%:R <= to_nneg x < n.+1%:R).
+Proof. by rewrite -to_nneg_eq_truncn; exact: eqP. Qed.
+
+Lemma truncn_eqP x n : 0 <= x -> reflect (truncn x = n) (n%:R <= x < n.+1%:R).
+Proof. by move=> /eq_truncn <-; exact: eqP. Qed.
+
+(* TODO: rename to truncn_eq *)
+Lemma truncn_def x n : n%:R <= x < n.+1%:R -> truncn x = n.
 Proof.
-by move=> xr; apply/eqP/idP => [<-|]; [exact: truncn_itv|exact: truncn_def].
+by move=> /[dup] /andP[lenx _] ?; apply/truncn_eqP; first exact: le_trans lenx.
 Qed.
 
 Lemma le_truncn : {homo truncn : x y / x <= y >-> (x <= y)%N}.
 Proof.
-move=> x y lexy; move: (truncnP x) (truncnP y).
-case: ifP => [x0 /andP[letx _] | x0 /eqP->//].
-case: ifP => [y0 /andP[_] | y0 /eqP->]; [|by rewrite (le_trans x0 lexy) in y0].
-by move=> /(le_lt_trans lexy) /(le_lt_trans letx); rewrite ltr_nat ltnS.
+move=> x y lexy; rewrite to_nneg_truncn_geq.
+by apply: le_trans (to_nneg_truncn_le x) (ler_to_nneg lexy).
 Qed.
 
 Lemma natrK : cancel (GRing.natmul 1) truncn.
@@ -611,11 +777,14 @@ Proof.
 by apply/natrP/eqP => [[n ->]|<-]; [rewrite natrK | exists (truncn x)].
 Qed.
 
-Lemma archi_boundP x : 0 <= x -> x < (bound x)%:R.
+Lemma to_nneg_archi_boundP x : to_nneg x < (bound x)%:R.
 Proof.
-move=> x_ge0; case/truncn_itv/andP: (normr_ge0 x) => _.
-exact/le_lt_trans/real_ler_norm/ger0_real.
+rewrite -truncn_ltn; first exact: nneg_to_nneg.
+by rewrite ltnS le_truncn// /to_nneg; case: ifPn => // /normr_idP->.
 Qed.
+
+Lemma archi_boundP x : 0 <= x -> x < (bound x)%:R.
+Proof. by move=> x_ge0; have := to_nneg_archi_boundP x; rewrite to_nnegT. Qed.
 
 Lemma truncnK : {in nat_num, cancel truncn (GRing.natmul 1)}.
 Proof. by move=> x; rewrite natrEtruncn => /eqP. Qed.
@@ -624,12 +793,20 @@ Lemma truncn0 : truncn 0 = 0%N. Proof. exact: natrK 0%N. Qed.
 Lemma truncn1 : truncn 1 = 1%N. Proof. exact: natrK 1%N. Qed.
 #[local] Hint Resolve truncn0 truncn1 : core.
 
+Lemma to_nneg_truncnDnr x y :
+  x \is a nat_num -> truncn (x + to_nneg y) = (truncn x + truncn y)%N.
+Proof.
+move=> /natrP[n ->]; apply: truncn_def.
+by rewrite -addnS !natrD !natrK lerD2l ltrD2l to_nneg_truncn_itv.
+Qed.
+
+Lemma to_nneg_truncnDrn x y :
+  y \is a nat_num -> truncn (to_nneg x + y) = (truncn x + truncn y)%N.
+Proof. by move=> yn; rewrite addrC to_nneg_truncnDnr// addnC. Qed.
+
 Lemma truncnDnr :
   {in nat_num & nneg_num, {morph truncn : x y / x + y >-> (x + y)%N}}.
-Proof.
-move=> _ y /natrP[n ->] y_ge0; apply: truncn_def.
-by rewrite -addnS !natrD !natrK lerD2l ltrD2l truncn_itv.
-Qed.
+Proof. by move=> x y ? ?; rewrite -to_nneg_truncnDnr// to_nnegT. Qed.
 
 Lemma truncnDrn :
   {in nneg_num & nat_num, {morph truncn : x y / x + y >-> (x + y)%N}}.
@@ -642,10 +819,7 @@ Lemma truncnX n : {in nat_num, {morph truncn : x / x ^+ n >-> (x ^ n)%N}}.
 Proof. by move=> _ /natrP[n1 ->]; rewrite -natrX !natrK. Qed.
 
 Lemma truncn_gt0 x : (0 < truncn x)%N = (1 <= x).
-Proof.
-case: ifP (truncnP x) => [x0 | x0 /eqP<-]; first by rewrite truncn_geq.
-by rewrite ltnn; apply/esym/(contraFF _ x0)/le_trans.
-Qed.
+Proof. by rewrite truncn_gtn. Qed.
 
 Lemma truncn0Pn x : reflect (truncn x = 0%N) (~~ (1 <= x)).
 Proof. by rewrite -truncn_gt0 -eqn0Ngt; apply: eqP. Qed.
@@ -811,14 +985,14 @@ Section ArchiRealDomainTheory.
 Variables (R : archiRealDomainType).
 Implicit Type x : R.
 
-Lemma upper_nthrootP x i : (bound x <= i)%N -> x < 2%:R ^+ i.
-Proof.
-case/truncn_itv/andP: (normr_ge0 x) => _ /ltr_normlW xlt le_b_i.
-by rewrite (lt_le_trans xlt) // -natrX ler_nat (ltn_trans le_b_i) // ltn_expl.
-Qed.
-
 Lemma truncnS_gt x : x < (truncn x).+1%:R.
 Proof. exact: real_truncnS_gt. Qed.
+
+Lemma upper_nthrootP x i : (bound x <= i)%N -> x < 2%:R ^+ i.
+Proof.
+move=> le_b_i; have/ltr_normlW/lt_le_trans->// := truncnS_gt `|x|.
+by rewrite -natrX ler_nat (ltn_trans le_b_i)// ltn_expl.
+Qed.
 
 Lemma truncn_leq x n : (truncn x <= n)%N = (x < n.+1%:R).
 Proof. exact: real_truncn_leq. Qed.
@@ -830,6 +1004,9 @@ Lemma floor_le x : (floor x)%:~R <= x. Proof. exact: real_floor_le. Qed.
 
 Lemma floorD1_gt x : x < (floor x + 1)%:~R.
 Proof. exact: real_floorD1_gt. Qed.
+
+Lemma floor_eqP x n : reflect (floor x = n) (n%:~R <= x < (n + 1)%:~R).
+Proof. exact: real_floor_eqP. Qed.
 
 Lemma floor_gez x n : (n <= floor x) = (n%:~R <= x).
 Proof. exact: real_floor_gez. Qed.
@@ -844,7 +1021,7 @@ Lemma floorDzr : {in @int_num R, {morph floor : x y / x + y}}.
 Proof. by move=> x xz y; apply/real_floorDzr/num_real. Qed.
 
 Lemma floorDrz x y : y \is a int_num -> floor (x + y) = floor x + floor y.
-Proof. by move=> yz; apply/real_floorDrz/yz/num_real. Qed.
+Proof. exact/real_floorDrz/num_real. Qed.
 
 Lemma floor_ge0 x : (0 <= floor x) = (0 <= x).
 Proof. exact: real_floor_ge0. Qed.
@@ -860,6 +1037,9 @@ Proof. exact: real_ceilB1_lt. Qed.
 
 Lemma ceil_ge x : x <= (ceil x)%:~R. Proof. exact: real_ceil_ge. Qed.
 
+Lemma ceil_eqP x n : reflect (ceil x = n) ((n - 1)%:~R < x <= n%:~R).
+Proof. exact: real_ceil_eqP. Qed.
+
 Lemma ceil_lez x n : (ceil x <= n) = (x <= n%:~R).
 Proof. exact: real_ceil_lez. Qed.
 
@@ -873,9 +1053,9 @@ Lemma ceilDzr : {in @int_num R, {morph ceil : x y / x + y}}.
 Proof. by move=> x xz y; apply/real_ceilDzr/num_real. Qed.
 
 Lemma ceilDrz x y : y \is a int_num -> ceil (x + y) = ceil x + ceil y.
-Proof. by move=> yz; apply/real_ceilDrz/yz/num_real. Qed.
+Proof. exact/real_ceilDrz/num_real. Qed.
 
-Lemma ceil_ge0 x : (0 <= ceil x) = (-1 < x).
+Lemma ceil_ge0 x : (0 <= ceil x) = (- 1 < x).
 Proof. exact: real_ceil_ge0. Qed.
 
 Lemma ceil_le0 x : (ceil x <= 0) = (x <= 0).
@@ -956,6 +1136,48 @@ End Theory.
 
 (* Factories *)
 
+HB.factory Record NumDomain_hasFloorCeilTruncn R & Num.NumDomain R := {
+  floor : R -> int;
+  ceil  : R -> int;
+  truncn : R -> nat;
+  int_num_subdef : pred R;
+  nat_num_subdef : pred R;
+  floor_subproof :
+    forall x,
+      if x \is real_num then (floor x)%:~R <= x < (floor x + 1)%:~R
+      else floor x == 0;
+  ceil_subproof : forall x, ceil x = - floor (- x);
+  truncn_subproof : forall x, truncn x = if floor x is Posz n then n else 0;
+  int_num_subproof : forall x, reflect (exists n, x = n%:~R) (int_num_subdef x);
+  nat_num_subproof : forall x, reflect (exists n, x = n%:R) (nat_num_subdef x);
+}.
+
+HB.builders Context R & NumDomain_hasFloorCeilTruncn R.
+
+Fact floor_subproof' x : (floor x)%:~R <= to_real x < (floor x + 1)%:~R.
+Proof.
+have := floor_subproof x; rewrite /to_real.
+by case: ifPn => // _ /eqP ->; rewrite add0r lexx ltr01.
+Qed.
+
+Fact truncn_subproof' x : truncn x = if 0 <= x then `|floor x|%N else 0%N.
+Proof.
+have := floor_subproof x; rewrite realE truncn_subproof.
+have []//= := comparableP x 0.
+- by move=> x_lt0 /andP[/le_lt_trans/(_ x_lt0) + _]; rewrite ltrz0; case: floor.
+- by move=> x_gt0 /andP[_ /(lt_trans x_gt0)]; rewrite ltr0z ltzD1; case: floor.
+- by move=> _ /eqP ->.
+- by move=> -> /andP[_]; rewrite ltr0z ltzD1; case: floor.
+Qed.
+
+HB.instance Definition _ :=
+  @NumDomain_hasFloorCeilTruncn_truncn_abs_floor.Build R
+    floor ceil truncn int_num_subdef nat_num_subdef
+    floor_subproof' ceil_subproof truncn_subproof'
+    int_num_subproof nat_num_subproof.
+
+HB.end.
+
 HB.factory Record NumDomain_hasTruncn R & Num.NumDomain R := {
   truncn : R -> nat;
   nat_num : pred R;
@@ -977,19 +1199,20 @@ End NumDomain_isArchimedean.
 HB.builders Context R & NumDomain_hasTruncn R.
 
 Fact truncn_itv x : 0 <= x -> (truncn x)%:R <= x < (truncn x).+1%:R.
-Proof. by move=> x_ge0; move: (truncn_subproof x); rewrite x_ge0. Qed.
+Proof. by move=> x_ge0; have := truncn_subproof x; rewrite x_ge0. Qed.
 
 Definition floor (x : R) : int :=
   if 0 <= x then Posz (truncn x)
   else if x < 0 then - Posz (truncn (- x) + ~~ int_num x) else 0.
 
-Fact floor_subproof x :
-  if x \is real_num then (floor x)%:~R <= x < (floor x + 1)%:~R else floor x == 0.
+Fact floor_subproof x : (floor x)%:~R <= to_real x < (floor x + 1)%:~R.
 Proof.
-rewrite /floor intrE !natrE negb_or realE.
-case: (comparableP x 0) (@truncn_itv x) => //=;
-  try by rewrite -PoszD addn1 -pmulrn => _ ->.
-move=> x_lt0 _; move: (truncn_subproof x); rewrite lt_geF // => /eqP ->.
+rewrite /to_real realE /floor intrE !natrE negb_or.
+have []/= := comparableP x 0; last first.
+- by move=> ->; rewrite -PoszD addn1 -!pmulrn truncn_itv.
+- by rewrite lexx ltr01.
+- by move=> /ltW ?; rewrite -PoszD addn1 -!pmulrn truncn_itv.
+move=> x_lt0; have := truncn_subproof x; rewrite lt_geF// => /eqP ->.
 rewrite gt_eqF //=; move: x_lt0.
 rewrite [_ + 1]addrC -opprB !intrN lerNl ltrNr andbC -oppr_gt0.
 move: {x}(- x) => x x_gt0; rewrite PoszD -addrA -PoszD.
@@ -1001,17 +1224,15 @@ case: eqVneq => /=; last first.
 by rewrite intrB mulr1z addn0 -!pmulrn => -> _; rewrite gtrBl lexx andbT.
 Qed.
 
-Fact truncnE x : truncn x = if floor x is Posz n then n else 0.
+Fact truncnE x : truncn x = if 0 <= x then `|floor x|%N else 0%N.
 Proof.
-rewrite /floor.
-case: (comparableP x 0) (truncn_subproof x) => [+ /eqP ->| |_ /eqP ->|] //=.
-by case: (_ + _)%N.
+by rewrite /floor; case: (comparableP x 0) (truncn_subproof x) => //= _ /eqP ->.
 Qed.
 
 Fact truncn_def x n : n%:R <= x < n.+1%:R -> truncn x = n.
 Proof.
-case/andP=> lemx ltxm1; apply/eqP; rewrite eqn_leq -ltnS -[(n <= _)%N]ltnS.
-have/truncn_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lemx; apply: ler0n.
+case/andP=> lenx ltx1; apply/eqP; rewrite eqn_leq -ltnS -[(n <= _)%N]ltnS.
+have/truncn_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lenx; apply: ler0n.
 by rewrite -!(ltr_nat R) 2?(@le_lt_trans _ _ x).
 Qed.
 
@@ -1033,7 +1254,8 @@ by apply: (iffP eqP) => [<-|[n ->]]; [exists (truncn x) | rewrite natrK].
 Qed.
 
 HB.instance Definition _ :=
-  @NumDomain_hasFloorCeilTruncn.Build R floor _ truncn int_num nat_num
+  @NumDomain_hasFloorCeilTruncn_truncn_abs_floor.Build R
+    floor _ truncn int_num nat_num
     floor_subproof (fun=> erefl) truncnE intrP natrP.
 
 HB.end.

--- a/algebra/archimedean.v
+++ b/algebra/archimedean.v
@@ -53,25 +53,24 @@ Import Order.TTheory GRing.Theory Num.Theory.
 Module Num.
 Import Num.Def.
 
-HB.mixin Record NumDomain_hasFloorCeilTruncn R & Num.NumDomain R := {
+(* TODO: rename to NumDomain_hasFloorCeilTruncn (MC 2.8 or later) *)
+HB.mixin Record NumDomain_hasFloorCeilTruncn_truncn_abs_floor
+  R & Num.NumDomain R := {
   floor : R -> int;
   ceil  : R -> int;
   truncn : R -> nat;
   int_num_subdef : pred R;
   nat_num_subdef : pred R;
-  floor_subproof :
-    forall x,
-      if x \is real_num then (floor x)%:~R <= x < (floor x + 1)%:~R
-      else floor x == 0;
+  floor_subproof : forall x, (floor x)%:~R <= num_to_real x < (floor x + 1)%:~R;
   ceil_subproof : forall x, ceil x = - floor (- x);
-  truncn_subproof : forall x, truncn x = if floor x is Posz n then n else 0;
+  truncn_subproof : forall x, truncn x = if 0 <= x then `|floor x|%N else 0%N;
   int_num_subproof : forall x, reflect (exists n, x = n%:~R) (int_num_subdef x);
   nat_num_subproof : forall x, reflect (exists n, x = n%:R) (nat_num_subdef x);
 }.
 
 #[short(type="archiNumDomainType")]
 HB.structure Definition ArchiNumDomain :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.NumDomain R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R & Num.NumDomain R }.
 
 Module ArchiNumDomainExports.
 Bind Scope ring_scope with ArchiNumDomain.sort.
@@ -80,7 +79,7 @@ HB.export ArchiNumDomainExports.
 
 #[short(type="archiNumFieldType")]
 HB.structure Definition ArchiNumField :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.NumField R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R & Num.NumField R }.
 
 Module ArchiNumFieldExports.
 Bind Scope ring_scope with ArchiNumField.sort.
@@ -89,7 +88,7 @@ HB.export ArchiNumFieldExports.
 
 #[short(type="archiClosedFieldType")]
 HB.structure Definition ArchiClosedField :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.ClosedField R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R & Num.ClosedField R }.
 
 Module ArchiClosedFieldExports.
 Bind Scope ring_scope with ArchiClosedField.sort.
@@ -98,7 +97,7 @@ HB.export ArchiClosedFieldExports.
 
 #[short(type="archiRealDomainType")]
 HB.structure Definition ArchiRealDomain :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.RealDomain R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R & Num.RealDomain R }.
 
 Module ArchiRealDomainExports.
 Bind Scope ring_scope with ArchiRealDomain.sort.
@@ -107,7 +106,7 @@ HB.export ArchiRealDomainExports.
 
 #[short(type="archiRealFieldType")]
 HB.structure Definition ArchiRealField :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.RealField R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R & Num.RealField R }.
 
 Module ArchiRealFieldExports.
 Bind Scope ring_scope with ArchiRealField.sort.
@@ -116,7 +115,8 @@ HB.export ArchiRealFieldExports.
 
 #[short(type="archiRcfType")]
 HB.structure Definition ArchiRealClosedField :=
-  { R of NumDomain_hasFloorCeilTruncn R & Num.RealClosedField R }.
+  { R of NumDomain_hasFloorCeilTruncn_truncn_abs_floor R
+    & Num.RealClosedField R }.
 
 Module ArchiRealClosedFieldExports.
 Bind Scope ring_scope with ArchiRealClosedField.sort.
@@ -160,9 +160,13 @@ Section intArchimedean.
 
 Implicit Types n : int.
 
-Fact floor_subproof n :
-  if n \is real_num then n%:~R <= n < (n + 1)%:~R else n == 0.
-Proof. by rewrite num_real !intz ltzD1 lexx. Qed.
+Let truncz n := if n is Posz n then n else 0%N.
+
+Fact floor_subproof n : n%:~R <= num_to_real n < (n + 1)%:~R.
+Proof. by rewrite to_realT ?num_real// !intz ltzD1 lexx. Qed.
+
+Fact truncn_subproof n : truncz n = if 0 <= n then `|n|%N else 0%N.
+Proof. by rewrite /truncz; case: n. Qed.
 
 Fact intrP n : reflect (exists m, n = m%:~R) true.
 Proof. by apply: ReflectT; exists n; rewrite intz. Qed.
@@ -178,9 +182,10 @@ End intArchimedean.
 
 #[export]
 HB.instance Definition _ :=
-  @NumDomain_hasFloorCeilTruncn.Build int id id _ xpredT nneg_num_pred
-    intArchimedean.floor_subproof (fun=> esym (opprK _)) (fun=> erefl)
-    intArchimedean.intrP intArchimedean.natrP.
+  @NumDomain_hasFloorCeilTruncn_truncn_abs_floor.Build int
+    id id _ xpredT nneg_num_pred
+    intArchimedean.floor_subproof (fun=> esym (opprK _))
+    intArchimedean.truncn_subproof intArchimedean.intrP intArchimedean.natrP.
 
 Module Import Theory.
 Export Num.Theory.
@@ -196,19 +201,11 @@ Local Notation ceil := (@ceil R).
 Local Notation nat_num := (@Def.nat_num R).
 Local Notation int_num := (@Def.int_num R).
 
-Local Lemma floorP x :
-  if x \is real_num then (floor x)%:~R <= x < (floor x + 1)%:~R
-  else floor x == 0.
-Proof. exact: floor_subproof. Qed.
-
 Lemma floorNceil x : floor x = - ceil (- x).
 Proof. by rewrite ceil_subproof !opprK. Qed.
 
 Lemma ceilNfloor x : ceil x = - floor (- x).
 Proof. exact: ceil_subproof. Qed.
-
-Lemma truncEfloor x : truncn x = if floor x is Posz n then n else 0.
-Proof. exact: truncn_subproof. Qed.
 
 Lemma natrP x : reflect (exists n, x = n%:R) (x \is a nat_num).
 Proof. exact: nat_num_subproof. Qed.
@@ -326,46 +323,79 @@ Qed.
 
 (* floor and int_num *)
 
+Lemma to_real_floor_itv x : (floor x)%:~R <= num_to_real x < (floor x + 1)%:~R.
+Proof. exact: floor_subproof. Qed.
+
 Lemma real_floor_itv x :
   x \is real_num -> (floor x)%:~R <= x < (floor x + 1)%:~R.
-Proof. by case: ifP (floorP x). Qed.
+Proof. by move=> xr; have := to_real_floor_itv x; rewrite to_realT. Qed.
+
+#[deprecated(since="mathcomp 2.7.0", use=to_real_floor_itv)]
+Local Lemma floorP x :
+  if x \is real_num then (floor x)%:~R <= x < (floor x + 1)%:~R
+  else floor x == 0.
+Proof.
+have := to_real_floor_itv x; rewrite /num_to_real; case: ifP => //= _.
+by rewrite lerz0 ltr0z ltzD1 -eq_le.
+Qed.
+
+Lemma to_real_floor_le x : (floor x)%:~R <= num_to_real x.
+Proof. by have/andP[] := to_real_floor_itv x. Qed.
 
 Lemma real_floor_le x : x \is real_num -> (floor x)%:~R <= x.
 Proof. by case/real_floor_itv/andP. Qed.
 
+Lemma to_real_floorD1_gt x : num_to_real x < (floor x + 1)%:~R.
+Proof. by have/andP[] := to_real_floor_itv x. Qed.
+
 Lemma real_floorD1_gt x : x \is real_num -> x < (floor x + 1)%:~R.
 Proof. by case/real_floor_itv/andP. Qed.
 
-Lemma floor_def x m : m%:~R <= x < (m + 1)%:~R -> floor x = m.
+Lemma to_real_floor_gez x n : (n <= floor x) = (n%:~R <= num_to_real x).
 Proof.
-case/andP=> lemx ltxm1; apply/eqP; rewrite eq_le -!ltzD1.
-move: (ger_real lemx); rewrite realz => /real_floor_itv/andP[lefx ltxf1].
-by rewrite -!(ltr_int R) 2?(@le_lt_trans _ _ x).
+apply/idP/idP; first by rewrite -(ler_int R); apply/le_geP/to_real_floor_le.
+by rewrite -ltzD1 -(ltr_int R); apply/lt_gtP/to_real_floorD1_gt.
 Qed.
 
 Lemma real_floor_gez x n : x \is real_num -> (n <= floor x) = (n%:~R <= x).
+Proof. by rewrite to_real_floor_gez => /to_realT->. Qed.
+
+Lemma to_real_floor_ltz x n : (floor x < n) = (num_to_real x < n%:~R).
 Proof.
-move=> /real_floor_itv /andP[lefx ltxf1]; apply/idP/idP => lenx.
-  by apply: le_trans lefx; rewrite ler_int.
-by rewrite -ltzD1 -(ltr_int R); apply: le_lt_trans ltxf1.
+apply/idP/idP; last by rewrite -(ltr_int R); apply/le_lt_trans/to_real_floor_le.
+by rewrite -lezD1 -(ler_int R); apply/lt_ltP/to_real_floorD1_gt.
 Qed.
 
 Lemma real_floor_ltz x n : x \is real_num -> (floor x < n) = (x < n%:~R).
-Proof.
-by move=> ?; rewrite [RHS]real_ltNge ?realz -?real_floor_gez -?ltNge.
-Qed.
+Proof. by rewrite to_real_floor_ltz => /to_realT->. Qed.
+
+Lemma to_real_eq_floor x n :
+  (floor x == n) = (n%:~R <= num_to_real x < (n + 1)%:~R).
+Proof. by rewrite -to_real_floor_gez -to_real_floor_ltz ltzD1 andbC -eq_le. Qed.
 
 Lemma real_eq_floor x n : x \is real_num ->
   (floor x == n) = (n%:~R <= x < (n + 1)%:~R).
+Proof. by rewrite to_real_eq_floor => /to_realT->. Qed.
+
+Lemma to_real_floor_eqP x n :
+  reflect (floor x = n) (n%:~R <= num_to_real x < (n + 1)%:~R).
+Proof. by rewrite -to_real_eq_floor; exact/eqP. Qed.
+
+Lemma real_floor_eqP x n : x \is real_num ->
+  reflect (floor x = n) (n%:~R <= x < (n + 1)%:~R).
+Proof. by move=> /real_eq_floor <-; exact/eqP. Qed.
+
+(* TODO: rename to floor_eq *)
+Lemma floor_def x n : n%:~R <= x < (n + 1)%:~R -> floor x = n.
 Proof.
-by move=> xr; apply/eqP/idP => [<-|]; [exact: real_floor_itv|exact: floor_def].
+move=> /[dup] /andP[lenx _] ?.
+by apply/real_floor_eqP; rewrite // (ger_real lenx) realz.
 Qed.
 
 Lemma le_floor : {homo floor : x y / x <= y}.
 Proof.
-move=> x y lexy; move: (floorP x) (floorP y); rewrite (ger_real lexy).
-case: ifP => [_ /andP[lefx _] /andP[_] | _ /eqP-> /eqP-> //].
-by move=> /(le_lt_trans lexy) /(le_lt_trans lefx); rewrite ltr_int ltzD1.
+move=> x y /ler_to_real; rewrite to_real_floor_gez.
+exact/le_leP/to_real_floor_le.
 Qed.
 
 Lemma intrKfloor : cancel intr floor.
@@ -373,7 +403,7 @@ Proof. by move=> m; apply: floor_def; rewrite lexx rmorphD ltrDl ltr01. Qed.
 
 Lemma intrEfloor x : (x \is a int_num) = ((floor x)%:~R == x).
 Proof.
-by apply/intrP/eqP => [[n ->] | <-]; [rewrite intrKfloor | exists (floor x)].
+by apply/idP/eqP => [/intrP[n ->]|<-]; rewrite (intrKfloor, intr_int).
 Qed.
 
 Lemma floorK : {in int_num, cancel floor intr}.
@@ -383,14 +413,22 @@ Lemma floor0 : floor 0 = 0. Proof. exact: intrKfloor 0. Qed.
 Lemma floor1 : floor 1 = 1. Proof. exact: intrKfloor 1. Qed.
 #[local] Hint Resolve floor0 floor1 : core.
 
-Lemma real_floorDzr : {in int_num & real_num, {morph floor : x y / x + y}}.
+Lemma to_real_floorDzr x y :
+  x \is a int_num -> floor (x + num_to_real y) = floor x + floor y.
 Proof.
-move=> _ y /intrP[m ->] Ry; apply: floor_def.
-by rewrite -addrA 2!rmorphD /= intrKfloor lerD2l ltrD2l real_floor_itv.
+move=> /intrP[m ->]; apply: floor_def.
+by rewrite -addrA 2!rmorphD/= intrKfloor lerD2l ltrD2l to_real_floor_itv.
 Qed.
 
+Lemma real_floorDzr : {in int_num & real_num, {morph floor : x y / x + y}}.
+Proof. by move=> x y xz yr; rewrite -to_real_floorDzr// to_realT. Qed.
+
+Lemma to_real_floorDrz x y :
+  y \is a int_num -> floor (num_to_real x + y) = floor x + floor y.
+Proof. by move=> yz; rewrite addrC to_real_floorDzr// addrC. Qed.
+
 Lemma real_floorDrz : {in real_num & int_num, {morph floor : x y / x + y}}.
-Proof. by move=> x y xr yz; rewrite addrC real_floorDzr // addrC. Qed.
+Proof. by move=> x y xr yz; rewrite -to_real_floorDrz// to_realT. Qed.
 
 Lemma floorN : {in int_num, {morph floor : x / - x}}.
 Proof. by move=> _ /intrP[m ->]; rewrite -rmorphN !intrKfloor. Qed.
@@ -403,31 +441,32 @@ Qed.
 Lemma floorX n : {in int_num, {morph floor : x / x ^+ n}}.
 Proof. by move=> _ /intrP[m ->]; rewrite -rmorphXn !intrKfloor. Qed.
 
+Lemma to_real_floor_ge0 x : (0 <= floor x) = (0 <= num_to_real x).
+Proof. exact: to_real_floor_gez. Qed.
+
 Lemma real_floor_ge0 x : x \is real_num -> (0 <= floor x) = (0 <= x).
-Proof. by move=> ?; rewrite real_floor_gez. Qed.
+Proof. exact: real_floor_gez. Qed.
 
 Lemma floor_lt0 x : (floor x < 0) = (x < 0).
 Proof.
-case: ifP (floorP x) => [xr _ | xr /eqP <-]; first by rewrite real_floor_ltz.
-by rewrite ltxx; apply/esym/(contraFF _ xr)/ltr0_real.
+rewrite to_real_floor_ltz /num_to_real; case: ifPn => // xr.
+by rewrite ltxx; apply/esym/(contraNF _ xr)/ltr0_real.
 Qed.
 
+Lemma to_real_floor_le0 x : (floor x <= 0) = (num_to_real x < 1).
+Proof. by rewrite -ltzD1 add0r to_real_floor_ltz. Qed.
+
 Lemma real_floor_le0 x : x \is real_num -> (floor x <= 0) = (x < 1).
-Proof. by move=> ?; rewrite -ltzD1 add0r real_floor_ltz. Qed.
+Proof. by move=> ?; rewrite to_real_floor_le0 to_realT. Qed.
 
 Lemma floor_gt0 x : (floor x > 0) = (x >= 1).
 Proof.
-case: ifP (floorP x) => [xr _ | xr /eqP->].
-  by rewrite gtz0_ge1 real_floor_gez.
-by rewrite ltxx; apply/esym/(contraFF _ xr)/ger1_real.
+rewrite gtz0_ge1 to_real_floor_gez /num_to_real; case: ifPn => // xr.
+by rewrite ler10; apply/esym/(contraNF _ xr)/ger1_real.
 Qed.
 
 Lemma floor_neq0 x : (floor x != 0) = (x < 0) || (x >= 1).
-Proof.
-case: ifP (floorP x) => [xr _ | xr /eqP->]; rewrite ?eqxx/=.
-  by rewrite neq_lt floor_lt0 floor_gt0.
-by apply/esym/(contraFF _ xr) => /orP[/ltr0_real|/ger1_real].
-Qed.
+Proof. by rewrite neq_lt floor_lt0 floor_gt0. Qed.
 
 Lemma floorpK : {in polyOver int_num, cancel (map_poly floor) (map_poly intr)}.
 Proof.
@@ -442,36 +481,62 @@ Proof. by exists (map_poly floor p); rewrite floorpK. Qed.
 
 (* ceil and int_num *)
 
-Lemma real_ceil_itv x : x \is real_num -> (ceil x - 1)%:~R < x <= (ceil x)%:~R.
+Lemma to_real_ceil_itv x : (ceil x - 1)%:~R < num_to_real x <= (ceil x)%:~R.
 Proof.
-rewrite ceilNfloor -opprD !intrN ltrNl lerNr andbC -realN.
-exact: real_floor_itv.
+rewrite ceilNfloor -opprD !intrN ltrNl lerNr andbC -to_realN.
+by rewrite to_real_floor_itv.
 Qed.
+
+Lemma real_ceil_itv x : x \is real_num -> (ceil x - 1)%:~R < x <= (ceil x)%:~R.
+Proof. by move=> xr; have := to_real_ceil_itv x; rewrite to_realT. Qed.
+
+Lemma to_real_ceilB1_lt x : (ceil x - 1)%:~R < num_to_real x.
+Proof. by have/andP[] := to_real_ceil_itv x. Qed.
 
 Lemma real_ceilB1_lt x : x \is real_num -> (ceil x - 1)%:~R < x.
 Proof. by case/real_ceil_itv/andP. Qed.
 
+Lemma to_real_ceil_ge x : num_to_real x <= (ceil x)%:~R.
+Proof. by have/andP[] := to_real_ceil_itv x. Qed.
+
 Lemma real_ceil_ge x : x \is real_num -> x <= (ceil x)%:~R.
 Proof. by case/real_ceil_itv/andP. Qed.
 
-Lemma ceil_def x m : (m - 1)%:~R < x <= m%:~R -> ceil x = m.
-Proof.
-rewrite -ltrN2 -lerN2 andbC -!intrN opprD opprK ceilNfloor.
-by move=> /floor_def ->; rewrite opprK.
-Qed.
+Lemma to_real_ceil_lez x n : (ceil x <= n) = (num_to_real x <= n%:~R).
+Proof. by rewrite ceilNfloor lerNl to_real_floor_gez intrN to_realN lerN2. Qed.
 
 Lemma real_ceil_lez x n : x \is real_num -> (ceil x <= n) = (x <= n%:~R).
-Proof.
-by rewrite ceilNfloor lerNl -realN => /real_floor_gez ->; rewrite intrN lerN2.
-Qed.
+Proof. by rewrite to_real_ceil_lez => /to_realT->. Qed.
+
+Lemma to_real_ceil_gtz x n : (n < ceil x) = (n%:~R < num_to_real x).
+Proof. by rewrite ceilNfloor ltrNr to_real_floor_ltz to_realN intrN ltrN2. Qed.
 
 Lemma real_ceil_gtz x n : x \is real_num -> (n < ceil x) = (n%:~R < x).
-Proof. by move=> ?; rewrite [RHS]real_ltNge ?realz -?real_ceil_lez ?ltNge. Qed.
+Proof. by rewrite to_real_ceil_gtz => /to_realT->. Qed.
+
+Lemma to_real_eq_ceil x n :
+  (ceil x == n) = ((n - 1)%:~R < num_to_real x <= n%:~R).
+Proof.
+by rewrite -to_real_ceil_lez -to_real_ceil_gtz ltrBlDr ltzD1 andbC -eq_le.
+Qed.
 
 Lemma real_eq_ceil x n : x \is real_num ->
   (ceil x == n) = ((n - 1)%:~R < x <= n%:~R).
+Proof. by rewrite to_real_eq_ceil => /to_realT->. Qed.
+
+Lemma to_real_ceil_eqP x n :
+  reflect (ceil x = n) ((n - 1)%:~R < num_to_real x <= n%:~R).
+Proof. by rewrite -to_real_eq_ceil; exact/eqP. Qed.
+
+Lemma real_ceil_eqP x n : x \is real_num ->
+  reflect (ceil x = n) ((n - 1)%:~R < x <= n%:~R).
+Proof. by move=> /real_eq_ceil<-; exact/eqP. Qed.
+
+(* TODO: rename to ceil_eq *)
+Lemma ceil_def x n : (n - 1)%:~R < x <= n%:~R -> ceil x = n.
 Proof.
-by move=> xr; apply/eqP/idP => [<-|]; [exact: real_ceil_itv|exact: ceil_def].
+move=> /[dup] /andP[_ lexn] ?.
+by apply/real_ceil_eqP; rewrite // (ler_real lexn) realz.
 Qed.
 
 Lemma le_ceil : {homo ceil : x y / x <= y}.
@@ -490,14 +555,22 @@ Lemma ceil0 : ceil 0 = 0. Proof. exact: intrKceil 0. Qed.
 Lemma ceil1 : ceil 1 = 1. Proof. exact: intrKceil 1. Qed.
 #[local] Hint Resolve ceil0 ceil1 : core.
 
-Lemma real_ceilDzr : {in int_num & real_num, {morph ceil : x y / x + y}}.
+Lemma to_real_ceilDzr x y :
+  x \is a int_num -> ceil (x + num_to_real y) = ceil x + ceil y.
 Proof.
-move=> x y x_int y_real.
-by rewrite ceilNfloor opprD real_floorDzr ?rpredN // opprD -!ceilNfloor.
+move=> xz; rewrite ceilNfloor opprD -to_realN.
+by rewrite to_real_floorDzr 1?rpredN// opprD -!ceilNfloor.
 Qed.
 
+Lemma real_ceilDzr : {in int_num & real_num, {morph ceil : x y / x + y}}.
+Proof. by move=> x y xz yr; rewrite -to_real_ceilDzr// to_realT. Qed.
+
+Lemma to_real_ceilDrz x y :
+  y \is a int_num -> ceil (num_to_real x + y) = ceil x + ceil y.
+Proof. by move=> yz; rewrite addrC to_real_ceilDzr// addrC. Qed.
+
 Lemma real_ceilDrz : {in real_num & int_num, {morph ceil : x y / x + y}}.
-Proof. by move=> x y xr yz; rewrite addrC real_ceilDzr // addrC. Qed.
+Proof. by move=> x y xr yz; rewrite -to_real_ceilDrz// to_realT. Qed.
 
 Lemma ceilN : {in int_num, {morph ceil : x / - x}}.
 Proof. by move=> ? ?; rewrite !ceilNfloor !opprK floorN. Qed.
@@ -510,97 +583,148 @@ Qed.
 Lemma ceilX n : {in int_num, {morph ceil : x / x ^+ n}}.
 Proof. by move=> _ /intrP[m ->]; rewrite -rmorphXn !intrKceil. Qed.
 
-Lemma real_ceil_ge0 x : x \is real_num -> (0 <= ceil x) = (-1 < x).
-Proof.
-by move=> ?; rewrite ceilNfloor oppr_ge0 real_floor_le0 ?realN 1?ltrNl.
-Qed.
+Lemma to_real_ceil_ge0 x : (0 <= ceil x) = (- 1 < num_to_real x).
+Proof. by rewrite ceilNfloor oppr_ge0 to_real_floor_le0 to_realN ltrNl. Qed.
 
-Lemma ceil_lt0 x : (ceil x < 0) = (x <= -1).
+Lemma real_ceil_ge0 x : x \is real_num -> (0 <= ceil x) = (- 1 < x).
+Proof. by rewrite to_real_ceil_ge0 => /to_realT->. Qed.
+
+Lemma ceil_lt0 x : (ceil x < 0) = (x <= - 1).
 Proof. by rewrite ceilNfloor oppr_lt0 floor_gt0 lerNr. Qed.
 
+Lemma to_real_ceil_le0 x : (ceil x <= 0) = (num_to_real x <= 0).
+Proof. exact: to_real_ceil_lez. Qed.
+
 Lemma real_ceil_le0 x : x \is real_num -> (ceil x <= 0) = (x <= 0).
-Proof. by move=> ?; rewrite real_ceil_lez. Qed.
+Proof. exact: real_ceil_lez. Qed.
 
 Lemma ceil_gt0 x : (ceil x > 0) = (x > 0).
 Proof. by rewrite ceilNfloor oppr_gt0 floor_lt0 oppr_lt0. Qed.
 
-Lemma ceil_neq0 x : (ceil x != 0) = (x <= -1) || (x > 0).
-Proof. by rewrite ceilNfloor oppr_eq0 floor_neq0 oppr_lt0 lerNr orbC. Qed.
+Lemma ceil_neq0 x : (ceil x != 0) = (x <= - 1) || (x > 0).
+Proof. by rewrite neq_lt ceil_lt0 ceil_gt0. Qed.
+
+(* TODO: *)
+(* Lemma to_real_ceil_floor x : ceil x = floor x + (to_real x \isn't a int_num). *)
 
 Lemma real_ceil_floor x : x \is real_num ->
   ceil x = floor x + (x \isn't a int_num).
 Proof.
 case Ix: (x \is a int_num) => Rx /=.
   by apply/eqP; rewrite addr0 ceilNfloor eqr_oppLR floorN.
-apply/ceil_def; rewrite addrK; move: (real_floor_itv Rx).
-by rewrite le_eqVlt -intrEfloor Ix /= => /andP[-> /ltW].
+apply/to_real_ceil_eqP; rewrite addrK; have := to_real_floor_itv x.
+by rewrite to_realT// le_eqVlt -intrEfloor Ix /= => /andP[-> /ltW].
 Qed.
 
 (* Relating Cnat and oldCnat. *)
 
 Lemma truncn_floor x : truncn x = if 0 <= x then `|floor x|%N else 0%N.
+Proof. exact: truncn_subproof. Qed.
+
+Lemma truncEfloor x : truncn x = if floor x is Posz n then n else 0.
 Proof.
-move: (floorP x); rewrite truncEfloor realE.
-have [/le_floor|_]/= := boolP (0 <= x); first by rewrite floor0; case: floor.
-by case: ifP => [/le_floor|_ /eqP->//]; rewrite floor0; case: floor => [[]|].
+move: (to_real_floor_le0 x) (to_real_floor_ge0 x).
+rewrite truncn_floor /num_to_real realE; have []//= := comparableP 0 x.
+- by move=> /ltW ->; case: floor.
+- by case: comparableP => //; case: floor.
+- by rewrite ltr01 lexx; case: floor => [[]|].
+- by move=> <-; rewrite ltr01 lexx; case: floor.
 Qed.
 
 (* trunc and nat_num *)
 
-Local Lemma truncnP x :
-  if 0 <= x then (truncn x)%:R <= x < (truncn x).+1%:R else truncn x == 0%N.
+Lemma to_nneg_truncn_itv x : (truncn x)%:R <= num_to_nneg x < (truncn x).+1%:R.
 Proof.
-rewrite truncn_floor.
-case: (boolP (0 <= x)) => //= /[dup] /le_floor + /ger0_real/real_floor_itv.
-by rewrite floor0; case: (floor x) => // n _; rewrite absz_nat addrC -intS.
+rewrite truncn_floor /num_to_nneg.
+case: ifP => le0x; last by rewrite lexx ltr01.
+rewrite 2!pmulrn intS addrC gez0_abs.
+  by rewrite real_floor_ge0// ger0_real.
+by rewrite real_floor_itv// ger0_real.
 Qed.
 
 Lemma truncn_itv x : 0 <= x -> (truncn x)%:R <= x < (truncn x).+1%:R.
-Proof. by move=> x_ge0; move: (truncnP x); rewrite x_ge0. Qed.
+Proof. by move=> le0x; have := to_nneg_truncn_itv x; rewrite to_nnegT. Qed.
+
+#[deprecated(since="mathcomp 2.7.0", use=to_nneg_truncn_itv)]
+Local Lemma truncnP x :
+  if 0 <= x then (truncn x)%:R <= x < (truncn x).+1%:R else truncn x == 0%N.
+Proof.
+have := to_nneg_truncn_itv x; rewrite /num_to_nneg.
+by case: ifP; last by rewrite lern0 => _ /andP[].
+Qed.
+
+Lemma to_nneg_truncn_le x : (truncn x)%:R <= num_to_nneg x.
+Proof. by have/andP[] := to_nneg_truncn_itv x. Qed.
 
 Lemma truncn_le x : ((truncn x)%:R <= x) = (0 <= x).
-Proof. by case: ifP (truncnP x) => [+ /andP[] | + /eqP->//]. Qed.
+Proof. by apply/idP/idP => [|/truncn_itv /andP[] //]; exact: le_trans. Qed.
+
+Lemma to_nneg_truncnS_gt x : num_to_nneg x < (truncn x).+1%:R.
+Proof. by have/andP[] := to_nneg_truncn_itv x. Qed.
+
+Lemma to_real_truncnS_gt x : num_to_real x < (truncn x).+1%:R.
+Proof. by apply/le_lt_trans/to_real_le_nneg: (to_nneg_truncnS_gt x). Qed.
 
 Lemma real_truncnS_gt x : x \is real_num -> x < (truncn x).+1%:R.
-Proof. by move/real_ge0P => [/truncn_itv/andP[]|/lt_le_trans->]. Qed.
+Proof. by move=> xr; have := to_real_truncnS_gt x; rewrite to_realT. Qed.
 
-Lemma truncn_def x n : n%:R <= x < n.+1%:R -> truncn x = n.
+Lemma to_nneg_truncn_geq x n : (n <= truncn x)%N = (n%:R <= num_to_nneg x).
 Proof.
-case/andP=> lemx ltxm1; apply/eqP; rewrite eqn_leq -ltnS -[(n <= _)%N]ltnS.
-have/truncn_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lemx; apply: ler0n.
-by rewrite -!(ltr_nat R) 2?(@le_lt_trans _ _ x).
+apply/idP/idP => lenx.
+  by apply: le_trans (to_nneg_truncn_le x); rewrite ler_nat.
+by rewrite -ltnS -(ltr_nat R); apply: le_lt_trans (to_nneg_truncnS_gt x).
 Qed.
 
 Lemma truncn_geq x n : 0 <= x -> (n <= truncn x)%N = (n%:R <= x).
-Proof.
-move=> /truncn_itv /andP[letx ltxt1]; apply/idP/idP => lenx.
-  by apply: le_trans letx; rewrite ler_nat.
-by rewrite -ltnS -(ltr_nat R); apply: le_lt_trans ltxt1.
-Qed.
+Proof. by rewrite to_nneg_truncn_geq => /to_nnegT->. Qed.
 
 Lemma truncn_gtn x n : (n < truncn x)%N = (n.+1%:R <= x).
 Proof.
-case: ifP (truncnP x) => [x0 _ | x0 /eqP->]; first by rewrite truncn_geq.
-by rewrite ltn0; apply/esym/(contraFF _ x0)/le_trans.
+rewrite to_nneg_truncn_geq /num_to_nneg; case: ifPn => // x0.
+by rewrite lern0/=; apply/esym/(contraNF _ x0)/le_trans.
 Qed.
 
+Lemma to_nneg_truncn_ltn x n : (truncn x < n)%N = (num_to_nneg x < n%:R).
+Proof. by rewrite ltnNge to_nneg_truncn_geq -real_ltNge// real_to_nneg. Qed.
+
 Lemma truncn_ltn x n : 0 <= x -> (truncn x < n)%N = (x < n%:R).
-Proof. by move=> ?; rewrite real_ltNge ?ger0_real// ltnNge truncn_geq. Qed.
+Proof. by rewrite to_nneg_truncn_ltn => /to_nnegT->. Qed.
+
+Lemma to_real_truncn_leq x n : (truncn x <= n)%N = (num_to_real x < n.+1%:R).
+Proof.
+rewrite -ltnS to_nneg_truncn_ltn /num_to_real /num_to_nneg realE.
+by have []//= := comparableP 0 x; rewrite ltr0Sn => /lt_le_trans->.
+Qed.
 
 Lemma real_truncn_leq x n : x \is real_num -> (truncn x <= n)%N = (x < n.+1%:R).
-Proof. by move=> ?; rewrite real_ltNge// leqNgt truncn_gtn. Qed.
+Proof. by rewrite to_real_truncn_leq => /to_realT->. Qed.
+
+Lemma to_nneg_eq_truncn x n :
+  (truncn x == n) = (n%:R <= num_to_nneg x < n.+1%:R).
+Proof.
+by rewrite -to_nneg_truncn_geq -to_nneg_truncn_ltn ltnS -eqn_leq eq_sym.
+Qed.
 
 Lemma eq_truncn x n : 0 <= x -> (truncn x == n) = (n%:R <= x < n.+1%:R).
+Proof. by rewrite to_nneg_eq_truncn => /to_nnegT->. Qed.
+
+Lemma to_nneg_truncn_eqP x n :
+  reflect (truncn x = n) (n%:R <= num_to_nneg x < n.+1%:R).
+Proof. by rewrite -to_nneg_eq_truncn; exact: eqP. Qed.
+
+Lemma truncn_eqP x n : 0 <= x -> reflect (truncn x = n) (n%:R <= x < n.+1%:R).
+Proof. by move=> /eq_truncn <-; exact: eqP. Qed.
+
+(* TODO: rename to truncn_eq *)
+Lemma truncn_def x n : n%:R <= x < n.+1%:R -> truncn x = n.
 Proof.
-by move=> xr; apply/eqP/idP => [<-|]; [exact: truncn_itv|exact: truncn_def].
+by move=> /[dup] /andP[lenx _] ?; apply/truncn_eqP; first exact: le_trans lenx.
 Qed.
 
 Lemma le_truncn : {homo truncn : x y / x <= y >-> (x <= y)%N}.
 Proof.
-move=> x y lexy; move: (truncnP x) (truncnP y).
-case: ifP => [x0 /andP[letx _] | x0 /eqP->//].
-case: ifP => [y0 /andP[_] | y0 /eqP->]; [|by rewrite (le_trans x0 lexy) in y0].
-by move=> /(le_lt_trans lexy) /(le_lt_trans letx); rewrite ltr_nat ltnS.
+move=> x y lexy; rewrite to_nneg_truncn_geq.
+by apply: le_trans (to_nneg_truncn_le x) (ler_to_nneg lexy).
 Qed.
 
 Lemma natrK : cancel (GRing.natmul 1) truncn.
@@ -611,11 +735,14 @@ Proof.
 by apply/natrP/eqP => [[n ->]|<-]; [rewrite natrK | exists (truncn x)].
 Qed.
 
-Lemma archi_boundP x : 0 <= x -> x < (bound x)%:R.
+Lemma to_nneg_archi_boundP x : num_to_nneg x < (bound x)%:R.
 Proof.
-move=> x_ge0; case/truncn_itv/andP: (normr_ge0 x) => _.
-exact/le_lt_trans/real_ler_norm/ger0_real.
+rewrite -truncn_ltn; first exact: nneg_to_nneg.
+by rewrite ltnS le_truncn// /num_to_nneg; case: ifPn => // /normr_idP->.
 Qed.
+
+Lemma archi_boundP x : 0 <= x -> x < (bound x)%:R.
+Proof. by move=> x_ge0; have := to_nneg_archi_boundP x; rewrite to_nnegT. Qed.
 
 Lemma truncnK : {in nat_num, cancel truncn (GRing.natmul 1)}.
 Proof. by move=> x; rewrite natrEtruncn => /eqP. Qed.
@@ -624,12 +751,20 @@ Lemma truncn0 : truncn 0 = 0%N. Proof. exact: natrK 0%N. Qed.
 Lemma truncn1 : truncn 1 = 1%N. Proof. exact: natrK 1%N. Qed.
 #[local] Hint Resolve truncn0 truncn1 : core.
 
+Lemma to_nneg_truncnDnr x y :
+  x \is a nat_num -> truncn (x + num_to_nneg y) = (truncn x + truncn y)%N.
+Proof.
+move=> /natrP[n ->]; apply: truncn_def.
+by rewrite -addnS !natrD !natrK lerD2l ltrD2l to_nneg_truncn_itv.
+Qed.
+
+Lemma to_nneg_truncnDrn x y :
+  y \is a nat_num -> truncn (num_to_nneg x + y) = (truncn x + truncn y)%N.
+Proof. by move=> yn; rewrite addrC to_nneg_truncnDnr// addnC. Qed.
+
 Lemma truncnDnr :
   {in nat_num & nneg_num, {morph truncn : x y / x + y >-> (x + y)%N}}.
-Proof.
-move=> _ y /natrP[n ->] y_ge0; apply: truncn_def.
-by rewrite -addnS !natrD !natrK lerD2l ltrD2l truncn_itv.
-Qed.
+Proof. by move=> x y ? ?; rewrite -to_nneg_truncnDnr// to_nnegT. Qed.
 
 Lemma truncnDrn :
   {in nneg_num & nat_num, {morph truncn : x y / x + y >-> (x + y)%N}}.
@@ -642,10 +777,7 @@ Lemma truncnX n : {in nat_num, {morph truncn : x / x ^+ n >-> (x ^ n)%N}}.
 Proof. by move=> _ /natrP[n1 ->]; rewrite -natrX !natrK. Qed.
 
 Lemma truncn_gt0 x : (0 < truncn x)%N = (1 <= x).
-Proof.
-case: ifP (truncnP x) => [x0 | x0 /eqP<-]; first by rewrite truncn_geq.
-by rewrite ltnn; apply/esym/(contraFF _ x0)/le_trans.
-Qed.
+Proof. by rewrite truncn_gtn. Qed.
 
 Lemma truncn0Pn x : reflect (truncn x = 0%N) (~~ (1 <= x)).
 Proof. by rewrite -truncn_gt0 -eqn0Ngt; apply: eqP. Qed.
@@ -811,14 +943,14 @@ Section ArchiRealDomainTheory.
 Variables (R : archiRealDomainType).
 Implicit Type x : R.
 
-Lemma upper_nthrootP x i : (bound x <= i)%N -> x < 2%:R ^+ i.
-Proof.
-case/truncn_itv/andP: (normr_ge0 x) => _ /ltr_normlW xlt le_b_i.
-by rewrite (lt_le_trans xlt) // -natrX ler_nat (ltn_trans le_b_i) // ltn_expl.
-Qed.
-
 Lemma truncnS_gt x : x < (truncn x).+1%:R.
 Proof. exact: real_truncnS_gt. Qed.
+
+Lemma upper_nthrootP x i : (bound x <= i)%N -> x < 2%:R ^+ i.
+Proof.
+move=> le_b_i; have/ltr_normlW/lt_le_trans->// := truncnS_gt `|x|.
+by rewrite -natrX ler_nat (ltn_trans le_b_i)// ltn_expl.
+Qed.
 
 Lemma truncn_leq x n : (truncn x <= n)%N = (x < n.+1%:R).
 Proof. exact: real_truncn_leq. Qed.
@@ -830,6 +962,9 @@ Lemma floor_le x : (floor x)%:~R <= x. Proof. exact: real_floor_le. Qed.
 
 Lemma floorD1_gt x : x < (floor x + 1)%:~R.
 Proof. exact: real_floorD1_gt. Qed.
+
+Lemma floor_eqP x n : reflect (floor x = n) (n%:~R <= x < (n + 1)%:~R).
+Proof. exact: real_floor_eqP. Qed.
 
 Lemma floor_gez x n : (n <= floor x) = (n%:~R <= x).
 Proof. exact: real_floor_gez. Qed.
@@ -844,7 +979,7 @@ Lemma floorDzr : {in @int_num R, {morph floor : x y / x + y}}.
 Proof. by move=> x xz y; apply/real_floorDzr/num_real. Qed.
 
 Lemma floorDrz x y : y \is a int_num -> floor (x + y) = floor x + floor y.
-Proof. by move=> yz; apply/real_floorDrz/yz/num_real. Qed.
+Proof. exact/real_floorDrz/num_real. Qed.
 
 Lemma floor_ge0 x : (0 <= floor x) = (0 <= x).
 Proof. exact: real_floor_ge0. Qed.
@@ -860,6 +995,9 @@ Proof. exact: real_ceilB1_lt. Qed.
 
 Lemma ceil_ge x : x <= (ceil x)%:~R. Proof. exact: real_ceil_ge. Qed.
 
+Lemma ceil_eqP x n : reflect (ceil x = n) ((n - 1)%:~R < x <= n%:~R).
+Proof. exact: real_ceil_eqP. Qed.
+
 Lemma ceil_lez x n : (ceil x <= n) = (x <= n%:~R).
 Proof. exact: real_ceil_lez. Qed.
 
@@ -873,9 +1011,9 @@ Lemma ceilDzr : {in @int_num R, {morph ceil : x y / x + y}}.
 Proof. by move=> x xz y; apply/real_ceilDzr/num_real. Qed.
 
 Lemma ceilDrz x y : y \is a int_num -> ceil (x + y) = ceil x + ceil y.
-Proof. by move=> yz; apply/real_ceilDrz/yz/num_real. Qed.
+Proof. exact/real_ceilDrz/num_real. Qed.
 
-Lemma ceil_ge0 x : (0 <= ceil x) = (-1 < x).
+Lemma ceil_ge0 x : (0 <= ceil x) = (- 1 < x).
 Proof. exact: real_ceil_ge0. Qed.
 
 Lemma ceil_le0 x : (ceil x <= 0) = (x <= 0).
@@ -956,6 +1094,61 @@ End Theory.
 
 (* Factories *)
 
+HB.factory Record NumDomain_hasFloorCeilTruncn_deprecated R
+    & Num.NumDomain R := {
+  floor : R -> int;
+  ceil  : R -> int;
+  truncn : R -> nat;
+  int_num_subdef : pred R;
+  nat_num_subdef : pred R;
+  floor_subproof :
+    forall x,
+      if x \is real_num then (floor x)%:~R <= x < (floor x + 1)%:~R
+      else floor x == 0;
+  ceil_subproof : forall x, ceil x = - floor (- x);
+  truncn_subproof : forall x, truncn x = if floor x is Posz n then n else 0;
+  int_num_subproof : forall x, reflect (exists n, x = n%:~R) (int_num_subdef x);
+  nat_num_subproof : forall x, reflect (exists n, x = n%:R) (nat_num_subdef x);
+}.
+
+#[deprecated(since="mathcomp 2.7.0",
+             use=NumDomain_hasFloorCeilTruncn_truncn_abs_floor)]
+Notation NumDomain_hasFloorCeilTruncn R :=
+ (NumDomain_hasFloorCeilTruncn_deprecated R) (only parsing).
+
+Module NumDomain_hasFloorCeilTruncn.
+#[deprecated(since="mathcomp 2.7.0",
+             use=NumDomain_hasFloorCeilTruncn_truncn_abs_floor)]
+Notation Build T U :=
+  (NumDomain_hasFloorCeilTruncn_deprecated.Build T U) (only parsing).
+End NumDomain_hasFloorCeilTruncn.
+
+HB.builders Context R & NumDomain_hasFloorCeilTruncn_deprecated R.
+
+Fact floor_subproof' x : (floor x)%:~R <= num_to_real x < (floor x + 1)%:~R.
+Proof.
+have := floor_subproof x; rewrite /num_to_real.
+by case: ifPn => // _ /eqP ->; rewrite add0r lexx ltr01.
+Qed.
+
+Fact truncn_subproof' x : truncn x = if 0 <= x then `|floor x|%N else 0%N.
+Proof.
+have := floor_subproof x; rewrite realE truncn_subproof.
+have []//= := comparableP x 0.
+- by move=> x_lt0 /andP[/le_lt_trans/(_ x_lt0) + _]; rewrite ltrz0; case: floor.
+- by move=> x_gt0 /andP[_ /(lt_trans x_gt0)]; rewrite ltr0z ltzD1; case: floor.
+- by move=> _ /eqP ->.
+- by move=> -> /andP[_]; rewrite ltr0z ltzD1; case: floor.
+Qed.
+
+HB.instance Definition _ :=
+  @NumDomain_hasFloorCeilTruncn_truncn_abs_floor.Build R
+    floor ceil truncn int_num_subdef nat_num_subdef
+    floor_subproof' ceil_subproof truncn_subproof'
+    int_num_subproof nat_num_subproof.
+
+HB.end.
+
 HB.factory Record NumDomain_hasTruncn R & Num.NumDomain R := {
   truncn : R -> nat;
   nat_num : pred R;
@@ -977,19 +1170,20 @@ End NumDomain_isArchimedean.
 HB.builders Context R & NumDomain_hasTruncn R.
 
 Fact truncn_itv x : 0 <= x -> (truncn x)%:R <= x < (truncn x).+1%:R.
-Proof. by move=> x_ge0; move: (truncn_subproof x); rewrite x_ge0. Qed.
+Proof. by move=> x_ge0; have := truncn_subproof x; rewrite x_ge0. Qed.
 
 Definition floor (x : R) : int :=
   if 0 <= x then Posz (truncn x)
   else if x < 0 then - Posz (truncn (- x) + ~~ int_num x) else 0.
 
-Fact floor_subproof x :
-  if x \is real_num then (floor x)%:~R <= x < (floor x + 1)%:~R else floor x == 0.
+Fact floor_subproof x : (floor x)%:~R <= num_to_real x < (floor x + 1)%:~R.
 Proof.
-rewrite /floor intrE !natrE negb_or realE.
-case: (comparableP x 0) (@truncn_itv x) => //=;
-  try by rewrite -PoszD addn1 -pmulrn => _ ->.
-move=> x_lt0 _; move: (truncn_subproof x); rewrite lt_geF // => /eqP ->.
+rewrite /num_to_real realE /floor intrE !natrE negb_or.
+have []/= := comparableP x 0; last first.
+- by move=> ->; rewrite -PoszD addn1 -!pmulrn truncn_itv.
+- by rewrite lexx ltr01.
+- by move=> /ltW ?; rewrite -PoszD addn1 -!pmulrn truncn_itv.
+move=> x_lt0; have := truncn_subproof x; rewrite lt_geF// => /eqP ->.
 rewrite gt_eqF //=; move: x_lt0.
 rewrite [_ + 1]addrC -opprB !intrN lerNl ltrNr andbC -oppr_gt0.
 move: {x}(- x) => x x_gt0; rewrite PoszD -addrA -PoszD.
@@ -1001,17 +1195,15 @@ case: eqVneq => /=; last first.
 by rewrite intrB mulr1z addn0 -!pmulrn => -> _; rewrite gtrBl lexx andbT.
 Qed.
 
-Fact truncnE x : truncn x = if floor x is Posz n then n else 0.
+Fact truncnE x : truncn x = if 0 <= x then `|floor x|%N else 0%N.
 Proof.
-rewrite /floor.
-case: (comparableP x 0) (truncn_subproof x) => [+ /eqP ->| |_ /eqP ->|] //=.
-by case: (_ + _)%N.
+by rewrite /floor; case: (comparableP x 0) (truncn_subproof x) => //= _ /eqP ->.
 Qed.
 
 Fact truncn_def x n : n%:R <= x < n.+1%:R -> truncn x = n.
 Proof.
-case/andP=> lemx ltxm1; apply/eqP; rewrite eqn_leq -ltnS -[(n <= _)%N]ltnS.
-have/truncn_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lemx; apply: ler0n.
+case/andP=> lenx ltx1; apply/eqP; rewrite eqn_leq -ltnS -[(n <= _)%N]ltnS.
+have/truncn_itv/andP[lefx ltxf1]: 0 <= x by apply: le_trans lenx; apply: ler0n.
 by rewrite -!(ltr_nat R) 2?(@le_lt_trans _ _ x).
 Qed.
 
@@ -1033,7 +1225,8 @@ by apply: (iffP eqP) => [<-|[n ->]]; [exists (truncn x) | rewrite natrK].
 Qed.
 
 HB.instance Definition _ :=
-  @NumDomain_hasFloorCeilTruncn.Build R floor _ truncn int_num nat_num
+  @NumDomain_hasFloorCeilTruncn_truncn_abs_floor.Build R
+    floor _ truncn int_num nat_num
     floor_subproof (fun=> erefl) truncnE intrP natrP.
 
 HB.end.

--- a/algebra/numeric_hierarchy/orderedzmod.v
+++ b/algebra/numeric_hierarchy/orderedzmod.v
@@ -40,6 +40,10 @@ From mathcomp Require Import rings_modules_and_algebras.
 (* x \is a Num.nneg <=> x is positive or 0 (:= x >= 0)                        *)
 (* x \is a Num.npos <=> x is negative or 0 (:= x <= 0)                        *)
 (* x \is a Num.real <=> x is real (:= x >= 0 or x < 0)                        *)
+(*    Num.to_real x == x if x is real, otherwise 0                            *)
+(*                  := if x \is Num.real then x else 0                        *)
+(*    Num.to_nneg x == x if x is positive or 0, otherwise 0                   *)
+(*                  := if 0 <= x then x else 0                                *)
 (*                                                                            *)
 (* - list of prefixes :                                                       *)
 (*   p : positive                                                             *)
@@ -194,6 +198,9 @@ Definition npos_num : qualifier 0 R := [qualify x : R | npos_num_pred x].
 Definition real_num_pred := fun x : R => (ler 0 x) || (ler x 0).
 Definition real_num : qualifier 0 R := [qualify x : R | real_num_pred x].
 
+Definition num_to_real (x : R) : R := if x \is real_num then x else 0.
+Definition num_to_nneg (x : R) : R := if ler 0 x then x else 0.
+
 End Def.
 
 Arguments pos_num_pred _ _ /.
@@ -239,6 +246,9 @@ Notation neg := neg_num.
 Notation nneg := nneg_num.
 Notation npos := npos_num.
 Notation real := real_num.
+
+Notation to_real := num_to_real.
+Notation to_nneg := num_to_nneg.
 
 (* (Exported) symbolic syntax. *)
 Module Import Syntax.
@@ -817,6 +827,33 @@ Proof. by case: C; rewrite /= lterBDl. Qed.
 
 Definition lteifBDl := (lteifBlDl, lteifBrDl).
 
+Lemma to_realT x : x \is real_num -> to_real x = x.
+Proof. exact: ifT. Qed.
+
+Lemma real_to_real x : to_real x \is real_num.
+Proof. by rewrite /to_real; case: ifP. Qed.
+
+Lemma to_nnegT x : 0 <= x -> to_nneg x = x.
+Proof. exact: ifT. Qed.
+
+Lemma ler_to_nneg : {homo @to_nneg R : x y / x <= y}.
+Proof.
+move=> x y lexy; rewrite /to_nneg; case: ifP => [le0x|]; last by case: ifP.
+by rewrite (le_trans le0x lexy).
+Qed.
+
+Lemma nneg_to_nneg x : to_nneg x \is nneg_num.
+Proof. by rewrite nnegrE /to_nneg; case: ifP. Qed.
+
+Lemma real_to_nneg x : to_nneg x \is real_num.
+Proof. exact/ger0_real/nneg_to_nneg. Qed.
+
+(* TOTHINK: is this the right name? *)
+Lemma to_real_le_nneg x : to_real x <= to_nneg x.
+Proof.
+by rewrite /to_real /to_nneg realE; have []//= := comparableP 0 x => /ltW.
+Qed.
+
 End porderZmodTypeTheory.
 
 #[global]
@@ -1032,6 +1069,12 @@ Qed.
 
 Lemma real_addr_maxr : {in real & real & real, @right_distributive R R +%R max}.
 Proof. by move=> x y z xr yr zr; rewrite !(addrC x) real_addr_maxl. Qed.
+
+Lemma ler_to_real : {homo @to_real R : x y / x <= y}.
+Proof. by move=> x y lexy; rewrite /to_real (ler_real lexy); case: ifP. Qed.
+
+Lemma to_realN x : to_real (- x) = - to_real x.
+Proof. by rewrite /to_real realN; case: ifP; rewrite // oppr0. Qed.
 
 End NumZmoduleTheory.
 

--- a/algebra/rat.v
+++ b/algebra/rat.v
@@ -781,18 +781,17 @@ Let is_int x := denq x == 1.
 
 Let is_nat x := (0 <= x) && (denq x == 1).
 
-Fact floorP x :
-  if x \is Num.real then (floor x)%:~R <= x < (floor x + 1)%:~R
-  else floor x == 0.
+Fact floorP x : (floor x)%:~R <= Num.to_real x < (floor x + 1)%:~R.
 Proof.
-rewrite num_real /floor; case: (ratP x) => n d _ {x}; rewrite ler_pdivlMr//.
+rewrite to_realT ?num_real// /floor.
+case: (ratP x) => n d _ {x}; rewrite ler_pdivlMr//.
 by rewrite ltr_pdivrMr// -!intrM ler_int ltr_int lez_floor ?ltz_ceil.
 Qed.
 
 Fact ceilP x : ceil x = - floor (- x).
 Proof. by rewrite /ceil /floor numqN denqN. Qed.
 
-Fact truncnP x : truncn x = if floor x is Posz n then n else 0.
+Fact truncnP x : truncn x = if 0 <= x then `|floor x|%N else 0%N.
 Proof.
 rewrite /truncn /floor; case: (ratP x) => n d _ {x} /=.
 by rewrite !ler_pdivlMr// mul0r; case: n => n; rewrite ler0z//= mul1n.
@@ -815,7 +814,7 @@ End ratArchimedean.
 End ratArchimedean.
 
 HB.instance Definition _ :=
-  Num.NumDomain_hasFloorCeilTruncn.Build rat
+  Num.NumDomain_hasFloorCeilTruncn_truncn_abs_floor.Build rat
     ratArchimedean.floorP ratArchimedean.ceilP ratArchimedean.truncnP
     ratArchimedean.intrP ratArchimedean.natrP.
 

--- a/doc/changelog/01-added/1510-archimedan-lemmas.md
+++ b/doc/changelog/01-added/1510-archimedan-lemmas.md
@@ -1,0 +1,26 @@
+- in `orderedzmod.v`
+  + Definitions `Num.to_real` and `Num.to_nneg`
+  + Lemmas `to_realT`, `real_to_real`, `to_nnegT`, `ler_to_nneg`,
+    `nneg_to_nneg`, `real_to_nneg`, `to_real_le_nneg`, `ler_to_real`, `to_realN`
+    ([#1510](https://github.com/math-comp/math-comp/pull/1510),
+    fixes [#1377](https://github.com/math-comp/math-comp/issues/1377)).
+
+- in `archimedean.v`
+  + Mixin `NumDomain_hasFloorCeilTruncn_truncn_abs_floor` which
+    eventually replaces the old archimedean mixin
+	`NumDomain_hasFloorCeilTruncn`
+  + Lemmas `truncnDrn`, `to_real_floor_itv`, `to_real_floor_le`,
+    `to_real_floorD1_gt`, `to_real_floor_gez`, `to_real_floor_ltz`,
+    `to_real_eq_floor`, `to_real_floor_eqP`, `real_floor_eqP`,
+    `to_real_floorDzr`, `to_real_floorDrz`, `to_real_floor_ge0`,
+    `to_real_floor_le0`, `to_real_ceil_itv`, `to_real_ceilB1_lt`,
+    `to_real_ceil_ge`, `to_real_ceil_lez`, `to_real_ceil_gtz`,
+    `to_real_eq_ceil`, `to_real_ceil_eqP`, `real_ceil_eqP`, `to_real_ceilDzr`,
+    `to_real_ceilDrz`, `to_real_ceil_ge0`, `to_real_ceil_le0`,
+    `to_nneg_truncn_itv`, `to_nneg_truncn_le`, `to_nneg_truncnS_gt`,
+    `to_real_truncnS_gt`, `to_nneg_truncn_geq`, `to_nneg_truncn_ltn`,
+    `to_real_truncn_leq`, `to_nneg_eq_truncn`, `to_nneg_truncn_eqP`,
+    `truncn_eqP`, `to_nneg_archi_boundP`, `to_nneg_truncnDnr`,
+    `to_nneg_truncnDrn`, `floor_eqP`, `ceil_eqP`
+    ([#1510](https://github.com/math-comp/math-comp/pull/1510),
+    fixes [#1377](https://github.com/math-comp/math-comp/issues/1377)).

--- a/doc/changelog/03-renamed/1510-archimedan-lemmas.md
+++ b/doc/changelog/03-renamed/1510-archimedan-lemmas.md
@@ -1,0 +1,22 @@
+- in `archimedean.v`
+  + `real_floor_ge_int` -> `real_floor_gez`
+  + `floor_ge_int` -> `floor_gez`
+  + `real_floor_lt_int` -> `real_floor_ltz`
+  + `floor_lt_int` -> `floor_ltz`
+  + `real_ceil_le_int` -> `real_ceil_lez`
+  + `ceil_le_int` -> `ceil_lez`
+  + `real_ceil_gt_int` -> `real_ceil_gtz`
+  + `ceil_gt_int` -> `ceil_gtz`
+  + `truncn_ge_nat` -> `truncn_geq`
+  + `truncn_gt_nat` -> `truncn_gtn`
+  + `truncn_lt_nat` -> `truncn_ltn`
+  + `real_truncn_le_nat` -> `real_truncn_leq`
+  + `truncn_le_nat` -> `truncn_leq`
+  + `real_floor_eq` -> `real_eq_floor`
+  + `floor_eq` -> `eq_floor`
+  + `real_ceil_eq` -> `real_eq_ceil`
+  + `ceil_eq` -> `eq_ceil`
+  + `truncn_eq` -> `eq_truncn`
+  + `truncnD` -> `truncnDnr`
+    ([#1510](https://github.com/math-comp/math-comp/pull/1510),
+    fixes [#1377](https://github.com/math-comp/math-comp/issues/1377)).

--- a/doc/changelog/05-deprecated/1510-archimedan-lemmas.md
+++ b/doc/changelog/05-deprecated/1510-archimedan-lemmas.md
@@ -1,0 +1,6 @@
+- in `archimedean.v`
+  + Lemma `floorP`, `truncnP`
+  + Mixin `NumDomain_hasFloorCeilTruncn`, use
+    `NumDomain_hasFloorCeilTruncn_truncn_abs_floor` instead
+    ([#1510](https://github.com/math-comp/math-comp/pull/1510),
+    fixes [#1377](https://github.com/math-comp/math-comp/issues/1377)).

--- a/group_representation/character.v
+++ b/group_representation/character.v
@@ -2611,7 +2611,7 @@ Lemma cfDetD :
   {in character &, {morph cfDet : phi psi / phi + psi >-> phi * psi}}.
 Proof.
 move=> phi psi Nphi Npsi; rewrite unlock /= -big_split; apply: eq_bigr => i _ /=.
-by rewrite -exprD cfdotDl truncnD ?nnegrE ?natr_ge0 // Cnat_cfdot_char_irr.
+by rewrite -exprD cfdotDl truncnDnr ?nnegrE ?natr_ge0 // Cnat_cfdot_char_irr.
 Qed.
 
 Lemma cfDet0 : cfDet 0 = 1.


### PR DESCRIPTION
##### Motivation for this change

This PR adds some lemmas for `archiNumDomainType` and `archiRealDomainType` using `to_real` (also `to_nneg`) suggested by @CohenCyril (cf. https://github.com/math-comp/math-comp/issues/1377#issuecomment-2779452638).

Most of these lemmas for `floor` and `ceil` generalize existing lemmas requiring the `Num.real` condition on a variable. Since the names of these lemmas have the prefix `real_`, the names of their general versions replace it with `to_real_` for the moment. Similarly, some of the new lemmas for `truncn` have the prefix `to_nneg_`. (We probably need to think a bit more about the naming convention here.)

In the end, I didn't find `floorP`, `ceilP`, and `truncnP` stated using `spec` datatypes very useful (cf. https://github.com/math-comp/math-comp/issues/1377#issuecomment-2776253420). I keep their statements as comments for the moment.

**I suggest extensively testing the new lemmas in MCA before merging this PR.**

(Eventually) Fix #1377

##### Dependencies

- #1526

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
