### PR TITLE
Added IsoTop and IsoBottom factories

### DIFF
--- a/doc/changelog/01-added/1525-isotopbot.md
+++ b/doc/changelog/01-added/1525-isotopbot.md
@@ -1,0 +1,4 @@
+- in `order.v`
+  + Added two new factories for isomorphic bounded orders:
+    `IsoTop` :satisfied: and `IsoBottom`
+    ([#1525](https://github.com/math-comp/math-comp/pull/1525)).

--- a/order/order.v
+++ b/order/order.v
@@ -4580,6 +4580,45 @@ Definition CanIsTotal : DistrLattice_isTotal _ (can_type f_can) :=
 End Can.
 End CancelTotal.
 
+HB.factory Record IsoBottom disp T of Order.POrder disp T := {
+  disp' : Order.disp_t;
+  T' : bPOrderType disp';
+  f : T -> T';
+  f' : T' -> T;
+  f_can : cancel f f';
+  f'_can : cancel f' f;
+  f_mono : {mono f : x y / x <= y}%O;
+}.
+
+HB.builders Context disp T of IsoBottom disp T.
+
+Definition bottom := f' \bot%O.
+Lemma isobottom x : (bottom <= x)%O.
+Proof. by rewrite /bottom -f_mono f'_can Order.le0x. Qed.
+
+HB.instance Definition _ := Order.hasBottom.Build _ T isobottom.
+HB.end.
+
+HB.factory Record IsoTop disp T of Order.POrder disp T := {
+  disp' : Order.disp_t;
+  T' : tPOrderType disp';
+  f : T -> T';
+  f' : T' -> T;
+  f_can : cancel f f';
+  f'_can : cancel f' f;
+  f_mono : {mono f : x y / x <= y}%O;
+}.
+
+HB.builders Context disp T of IsoTop disp T.
+
+Definition top := f' \top%O.
+Lemma isotop x : (x <= top)%O.
+Proof. by rewrite /top -f_mono f'_can Order.lex1. Qed.
+
+HB.instance Definition _ := Order.hasTop.Build _ T isotop.
+HB.end.
+
+
 HB.factory Record IsoLattice disp T of POrder disp T := {
   disp' : disp_t;
   T' : latticeType disp';


### PR DESCRIPTION
##### Motivation for this change

The main motivation is to have a radioactive :satisfied: commit !  More seriously I had a couple of use case for these two so I figured out that they where better in MathComp.

There is no documentation for `IsoLattice` and `IsoDistrLattice`. Is is intended or an oversight ?

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
