### PR TITLE
seq doc: fix typo

### DIFF
--- a/boot/seq.v
+++ b/boot/seq.v
@@ -138,7 +138,7 @@ From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat.
 (*                   s and t, respectively, in row-major order,               *)
 (*                   and where t is possibly dependent in elements of s       *)
 (* allpairs_dep f s t := self expanding definition for                        *)
-(*                       [seq f x y | x <- s, y <- t y]                       *)
+(*                       [seq f x y | x <- s, y <- t x]                       *)
 (*  ** Iterators: for s == [:: x_1, ..., x_n], t == [:: y_1, ..., y_m],       *)
 (* allpairs f s t := same as allpairs_dep but where t is non dependent,       *)
 (*                    i.e. self expanding definition for                      *)


### PR DESCRIPTION
##### Motivation for this change
fix a typo "y" -> "x" in `boot/seq.v` documentation
##### Minimal TODO list
- [ ] ~added changelog entries with `doc/changelog/make-entry.sh`~
- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).