### PR TITLE
Reduce `Require Import` and `Open Scope` in `num_theory`

### DIFF
--- a/algebra/num_theory/numdomain.v
+++ b/algebra/num_theory/numdomain.v
@@ -2,8 +2,8 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import ssrAC div fintype path bigop order finset fingroup.
-From mathcomp Require Import interval ssralg poly orderedzmod.
+From mathcomp Require Import fintype bigop finset fingroup nmodule order.
+From mathcomp Require Import interval algebra divalg poly orderedzmod.
 
 (******************************************************************************)
 (*                    Number structures (numdomain.v)                         *)
@@ -43,8 +43,6 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Local Open Scope order_scope.
-Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Import Order.TTheory GRing.Theory.
@@ -1393,12 +1391,12 @@ Context {I : finType} (i0 : I).
 Context (P : pred I) (F : I -> R) (Pi0 : P i0).
 Hypothesis F_real : {in P, forall i, F i \is real}.
 
-Lemma real_arg_minP : extremum_spec <=%R P F [arg min_(i < i0 | P i) F i].
+Lemma real_arg_minP : extremum_spec <=%R P F [arg min_(i < i0 | P i) F i]%O.
 Proof.
 by apply: comparable_arg_minP => // i j iP jP; rewrite real_comparable ?F_real.
 Qed.
 
-Lemma real_arg_maxP : extremum_spec >=%R P F [arg max_(i > i0 | P i) F i].
+Lemma real_arg_maxP : extremum_spec >=%R P F [arg max_(i > i0 | P i) F i]%O.
 Proof.
 by apply: comparable_arg_maxP => // i j iP jP; rewrite real_comparable ?F_real.
 Qed.
@@ -2034,10 +2032,10 @@ Proof. by rewrite ltr0n cardG_gt0. Qed.
 Lemma natrG_neq0 G : #|G|%:R != 0 :> R.
 Proof. by rewrite gt_eqF // natrG_gt0. Qed.
 
-Lemma natr_indexg_gt0 G B : #|G : B|%:R > 0 :> R.
+Lemma natr_indexg_gt0 G B : #|G : B|%g%:R > 0 :> R.
 Proof. by rewrite ltr0n indexg_gt0. Qed.
 
-Lemma natr_indexg_neq0 G B : #|G : B|%:R != 0 :> R.
+Lemma natr_indexg_neq0 G B : #|G : B|%g%:R != 0 :> R.
 Proof. by rewrite gt_eqF // natr_indexg_gt0. Qed.
 
 End FinGroup.

--- a/algebra/num_theory/numfield.v
+++ b/algebra/num_theory/numfield.v
@@ -2,8 +2,9 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import ssrAC div fintype path bigop order finset fingroup.
-From mathcomp Require Import interval ssralg poly orderedzmod numdomain.
+From mathcomp Require Import div path fintype bigop ssrAC finset fingroup.
+From mathcomp Require Import nmodule order interval algebra divalg decfield.
+From mathcomp Require Import poly orderedzmod numdomain.
 
 (******************************************************************************)
 (*                      Number structures (numfield.v)                        *)
@@ -65,8 +66,6 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Local Open Scope order_scope.
-Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Import Order.TTheory GRing.Theory.
@@ -457,7 +456,7 @@ by rewrite le_gtF // ub_q // normfV invf_le1 ?normr_gt0.
 Qed.
 
 Lemma natf_indexg (gT : finGroupType) (G H : {group gT}) :
-  H \subset G -> #|G : H|%:R = (#|G|%:R / #|H|%:R)%R :> F.
+  H \subset G -> #|G : H|%g%:R = (#|G|%:R / #|H|%:R)%R :> F.
 Proof. by move=> sHG; rewrite -divgS // natf_div ?cardSg. Qed.
 
 End NumFieldTheory.

--- a/algebra/num_theory/orderedzmod.v
+++ b/algebra/num_theory/orderedzmod.v
@@ -2,8 +2,7 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import ssrAC div fintype path bigop order finset fingroup.
-From mathcomp Require Import ssralg poly.
+From mathcomp Require Import fintype bigop nmodule order algebra.
 
 (******************************************************************************)
 (*                    Number structures (orderedzmod.v)                       *)
@@ -55,8 +54,6 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Local Open Scope order_scope.
-Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Import Order.TTheory GRing.Theory.
@@ -84,7 +81,7 @@ End POrderZmoduleExports.
 HB.export POrderZmoduleExports.
 
 HB.mixin Record Add_isHomo R of POrderNmodule R := {
-  ler_wD2l : forall x : R, {homo +%R x : y z / y <= z}
+  ler_wD2l : forall x : R, {homo +%R x : y z / (y <= z)%O}
 }.
 
 #[short(type="porderedNmodType")]
@@ -185,15 +182,15 @@ Notation "@ 'minr' R" := (@Order.min ring_display R)
 Section Def.
 Context {R : porderNmodType}.
 
-Definition pos_num_pred := fun x : R => 0 < x.
+Definition pos_num_pred := fun x : R => ltr 0 x.
 Definition pos_num : qualifier 0 R := [qualify x | pos_num_pred x].
-Definition neg_num_pred := fun x : R => x < 0.
+Definition neg_num_pred := fun x : R => ltr x 0.
 Definition neg_num : qualifier 0 R := [qualify x : R | neg_num_pred x].
-Definition nneg_num_pred := fun x : R => 0 <= x.
+Definition nneg_num_pred := fun x : R => ler 0 x.
 Definition nneg_num : qualifier 0 R := [qualify x : R | nneg_num_pred x].
-Definition npos_num_pred := fun x : R => x <= 0.
+Definition npos_num_pred := fun x : R => ler x 0.
 Definition npos_num : qualifier 0 R := [qualify x : R | npos_num_pred x].
-Definition real_num_pred := fun x : R => (0 <= x) || (x <= 0).
+Definition real_num_pred := fun x : R => (ler 0 x) || (ler x 0).
 Definition real_num : qualifier 0 R := [qualify x : R | real_num_pred x].
 
 End Def.


### PR DESCRIPTION
##### Motivation for this change

This change will potentially enable more parallel compilation. Most notably, `orderedzmod.v` now depends only on the first part of ssralg (which is now called `algebra.v`).

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
