### PR TITLE
seq doc: fix yet another typo

### DIFF
--- a/boot/seq.v
+++ b/boot/seq.v
@@ -185,7 +185,7 @@ From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat.
 (*         [seq x <- s | C] := filter (fun x => C) s.                         *)
 (*         [seq E | x <- s] := map (fun x => E) s.                            *)
 (*   [seq x <- s | C1 & C2] := [seq x <- s | C1 && C2].                       *)
-(*     [seq E | x <- s & C] := [seq E | x <- [seq x | C]].                    *)
+(*     [seq E | x <- s & C] := [seq E | x <- [seq x <- s | C]].               *)
 (*  --> The above allow optional type casts on the eigenvariables, as in      *)
 (*  [seq x : T <- s | C] or [seq E | x : T <- s, y : U <- t]. The cast may be *)
 (*  needed as type inference considers E or C before s.                       *)


### PR DESCRIPTION
##### Motivation for this change
fix a typo in comprehension in the doc
##### Minimal TODO list
- [ ] ~added changelog entries with `doc/changelog/make-entry.sh`~
- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).