### PR TITLE
define joins of POrderedZmodule and (Semi)NormedZmodule

### DIFF
--- a/algebra/num_theory/numdomain.v
+++ b/algebra/num_theory/numdomain.v
@@ -100,6 +100,18 @@ Notation "[ 'normedZmodType' R 'of' T ]" := (@clone _ (Phant R) T _ _ id)
 End NormedZmoduleExports.
 HB.export NormedZmoduleExports.
 
+HB.structure Definition POrderSemiNormedZmodule (R : porderZmodType) :=
+  { M of POrderZmodule M & Zmodule_isSemiNormed R M}.
+
+HB.structure Definition POrderNormedZmodule (R : porderZmodType) :=
+  { M of POrderZmodule M & Zmodule_isNormed R M}.
+
+HB.structure Definition POrderedSemiNormedZmodule (R : porderZmodType) :=
+  { M of POrderedZmodule M & Zmodule_isSemiNormed R M}.
+
+HB.structure Definition POrderedNormedZmodule (R : porderZmodType) :=
+  { M of POrderedZmodule M & Zmodule_isNormed R M}.
+
 HB.mixin Record NumZmod_isNumRing R of GRing.NzRing R & POrderZmodule R
   & NormedZmodule (POrderZmodule.clone R _) R := {
  addr_gt0 : forall x y : R, 0 < x -> 0 < y -> 0 < (x + y);


### PR DESCRIPTION
##### Motivation for this change

Define the joins between POrderedZmodule and SemiNormedZmodule/NormedZmodule (in algebra/num_theory/numdomain.v).

This allows for the subsequent development of mathematical theories related to vector orders.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
