### PR TITLE
Added lemma uniq_map_indexE and uniq_map_in_inj to seq

### DIFF
--- a/boot/seq.v
+++ b/boot/seq.v
@@ -2848,36 +2848,29 @@ case/subseqP=> m sz_m ->; apply/subseqP.
 by exists m; rewrite ?size_map ?map_mask.
 Qed.
 
-Lemma nth_index_map s x0 x :
-  {in s &, injective f} -> x \in s -> nth x0 s (index (f x) (map f s)) = x.
-Proof.
-elim: s => //= y s IHs inj_f s_x; rewrite (inj_in_eq inj_f) ?mem_head //.
-move: s_x; rewrite inE; have [-> // | _] := eqVneq; apply: IHs.
-by apply: sub_in2 inj_f => z; apply: predU1r.
-Qed.
-
 Lemma index_map_in s x :
   {in s &, injective f} -> x \in s -> index (f x) (map f s) = index x s.
 Proof.
-elim: s => // y s IHs inj_f s_x /=.
-have -> : (f y == f x) = (y == x).
-  by apply/eqP/eqP => [/inj_f ->| ->] //; rewrite inE eqxx.
-case: (boolP (y == x)) => [//| /negbTE neq_x_y].
-rewrite {}IHs //.
-  by move=> {s_x neq_x_y}x z sx sz; apply: inj_f; apply: predU1r.
-by move: s_x; rewrite inE eq_sym neq_x_y.
+move=> f_inj x_in_s; rewrite /index find_map.
+by apply: eq_in_find => y /= y_s; rewrite (inj_in_eq f_inj).
+Qed.
+
+Lemma index_map_inW s x : {in s, injective f} -> index (f x) (map f s) = index x s.
+Proof.
+move=> fI; have [/index_map_in-> // _ _ _ _ /fI-> //|xs] := boolP (x \in s).
+rewrite !memNindex ?size_map//; apply/mapP => -[y ys].
+by move=> /esym/fI -/(_ ys) yx; rewrite -yx ys in xs.
 Qed.
 
 Lemma uniq_map_inj_in s : uniq (map f s) -> {in s &, injective f}.
 Proof.
-move=> f_uniq.
-have indmap x : x \in s -> index (f x) (map f s) = index x s.
-  move=> /[dup] sx /map_f sfx; apply/eqP.
-  rewrite -(nth_uniq (f x) _ _ f_uniq) ?index_mem ?size_map ?index_mem //.
-  by rewrite nth_index // (nth_map x) ?index_mem // nth_index.
-move=> x y sx sy eqfxy; apply: (index_inj x sx sy).
-by rewrite -!indmap ?eqfxy.
+move=> f_uniq x y /(nthP x)[i ilt <-] /(nthP x)[j jlt <-].
+by rewrite -!(nth_map _ (f x))// => /uniqP /[!(inE, size_map)] ->.
 Qed.
+
+Lemma nth_index_map s x0 x :
+  {in s &, injective f} -> x \in s -> nth x0 s (index (f x) (map f s)) = x.
+Proof. by move=> f_inj x_in_s; rewrite index_map_in// nth_index. Qed.
 
 Lemma perm_map s t : perm_eq s t -> perm_eq (map f s) (map f t).
 Proof. by move/permP=> Est; apply/permP=> a; rewrite !count_map Est. Qed.
@@ -2894,7 +2887,7 @@ Lemma mem_map s x : (f x \in map f s) = (x \in s).
 Proof. by apply/mapP/idP=> [[y Hy /Hf->] //|]; exists x. Qed.
 
 Lemma index_map s x : index (f x) (map f s) = index x s.
-Proof. by rewrite /index; elim: s => //= y s IHs; rewrite (inj_eq Hf) IHs. Qed.
+Proof. by apply: index_map_inW; apply: in1W. Qed.
 
 Lemma map_inj_uniq s : uniq (map f s) = uniq s.
 Proof. by apply: map_inj_in_uniq; apply: in2W. Qed.

--- a/doc/changelog/01-added/1514-seq_index.md
+++ b/doc/changelog/01-added/1514-seq_index.md
@@ -1,3 +1,3 @@
 - in `boot/seq.v`
-  + added lemmas `take_mkseq`, `drop_mkseq`, `index_map_uniq` and `uniq_map_inj_in`
+  + added lemmas `take_mkseq`, `drop_mkseq`, `index_map_in`, `index_map_inW`,  and `uniq_map_inj_in`
     ([#1514](https://github.com/math-comp/math-comp/pull/1514)).


### PR DESCRIPTION
##### Motivation for this change

Add some missing lemma about unicity and map in seq.v
Should be ready for review now.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
