### PR TITLE
[OPAM] Remove redundant | = "dev"

### DIFF
--- a/rocq-mathcomp-boot.opam
+++ b/rocq-mathcomp-boot.opam
@@ -10,8 +10,7 @@ license: "CECILL-B"
 build: [ make "-C" "boot" "-j" "%{jobs}%" ]
 install: [ make "-C" "boot" "install" ]
 depends: [
-  "rocq-core" {>= "9.0" | = "dev"}
-  # Please keep the "dev" above as it is required for the coq-dev Docker images
+  "rocq-core" {>= "9.0"}
   "elpi" {>= "1.17.0"}
   "rocq-hierarchy-builder" {>= "1.9.0"}
 ]


### PR DESCRIPTION
This is useless since there is no upper bound (since "dev" > "X.Y.Z" for any number X in OPAM/Debian order)

This was pointed out by @silene