### PR TITLE
Remove `Global Set SsrOldRewriteGoalsOrder`

### DIFF
--- a/algebra/alg/algebra.v
+++ b/algebra/alg/algebra.v
@@ -1262,7 +1262,7 @@ Lemma exprBn_comm x y n (cxy : comm x y) :
   (x - y) ^+ n =
     \sum_(i < n.+1) ((-1) ^+ i * x ^+ (n - i) * y ^+ i) *+ 'C(n, i).
 Proof.
-rewrite exprDn_comm; last exact: commrN.
+rewrite exprDn_comm; first exact: commrN.
 by apply: eq_bigr => i _; congr (_ *+ _); rewrite -commr_sign -mulrA -exprNn.
 Qed.
 

--- a/algebra/alg/decfield.v
+++ b/algebra/alg/decfield.v
@@ -455,7 +455,7 @@ elim: t r0 m => /=; try do [
   by elim: r1 m => //= u r1 IHr1 m; rewrite IHr1].
 move=> t1 IH r m letm /IH {IH} /(_ letm) {letm}.
 case: to_rterm => t1' r1 /= [def_r ub_t1' ub_r1 <-].
-rewrite size_rcons addnS leqnn -{1}cats1 takel_cat ?def_r; last first.
+rewrite size_rcons addnS leqnn -{1}cats1 takel_cat ?def_r.
   by rewrite -def_r size_take geq_min leqnn orbT.
 elim: r1 m ub_r1 ub_t1' {def_r} => /= [|u r1 IHr1] m => [_|[->]].
   by rewrite addn0 eqxx.
@@ -641,7 +641,7 @@ Lemma Pick_form_qf :
 Proof.
 move=> qfp qft qfe; have mA := (big_morph qf_form) true andb.
 rewrite mA // big1 //= => p _.
-rewrite mA // big1 => [|i _]; first by case: pick.
+rewrite mA // big1 => [i _|]; last by case: pick.
 by rewrite fun_if if_same /= qfp.
 Qed.
 
@@ -653,12 +653,12 @@ move=> P; rewrite ((big_morph qev) false orb) //= big_orE /=.
 apply/existsP/idP=> [[p] | true_at_P].
   rewrite ((big_morph qev) true andb) //= big_andE /=.
   case/andP=> /forallP-eq_p_P.
-  rewrite (@eq_pick _ _ P) => [|i]; first by case: pick.
+  rewrite (@eq_pick _ _ P) => [i|]; last by case: pick.
   by move/(_ i): eq_p_P => /=; case: (p i) => //= /negPf.
 exists [ffun i => P i] => /=; apply/andP; split.
   rewrite ((big_morph qev) true andb) //= big_andE /=.
   by apply/forallP=> i; rewrite /= ffunE; case Pi: (P i) => //=; apply: negbT.
-rewrite (@eq_pick _ _ P) => [|i]; first by case: pick true_at_P.
+rewrite (@eq_pick _ _ P) => [i|]; last by case: pick true_at_P.
 by rewrite ffunE.
 Qed.
 

--- a/algebra/alg/divalg.v
+++ b/algebra/alg/divalg.v
@@ -308,7 +308,7 @@ Qed.
 
 Lemma unitrX_pos x n : n > 0 -> (x ^+ n \in unit) = (x \in unit).
 Proof.
-case: n => // n _; rewrite exprS unitrM_comm; last exact: commrX.
+case: n => // n _; rewrite exprS unitrM_comm; first exact: commrX.
 by case Ux: (x \is a unit); rewrite // unitrX.
 Qed.
 

--- a/algebra/intdiv.v
+++ b/algebra/intdiv.v
@@ -975,7 +975,7 @@ exists (block_mx 1 Mu 0 R).
   by rewrite unitmxE det_ublock det_scalar1 mul1r.
 exists (1 :: d); set D1 := \matrix_(i, j) _ in dM1.
   by rewrite /= path_min_sorted //; apply/allP => g _; apply: dvd1n.
-rewrite [D in _ *m D *m _](_ : _ = block_mx 1 0 0 D1); last first.
+rewrite [D in _ *m D *m _](_ : _ = block_mx 1 0 0 D1).
   by apply/matrixP=> i j; do 3?[rewrite ?mxE ?ord1 //=; case: splitP => ? ->].
 rewrite !mulmx_block !(mul0mx, mulmx0, addr0) !mulmx1 add0r mul1mx -Da -dM1.
 by rewrite addNKr submxK.

--- a/algebra/matrix.v
+++ b/algebra/matrix.v
@@ -2291,9 +2291,9 @@ Lemma matrix_sum_delta A : A = \sum_(i < m) \sum_(j < n) A i j *: delta_mx i j.
 Proof.
 apply/matrixP=> i j.
 rewrite summxE (bigD1_ord i) // summxE (bigD1_ord j) //= !mxE !eqxx mulr1.
-rewrite !big1 ?addr0 //= => [i' | j'] _.
-  by rewrite summxE big1// => j' _; rewrite !mxE eq_liftF mulr0.
-by rewrite !mxE eqxx eq_liftF mulr0.
+rewrite !big1 ?addr0 //= => [j' | i'] _.
+  by rewrite !mxE eqxx eq_liftF mulr0.
+by rewrite summxE big1// => j' _; rewrite !mxE eq_liftF mulr0.
 Qed.
 
 End SemiRingModule.
@@ -2637,9 +2637,9 @@ apply/matrixP=> i k; rewrite !mxE !leq_min.
 have [le_n_i | lt_i_n] := leqP n i.
   rewrite andbF big1 // => j _.
   by rewrite -pid_mx_minh !mxE leq_min ltnNge le_n_i andbF mul0r.
-rewrite (bigD1 (Ordinal lt_i_n)) //= big1 ?addr0 => [|j].
-  by rewrite !mxE eqxx /= -natrM mulnb andbCA.
-by rewrite -val_eqE /= !mxE eq_sym -natrM => /negPf->.
+rewrite (bigD1 (Ordinal lt_i_n)) //= big1 ?addr0 => [j|].
+  by rewrite -val_eqE /= !mxE eq_sym -natrM => /negPf->.
+by rewrite !mxE eqxx /= -natrM mulnb andbCA.
 Qed.
 
 Lemma pid_mx_id m n p r :
@@ -3480,7 +3480,7 @@ Qed.
 
 Lemma det_perm n (s : 'S_n) : \det (perm_mx s) = (-1) ^+ s :> R.
 Proof.
-rewrite [\det _](bigD1 s) //= big1 => [|i _]; last by rewrite /= !mxE eqxx.
+rewrite [\det _](bigD1 s) //= big1 => [i _|]; first by rewrite /= !mxE eqxx.
 rewrite mulr1 big1 ?addr0 => //= t Dst.
 case: (pickP (fun i => s i != t i)) => [i ist | Est].
   by rewrite (bigD1 i) // mulrCA /= !mxE (negPf ist) mul0r.
@@ -3520,21 +3520,21 @@ transitivity (\sum_(f : F) \sum_(s : 'S_n) (-1) ^+ s * \prod_i AB s i (f i)).
   rewrite exchange_big; apply: eq_bigr => /= s _; rewrite -big_distrr /=.
   congr (_ * _); rewrite -(bigA_distr_bigA (AB s)) /=.
   by apply: eq_bigr => x _; rewrite mxE.
-rewrite (bigID (fun f : F => injectiveb f)) /= addrC big1 ?add0r => [|f Uf].
-  rewrite (reindex (@pval _)) /=; last first.
-    pose in_Sn := insubd (1%g : 'S_n).
-    by exists in_Sn => /= f Uf; first apply: val_inj; apply: insubdK.
-  apply: eq_big => /= [s | s _]; rewrite ?(valP s) // big_distrr /=.
-  rewrite (reindex_inj (mulgI s)); apply: eq_bigr => t _ /=.
-  rewrite big_split /= [RHS]mulrACA 2!mulrA -signr_addb odd_permM !pvalE.
-  congr (_ * _); rewrite [RHS](reindex_perm s).
-  by apply: eq_bigr => i; rewrite permM.
-transitivity (\det (\matrix_(i, j) B (f i) j) * \prod_i A i (f i)).
-  rewrite mulrC big_distrr /=; apply: eq_bigr => s _.
-  rewrite mulrCA big_split //=; congr (_ * (_ * _)).
-  by apply: eq_bigr => x _; rewrite mxE.
-case/injectivePn: Uf => i1 [i2 Di12 Ef12].
-by rewrite (determinant_alternate Di12) ?simp //= => j; rewrite !mxE Ef12.
+rewrite (bigID (fun f : F => injectiveb f)) /= addrC big1 ?add0r => [f Uf|].
+  transitivity (\det (\matrix_(i, j) B (f i) j) * \prod_i A i (f i)).
+    rewrite mulrC big_distrr /=; apply: eq_bigr => s _.
+    rewrite mulrCA big_split //=; congr (_ * (_ * _)).
+    by apply: eq_bigr => x _; rewrite mxE.
+  case/injectivePn: Uf => i1 [i2 Di12 Ef12].
+  by rewrite (determinant_alternate Di12) ?simp //= => j; rewrite !mxE Ef12.
+rewrite (reindex (@pval _)) /=.
+  pose in_Sn := insubd (1%g : 'S_n).
+  by exists in_Sn => /= f Uf; first apply: val_inj; apply: insubdK.
+apply: eq_big => /= [s | s _]; rewrite ?(valP s) // big_distrr /=.
+rewrite (reindex_inj (mulgI s)); apply: eq_bigr => t _ /=.
+rewrite big_split /= [RHS]mulrACA 2!mulrA -signr_addb odd_permM !pvalE.
+congr (_ * _); rewrite [RHS](reindex_perm s).
+by apply: eq_bigr => i; rewrite permM.
 Qed.
 
 Lemma detM n' (A B : 'M[R]_n'.+1) : \det (A * B) = \det A * \det B.
@@ -3546,7 +3546,7 @@ Lemma expand_cofactor n (A : 'M[R]_n) i j :
     \sum_(s : 'S_n | s i == j) (-1) ^+ s * \prod_(k | i != k) A k (s k).
 Proof.
 case: n A i j => [|n] A i0 j0; first by case: i0.
-rewrite (reindex (lift_perm i0 j0)); last first.
+rewrite (reindex (lift_perm i0 j0)).
   pose ulsf i (s : 'S_n.+1) k := odflt k (unlift (s i) (s (lift i k))).
   have ulsfK i (s : 'S_n.+1) k: lift (s i) (ulsf i s k) = s (lift i k).
     rewrite /ulsf; have:= neq_lift i k.
@@ -3563,8 +3563,8 @@ rewrite /cofactor big_distrr /=.
 apply: eq_big => [s | s _]; first by rewrite lift_perm_id eqxx.
 rewrite -signr_odd mulrA -signr_addb oddD -odd_lift_perm; congr (_ * _).
 case: (pickP 'I_n) => [k0 _ | n0]; last first.
-  by rewrite !big1 // => [j /unlift_some[i] | i _]; have:= n0 i.
-rewrite (reindex (lift i0)).
+  by rewrite !big1 // => [i _ | j /unlift_some[i]]; have:= n0 i.
+rewrite (reindex (lift i0)); last first.
   by apply: eq_big => [k | k _] /=; rewrite ?neq_lift // !mxE lift_perm_lift.
 exists (fun k => odflt k0 (unlift i0 k)) => k; first by rewrite liftK.
 by case/unlift_some=> k' -> ->.
@@ -3643,7 +3643,7 @@ elim: n1 => [|n1 IHn1] in Aul Aur *.
   rewrite det1 mul1r; congr (\det _); apply/matrixP=> i j.
   by do 2![rewrite !mxE; case: splitP => [[]|k] //=; move/val_inj=> <- {k}].
 rewrite (expand_det_col _ (lshift n2 0)) big_split_ord /=.
-rewrite addrC big1 1?simp => [|i _]; last by rewrite block_mxEdl mxE simp.
+rewrite addrC big1 1?simp => [i _|]; first by rewrite block_mxEdl mxE simp.
 rewrite (expand_det_col _ 0) big_distrl /=; apply: eq_bigr=> i _.
 rewrite block_mxEul -!mulrA; do 2!congr (_ * _).
 by rewrite col'_col_mx !col'Kl raddf0 row'Ku row'_row_mx IHn1.
@@ -5053,7 +5053,7 @@ pose b : 'rV_n := \row_i a 0 (lift 0 i).
 pose C : 'M_n := diag_mx (\row_(i < n) (b 0 i - a 0 0)).
 pose D : 'M_n.+1 := 1 - a 0 0 *: \matrix_(i, j) (i == j.+1 :> nat)%:R. 
 have detD : \det D = 1.
-  rewrite det_trig ?big_ord_recl ?mxE ?mulr0 ?subr0 ?eqxx.
+  rewrite det_trig ?big_ord_recl ?mxE ?mulr0 ?subr0 ?eqxx; last first.
     by rewrite ?big1 ?mulr1// => i; rewrite !mxE eqxx ltn_eqF// mulr0 subr0.
   by apply/is_trig_mxP => *; rewrite !mxE ![_ == _]ltn_eqF ?mulr0 ?subr0 ?leqW.
 suff: D * V _ _ a = block_mx 1 (const_mx 1) 0 (V _ _ b *m C) :> 'M_(1 + n).
@@ -5065,7 +5065,7 @@ suff: D * V _ _ a = block_mx 1 (const_mx 1) 0 (V _ _ b *m C) :> 'M_(1 + n).
   by rewrite big_mkcond [RHS]big_mkcond big_ord_recl/= mul1r.
 rewrite mulrBl mul1r -[_ * _]scalemxAl; apply/matrixP => i j; rewrite !mxE.
 under eq_bigr do rewrite !mxE; case: splitP => [{i}_ -> /[!ord1]|{}i ->].
-  rewrite !expr0 big1; last by move=> ?; rewrite mul0r.
+  rewrite !expr0 big1; first by move=> ?; rewrite mul0r.
   by rewrite ?mulr0 ?subr0 ?mxE; case: splitP => k; rewrite ?ord1 mxE//.
 under eq_bigr do rewrite eqSS mulr_natl mulrb eq_sym.
 rewrite -big_mkcond/= big_ord1_eq exprS ifT// ?leqW// -mulrBl !mxE/=.

--- a/algebra/mxalgebra.v
+++ b/algebra/mxalgebra.v
@@ -1029,7 +1029,7 @@ Lemma eqmx_rowsub_comp (m n p q : nat) f (g : 'I_n -> 'I_p) (A : 'M_(m, q)) :
 Proof.
 move=> leq_pn g_inj; have eq_np : n == p by rewrite eqn_leq leq_pn (inj_leq g).
 rewrite (eqP eq_np) in g g_inj *.
-rewrite (eq_rowsub (f \o (perm g_inj))); last by move=> i; rewrite /= permE.
+rewrite (eq_rowsub (f \o (perm g_inj))); first by move=> i; rewrite /= permE.
 exact: eqmx_rowsub_comp_perm.
 Qed.
 
@@ -1620,7 +1620,7 @@ Proof.
 apply/eqP; set K := kermx B; set C := (A :&: K)%MS.
 rewrite -(eqmxMr B (eq_row_base A)); set K' := _ *m B.
 rewrite -{2}(subnKC (rank_leq_row K')) -mxrank_ker eqn_add2l.
-rewrite -(mxrankMfree _ (row_base_free A)) mxrank_leqif_sup.
+rewrite -(mxrankMfree _ (row_base_free A)) mxrank_leqif_sup; last first.
   by rewrite sub_capmx -(eq_row_base A) submxMl sub_kermx -mulmxA mulmx_ker/=.
 have /submxP[C' defC]: (C <= row_base A)%MS by rewrite eq_row_base capmxSl.
 by rewrite defC submxMr // sub_kermx mulmxA -defC -sub_kermx capmxSr.
@@ -1695,7 +1695,7 @@ Lemma mxrank_sum_cap m1 m2 n (A : 'M_(m1, n)) (B : 'M_(m2, n)) :
 Proof.
 set C := (A :&: B)%MS; set D := (A :\: B)%MS.
 have rDB: \rank (A + B)%MS = \rank (D + B)%MS.
-  apply/eqP; rewrite mxrank_leqif_sup; first by rewrite addsmxS ?diffmxSl.
+  apply/eqP; rewrite mxrank_leqif_sup; last by rewrite addsmxS ?diffmxSl.
   by rewrite addsmx_sub addsmxSr -(addsmx_diff_cap_eq A B) addsmxS ?capmxSr.
 rewrite {1}rDB mxrank_disjoint_sum ?capmx_diff //.
 by rewrite addnC addnA mxrank_cap_compl.
@@ -1865,7 +1865,7 @@ Qed.
 
 Lemma eq_maxrowsub : (rowsub mxf A :=: A)%MS.
 Proof.
-apply/eqmxP; rewrite -(eq_leqif (mxrank_leqif_eq _))//.
+apply/eqmxP; rewrite -(eq_leqif (mxrank_leqif_eq _))//; last first.
   exact: maxrowsub_free.
 apply/row_subP => i; apply/submxP; exists (delta_mx 0 (mxf i)).
 by rewrite -rowE; apply/rowP => j; rewrite !mxE.
@@ -2128,7 +2128,7 @@ set Q := P; have [m] := ubnP #|Q|; have: Q \subset P by [].
 elim: m Q => // m IHm Q /subsetP-sQP.
 case: (pickP Q) => [i Qi | Q0]; last by rewrite !big_pred0 ?mxrank0.
 rewrite (cardD1x Qi) !((bigD1 i) Q) //=.
-move/IHm=> <- {IHm}/=; last by apply/subsetP=> j /andP[/sQP].
+move/IHm=> <- {IHm}/=; first by apply/subsetP=> j /andP[/sQP].
 case: (dxS i (sQP i Qi)) => /eqnP=> <- TiQ_0; rewrite mxrank_disjoint_sum //.
 apply/eqP; rewrite -submx0 -{2}TiQ_0 capmxS //=.
 by apply/sumsmx_subP=> j /= /andP[Qj i'j]; rewrite (sumsmx_sup j) ?[P j]sQP.
@@ -2242,11 +2242,11 @@ have nz_aij: a_ i - a_ j != 0.
   by case/andP: Pi'j => Pj ne_ji; rewrite subr_eq0 eq_sym (inj_in_eq inj_a).
 case: (sub_dsumsmx dxVi' (sub0mx 1 _)) => C _ _ uniqC.
 rewrite -(eqmx_eq0 (eqmx_scale _ nz_aij)).
-rewrite (uniqC (fun k => (a_ i - a_ k) *: u k)) => // [|k Pi'k|].
-- by rewrite -(uniqC (fun _ => 0)) ?big1 // => k Pi'k; apply: sub0mx.
+rewrite (uniqC (fun k => (a_ i - a_ k) *: u k)) => // [k Pi'k| |].
 - by rewrite scalemx_sub ?Vi'u.
-rewrite -{1}(subrr (v *m g)) {1}def_vg def_v scaler_sumr mulmx_suml -sumrB.
-by apply: eq_bigr => k /Vi'u/eigenspaceP->; rewrite scalerBl.
+- rewrite -{1}(subrr (v *m g)) {1}def_vg def_v scaler_sumr mulmx_suml -sumrB.
+  by apply: eq_bigr => k /Vi'u/eigenspaceP->; rewrite scalerBl.
+by rewrite -(uniqC (fun _ => 0)) ?big1 // => k Pi'k; apply: sub0mx.
 Qed.
 
 End Eigenspace.
@@ -2483,12 +2483,12 @@ have: m <= n by []; elim: m => [_ | m IHm /ltnW-le_mn].
   by rewrite flatmx0 !inE mxrank.unlock !eqxx.
 rewrite big_nat_recr // -{}IHm //= !subSS mulnBr muln1 -expnD subnKC //.
 rewrite -sum_nat_const /= -sum1_card -add1n.
-rewrite (partition_big dsubmx (fr m)) /= => [|A]; last first.
+rewrite (partition_big dsubmx (fr m)) /= => [A|].
   rewrite !inE -{1}(vsubmxK A); move: {A}(_ A) (_ A) => Ad Au Afull.
   rewrite eqn_leq rank_leq_row -(leq_add2l (\rank Au)) -mxrank_sum_cap.
   rewrite {1 3}[@mxrank]lock addsmxE (eqnP Afull) -lock -addnA.
   by rewrite leq_add ?rank_leq_row ?leq_addr.
-apply: eq_bigr => A rAm; rewrite (reindex (col_mx^~ A)) /=; last first.
+apply: eq_bigr => A rAm; rewrite (reindex (col_mx^~ A)) /=.
   exists usubmx => [v _ | vA]; first by rewrite col_mxKu.
   by case/andP=> _ /eqP <-; rewrite vsubmxK.
 transitivity #|~: [set v *m A | v in 'rV_m]|; last first.
@@ -2515,7 +2515,7 @@ elim: {n'}n => [|n IHn].
 rewrite !big_nat_recr //= expnD mulnAC mulnA -{}IHn -mulnA mulnC.
 set LHS := #|_|; rewrite -[n.+1]muln1 -{2}[n]mul1n {}/LHS.
 rewrite -!card_mx subn1 -(cardC1 0) -mulnA; set nzC := predC1 _.
-rewrite -sum1_card (partition_big lsubmx nzC) => [|A]; last first.
+rewrite -sum1_card (partition_big lsubmx nzC) => [A|].
   rewrite unitmxE unitfE; apply: contra; move/eqP=> v0.
   rewrite -[A]hsubmxK v0 -[n.+1]/(1 + n)%N -col_mx0.
   rewrite -[rsubmx _]vsubmxK -det_tr tr_row_mx !tr_col_mx !trmx0.
@@ -2532,7 +2532,7 @@ have def_a: usubmx v1 = a%:M.
 pose Schur := dsubmx v1 *m (a^-1 *: u).
 pose L : 'M_(1 + n) := block_mx a%:M 0 (dsubmx v1) 1%:M.
 pose U B : 'M_(1 + n) := block_mx 1 (a^-1 *: u) 0 B.
-rewrite (reindex (fun B => L *m U B)); last first.
+rewrite (reindex (fun B => L *m U B)).
   exists (fun A1 => drsubmx A1 - Schur) => [B _ | A1].
     by rewrite mulmx_block block_mxKdr mul1mx addrC addKr.
   rewrite !inE mulmx_block !mulmx0 mul0mx !mulmx1 !addr0 mul1mx addrC subrK.
@@ -2906,14 +2906,14 @@ apply/eqmxP/andP; split.
     have Rz2 := submx_trans R2z2 (addsmxSr R1 R2).
     rewrite -{1}[z.1](addrK z.2) mulmxBr (cent_mxP Cz) // mulmxDl.
     rewrite [A *m z.2]memmx0 1?[z.2 *m A]memmx0 ?addrK //.
-      by rewrite -dxR12 sub_capmx (mulsmx_subP idlR1) // (mulsmx_subP idrR2).
-    by rewrite -dxR12 sub_capmx (mulsmx_subP idrR1) // (mulsmx_subP idlR2).
+      by rewrite -dxR12 sub_capmx (mulsmx_subP idrR1) // (mulsmx_subP idlR2).
+    by rewrite -dxR12 sub_capmx (mulsmx_subP idlR1) // (mulsmx_subP idrR2).
   apply/cent_mxP=> A R2_A; have R_A := submx_trans R2_A (addsmxSr R1 R2).
   have Rz1 := submx_trans R1z1 (addsmxSl R1 R2).
   rewrite -{1}[z.2](addKr z.1) mulmxDr (cent_mxP Cz) // mulmxDl.
   rewrite mulmxN [A *m z.1]memmx0 1?[z.1 *m A]memmx0 ?addKr //.
-    by rewrite -dxR12 sub_capmx (mulsmx_subP idrR1) // (mulsmx_subP idlR2).
-  by rewrite -dxR12 sub_capmx (mulsmx_subP idlR1) // (mulsmx_subP idrR2).
+    by rewrite -dxR12 sub_capmx (mulsmx_subP idlR1) // (mulsmx_subP idrR2).
+  by rewrite -dxR12 sub_capmx (mulsmx_subP idrR1) // (mulsmx_subP idlR2).
 rewrite addsmx_sub; apply/andP; split.
   apply/memmx_subP=> z; rewrite sub_capmx => /andP[R1z cR1z].
   have Rz := submx_trans R1z (addsmxSl R1 R2).
@@ -2922,16 +2922,16 @@ rewrite addsmx_sub; apply/andP; split.
   have R_A2 := submx_trans R2_A2 (addsmxSr R1 R2).
   rewrite mulmxDl mulmxDr (cent_mxP cR1z) //; congr (_ + _).
   rewrite [A.2 *m z]memmx0 1?[z *m A.2]memmx0 //.
-    by rewrite -dxR12 sub_capmx (mulsmx_subP idrR1) // (mulsmx_subP idlR2).
-  by rewrite -dxR12 sub_capmx (mulsmx_subP idlR1) // (mulsmx_subP idrR2).
+    by rewrite -dxR12 sub_capmx (mulsmx_subP idlR1) // (mulsmx_subP idrR2).
+  by rewrite -dxR12 sub_capmx (mulsmx_subP idrR1) // (mulsmx_subP idlR2).
 apply/memmx_subP=> z; rewrite !sub_capmx => /andP[R2z cR2z].
 have Rz := submx_trans R2z (addsmxSr R1 R2); rewrite Rz.
 apply/cent_mxP=> _ /memmx_addsP[A [R1_A1 R2_A2 ->]].
 rewrite mulmxDl mulmxDr (cent_mxP cR2z _ R2_A2) //; congr (_ + _).
 have R_A1 := submx_trans R1_A1 (addsmxSl R1 R2).
 rewrite [A.1 *m z]memmx0 1?[z *m A.1]memmx0 //.
-  by rewrite -dxR12 sub_capmx (mulsmx_subP idlR1) // (mulsmx_subP idrR2).
-by rewrite -dxR12 sub_capmx (mulsmx_subP idrR1) // (mulsmx_subP idlR2).
+  by rewrite -dxR12 sub_capmx (mulsmx_subP idrR1) // (mulsmx_subP idlR2).
+by rewrite -dxR12 sub_capmx (mulsmx_subP idlR1) // (mulsmx_subP idrR2).
 Qed.
 
 Lemma mxdirect_sums_center (I : finType) m n (R : 'A_(m, n)) R_ :
@@ -2945,22 +2945,22 @@ have anhR i j A B : i != j -> A \in R_ i -> B \in R_ j -> A *m B = 0.
   move=> ne_ij RiA RjB; apply: memmx0.
   have [[_ idRiR] [idRRj _]] := (andP (idealR i), andP (idealR j)).
   rewrite -(mxdirect_sumsP dxR j) // sub_capmx (sumsmx_sup i) //.
-    by rewrite (mulsmx_subP idRRj) // (memmx_subP (sR_R i)).
-  by rewrite (mulsmx_subP idRiR) // (memmx_subP (sR_R j)).
+    by rewrite (mulsmx_subP idRiR) // (memmx_subP (sR_R j)).
+  by rewrite (mulsmx_subP idRRj) // (memmx_subP (sR_R i)).
 apply/eqmxP/andP; split.
   apply/memmx_subP=> Z; rewrite sub_capmx => /andP[].
   rewrite -{1}defR => /memmx_sumsP[z ->{Z} Rz cRz].
   apply/memmx_sumsP; exists z => // i; rewrite sub_capmx Rz.
   apply/cent_mxP=> A RiA; have:= cent_mxP cRz A (memmx_subP (sR_R i) A RiA).
   rewrite (bigD1 i) //= mulmxDl mulmxDr mulmx_suml mulmx_sumr.
-  by rewrite !big1 ?addr0 // => j; last rewrite eq_sym; move/anhR->.
+  by rewrite !big1 ?addr0 // => j; first rewrite eq_sym; move/anhR->.
 apply/sumsmx_subP => i _; apply/memmx_subP=> z; rewrite sub_capmx.
 case/andP=> Riz cRiz; rewrite sub_capmx (memmx_subP (sR_R i)) //=.
 apply/cent_mxP=> A; rewrite -{1}defR; case/memmx_sumsP=> a -> R_a.
 rewrite (bigD1 i) // mulmxDl mulmxDr mulmx_suml mulmx_sumr.
-rewrite !big1 => [|j|j]; first by rewrite !addr0 (cent_mxP cRiz).
-  by rewrite eq_sym => /anhR->.
-by move/anhR->.
+rewrite !big1 => [j|j|]; last by rewrite !addr0 (cent_mxP cRiz).
+  by move/anhR->.
+by rewrite eq_sym => /anhR->.
 Qed.
 
 End MatrixAlgebra.
@@ -3005,7 +3005,7 @@ Proof.
 rewrite mxrankE /row_ebase /col_ebase unlock.
 elim: m n A => [|m IHm] [|n] A /=; rewrite ?map_mx1 //.
 set pAnz := [pred k | A k.1 k.2 != 0].
-rewrite (@eq_pick _ _ pAnz) => [|k]; last by rewrite /= mxE fmorph_eq0.
+rewrite (@eq_pick _ _ pAnz) => [k|]; first by rewrite /= mxE fmorph_eq0.
 case: {+}(pick _) => [[i j]|]; last by rewrite !map_mx1.
 rewrite mxE -fmorphV  -map_xcol -map_xrow -map_dlsubmx -map_drsubmx.
 rewrite -map_ursubmx -map_mxZ -map_mxM -map_mxB {}IHm /=.

--- a/algebra/mxpoly.v
+++ b/algebra/mxpoly.v
@@ -241,19 +241,19 @@ have: rj0T (Ss_ dj.+1) = 'X^dj *: rj0T (S_ j1) + 1 *: rj0T (Ss_ dj).
   apply/rowP=> i; apply/polyP=> k; rewrite scale1r !(Sylvester_mxE, mxE) eqxx.
   rewrite coefD coefXnM coefC !coef_poly ltnS subn_eq0 ltn_neqAle andbC.
   have [k_le_dj | k_gt_dj] /= := leqP k dj; last by rewrite addr0.
-  rewrite Sylvester_mxE insubdK; last exact: leq_ltn_trans (ltjS).
+  rewrite Sylvester_mxE insubdK; first exact: leq_ltn_trans (ltjS).
   by have [->|] := eqP; rewrite (addr0, add0r).
 rewrite -det_tr => /determinant_multilinear->;
   try by apply/matrixP=> i j; rewrite !mxE lift_eqF.
 have [dj0 | dj_gt0] := posnP dj; rewrite ?dj0 !mul1r.
-  rewrite !det_tr det_map_mx addrC (expand_det_col _ j0) big1 => [|i _].
-    rewrite add0r; congr (\det _)%:P.
-    apply/matrixP=> i j; rewrite [in RHS]mxE; case: eqP => // ->.
-    by congr (S i _); apply: val_inj.
-  by rewrite mxE /= [Ss0_ _ _]poly_def big_ord0 mul0r.
+  rewrite !det_tr det_map_mx addrC (expand_det_col _ j0) big1 => [i _|].
+    by rewrite mxE /= [Ss0_ _ _]poly_def big_ord0 mul0r.
+  rewrite add0r; congr (\det _)%:P.
+  apply/matrixP=> i j; rewrite [in RHS]mxE; case: eqP => // ->.
+  by congr (S i _); apply: val_inj.
 have /determinant_alternate->: j1 != j0 by rewrite -val_eqE -lt0n.
-  by rewrite mulr0 add0r det_tr IHj // ltnW.
-by move=> i; rewrite !mxE if_same.
+  by move=> i; rewrite !mxE if_same.
+by rewrite mulr0 add0r det_tr IHj // ltnW.
 Qed.
 
 Lemma resultant_eq0 (R : idomainType) (p q : {poly R}) :
@@ -271,11 +271,11 @@ apply/det0P/idP=> [[uv nz_uv] | r_nonC].
   do [rewrite -[uv]hsubmxK -{1}row_mx0 mul_row_col !mul_rV_lin1 /=] in nz_uv *.
   set u := rVpoly _; set v := rVpoly _; pose m := gcdp (v * p) (v * q).
   have lt_vp: size v < size p by rewrite (polySpred p_nz) ltnS size_poly.
-  move/(congr1 rVpoly)/eqP; rewrite -linearD linear0 poly_rV_K; last first.
+  move/(congr1 rVpoly)/eqP; rewrite -linearD linear0 poly_rV_K.
     rewrite (leq_trans (size_polyD _ _)) // geq_max.
     rewrite !(leq_trans (size_polyMleq _ _)) // -subn1 leq_subLR.
-      by rewrite addnC addnA leq_add ?leqSpred ?size_poly.
-    by rewrite addnCA leq_add ?leqSpred ?size_poly.
+      by rewrite addnCA leq_add ?leqSpred ?size_poly.
+    by rewrite addnC addnA leq_add ?leqSpred ?size_poly.
   rewrite addrC addr_eq0 => /eqP vq_up.
   have nz_v: v != 0.
     apply: contraNneq nz_uv => v0; apply/eqP.
@@ -359,8 +359,8 @@ apply/matrixP => i j; rewrite !mxE.
 elim/poly_ind: p => [|p c ihp]; first by rewrite rmorph0 horner0 mxE mul0rn.
 rewrite !hornerE mulrnDl rmorphD rmorphM /= horner_mx_X horner_mx_C !mxE.
 rewrite (bigD1 j)//= ihp mxE eqxx mulr1n -mulrnAl big1 ?addr0.
-  by have [->|_] := eqVneq; rewrite /= !(mulr1n, addr0, mul0r).
-by move=> k /negPf nkF; rewrite mxE nkF mulr0.
+  by move=> k /negPf nkF; rewrite mxE nkF mulr0.
+by have [->|_] := eqVneq; rewrite /= !(mulr1n, addr0, mul0r).
 Qed.
 
 Lemma comm_mx_horner A B p : comm_mx A B -> comm_mx A (horner_mx B p).
@@ -529,7 +529,7 @@ Qed.
 Lemma char_poly_trig {R : comNzRingType} n (A : 'M[R]_n) : is_trig_mx A ->
   char_poly A = \prod_(i < n) ('X - (A i i)%:P).
 Proof.
-move=> /is_trig_mxP Atrig; rewrite /char_poly det_trig.
+move=> /is_trig_mxP Atrig; rewrite /char_poly det_trig; last first.
   by apply: eq_bigr => i; rewrite !mxE eqxx.
 by apply/is_trig_mxP => i j lt_ij; rewrite !mxE -val_eqE ltn_eqF ?Atrig ?subrr.
 Qed.
@@ -546,7 +546,7 @@ pose D n : 'M[{poly R}]_n := \matrix_(i, j)
 have detD n : \det (D n) = (-1) ^+ n.
   elim: n => [|n IHn]; first by rewrite det_mx00.
   rewrite (expand_det_row _ ord0) big_ord_recl !mxE /= sub0r.
-  rewrite big1 ?addr0; last by move=> i _; rewrite !mxE /= subrr mul0r.
+  rewrite big1 ?addr0; first by move=> i _; rewrite !mxE /= subrr mul0r.
   rewrite /cofactor mul1r [X in \det X](_ : _ = D _) ?IHn ?exprS//.
   by apply/matrixP=> i j; rewrite !mxE /= /bump !add1n eqSS.
 elim/poly_ind: p => [|p c IHp].
@@ -554,7 +554,7 @@ elim/poly_ind: p => [|p c IHp].
 have [->|p_neq0] := eqVneq p 0.
   rewrite mul0r add0r monicE lead_coefC => /eqP->.
   by rewrite /companionmx /char_poly size_poly1 det_mx00.
-rewrite monicE lead_coefDl ?lead_coefMX => [p_monic|]; last first.
+rewrite monicE lead_coefDl ?lead_coefMX => [|p_monic].
   rewrite size_polyC size_mulX ?polyX_eq0// ltnS.
   by rewrite (leq_trans (leq_b1 _)) ?size_poly_gt0.
 rewrite -[in RHS]IHp // /companionmx size_MXaddC (negPf p_neq0) /=.
@@ -563,7 +563,7 @@ have [->|spV1_gt0] := posnP (size p).-1.
   rewrite [X in \det X]mx11_scalar det_scalar1 !mxE ?eqxx det_mx00.
   by rewrite mul1r -horner_coef0 hornerMXaddC mulr0 add0r rmorphN opprK.
 rewrite (expand_det_col _ ord0) /= -[(size p).-1]prednK //.
-rewrite big_ord_recr big_ord_recl/= big1 ?add0r //=; last first.
+rewrite big_ord_recr big_ord_recl/= big1 ?add0r //=.
   move=> i _; rewrite !mxE -val_eqE /= /bump leq0n add1n eqSS.
   by rewrite ltn_eqF ?subrr ?mul0r.
 rewrite !mxE ?subnn -horner_coef0 /= hornerMXaddC.
@@ -572,7 +572,7 @@ rewrite mulrC /cofactor; congr (_ * 'X + _).
   rewrite /cofactor -signr_odd oddD addbb mul1r; congr (\det _).
   apply/matrixP => i j; rewrite !mxE -val_eqE coefD coefMX coefC.
   by rewrite /= /bump /= !add1n !eqSS addr0.
-rewrite /cofactor [X in \det X](_ : _ = D _).
+rewrite /cofactor [X in \det X](_ : _ = D _); last first.
   by rewrite detD /= addn0 -signr_odd -signr_addb addbb mulr1.
 apply/matrixP=> i j; rewrite !mxE -!val_eqE /= /bump /=.
 by rewrite leqNgt ltn_ord add0n add1n [_ == _.-2.+1]ltn_eqF.
@@ -583,7 +583,7 @@ Lemma mulmx_delta_companion (R : nzRingType) (p : seq R)
   delta_mx 0 i *m companionmx p = delta_mx 0 (Ordinal i_small) :> 'rV__.
 Proof.
 apply/rowP => j; rewrite !mxE (bigD1 i) //= ?(=^~val_eqE, mxE) /= eqxx mul1r.
-rewrite ltn_eqF ?big1 ?addr0 1?eq_sym //; last first.
+rewrite ltn_eqF ?big1 ?addr0 1?eq_sym //.
   by rewrite -ltnS prednK // (leq_trans  _ i_small).
 by move=> k /negPf ki_eqF; rewrite !mxE eqxx ki_eqF mul0r.
 Qed.
@@ -637,7 +637,7 @@ rewrite rmorphD rmorphM /= horner_mx_C horner_mx_X.
 rewrite addrC -scalemx1 linearP /= -(mul_vec_lin (mulmxr A)).
 case/submxP: IHp => u ->{p}.
 have: (powers_mx A (1 + d) <= Ad)%MS.
-  rewrite -(geq_leqif (mxrank_leqif_sup _)).
+  rewrite -(geq_leqif (mxrank_leqif_sup _)); last first.
     by rewrite (eqnP minpoly_mx_free) /d; case: ex_minnP.
   rewrite addnC; apply/row_subP=> i.
   by apply: eq_row_sub (lshift 1 i) _; rewrite !rowK.
@@ -765,7 +765,7 @@ Lemma mxminpoly_diag {F : fieldType} {n} (d : 'rV[F]_n.+1)
   mxminpoly (diag_mx d) = \prod_(r <- u) ('X - r%:P).
 Proof.
 apply/eqP; rewrite -eqp_monic ?mxminpoly_monic ?monic_prod_XsubC// /eqp.
-rewrite mxminpoly_min/=; last first.
+rewrite mxminpoly_min/=.
   rewrite horner_mx_diag; apply/matrixP => i j; rewrite !mxE horner_prod.
   case: (altP (i =P j)) => [->|neq_ij//]; rewrite mulr1n.
   rewrite (bigD1_seq (d 0 j)) ?undup_uniq ?mem_undup ?map_f// /=.
@@ -962,7 +962,7 @@ move=> j js ihjs /= /andP[jNjs js_uniq]; apply/eqmxP.
 rewrite !big_cons; case: ifP => [Pj|PNj]; rewrite ?ihjs ?submx_refl//.
 suff cjjs: coprimep (p_ j) (\prod_(i <- js | P i) p_ i).
   by rewrite !kermxpolyM// !(adds_eqmx (eqmx_refl _) (ihjs _)) ?submx_refl.
-rewrite (@big_morph _ _ _ true andb) ?big_all_cond ?coprimep1//; last first.
+rewrite (@big_morph _ _ _ true andb) ?big_all_cond ?coprimep1//.
   by move=> p q; rewrite coprimepMr.
 apply/allP => i i_js; apply/implyP => Pi; apply: p_coprime => //.
 by apply: contraNneq jNjs => <-.
@@ -979,7 +979,7 @@ have cpNi : {in [pred j | P j && (j != i)] &,
   by move=> j k /andP[Pj _] /andP[Pk _]; apply: p_coprime.
 rewrite -!(cap_eqmx (eqmx_refl _) (kermxpoly_prod g _))//.
 rewrite mxdirect_kermxpoly ?submx_refl//.
-rewrite (@big_morph _ _ _ true andb) ?big_all_cond ?coprimep1//; last first.
+rewrite (@big_morph _ _ _ true andb) ?big_all_cond ?coprimep1//.
   by move=> p q; rewrite coprimepMr.
 by apply/allP => j _; apply/implyP => /andP[Pj neq_ji]; apply: p_coprime.
 Qed.
@@ -1302,7 +1302,7 @@ case=> p nz_p pu0; exists (Poly (rev p)).
   apply/eqP=> /polyP/(_ 0); rewrite coef_Poly coef0 nth_rev ?size_poly_gt0 //.
   by apply/eqP; rewrite subn1 lead_coef_eq0.
 apply/eqP/(mulfI (nz_u_n (size p).-1)); rewrite mulr0 -(rootP pu0).
-rewrite (@horner_coef_wide _ (size p)); last first.
+rewrite (@horner_coef_wide _ (size p)).
   by rewrite size_map_poly -(size_rev p) size_Poly.
 rewrite horner_coef mulr_sumr size_map_poly.
 rewrite [rhs in _ = rhs](reindex_inj rev_ord_inj) /=.
@@ -1401,7 +1401,7 @@ Lemma eval_mxrank e r m n (A : 'M_(m, n)) :
 Proof.
 elim: m r n A => [|m IHm] r [|n] A /=; try by case r; rewrite unlock.
 rewrite GRing.eval_Pick !unlock /=; set pf := fun _ => _.
-rewrite -(@eq_pick _ pf) => [|k]; rewrite {}/pf ?mxE // eq_sym.
+rewrite -(@eq_pick _ pf) => [k|]; rewrite {}/pf ?mxE // eq_sym.
 case: pick => [[i j]|] //=; set B := _ - _; have:= mxrankE B.
 case: (Gaussian_elimination_ B) r => [[_ _] _] [|r] //= <-; rewrite {}IHm eqSS.
 by congr (\rank _ == r); apply/matrixP=> k l; rewrite !(mxE, big_ord1) !tpermR.
@@ -1848,12 +1848,12 @@ apply/codiagonalizablePfull; eexists _; last exists P; rewrite /=.
 - rewrite -sub1mx eqmx_col.
   by under eq_bigr do rewrite (eq_genmx (PrV _)); rewrite -genmx_sums genmxE V1.
 apply/allP => A AAs /=; rewrite diagonalizable_for_sum.
-- by apply/forallP => i; apply: P_diag.
 - rewrite mxdirectE/=.
   under eq_bigr do rewrite (eq_genmx (PrV _)); rewrite -genmx_sums genmxE V1.
   by under eq_bigr do rewrite genmxE PrV; rewrite  -(mxdirectP Vdirect)//= V1.
 - by move=> i; rewrite (eqmx_stable _ (PrV _)) ?AV.
 - by move=> i; rewrite /row_free eqmxMfull ?eq_row_base ?row_full_unit.
+- by apply/forallP => i; apply: P_diag.
 Qed.
 
 Lemma diagonalizable_diag {n} (d : 'rV[F]_n) : diagonalizable (diag_mx d).
@@ -1902,7 +1902,7 @@ apply/(codiagonalizable_on _ mxdirect_eigenspaces) => // i/=.
     by rewrite thinmx0 sub0mx.
   by rewrite comm_mx_stable_eigenspace.
 apply/codiagonalizable1.
-rewrite (@conjmx_eigenvalue _ _ _ rs`_i); first exact: diagonalizable_scalar.
+rewrite (@conjmx_eigenvalue _ _ _ rs`_i); last exact: diagonalizable_scalar.
   by rewrite eq_row_base.
 by rewrite row_base_free.
 Qed.
@@ -1972,7 +1972,7 @@ have := dAAs B; rewrite inE BAs orbT => /(_ isT) [P Punit].
 move=> /diagonalizable_forPex[D /(simmxLR Punit)->] sePD.
 have rAeP : row_free (row_base (eigenspace A rs`_i) *m invmx P).
   by rewrite /row_free mxrankMfree ?row_free_unit ?unitmx_inv// eq_row_base.
-rewrite -conjMumx ?unitmx_inv ?row_base_free => [|//|//|//].
+rewrite -conjMumx ?unitmx_inv ?row_base_free => [//|//|//|].
 apply/diagonalizable_conj_diag => //.
 by rewrite stablemx_comp// stablemx_unit ?unitmx_inv.
 Qed.

--- a/algebra/mxred.v
+++ b/algebra/mxred.v
@@ -406,12 +406,12 @@ apply/codiagonalizablePfull; eexists _; last exists P; rewrite /=.
 - rewrite -sub1mx eqmx_col.
   by under eq_bigr do rewrite (eq_genmx (PrV _)); rewrite -genmx_sums genmxE V1.
 apply/allP => A AAs /=; rewrite similar_diag_sum.
-- by apply/forallP => i; apply: P_diag.
 - rewrite mxdirectE/=.
   under eq_bigr do rewrite (eq_genmx (PrV _)); rewrite -genmx_sums genmxE V1.
   by under eq_bigr do rewrite genmxE PrV; rewrite  -(mxdirectP Vdirect)//= V1.
 - by move=> i; rewrite (eqmx_stable _ (PrV _)) ?AV.
 - by move=> i; rewrite /row_free eqmxMfull ?eq_row_base ?row_full_unit.
+- by apply/forallP => i; apply: P_diag.
 Qed.
 
 Lemma diagonalizable_diag {n} (d : 'rV[F]_n) : diagonalizable (diag_mx d).

--- a/algebra/num_theory/numdomain.v
+++ b/algebra/num_theory/numdomain.v
@@ -1940,7 +1940,7 @@ have ->: \sum_(k in A') E' k = mu *+ n'.
   apply: (addrI mu); rewrite -mulrS -Dn -sumrMnl (bigD1 i Ai) big_andbC /=.
   rewrite !(bigD1 j A'j) /= eqxx addrA subrKC addrA; congr (_ + _).
   by apply: eq_bigr => k /andP[_ /negPf->].
-rewrite prodrMn_const exprMn_n -/n' ler_pMn2r ?expn_gt0; last by case: (n').
+rewrite prodrMn_const exprMn_n -/n' ler_pMn2r ?expn_gt0; first by case: (n').
 have ->: \prod_(k in A') E' k = E' j * pi.
   by rewrite (bigD1 j) //=; congr *%R; apply: eq_bigr => k /andP[_ /negPf->].
 rewrite -(ler_pM2l mu_gt0) -exprS -Dn mulrA; apply: lt_le_trans.

--- a/algebra/num_theory/numfield.v
+++ b/algebra/num_theory/numfield.v
@@ -1251,7 +1251,7 @@ Proof.
 move=> Ege0; have [n0 | n_gt0] := posnP n.
   rewrite n0 root0C invr0 mulr0; apply/leif_refl/forall_inP=> i.
   by rewrite (card0_eq n0).
-rewrite -(mono_in_leif (ler_pXn2r n_gt0)) ?rootCK //=; first 1 last.
+rewrite -(mono_in_leif (ler_pXn2r n_gt0)) ?rootCK //=.
 - by rewrite qualifE /= rootC_ge0 // prodr_ge0.
 - by rewrite rpred_div ?rpred_nat ?rpred_sum.
 exact: leif_AGM.

--- a/algebra/poly.v
+++ b/algebra/poly.v
@@ -463,13 +463,13 @@ Qed.
 Fact mul_1poly : left_id 1%:P mul_poly.
 Proof.
 move=> p; apply/polyP => i; rewrite coef_mul_poly big_ord_recl subn0.
-by rewrite big1 => [|j _]; rewrite coefC !simp.
+by rewrite big1 => [j _|]; rewrite coefC !simp.
 Qed.
 
 Fact mul_poly1 : right_id 1%:P mul_poly.
 Proof.
 move=> p; apply/polyP => i; rewrite coef_mul_poly_rev big_ord_recl subn0.
-by rewrite big1 => [|j _]; rewrite coefC !simp.
+by rewrite big1 => [j _|]; rewrite coefC !simp.
 Qed.
 
 Fact mul_polyDl : left_distributive mul_poly +%R.
@@ -487,13 +487,13 @@ Qed.
 Fact mul_0poly : left_zero 0%:P mul_poly.
 Proof.
 move=> p; apply/polyP => i; rewrite coef_mul_poly big_ord_recl subn0.
-by rewrite big1 => [|j _]; rewrite coefC !simp // coefC; case: ifP.
+by rewrite big1 => [j _|]; rewrite coefC !simp // coefC; case: ifP.
 Qed.
 
 Fact mul_poly0 : right_zero 0%:P mul_poly.
 Proof.
 move=> p; apply/polyP => i; rewrite coef_mul_poly_rev big_ord_recl subn0.
-by rewrite big1 => [|j _]; rewrite coefC !simp // coefC; case: ifP.
+by rewrite big1 => [j _|]; rewrite coefC !simp // coefC; case: ifP.
 Qed.
 
 Fact poly1_neq0 : 1%:P != 0 :> {poly R}.
@@ -582,12 +582,12 @@ Qed.
 
 Lemma coefCM c p i : (c%:P * p)`_i = c * p`_i.
 Proof.
-by rewrite coefM big_ord_recl subn0 big1 => [|j _]; rewrite coefC !simp.
+by rewrite coefM big_ord_recl subn0 big1 => [j _|]; rewrite coefC !simp.
 Qed.
 
 Lemma coefMC c p i : (p * c%:P)`_i = p`_i * c.
 Proof.
-by rewrite coefMr big_ord_recl subn0 big1 => [|j _]; rewrite coefC !simp.
+by rewrite coefMr big_ord_recl subn0 big1 => [j _|]; rewrite coefC !simp.
 Qed.
 
 Lemma polyCM : {morph polyC : a b / a * b}.
@@ -1197,7 +1197,7 @@ Qed.
 Lemma derivn_poly0 p n : size p <= n -> p^`(n) = 0.
 Proof.
 move=> le_p_n; apply/polyP=> i; rewrite coef_derivn.
-rewrite nth_default; first by rewrite mul0rn coef0.
+rewrite nth_default; last by rewrite mul0rn coef0.
 exact/(leq_trans le_p_n)/leq_addr.
 Qed.
 
@@ -1278,7 +1278,7 @@ Qed.
 Lemma nderivn_poly0 p n : size p <= n -> p^`N(n) = 0.
 Proof.
 move=> le_p_n; apply/polyP=> i; rewrite coef_nderivn.
-rewrite nth_default; first by rewrite mul0rn coef0.
+rewrite nth_default; last by rewrite mul0rn coef0.
 exact/(leq_trans le_p_n)/leq_addr.
 Qed.
 
@@ -1389,7 +1389,7 @@ Proof. by move/rreg_neq0; rewrite lead_coef_eq0. Qed.
 Lemma lreg_size c p : GRing.lreg c -> size (c *: p) = size p.
 Proof.
 move=> reg_c; have [-> | nz_p] := eqVneq p 0; first by rewrite scaler0.
-rewrite -mul_polyC size_proper_mul; first by rewrite size_polyC lreg_neq0.
+rewrite -mul_polyC size_proper_mul; last by rewrite size_polyC lreg_neq0.
 by rewrite lead_coefC mulrI_eq0 ?lead_coef_eq0.
 Qed.
 
@@ -1402,7 +1402,7 @@ Proof. by move=> reg_c; rewrite !lead_coefE coefZ lreg_size. Qed.
 Lemma rreg_size c p : GRing.rreg c -> size (p * c%:P) =  size p.
 Proof.
 move=> reg_c; have [-> | nz_p] := eqVneq p 0; first by rewrite mul0r.
-rewrite size_proper_mul; first by rewrite size_polyC rreg_neq0 ?addn1.
+rewrite size_proper_mul; last by rewrite size_polyC rreg_neq0 ?addn1.
 by rewrite lead_coefC mulIr_eq0 ?lead_coef_eq0.
 Qed.
 
@@ -1416,7 +1416,7 @@ Proof.
 move=> /mulIr_eq0 reg_d lt_r_d; rewrite addrC.
 have [-> | nz_q] := eqVneq q 0; first by rewrite mul0r addr0.
 have qd0: lead_coef q * lead_coef d != 0 by rewrite reg_d lead_coef_eq0.
-apply/negbTE; rewrite -size_poly_eq0 addrC size_polyDl.
+apply/negbTE; rewrite -size_poly_eq0 addrC size_polyDl; last first.
   by rewrite size_poly_eq0 -lead_coef_eq0 lead_coef_proper_mul.
 apply: leq_trans lt_r_d _; rewrite size_proper_mul //.
 move: nz_q; rewrite -size_poly_eq0.
@@ -1836,7 +1836,7 @@ set q := (n %/ d)%N; rewrite /q.-primitive_root ltn_divRL // n_gt0.
 apply/forallP=> i; rewrite unity_rootE -exprM -prim_order_dvd.
 rewrite -(divnK d_dv_n) -/q -(divnK d_dv_k) mulnAC dvdn_pmul2r //.
 apply/eqP; apply/idP/idP=> [|/eqP->]; last by rewrite dvdn_mull.
-rewrite Gauss_dvdr; first by rewrite eqn_leq ltn_ord; apply: dvdn_leq.
+rewrite Gauss_dvdr; last by rewrite eqn_leq ltn_ord; apply: dvdn_leq.
 by rewrite /coprime gcdnC -(eqn_pmul2r d_gt0) mul1n muln_gcdl !divnK.
 Qed.
 
@@ -2806,7 +2806,7 @@ set f : 'I_(size ps) -> {set 'I_(size ps)} := fun a => [set a].
 transitivity (\sum_(I in imset f (mem setT)) \prod_(i in I) ps`_i).
   apply: congr_big => // I /=.
   by apply/cards1P/imsetP => [[a ->] | [a _ ->]]; exists a.
-rewrite big_imset/=; last first.
+rewrite big_imset/=.
   by move=> i j _ _ ij; apply/set1P; rewrite -/(f j) -ij set11.
 rewrite -[in RHS](in_tupleE ps) -(map_tnth_enum (_ ps)) big_map enumT.
 apply: congr_big => // i; first exact: in_setT.
@@ -2942,7 +2942,7 @@ Lemma size_prod_seq (I : eqType) (s : seq I) (F : I -> {poly R}) :
     (forall i, i \in s -> F i != 0) ->
   size (\prod_(i <- s) F i) = ((\sum_(i <- s) size (F i)).+1 - size s)%N.
 Proof.
-move=> nzF; rewrite big_tnth size_prod; last by move=> i; rewrite nzF ?mem_tnth.
+move=> nzF; rewrite big_tnth size_prod; first by move=> i; rewrite nzF ?mem_tnth.
 by rewrite cardT /= size_enum_ord [in RHS]big_tnth.
 Qed.
 
@@ -3017,7 +3017,7 @@ Lemma lead_coef_comp p q : size q > 1 ->
 Proof.
 move=> q_gt1; rewrite !lead_coefE coef_comp_poly size_comp_poly.
 have [->|nz_p] := eqVneq p 0; first by rewrite size_poly0 big_ord0 coef0 mul0r.
-rewrite polySpred //= big_ord_recr /= big1 ?add0r => [|i _].
+rewrite polySpred //= big_ord_recr /= big1 ?add0r => [i _|]; last first.
   by rewrite -!lead_coefE -lead_coef_exp !lead_coefE size_exp mulnC.
 rewrite [X in _ * X]nth_default ?mulr0 ?(leq_trans (size_poly_exp_leq _ _)) //.
 by rewrite mulnC ltn_mul2r -subn1 subn_gt0 q_gt1 /=.
@@ -3141,7 +3141,7 @@ have [|q' def_q] := factor_theorem q z _; last first.
 rewrite {p}def_p in rpz.
 elim/last_ind: rs drs rpz => [|rs t IHrs] /=; first by rewrite big_nil mulr1.
 rewrite all_rcons => /andP[/andP[/eqP czt Uzt] /IHrs{}IHrs].
-rewrite -cats1 big_cat big_seq1 /= mulrA rootE hornerM_comm; last first.
+rewrite -cats1 big_cat big_seq1 /= mulrA rootE hornerM_comm.
   by rewrite /comm_poly hornerXsubC mulrBl mulrBr czt.
 rewrite hornerXsubC -opprB mulrN oppr_eq0 -(mul0r (t - z)).
 by rewrite (inj_eq (mulIr Uzt)) => /IHrs.
@@ -3227,7 +3227,7 @@ Lemma factor_Xn_sub_1 : \prod_(0 <= i < n) ('X - (z ^+ i)%:P) = 'X^n - 1.
 Proof.
 transitivity (\prod_(w <- zn) ('X - w%:P)); first by rewrite big_map.
 have n_gt0: n > 0 := prim_order_gt0 prim_z.
-rewrite (@all_roots_prod_XsubC _ ('X^n - 1) zn); first 1 last.
+rewrite (@all_roots_prod_XsubC _ ('X^n - 1) zn).
 - by rewrite size_XnsubC // size_map size_iota subn0.
 - apply/allP=> _ /mapP[i _ ->] /=; rewrite rootE !hornerE.
   by rewrite exprAC (prim_expr_order prim_z) expr1n subrr.

--- a/algebra/polydiv.v
+++ b/algebra/polydiv.v
@@ -173,7 +173,7 @@ apply: ihn => //.
   rewrite coefB -scalerAl coefZ coefXnM ltn_subRL ltnNge.
   have hj : (size r).-1 <= j by apply: leq_trans hnj; rewrite -ltnS prednK.
   rewrite [leqLHS]polySpred -?size_poly_gt0 // coefMC.
-  rewrite (leq_ltn_trans hj) /=; last by rewrite -add1n leq_add2r.
+  rewrite (leq_ltn_trans hj) /=; first by rewrite -add1n leq_add2r.
   move: hj; rewrite leq_eqVlt prednK // => /predU1P [<- | hj].
     by rewrite -subn1 subnAC subKn // !subn1 !lead_coefE subrr.
   have/leq_sizeP-> //: size q <= j - (size r - size q).
@@ -370,7 +370,7 @@ apply/IHn=> [|Cda]; last first.
   rewrite mulrDl -addrA subrKC exprSr polyCM mulrA Heq //.
   by rewrite mulrDl -mulrA Cda mulrA.
 apply/leq_sizeP => j Hj; rewrite coefB coefMC -scalerAl coefZ coefXnM.
-rewrite ltn_subRL ltnNge (leq_trans Hr) /=; last first.
+rewrite ltn_subRL ltnNge (leq_trans Hr) /=.
   by apply: leq_ltn_trans Hj _; rewrite -add1n leq_add2r size_poly_gt0.
 move: Hj; rewrite leq_eqVlt; case/predU1P => [<-{j} | Hj]; last first.
   rewrite !nth_default ?simp ?oppr0 ?(leq_trans Hr) //.
@@ -435,7 +435,7 @@ suff e1 : q1 = q * (lead_coef d ^+ k)%:P.
 have : (q1 - q * (lead_coef d ^+ k)%:P) * d = r * (lead_coef d ^+ k)%:P - r1.
   apply/eqP; rewrite -subr_eq0 mulrDl !mulNr.
   by rewrite opprB addrACA -opprD -eC -mulrDl Heq subrr.
-move/eqP; rewrite -[_ == _ - _]subr_eq0 rreg_div0 //.
+move/eqP; rewrite -[_ == _ - _]subr_eq0 rreg_div0 //; last first.
   by case/andP; rewrite subr_eq0; move/eqP.
 rewrite size_polyN; apply: (leq_ltn_trans (size_polyD _ _)); rewrite size_polyN.
 rewrite gtn_max Hs (leq_ltn_trans (size_polyMleq _ _)) //.
@@ -461,7 +461,7 @@ rewrite /rdvdp -(rreg_polyMC_eq0 _ (@rregX _ _ (m - v) Rreg)).
 suff:
  ((rdivp p d) * (lq ^+ (m - v))%:P - q1 * (lq ^+ (m - k))%:P) * d +
   (rmodp p d) * (lq ^+ (m - v))%:P == 0.
-  rewrite rreg_div0 //; first by case/andP.
+  rewrite rreg_div0 //; last by case/andP.
   by rewrite rreg_size ?ltn_rmodp //; exact: rregX.
 rewrite mulrDl addrAC mulNr -!mulrA polyC_exp -(commrX (m-v) Cdl).
 rewrite -polyC_exp mulrA -mulrDl -rdivp_eq // [(_ ^+ (m - k))%:P]polyC_exp.
@@ -534,7 +534,7 @@ Qed.
 
 Lemma rdivp_eq p : p = rdivp p d * d + rmodp p d.
 Proof.
-rewrite -rdivp_eq (eqP mond); last exact: commr1.
+rewrite -rdivp_eq (eqP mond); first exact: commr1.
 by rewrite expr1n mulr1.
 Qed.
 
@@ -911,7 +911,7 @@ Proof.
 have hC : GRing.comm d (lead_coef d)%:P by apply: mulrC.
 move=> hsrd hu; rewrite unlock hu; case et: (redivp _ _) => [[s qq] rr].
 have cdn0 : lead_coef d != 0 by case: eqP hu => //= ->; rewrite unitr0.
-move: (et); rewrite RingComRreg.redivp_eq //; last exact/rregP.
+move: (et); rewrite RingComRreg.redivp_eq //; first exact/rregP.
 rewrite et /= mulrC (mulrC r) !mul_polyC; case=> <- <-.
 by rewrite !scalerA mulVr ?scale1r // unitrX.
 Qed.
@@ -972,7 +972,7 @@ Lemma divpp p : p != 0 -> p %/ p = (lead_coef p ^+ scalp p p)%:P.
 Proof.
 move=> np0; have := divp_eq p p.
 suff -> : p %% p = 0 by rewrite addr0 -mul_polyC; move/(mulIf np0).
-rewrite modpE Ring.rmodpp; last by red; rewrite mulrC.
+rewrite modpE Ring.rmodpp; first by red; rewrite mulrC.
 by rewrite scaler0 if_same.
 Qed.
 
@@ -1082,7 +1082,7 @@ move/(size_scale q)<-; rewrite divp_eq; have [->|quo0] := eqVneq (q %/ d) 0.
   rewrite mul0r add0r size_poly0 size_poly_gt0.
   have [->|pn0] := eqVneq p 0; first by rewrite mul0r size_poly0 ltn0.
   by rewrite size_mul // (polySpred pn0) addSn ltn_addl // ltn_modp.
-rewrite size_polyDl; last first.
+rewrite size_polyDl.
   by rewrite size_mul // (polySpred quo0) addSn /= ltn_addl // ltn_modp.
 have [->|pn0] := eqVneq p 0; first by rewrite mul0r size_poly0 !ltn0.
 by rewrite !size_mul ?quo0 // (polySpred dn0) !addnS ltn_add2r.
@@ -1106,10 +1106,10 @@ move=> nq0; case: (leqP (size q) (size p)) => sqp; last first.
 have np0 : p != 0.
   by rewrite -size_poly_gt0; apply: leq_trans sqp; rewrite size_poly_gt0.
 have /= := congr1 (size \o @polyseq R) (divp_eq p q).
-rewrite size_scale; last by rewrite expf_eq0 lead_coef_eq0 (negPf nq0) andbF.
+rewrite size_scale; first by rewrite expf_eq0 lead_coef_eq0 (negPf nq0) andbF.
 have [->|qq0] := eqVneq (p %/ q) 0.
   by rewrite mul0r add0r=> es; move: nq0; rewrite -(ltn_modp p) -es ltnNge sqp.
-rewrite size_polyDl.
+rewrite size_polyDl; last first.
   by move->; apply/eqP; rewrite size_mul // (polySpred nq0) addnS /= addnK.
 rewrite size_mul ?qq0 //.
 move: nq0; rewrite -(ltn_modp p); move/leq_trans; apply.
@@ -1146,7 +1146,7 @@ Proof. by move=> pq hq; apply: contraTneq pq => ->; rewrite dvd0p. Qed.
 Lemma dvdp1 d : (d %| 1) = (size d == 1).
 Proof.
 rewrite /dvdp modpE; case ud: (lead_coef d \in GRing.unit); last exact: rdvdp1.
-rewrite -size_poly_eq0 size_scale; first by rewrite size_poly_eq0 -rdvdp1.
+rewrite -size_poly_eq0 size_scale; last by rewrite size_poly_eq0 -rdvdp1.
 by rewrite invr_eq0 expf_neq0 //; apply: contraTneq ud => ->; rewrite unitr0.
 Qed.
 
@@ -1553,8 +1553,8 @@ have [->|Hp] := eqVneq p 0.
 move: pq; rewrite dvdp_eq; set c := _ ^+ _; set x := _ %/ _; move/eqP=> eqpq.
 have /= := congr1 (size \o @polyseq R) eqpq.
 have cn0 : c != 0 by rewrite expf_neq0 // lead_coef_eq0.
-rewrite (@eqp_size _ q); last exact: eqp_scale.
-rewrite size_mul ?p0 // => [-> HH|]; last first.
+rewrite (@eqp_size _ q); first exact: eqp_scale.
+rewrite size_mul ?p0 // => [|-> HH].
   apply/eqP=> HH; move: eqpq; rewrite HH mul0r.
   by move/eqP; rewrite scale_poly_eq0 (negPf Hq) (negPf cn0).
 suff: size x == 1%N.
@@ -2027,7 +2027,7 @@ Lemma Gauss_dvdpl p q d: coprimep d q -> (d %| p * q) = (d %| p).
 Proof.
 move/Bezout_coprimepP=>[[u v] Puv]; apply/idP/idP; last exact: dvdp_mulr.
 move/(eqp_mull p): Puv; rewrite mulr1 mulrDr eqp_sym=> peq dpq.
-rewrite (eqp_dvdr _ peq) dvdp_addr; first by rewrite mulrA mulrAC dvdp_mulr.
+rewrite (eqp_dvdr _ peq) dvdp_addr; last by rewrite mulrA mulrAC dvdp_mulr.
 by rewrite mulrA dvdp_mull ?dvdpp.
 Qed.
 
@@ -2058,7 +2058,7 @@ Qed.
 Lemma Gauss_gcdpr p m n : coprimep p m -> gcdp p (m * n) %= gcdp p n.
 Proof.
 move=> co_pm; apply/eqP; rewrite /eqp !dvdp_gcd !dvdp_gcdl /= andbC.
-rewrite dvdp_mull ?dvdp_gcdr // -(@Gauss_dvdpl _ m).
+rewrite dvdp_mull ?dvdp_gcdr // -(@Gauss_dvdpl _ m); last first.
   by rewrite mulrC dvdp_gcdr.
 apply/coprimepP=> d; rewrite dvdp_gcd; case/andP=> hdp _ hdm.
 by move/coprimepP: co_pm; apply.
@@ -2073,7 +2073,7 @@ apply/coprimepP/andP=> [hp | [/coprimepP-hq hr]].
   by split; apply/coprimepP=> d dp dq; rewrite hp //;
      [apply/dvdp_mulr | apply/dvdp_mull].
 move=> d dp dqr; move/(_ _ dp) in hq.
-rewrite Gauss_dvdpl in dqr; first exact: hq.
+rewrite Gauss_dvdpl in dqr; last exact: hq.
 by move/coprimep_dvdr: hr; apply.
 Qed.
 
@@ -2203,7 +2203,7 @@ have /size_poly1P [c cn0 em'] : size m' == 1.
   case: (eqVneq m' 0) def_m => [-> /eqP | m'_n0 def_m].
     by rewrite mul0r scale_poly_eq0 (negPf mn0) (negPf c2n0).
   have := hc _ (dvdpp _) hd; rewrite -size_poly_eq1.
-  rewrite polySpred; last by rewrite expf_eq0 negb_and m'_n0 orbT.
+  rewrite polySpred; first by rewrite expf_eq0 negb_and m'_n0 orbT.
   by rewrite size_exp eqSS muln_eq0 orbC eqn0Ngt k_gt0 /= -eqSS -polySpred.
 rewrite -(@dvdpZl c2) // def_m em' mul_polyC dvdpZl //.
 by rewrite -(@dvdpZr c1) // def_n dvdp_mull.
@@ -2282,8 +2282,8 @@ case dpq: (d %| gcdp p q).
   by apply: contraNneq p0 => d0; move: dp; rewrite d0 dvd0p.
 apply: contraLR dp => ndp'.
 rewrite (@eqp_dvdr ((lead_coef (gcdp p q) ^+ scalp p (gcdp p q))*:p)).
-  by rewrite e; rewrite Gauss_dvdpl //; apply: (coprimep_dvdl (dvdp_gcdr _ _)).
-by rewrite eqp_sym eqp_scale // lc_expn_scalp_neq0.
+  by rewrite eqp_sym eqp_scale // lc_expn_scalp_neq0.
+by rewrite e; rewrite Gauss_dvdpl //; apply: (coprimep_dvdl (dvdp_gcdr _ _)).
 Qed.
 
 Lemma gdcopP q p : gdcop_spec q p (gdcop q p).
@@ -2546,7 +2546,7 @@ have lcdn0 : lead_coef d != 0 by apply: contraTneq ulcd => ->; rewrite unitr0.
 have [-> /esym /eqP|abs] := eqVneq (p %/ d) q.
   by rewrite subrr mul0r subr_eq0 => /eqP<-.
 have hleq : size d <= size ((p %/ d - q) * d).
-  rewrite size_proper_mul; last first.
+  rewrite size_proper_mul.
     by rewrite mulf_eq0 (negPf lcdn0) orbF lead_coef_eq0 subr_eq0.
   by move: abs; rewrite -subr_eq0; move/polySpred->; rewrite addSn /= leq_addl.
 have hlt : size (r - p %% d) < size d.
@@ -2695,7 +2695,7 @@ Proof. by move=> dv_d_p; rewrite eq_sym -dvdp_eq_div // eq_sym. Qed.
 
 Lemma divp_mulA p q : d %| q -> p * (q %/ d) = p * q %/ d.
 Proof.
-move=> hdm; apply/eqP; rewrite eq_sym -dvdp_eq_mul.
+move=> hdm; apply/eqP; rewrite eq_sym -dvdp_eq_mul; last first.
   by rewrite -mulrA divpK.
 by move/divpK: hdm<-; rewrite mulrA dvdp_mull // dvdpp.
 Qed.
@@ -2727,7 +2727,7 @@ Proof. by move/subnK=> {2}<-; rewrite exprD mulpK // lead_coef_exp unitrX. Qed.
 
 Lemma divp_pmul2l p q : lead_coef q \in GRing.unit -> d * p %/ (d * q) = p %/ q.
 Proof.
-move=> uq; rewrite {1}(divp_eq uq p) mulrDr mulrCA divp_addl_mul //; last first.
+move=> uq; rewrite {1}(divp_eq uq p) mulrDr mulrCA divp_addl_mul //.
   by rewrite lead_coefM unitrM_comm ?ulcd //; red; rewrite mulrC.
 have dn0 : d != 0.
   by rewrite -lead_coef_eq0; apply: contraTneq ulcd => ->; rewrite unitr0.
@@ -2759,7 +2759,7 @@ have s : size ((q %/ p) %% r * p + q %% p) < size (p * r).
   have [-> | qn0] := eqVneq ((q %/ p) %% r) 0.
     rewrite mul0r add0r size_mul // (polySpred rn0) addnS /=.
     by apply: leq_trans (leq_addr _ _); rewrite ltn_modp.
-  rewrite size_polyDl mulrC.
+  rewrite size_polyDl mulrC; last first.
     by rewrite !size_mul // (polySpred pn0) !addSn /= ltn_add2l ltn_modp.
   rewrite size_mul // (polySpred qn0) addnS /=.
   by apply: leq_trans (leq_addr _ _); rewrite ltn_modp.
@@ -3276,7 +3276,7 @@ Proof.
 have [-> | bn0] := eqVneq b 0.
   rewrite (rmorph0 (map_poly f)) WeakIdomain.edivp_def !modp0 !divp0.
   by rewrite (rmorph0 (map_poly f)) scalp0.
-rewrite unlock redivp_map lead_coef_map rmorph_unit; last first.
+rewrite unlock redivp_map lead_coef_map rmorph_unit.
   by rewrite unitfE lead_coef_eq0.
 rewrite modpE divpE !map_polyZ [in RHS]rmorphV ?rmorphXn // unitfE.
 by rewrite expf_neq0 // lead_coef_eq0.

--- a/algebra/qpoly.v
+++ b/algebra/qpoly.v
@@ -209,7 +209,7 @@ Definition npoly_enum : seq {poly_n R} :=
 Lemma npoly_enum_uniq : uniq npoly_enum.
 Proof.
 rewrite /npoly_enum; case: n=> [|k] //.
-rewrite pmap_sub_uniq // map_inj_uniq => [|f g eqfg]; rewrite ?enum_uniq //.
+rewrite pmap_sub_uniq // map_inj_uniq => [f g eqfg|]; rewrite ?enum_uniq //.
 apply/ffunP => /= i; have /(congr1 (fun p : {poly _} => p`_i)) := eqfg.
 by rewrite !coef_poly ltn_ord inord_val.
 Qed.
@@ -228,7 +228,7 @@ Qed.
 
 Lemma card_npoly : #|{poly_n R}| = (#|R| ^ n)%N.
 Proof.
-rewrite -(card_imset _ (can_inj (@npoly_rV_K _ _))) eq_cardT.
+rewrite -(card_imset _ (can_inj (@npoly_rV_K _ _))) eq_cardT; last first.
   by rewrite -cardT /= card_mx mul1n.
 by move=> v; apply/imsetP; exists (rVnpoly v); rewrite ?rVnpolyK //.
 Qed.
@@ -286,8 +286,8 @@ Lemma npolyX_free : free npolyX.
 Proof.
 apply/freeP=> u /= sum_uX_eq0 i; have /npolyP /(_ i) := sum_uX_eq0.
 rewrite (@big_morph _ _ _ 0%R +%R) // coef_sum coef0.
-rewrite (bigD1 i) ?big1 /= ?addr0 ?coefZ ?(nth_map 0%N) ?size_iota //.
-  by rewrite nth_npolyX npolyXE coefXn eqxx mulr1.
+rewrite (bigD1 i) ?big1 /= ?addr0 ?coefZ ?(nth_map 0%N) ?size_iota //;
+  last by rewrite nth_npolyX npolyXE coefXn eqxx mulr1.
 move=> j; rewrite -val_eqE /= => neq_ji.
 by rewrite nth_npolyX npolyXE coefZ coefXn eq_sym (negPf neq_ji) mulr0.
 Qed.
@@ -343,13 +343,13 @@ Qed.
 
 Let size_lagrange_def i : size (lagrange_def i) = n.
 Proof.
-rewrite size_Cmul; last first.
+rewrite size_Cmul.
   suff : (lagrange_def i).[x i] != 0.
     by rewrite hornerE mulf_eq0 => /norP [].
   by rewrite lagrange_def_sample ?eqxx ?oner_eq0.
-rewrite size_prod /=; last first.
+rewrite size_prod /=.
   by move=> j neq_ji; rewrite polyXsubC_eq0.
-rewrite (eq_bigr (fun=> (2 * 1)%N)); last first.
+rewrite (eq_bigr (fun=> (2 * 1)%N)).
   by move=> j neq_ji; rewrite size_XsubC.
 rewrite -big_distrr /= sum1_card cardC1 card_ord /=.
 by case: (n) {i} n_gt0 => ?; rewrite mul2n -addnn -addSn addnK.
@@ -378,7 +378,7 @@ Proof.
 apply/freeP=> lambda eq_l i.
 have /(congr1 (fun p : {poly__ _} => p.[x i])) := eq_l.
 rewrite (@big_morph _ _ _ 0%R +%R) // horner_sum horner0.
-rewrite (bigD1 i) // big1 => [|j /= /negPf ji] /=;
+rewrite (bigD1 i) // big1 => [j /= /negPf ji|] /=;
 by rewrite ?hornerE nth_lagrange lagrange_sample ?eqxx ?ji ?mulr1 ?mulr0.
 Qed.
 
@@ -391,7 +391,7 @@ Lemma lagrange_coords (p : {poly_n K}) i : coord lagrange i p = p.[x i].
 Proof.
 rewrite [p in RHS](coord_basis lagrange_full) ?memvf //.
 rewrite (@big_morph _ _ _ 0%R +%R) // horner_sum.
-rewrite (bigD1 i) // big1 => [|j /= /negPf ji] /=;
+rewrite (bigD1 i) // big1 => [j /= /negPf ji|] /=;
 by rewrite ?hornerE nth_lagrange lagrange_sample ?eqxx ?ji ?mulr1 ?mulr0.
 Qed.
 
@@ -726,7 +726,7 @@ rewrite rmodp_mulml // -scalerAl rmodpZ // rmodp_mulml //.
 rewrite -[rmodp]/rmodp -!Pdiv.IdomainMonic.modpE //.
 have := eqp_modpl hQ F.
 rewrite modpD // modp_mull add0r // .
-rewrite [(1 %% _)%R]modp_small => // [egcdE|]; last first.
+rewrite [(1 %% _)%R]modp_small => // [|egcdE].
   by rewrite size_polyC oner_eq0 size_mk_monic_gt1.
 rewrite {2}(eqpfP egcdE) lead_coefC divr1 alg_polyC scale_polyC mulVf //.
 rewrite lead_coef_eq0.

--- a/algebra/rat.v
+++ b/algebra/rat.v
@@ -1066,7 +1066,7 @@ have [K kerK]: {K : 'M_(k, m) | map_mx intr K == kermx S}%MS.
   move: (mxrank_ker S); rewrite rE kE => krk.
   pose B := row_base (kermx S); pose d := \prod_ij denq (B ij.1 ij.2).
   exists (castmx (krk, erefl m) (map_mx numq (intr d *: B))).
-  rewrite map_castmx !eqmx_cast -map_mx_comp map_mx_id_in => [|i j]; last first.
+  rewrite map_castmx !eqmx_cast -map_mx_comp map_mx_id_in => [i j|].
     rewrite mxE mulrC [d](bigD1 (i, j)) //= rmorphM mulrA.
     by rewrite -numqE -rmorphM numq_int.
   suff nz_d: d%:Q != 0 by rewrite !eqmx_scale // !eq_row_base andbb.

--- a/algebra/sesquilinear.v
+++ b/algebra/sesquilinear.v
@@ -1177,7 +1177,7 @@ case/pairwise_orthogonalP=> [/=/andP[notS0 uniqS] oSS].
 rewrite -(in_tupleE S); apply/freeP => a aS0 i.
 have S_i: S`_i \in S by apply: mem_nth.
 have /eqP: '[S`_i, 0] = 0 := linear0r _ _.
-rewrite -{2}aS0 raddf_sum /= (bigD1 i) //= big1 => [|j neq_ji]; last 1 first.
+rewrite -{2}aS0 raddf_sum /= (bigD1 i) //= big1 => [j neq_ji|].
   by rewrite linearZ /= oSS ?mulr0 ?mem_nth // eq_sym nth_uniq.
 rewrite addr0 linearZ mulf_eq0 conjC_eq0 dnorm_eq0.
 by case/pred2P=> // Si0; rewrite -Si0 S_i in notS0.
@@ -1209,7 +1209,7 @@ without loss ou: u / '[u, v] = 0.
   rewrite (canRL (subrK _) (erefl u1)) rpredDr ?rpredZ ?memv_line //.
   rewrite linearDl /= ou add0r.
   rewrite linearZl_LR/= normrM (ger0_norm (dnorm_ge0 _ _)).
-  rewrite exprMn mulrA -dnormZ hnormDd/=; last by rewrite linearZr_LR/= ou mulr0.
+  rewrite exprMn mulrA -dnormZ hnormDd/=; first by rewrite linearZr_LR/= ou mulr0.
   have:= IHo _ ou.
   by rewrite mulrDl -leifBLR subrr ou normCK mul0r.
 rewrite ou normCK mul0r; split; first by rewrite mulr_ge0.

--- a/algebra/spectral.v
+++ b/algebra/spectral.v
@@ -70,7 +70,7 @@ move=> v vN0 /allP /= vP; exists (v *m (row_base (eigenspace A a))).
   by rewrite mulmx_free_eq0 ?row_base_free.
 apply/andP; split.
   by apply/eigenvectorP; exists a; rewrite mulmx_sub // eq_row_base.
-apply/allP => B B_in; rewrite -stablemx_restrict ?vP //.
+apply/allP => B B_in; rewrite -stablemx_restrict ?vP //; last first.
   by apply/mapP; exists B.
 by rewrite comm_mx_stable_eigenspace //; exact: A_comm.
 Qed.
@@ -464,9 +464,9 @@ have [v /and4P [vBn v_neq0 dAv_ge0 dAsub]] :
     rewrite orthomx_sym in vBn.
     exists v; rewrite vBn v_neq0 -pBE/=.
       rewrite ['[_, _]](hermmx_eq0P _ _) ?lexx //=.
+        by rewrite (submx_trans _ vBn) // proj_ortho_sub.
       rewrite (submx_trans (proj_ortho_sub _ _)) //.
       by rewrite -{1}[B]addr0 addmx_sub_adds ?sub0mx.
-    by rewrite (submx_trans _ vBn) // proj_ortho_sub.
   pose c := (sqrtC '[BoSn])^-1; have c_gt0 : c > 0.
     by rewrite invr_gt0 sqrtC_gt0 lt_def ?dnorm_eq0 ?dnorm_ge0 BoSn_neq0.
   exists BoSn; apply/and4P; split => //.
@@ -498,7 +498,7 @@ apply/forallP => i; case: (split_ordP i) => j -> /=.
   have /andP [sABj dot_gt0] := subAB j.
   rewrite rowKu -row_usubmx (submx_trans sABj) //=.
   rewrite (eq_rect _ (submx _) (submx_refl _)) //.
-  rewrite [in RHS](reindex (lshift 1)) /=.
+  rewrite [in RHS](reindex (lshift 1)) /=; last first.
     by apply: eq_bigr=> k k_le; rewrite rowKu.
   exists (fun k => insubd j k) => k; rewrite inE /= => le_kj;
   by apply/val_inj; rewrite /= insubdK // -topredE /= (leq_ltn_trans le_kj).
@@ -592,7 +592,7 @@ pose r A := S *m A *m S^t*.
 have vSvo X : stablemx v X ->
   schmidt (row_base v) *m X *m schmidt (row_base v^!%MS) ^t* = 0.
   move=> /eigenvectorP [a v_in].
-  rewrite (eigenspaceP (_ : (_ <= _ a))%MS); last first.
+  rewrite (eigenspaceP (_ : (_ <= _ a))%MS).
     by rewrite eqmx_schmidt_free ?row_base_free ?eq_row_base.
   rewrite -scalemxAl (orthomx1P _) ?scaler0 //.
   by do 2!rewrite eqmx_schmidt_free ?row_base_free ?eq_row_base // orthomx_sym.
@@ -601,7 +601,7 @@ have drrE X : drsubmx (r X) =
   by rewrite /r mul_col_mx tr_col_mx map_row_mx mul_col_row block_mxKdr.
 have vSv X a : (v <= eigenspace X a)%MS ->
   schmidt (row_base v) *m X *m schmidt (row_base v) ^t* = a%:M.
-  move=> vXa; rewrite (eigenspaceP (_ : (_ <= _ a)%MS)); last first.
+  move=> vXa; rewrite (eigenspaceP (_ : (_ <= _ a)%MS)).
     by rewrite eqmx_schmidt_free ?row_base_free ?eq_row_base.
   by rewrite -scalemxAl (unitarymxP _) ?scalemx1 ?schmidt_unitarymx ?rank_leq_col.
 have [] := IHN _ _ [seq drsubmx (r A) | A <- As].

--- a/algebra/ssrint.v
+++ b/algebra/ssrint.v
@@ -1684,7 +1684,7 @@ apply/leqifP; rewrite -ltz_nat -eqz_nat PoszD !abszE; apply/leifP.
 wlog le_m31 : m1 m3 / (m3 <= m1)%R.
   move=> IH; case/orP: (le_total m1 m3) => /IH //.
   by rewrite (addrC `|_|)%R orbC !(distrC m1) !(distrC m3).
-rewrite ger0_norm ?subr_ge0 // orb_idl => [|/andP[le_m12 le_m23]]; last first.
+rewrite ger0_norm ?subr_ge0 // orb_idl => [/andP[le_m12 le_m23]|].
   by have /eqP->: m2 == m3; rewrite ?lexx // eq_le le_m23 (le_trans le_m31).
 rewrite -{1}(subrK m2 m1) -(addrA _ m2) -subr_ge0 andbC -[X in X && _]subr_ge0.
 by apply: leifD; apply/real_leif_norm/num_real.

--- a/algebra/vector.v
+++ b/algebra/vector.v
@@ -1144,9 +1144,9 @@ pose fL : {linear _ -> _} := HB.pack f flM.
 exists fL => freeX eq_szX.
 apply/esym/(@eq_from_nth _ 0); rewrite ?size_map eq_szX // => i ltiX.
 rewrite (nth_map 0) //= /f (bigD1 (Ordinal ltiX)) //=.
-rewrite big1 => [|j /negbTE neqji]; rewrite (coord_free (Ordinal _)) //.
-  by rewrite eqxx scale1r addr0.
-by rewrite eq_sym neqji scale0r.
+rewrite big1 => [j /negbTE neqji|]; rewrite (coord_free (Ordinal _)) //.
+  by rewrite eq_sym neqji scale0r.
+by rewrite eqxx scale1r addr0.
 Qed.
 
 (* Subspace bases *)
@@ -2031,8 +2031,8 @@ exists (fun rw : 'rV_(\dim U) => vsproj (\sum_i rw 0 i *: (vbasis U)`_i)).
   move=> w /=; congr (vsproj _ = w): (vsvalK w).
   by rewrite {1}(coord_vbasis (subvsP w)); apply: eq_bigr => i _; rewrite mxE.
 move=> rw; apply/rowP=> i; rewrite mxE vsprojK.
-  by rewrite coord_sum_free ?(basis_free (vbasisP U)).
-by apply: rpred_sum => j _; rewrite rpredZ ?vbasis_mem ?memt_nth.
+  by apply: rpred_sum => j _; rewrite rpredZ ?vbasis_mem ?memt_nth.
+by rewrite coord_sum_free ?(basis_free (vbasisP U)).
 Qed.
 
 HB.instance Definition _ := Lmodule_hasFinDim.Build K subvs_of subvs_vect_iso.

--- a/boot/binomial.v
+++ b/boot/binomial.v
@@ -54,7 +54,7 @@ apply/idP/idP=> [pr_p | dv_pF]; last first.
   apply/primeP; split=> // d dv_dp; have: d <= p by apply: dvdn_leq.
   rewrite orbC leq_eqVlt => /orP[-> // | ltdp].
   have:= dvdn_trans dv_dp dv_pF; rewrite dFact // big_mkord.
-  rewrite (bigD1 (Ordinal ltdp)) /=; last by rewrite -lt0n (dvdn_gt0 p_gt0).
+  rewrite (bigD1 (Ordinal ltdp)) /=; first by rewrite -lt0n (dvdn_gt0 p_gt0).
   by rewrite orbC -addn1 dvdn_addr ?dvdn_mulr // dvdn1 => ->.
 pose Fp1 := Ordinal lt1p; pose Fp0 := Ordinal p_gt0.
 have ltp1p: p.-1 < p by [rewrite prednK]; pose Fpn1 := Ordinal ltp1p.
@@ -95,21 +95,21 @@ have vFpId i: (vFp i == i :> nat) = xpred2 Fp1 Fpn1 i.
   rewrite addnBA ?leq_sqr // mulnS -addnA -mulnn -mulnDl.
   rewrite -(subnK (le_pmFp (vFp i) i)) mulnDl addnCA.
   rewrite -[1 ^ 2]/(Fp1 : nat) -addnBA // dvdn_addl.
-    by rewrite Euclid_dvdM // -eqFp eq_sym orbC /dvdn Fp_mod eqn0Ngt lt0i.
-  by rewrite -eqn_mod_dvd // Fp_mod modnDl -(vFpV _ ni0).
+    by rewrite -eqn_mod_dvd // Fp_mod modnDl -(vFpV _ ni0).
+  by rewrite Euclid_dvdM // -eqFp eq_sym orbC /dvdn Fp_mod eqn0Ngt lt0i.
 suffices [mod_fact]: toFp (p.-1)`! = Fpn1.
   by rewrite /dvdn -addn1 -modnDml mod_fact addn1 prednK // modnn.
-rewrite dFact //; rewrite ((big_morph toFp) Fp1 mFpM) //; first last.
-- by apply: val_inj; rewrite /= modn_small.
+rewrite dFact //; rewrite ((big_morph toFp) Fp1 mFpM) //.
 - by move=> i j; apply: val_inj; rewrite /= modnMm.
-rewrite big_mkord (eq_bigr id) => [|i _]; last by apply: val_inj => /=.
+- by apply: val_inj; rewrite /= modn_small.
+rewrite big_mkord (eq_bigr id) => [i _|]; first by apply: val_inj => /=.
 pose ltv i := vFp i < i; rewrite (bigID ltv) -/mFpM [mFpM _ _]mFpC.
-rewrite (bigD1 Fp1) -/mFpM; last by rewrite [ltv _]ltn_neqAle vFpId.
-rewrite [mFpM _ _]mFp1 (bigD1 Fpn1) -?mFpA -/mFpM; last first.
+rewrite (bigD1 Fp1) -/mFpM; first by rewrite [ltv _]ltn_neqAle vFpId.
+rewrite [mFpM _ _]mFp1 (bigD1 Fpn1) -?mFpA -/mFpM.
   rewrite -lt0n -ltnS prednK // lt1p.
   by rewrite [ltv _]ltn_neqAle vFpId eqxx orbT eq_sym eqF1n1.
-rewrite (reindex_onto vFp vFp) -/mFpM => [|i]; last by do 3!case/andP; auto.
-rewrite (eq_bigl (xpredD1 ltv Fp0)) => [|i]; last first.
+rewrite (reindex_onto vFp vFp) -/mFpM => [i|]; first by do 3!case/andP; auto.
+rewrite (eq_bigl (xpredD1 ltv Fp0)) => [i|].
   rewrite andbC -!andbA -2!negb_or -vFpId orbC -leq_eqVlt -ltnNge.
   have [->|ni0] := eqVneq i; last by rewrite vFpK // eqxx vFp0.
   by case: eqP => // ->; rewrite !andbF.
@@ -374,11 +374,11 @@ Lemma card_uniq_tuples T n (A : pred T) :
 Proof.
 elim: n A => [|n IHn] A.
   by rewrite (@eq_card1 _ [tuple]) // => t; rewrite [t]tuple0 inE.
-rewrite -sum1dep_card (partition_big (@thead _ _) A) /= => [|t]; last first.
+rewrite -sum1dep_card (partition_big (@thead _ _) A) /= => [t|].
   by case/tupleP: t => x t; do 2!case/andP.
 rewrite ffactnS -sum_nat_const; apply: eq_bigr => x Ax.
 rewrite (cardD1 x) [x \in A]Ax /= -(IHn [predD1 A & x]) -sum1dep_card.
-rewrite (reindex (fun t : n.-tuple T => [tuple of x :: t])) /=; last first.
+rewrite (reindex (fun t : n.-tuple T => [tuple of x :: t])) /=.
   pose ttail (t : n.+1.-tuple T) := [tuple of behead t].
   exists ttail => [t _ | t /andP[_ /eqP <-]]; first exact: val_inj.
   by rewrite -tuple_eta.
@@ -416,8 +416,7 @@ apply/eqP; rewrite -(eqn_pmul2r (fact_gt0 k)) bin_ffact // eq_sym.
 rewrite -sum_nat_cond_const -{1 3}(card_ord k).
 rewrite -card_inj_ffuns_on -sum1dep_card.
 pose imIk (f : {ffun 'I_k -> T}) := f @: 'I_k.
-rewrite (partition_big imIk (fun A => (A \subset B) && (#|A| == k))) /=
-  => [|f]; last first.
+rewrite (partition_big imIk (fun A => (A \subset B) && (#|A| == k))) /= => [f|].
   move=> /andP [/ffun_onP f_ffun /injectiveP inj_f].
   rewrite card_imset ?card_ord // eqxx andbT.
   by apply/subsetP => x /imsetP [i _ ->]; rewrite f_ffun.
@@ -426,7 +425,7 @@ have [f0 inj_f0 im_f0]: exists2 f, injective f & f @: 'I_k = A.
   rewrite -cardAk; exists enum_val; first exact: enum_val_inj.
   apply/setP=> a; apply/imsetP/idP=> [[i _ ->] | Aa]; first exact: enum_valP.
   by exists (enum_rank_in Aa a); rewrite ?enum_rankK_in.
-rewrite (reindex (fun p : {ffun _} => [ffun i => f0 (p i)])) /=; last first.
+rewrite (reindex (fun p : {ffun _} => [ffun i => f0 (p i)])) /=.
   pose ff0' f i := odflt i [pick j | f i == f0 j].
   exists (fun f => [ffun i => ff0' f i]) => [p _ | f].
     apply/ffunP=> i; rewrite ffunE /ff0'; case: pickP => [j | /(_ (p i))].
@@ -469,7 +468,7 @@ have inc_A (A : {set 'I_n}) : sorted ltn (map val (enum A)).
   rewrite -[enum _](eq_filter (mem_enum _)).
   rewrite -(eq_filter (mem_map val_inj _)) -filter_map.
   by rewrite (sorted_filter ltn_trans) // unlock val_ord_enum iota_ltn_sorted.
-rewrite -!sum1dep_card (reindex_onto f_t f_A) /= => [|A]; last first.
+rewrite -!sum1dep_card (reindex_onto f_t f_A) /= => [A|].
   by move/eqP=> cardAm; apply/setP=> x; rewrite inE -(mem_enum A) -val_fA.
 apply: eq_bigl => t.
 apply/idP/idP => [inc_t|/andP [/eqP t_m /eqP <-]]; last by rewrite val_fA.
@@ -492,14 +491,14 @@ pose add_mn_nat (t : m.-tuple In1) i := i + nth x0 t i.
 have add_mnC t: val \o add_mn t =1 add_mn_nat t \o val.
   by move=> i; rewrite /= (tnth_nth x0).
 pose f_add t := [tuple of map (add_mn t) (ord_tuple m)].
-rewrite -card_ltn_sorted_tuples -!sum1dep_card (reindex f_add) /=.
+rewrite -card_ltn_sorted_tuples -!sum1dep_card (reindex f_add) /=; last first.
   apply: eq_bigl => t; rewrite -map_comp (eq_map (add_mnC t)) map_comp.
   rewrite enumT unlock val_ord_enum -[in LHS](drop0 t).
   have [m0 | m_gt0] := posnP m.
     by rewrite {2}m0 /= drop_oversize // size_tuple m0.
   have def_m := subnK m_gt0; rewrite -{2}def_m addn1 /= {1}/add_mn_nat.
   move: 0 (m - 1) def_m => i k; rewrite -[in RHS](size_tuple t) => def_m.
-  rewrite (drop_nth x0) /=; last by rewrite -def_m leq_addl.
+  rewrite (drop_nth x0) /=; first by rewrite -def_m leq_addl.
   elim: k i (nth x0 t i) def_m => [|k IHk] i x /=.
     by rewrite add0n => ->; rewrite drop_size.
   rewrite addSnnS => def_m; rewrite -addSn leq_add2l -IHk //.
@@ -532,7 +531,7 @@ Proof.
 symmetry; set In1 := 'I_n.+1; pose x0 : In1 := ord0.
 pose add_mn (i j : In1) : In1 := inord (i + j).
 pose f_add (t : m.-tuple In1) := [tuple of scanl add_mn x0 t].
-rewrite -card_sorted_tuples -!sum1dep_card (reindex f_add) /=.
+rewrite -card_sorted_tuples -!sum1dep_card (reindex f_add) /=; last first.
   apply: eq_bigl => t; rewrite -[\sum_(i <- t) i]add0n.
   transitivity (path leq x0 (map val (f_add t))) => /=; first by case: map.
   rewrite -{1 2}[0]/(val x0); elim: {t}(val t) (x0) => /= [|x t IHt] s.
@@ -562,7 +561,8 @@ Lemma card_ord_partitions m n :
 Proof.
 symmetry; set In1 := 'I_n.+1; pose x0 : In1 := ord0.
 pose f_add (t : m.-tuple In1) := [tuple of sub_ord (\sum_(x <- t) x) :: t].
-rewrite -card_partial_ord_partitions -!sum1dep_card (reindex f_add) /=.
+rewrite -card_partial_ord_partitions -!sum1dep_card (reindex f_add) /=;
+    last first.
   by apply: eq_bigl => t; rewrite big_cons /= addnC (sameP maxn_idPr eqP) maxnE.
 exists (fun t : m.+1.-tuple In1 => [tuple of behead t]) => [t _|].
   exact: val_inj.

--- a/boot/choice.v
+++ b/boot/choice.v
@@ -427,7 +427,7 @@ exists (fun sP nn => f sP (dc nn) nil) => [sP n ys | sP [ys] | sP sQ eqPQ n].
   case Df: (find _ n)=> // [x] _; exists (code (n :: dc n1)).
   by rewrite codeK /= Df /= (correct Df).
 elim: {n}(dc n) nil => [|n ns IHs] xs /=; first by rewrite eqPQ.
-rewrite (@extensional _ _ (r (f sQ ns) xs)) => [|x]; last by rewrite IHs.
+rewrite (@extensional _ _ (r (f sQ ns) xs)) => [x|]; first by rewrite IHs.
 by case: find => /=.
 Qed.
 HB.instance Definition _ := seq_hasChoice.
@@ -453,9 +453,9 @@ exists f => [tP n u | tP [[i x] tPxi] | sP sQ eqPQ n].
   case/complete=> ni tPn; exists (code [:: ni; nt]); rewrite /f codeK /fi.
   by case Df: find tPn => //= [j] _; have:= correct Df.
 rewrite /f /fi; case: (dc n) => [|ni [|nt []]] //=.
-rewrite (@extensional _ _ (ft sQ nt)) => [|i].
-  by case: find => //= i; congr (omap _ _); apply: extensional => x /=.
-by congr (omap _ _); apply: extensional => x /=.
+rewrite (@extensional _ _ (ft sQ nt)) => [i|].
+  by congr (omap _ _); apply: extensional => x /=.
+by case: find => //= i; congr (omap _ _); apply: extensional => x /=.
 Qed.
 HB.instance Definition _ := tagged_hasChoice.
 

--- a/boot/div.v
+++ b/boot/div.v
@@ -122,7 +122,7 @@ Lemma divnMl p m d : p > 0 -> p * m %/ (p * d) = m %/ d.
 Proof.
 move=> p_gt0; have [->|d_gt0] := posnP d; first by rewrite muln0.
 rewrite [RHS]/divn; case: edivnP; rewrite d_gt0 /= => q r ->{m} lt_rd.
-rewrite mulnDr mulnCA divnMDl; last by rewrite muln_gt0 p_gt0.
+rewrite mulnDr mulnCA divnMDl; first by rewrite muln_gt0 p_gt0.
 by rewrite addnC divn_small // ltn_pmul2l.
 Qed.
 Arguments divnMl [p m d].
@@ -636,7 +636,7 @@ Proof.
 elim/ltn_ind: m n => -[|m] IHm [|n] //=.
 rewrite gcdnE; case def_p: (_ %% _) => [|p]; first by rewrite /dvdn def_p.
 have lt_pm: p < m by rewrite -ltnS -def_p ltn_pmod.
-rewrite /= (divn_eq n.+1 m.+1) def_p dvdn_addr ?dvdn_mull //; last exact: IHm.
+rewrite /= (divn_eq n.+1 m.+1) def_p dvdn_addr ?dvdn_mull //; first exact: IHm.
 by rewrite gcdnE /= IHm // (ltn_trans (ltn_pmod _ _)).
 Qed.
 
@@ -713,7 +713,7 @@ case: posnP => [r0 {s le_ns1 IHs lt_rn}|r_gt0]; last first.
   by apply: IHs => //=; [rewrite natTrecE -def_m | rewrite (leq_trans lt_rn)].
 rewrite {r}r0 addn0 in def_m; set b := odd _; pose d := gcdn m n.
 pose km := ~~ b : nat; pose kn := if b then 1 else q.-1.
-rewrite [bz in Spec bz](_ : _ = Bezout_rec km kn qs); last first.
+rewrite [bz in Spec bz](_ : _ = Bezout_rec km kn qs).
   by rewrite /kn /km; case: (b) => //=; rewrite natTrecE addn0 muln1.
 have def_d: d = n by rewrite /d def_m gcdnC gcdnE modnMl gcd0n -[n]prednK.
 have: km * m + 2 * b * d = kn * n + d.

--- a/boot/finfun.v
+++ b/boot/finfun.v
@@ -432,7 +432,7 @@ have [y0 Fxy0 | Fx00] := pickP (F x0); last first.
   by rewrite !eq_card0 // => f; apply: contraFF (Fx00 (f x0))=> /familyP; apply.
 pose F1 x := if eqP is ReflectT Dx then xpred1 (ecast x (rT x) Dx y0) else F x.
 transitivity (#|[predX F x0 & family F1 : pred fT]|); last first.
-  rewrite cardX {}IH_E {uniqE}// => [|x E'x]; last first.
+  rewrite cardX {}IH_E {uniqE}// => [x E'x|].
     rewrite /F1; case: eqP => [Dx | /nesym/eqP-x0'x]; first exact: card1.
     by rewrite trivF // negb_or x0'x.
   congr (_ * foldr _ _ _); apply/eq_in_map=> x Ex.

--- a/boot/fingraph.v
+++ b/boot/fingraph.v
@@ -602,7 +602,7 @@ elim: {a b}#|b| {1 3 4}b (eqxx #|b|) => [|m IHm] b def_m f_b.
   by rewrite eq_card0 // => x; apply: (pred0P def_m).
 have [x b_x | b0] := pickP b; last by rewrite (eq_card0 b0) in def_m.
 have [r_x ox_n] := f_b x b_x; rewrite (cardD1 x) [x \in b]b_x eqSS in def_m.
-rewrite mulSn -{1}ox_n -(IHm _ def_m) => [|_ /andP[_ /f_b //]].
+rewrite mulSn -{1}ox_n -(IHm _ def_m) => [_ /andP[_ /f_b //]|].
 rewrite -(cardID (fconnect f x)); congr (_ + _); apply: eq_card => y.
   by apply: andb_idl => /= fxy; rewrite !inE -(rootP symf fxy) r_x.
 by congr (~~ _ && _); rewrite /= /in_mem /= symf -(root_connect symf) r_x.
@@ -622,7 +622,7 @@ Lemma fcard_gt0P (a : {pred T}) :
   fclosed f a -> reflect (exists x, x \in a) (0 < fcard f a).
 Proof.
 move=> clfA; apply: (iffP card_gt0P) => [[x /andP[]]|[x xA]]; first by exists x.
-exists (froot f x); rewrite inE roots_root /=; last exact: fconnect_sym.
+exists (froot f x); rewrite inE roots_root /=; first exact: fconnect_sym.
 by rewrite -(closed_connect clfA (connect_root _ x)).
 Qed.
 
@@ -838,8 +838,8 @@ Proof.
 have [xcycle|Ncycle] := boolP (fcycle f (orbit x)); constructor => //.
   by rewrite order_id_cycle.
 rewrite /order (eq_card (_ : _ =1 [predU1 x & fconnect f (f x)])).
-  by rewrite cardU1 inE (contraNN (all_iffLR orbitPcycle 2 0)).
-by move=> y; rewrite !inE fconnect_eqVf eq_sym.
+  by move=> y; rewrite !inE fconnect_eqVf eq_sym.
+by rewrite cardU1 inE (contraNN (all_iffLR orbitPcycle 2 0)).
 Qed.
 
 Lemma fconnect_f x : fconnect f (f x) x = fcycle f (orbit x).

--- a/boot/finset.v
+++ b/boot/finset.v
@@ -1625,9 +1625,9 @@ Lemma big_imset h (A : {pred I}) G : {in A &, injective h} ->
   \big[aop/idx]_(j in h @: A) G j = \big[aop/idx]_(i in A) G (h i).
 Proof.
 move=> injh; pose hA := mem (image h A).
-rewrite (eq_bigl hA) => [|j]; last exact/imsetP/imageP.
+rewrite (eq_bigl hA) => [j|]; first exact/imsetP/imageP.
 pose h' := omap (fun u : {j | hA j} => iinv (svalP u)) \o insub.
-rewrite (reindex_omap h h') => [|j hAj]; rewrite {}/h'/= ?insubT/= ?f_iinv//.
+rewrite (reindex_omap h h') => [j hAj|]; rewrite {}/h'/= ?insubT/= ?f_iinv//.
 apply: eq_bigl => i; case: insubP => [u /= -> def_u | nhAhi]; last first.
   by apply/andP/idP => [[]//| Ai]; case/imageP: nhAhi; exists i.
 set i' := iinv _; have Ai' : i' \in A := mem_iinv (svalP u).
@@ -1648,7 +1648,7 @@ Lemma big_cards1 (f : {set I} -> R) :
   \big[aop/idx]_(A : {set I} | #|A| == 1) f A
   = \big[aop/idx]_(i : I) f [set i].
 Proof.
-rewrite (reindex_omap set1 unset1) => [|A /cards1P[i ->] /[!set1K]//].
+rewrite (reindex_omap set1 unset1) => [A /cards1P[i ->] /[!set1K]//|].
 by apply: eq_bigl => i; rewrite set1K cards1 !eqxx.
 Qed.
 
@@ -1667,7 +1667,7 @@ transitivity (\big[add/zero]_(f0 in (imset f (mem setT)))
   suff <-: setT = imset f (mem setT) by apply: congr_big=>// i; rewrite in_setT.
   apply/esym/eqP; rewrite -subTset; apply/subsetP => b _.
   by apply/imsetP; exists (FinSet b).
-rewrite big_imset; last by case=> g; case=> h _ _; rewrite /f => /= ->.
+rewrite big_imset; first by case=> g; case=> h _ _; rewrite /f => /= ->.
 apply: congr_big => //; case=> g; first exact: in_setT.
 by move=> _; apply: eq_bigr => i _; congr (if _ then _ else _); rewrite unlock.
 Qed.
@@ -2240,11 +2240,11 @@ Let rhs P E := \big[op/idx]_(A in P) \big[op/idx]_(x in A) E x.
 Lemma big_trivIset_cond P (K : pred T) (E : T -> R) :
   trivIset P -> \big[op/idx]_(x in cover P | K x) E x = rhs_cond P K E.
 Proof.
-move=> tiP; rewrite (partition_big (pblock P) [in P]) -/op => /= [|x].
-  apply: eq_bigr => A PA; apply: eq_bigl => x; rewrite andbAC; congr (_ && _).
-  rewrite -mem_pblock; apply/andP/idP=> [[Px /eqP <- //] | Ax].
-  by rewrite (def_pblock tiP PA Ax).
-by case/andP=> Px _; apply: pblock_mem.
+move=> tiP; rewrite (partition_big (pblock P) [in P]) -/op => /= [x|].
+  by case/andP=> Px _; apply: pblock_mem.
+apply: eq_bigr => A PA; apply: eq_bigl => x; rewrite andbAC; congr (_ && _).
+rewrite -mem_pblock; apply/andP/idP=> [[Px /eqP <- //] | Ax].
+by rewrite (def_pblock tiP PA Ax).
 Qed.
 
 Lemma big_trivIset P (E : T -> R) :
@@ -2274,10 +2274,10 @@ have trivP: trivIset P.
 have ->: \bigcup_i F i = cover P.
   apply/esym; rewrite cover_imset big_mkcond; apply: eq_bigr => i _.
   by rewrite inE; case: eqP.
-rewrite big_trivIset // /rhs big_imset => [|i j _ /setIdP[_ notFj0] eqFij].
-  rewrite big_mkcond; apply: eq_bigr => i _; rewrite inE.
-  by case: eqP => //= ->; rewrite big_set0.
-by apply: contraNeq (disjF _ _) _; rewrite -setI_eq0 eqFij setIid.
+rewrite big_trivIset // /rhs big_imset => [i j _ /setIdP[_ notFj0] eqFij|].
+  by apply: contraNeq (disjF _ _) _; rewrite -setI_eq0 eqFij setIid.
+rewrite big_mkcond; apply: eq_bigr => i _; rewrite inE.
+by case: eqP => //= ->; rewrite big_set0.
 Qed.
 
 End BigOps.
@@ -2764,7 +2764,7 @@ Lemma big_tag_cond  (Q_ : forall i, {pred T_ i})
      untag idx (P_ i) j.
 Proof.
 rewrite (big_sub_cond (tagged_with T_ i)).
-rewrite (reindex (tag_with i)); last exact/onW_bij/tag_with_bij.
+rewrite (reindex (tag_with i)); first exact/onW_bij/tag_with_bij.
 by apply: eq_big => [x|x Qix]; rewrite ?untagE.
 Qed.
 
@@ -2790,7 +2790,7 @@ Section BigFProd.
     \big[plus/zero]_(g in family (tagged_with T_) | Q g)
      \big[times/one]_(i : I) (untag zero (P_ i) (g i)).
   Proof.
-  rewrite (reindex (@of_family_tagged_with _ T_)); last first.
+  rewrite (reindex (@of_family_tagged_with _ T_)).
     exact/onW_bij/of_family_tagged_with_bij.
   rewrite [in RHS]big_sub_cond; apply/esym/eq_bigr => -[/= f fP] Qf.
   apply: eq_bigr => i _; rewrite /fun_of_fprod/=.

--- a/boot/fintype.v
+++ b/boot/fintype.v
@@ -428,7 +428,7 @@ Lemma enum0 : enum pred0 = Nil T. Proof. exact: filter_pred0. Qed.
 
 Lemma enum1 x : enum (pred1 x) = [:: x].
 Proof.
-rewrite [enum _](all_pred1P x _ _); first by rewrite size_filter enumP.
+rewrite [enum _](all_pred1P x _ _); last by rewrite size_filter enumP.
 by apply/allP=> y; rewrite mem_enum.
 Qed.
 
@@ -481,9 +481,9 @@ Proof. by rewrite !cardE !size_filter count_predUI. Qed.
 
 Lemma cardID B A : #|[predI A & B]| + #|[predD A & B]| = #|A|.
 Proof.
-rewrite -cardUI addnC [#|predI _ _|]eq_card0 => [|x] /=.
-  by apply: eq_card => x; rewrite !inE andbC -andb_orl orbN.
-by rewrite !inE -!andbA andbC andbA andbN.
+rewrite -cardUI addnC [#|predI _ _|]eq_card0 => [x|] /=.
+  by rewrite !inE -!andbA andbC andbA andbN.
+by apply: eq_card => x; rewrite !inE andbC -andb_orl orbN.
 Qed.
 
 Lemma cardC A : #|A| + #|[predC A]| = #|T|.
@@ -494,7 +494,7 @@ Proof.
 case Ax: (x \in A).
   by apply: eq_card => y /[1!inE]/=; case: eqP => // ->.
 rewrite /= -(card1 x) -cardUI addnC.
-rewrite [#|predI _ _|]eq_card0 => [|y /=]; first exact: eq_card.
+rewrite [#|predI _ _|]eq_card0 => [y /=|]; last exact: eq_card.
 by rewrite !inE; case: eqP => // ->.
 Qed.
 
@@ -509,7 +509,7 @@ Proof.
 case Ax: (x \in A); last first.
   by apply: eq_card => y /[!inE]/=; case: eqP => // ->.
 rewrite /= -(card1 x) -cardUI addnC /=.
-rewrite [#|predI _ _|]eq_card0 => [|y]; last by rewrite !inE; case: eqP.
+rewrite [#|predI _ _|]eq_card0 => [y|]; first by rewrite !inE; case: eqP.
 by apply: eq_card => y /[!inE]; case: eqP => // ->.
 Qed.
 
@@ -541,7 +541,7 @@ Proof. by apply: (iffP eqP); [apply: card0_eq | apply: eq_card0]. Qed.
 Lemma pred0Pn P : reflect (exists x, P x) (~~ pred0b P).
 Proof.
 case: (pickP P) => [x Px | P0].
-  by rewrite (introN (pred0P P)) => [|P0]; [left; exists x | rewrite P0 in Px].
+  by rewrite (introN (pred0P P)) => [P0|]; [rewrite P0 in Px | left; exists x].
 by rewrite -lt0n eq_card0 //; right=> [[x]]; rewrite P0.
 Qed.
 
@@ -1478,7 +1478,7 @@ Proof. by rewrite pmap_sub_uniq // -enumT enum_uniq. Qed.
 
 Lemma val_sub_enum : map val sub_enum = enum P.
 Proof.
-rewrite pmap_filter; last exact: insubK.
+rewrite pmap_filter; first exact: insubK.
 by apply: eq_filter => x; apply: isSome_insub.
 Qed.
 
@@ -1752,7 +1752,7 @@ Definition ord_enum : seq ordinal := pmap insub (iota 0 n).
 
 Lemma val_ord_enum : map val ord_enum = iota 0 n.
 Proof.
-rewrite pmap_filter; last exact: insubK.
+rewrite pmap_filter; first exact: insubK.
 by apply/all_filterP; apply/allP=> i; rewrite mem_iota isSome_insub.
 Qed.
 
@@ -1943,7 +1943,7 @@ Proof. by move=> x; apply: enum_rankK_in. Qed.
 
 Lemma enum_valK_in x0 A Ax0 : cancel enum_val (@enum_rank_in T x0 A Ax0).
 Proof.
-move=> x; apply: ord_inj; rewrite enum_rank_in.unlock insubdK; last first.
+move=> x; apply: ord_inj; rewrite enum_rank_in.unlock insubdK.
   by rewrite cardE [_ \in _]index_mem mem_nth // -cardE.
 by rewrite index_uniq ?enum_uniq // -cardE.
 Qed.

--- a/boot/generic_quotient.v
+++ b/boot/generic_quotient.v
@@ -528,8 +528,8 @@ Definition type_of & (phantom (rel _) encD) := equivQuotient.
 Lemma canon_id : forall x, (invariant canon canon) x.
 Proof.
 move=> x /=; rewrite /canon (@eq_choose _ _ (eC x)).
-  by rewrite (@choose_id _ (eC x) _ x) ?chooseP ?equiv_refl.
-by move=> y; apply: equiv_ltrans; rewrite equiv_sym /= chooseP.
+  by move=> y; apply: equiv_ltrans; rewrite equiv_sym /= chooseP.
+by rewrite (@choose_id _ (eC x) _ x) ?chooseP ?equiv_refl.
 Qed.
 
 Definition pi := locked (fun x => EquivQuotient (canon_id x)).
@@ -548,7 +548,7 @@ Lemma pi_CD (x y : C) : reflect (pi x = pi y) (eC x y).
 Proof.
 apply: (iffP idP) => hxy.
   apply: (can_inj ereprK); unlock pi canon => /=.
-  rewrite -(@eq_choose _ (eC x) (eC y)); last first.
+  rewrite -(@eq_choose _ (eC x) (eC y)).
     by move=> z; rewrite /eC /=; apply: equiv_ltrans.
   by apply: choose_id; rewrite ?equiv_refl //.
 rewrite (equiv_trans (chooseP (equiv_refl _ _))) //=.

--- a/boot/monoid.v
+++ b/boot/monoid.v
@@ -680,7 +680,7 @@ Lemma expgnFr x m n : n <= m -> x ^+ (m - n) = x ^+ m / x ^+ n.
 Proof. by move=> lenm; rewrite -[in RHS](subnK lenm) expgnDr mulgK. Qed.
 
 Lemma expgnFl x y n : commute x y -> (x / y) ^+ n = x ^+ n / y ^+ n.
-Proof. by move=> xyC; rewrite expgMn 1?expVgn; last exact/commuteV. Qed.
+Proof. by move=> xyC; rewrite expgMn 1?expVgn; first exact/commuteV. Qed.
 
 Lemma conjgC x y : x * y = y * x ^ y.
 Proof. by rewrite mulVKg. Qed.

--- a/boot/nmodule.v
+++ b/boot/nmodule.v
@@ -626,8 +626,8 @@ Lemma telescope_sumr n m (f : nat -> V) : n <= m ->
   \sum_(n <= k < m) (f k.+1 - f k) = f m - f n.
 Proof.
 move=> nm; rewrite (telescope_big (fun i j => f j - f i)).
-  by case: ltngtP nm => // ->; rewrite subrr.
-by move=> k /andP[nk km]/=; rewrite addrC subrKA.
+  by move=> k /andP[nk km]/=; rewrite addrC subrKA.
+by case: ltngtP nm => // ->; rewrite subrr.
 Qed.
 
 Lemma telescope_sumr_eq n m (f u : nat -> V) : n <= m ->

--- a/boot/path.v
+++ b/boot/path.v
@@ -1202,7 +1202,7 @@ Let push_stable s1 ss :
 Proof.
 elim: ss s1 => [] // [] //= m s2 ss ihss s1; rewrite -cat_cons allrel_catr.
 move=> /and5P[sorted_s1 /andP[s1s2 s1ss] sorted_s2 s2ss hss]; apply: ihss.
-rewrite /= hss andbT merge_stable_sorted //=; last by rewrite allrelC.
+rewrite /= hss andbT merge_stable_sorted //=; first by rewrite allrelC.
 by apply/allrelP => ? ?; rewrite mem_merge mem_cat => /orP[]; apply/allrelP.
 Qed.
 
@@ -1211,7 +1211,7 @@ Let pop_stable s1 ss :
 Proof.
 elim: ss s1 => [s1 /and3P[]|s2 ss ihss s1] //=; rewrite allrel_catr.
 move=> /and5P[sorted_s1 /andP[s1s2 s1ss] sorted_s2 s2ss hss]; apply: ihss.
-rewrite /= hss andbT merge_stable_sorted //=; last by rewrite allrelC.
+rewrite /= hss andbT merge_stable_sorted //=; first by rewrite allrelC.
 by apply/allrelP => ? ?; rewrite mem_merge mem_cat => /orP[]; apply/allrelP.
 Qed.
 
@@ -1326,7 +1326,7 @@ Qed.
 Lemma sorted_mask_sort_in s m :
   all P s -> sorted leT (mask m s) -> {m_s | mask m_s (sort leT s) = mask m s}.
 Proof.
-move=> ? /(sorted_sort_in leT_tr _) <-; [exact: mask_sort_in | exact: all_mask].
+move=> ? /(sorted_sort_in leT_tr _) <-; [exact: all_mask | exact: mask_sort_in].
 Qed.
 
 End Stability_mask_in.
@@ -1371,7 +1371,7 @@ Lemma sorted_subseq_sort_in t s :
   {in s &, total leT} -> {in s & &, transitive leT} ->
   subseq t s -> sorted leT t -> subseq t (sort leT s).
 Proof.
-move=> ? leT_tr ? /(sorted_sort_in leT_tr) <-; last exact/allP/mem_subseq.
+move=> ? leT_tr ? /(sorted_sort_in leT_tr) <-; first exact/allP/mem_subseq.
 exact: subseq_sort_in.
 Qed.
 
@@ -1602,9 +1602,9 @@ Lemma next_prev : cancel (prev p) (next p).
 Proof.
 move=> x; rewrite next_nth mem_prev prev_nth; case p_x: (x \in p) => //.
 case def_p: p p_x => // [y q]; rewrite -def_p => p_x.
-rewrite index_uniq //; last by rewrite def_p ltnS index_size.
+rewrite index_uniq //; first by rewrite def_p ltnS index_size.
 case q_x: (x \in q); first exact: nth_index.
-rewrite nth_default; last by rewrite leqNgt index_mem q_x.
+rewrite nth_default; first by rewrite leqNgt index_mem q_x.
 by apply/eqP; rewrite def_p inE q_x orbF eq_sym in p_x.
 Qed.
 

--- a/boot/prime.v
+++ b/boot/prime.v
@@ -257,7 +257,7 @@ case def_b': (b - _) => [|b']; last first.
     by rewrite subnDA subnn addnC addSnnS.
   by rewrite mul1n -doubleB -doubleD subn1 !addn1 def_k1.
 have ltdp: d < p.
-  move/eqP: def_b'; rewrite subn_eq0 -(@leq_pmul2r kb); last first.
+  move/eqP: def_b'; rewrite subn_eq0 -(@leq_pmul2r kb).
     by rewrite -def_kb1.
   rewrite mulnBl -def_k2 ltnS -(leq_add2r c); move/leq_trans; apply.
   have{} ltc: c < k.*2.
@@ -279,7 +279,7 @@ have next_pm: lb_dvd p.+2 m.
      case/hasP: leppm; exists 2; first by rewrite /p -(subnKC lt0k).
     by rewrite /= def_q dvdn_mull // dvdn2 /= odd_double.
   move/(congr1 (dvdn p)): def_m; rewrite -!mul2n mulnA -mulnDl.
-  rewrite dvdn_mull // dvdn_addr; last by rewrite def_q dvdn_mull.
+  rewrite dvdn_mull // dvdn_addr; first by rewrite def_q dvdn_mull.
   case/dvdnP=> r; rewrite mul2n => def_r; move: ltdp (congr1 odd def_r).
   rewrite odd_double -ltn_double def_r -mul2n ltn_pmul2r //.
   by case: r def_r => [|[|[]]] //; rewrite def_d // mul1n /= odd_double.
@@ -300,12 +300,12 @@ rewrite -doubleS -{1}[m]mul1n -[1]/(k.+1.*2.+1 ^ 0)%N.
 apply: IHn; first exact: ltnW.
 rewrite doubleS -/p [ifnz 0 _ _]/=; do 2?split => //.
   rewrite orbT next_pm /= -(leq_add2r d.*2) def_m 2!addSnnS -doubleS leq_add.
-  - move: ltc; rewrite /kb {}/bc andbT; case e => //= e' _; case: ifnzP => //.
-    by case: edivn2P.
   - by rewrite -[ltnLHS]muln1 ltn_pmul2l.
-  by rewrite leq_double def_a mulSn (leq_trans ltdp) ?leq_addr.
+  - by rewrite leq_double def_a mulSn (leq_trans ltdp) ?leq_addr.
+  move: ltc; rewrite /kb {}/bc andbT; case e => //= e' _; case: ifnzP => //.
+  by case: edivn2P.
 rewrite mulnDl !muln2 -addnA addnCA doubleD addnCA.
-rewrite (_ : _ + bc.2 = d); last first.
+rewrite (_ : _ + bc.2 = d).
   rewrite /d {}/bc /kb -muln2.
   case: (e) (b) def_b' => //= _ []; first by case: edivn2P.
   by case c; do 2?case; rewrite // mul1n /= muln2.
@@ -537,7 +537,7 @@ Lemma ltn_pdiv2_prime n : 0 < n -> n < pdiv n ^ 2 -> prime n.
 Proof.
 case def_n: n => [|[|n']] // _; rewrite -def_n => lt_n_p2.
 suffices ->: n = pdiv n by rewrite pdiv_prime ?def_n.
-apply/eqP; rewrite eqn_leq leqNgt andbC pdiv_leq; last by rewrite def_n.
+apply/eqP; rewrite eqn_leq leqNgt andbC pdiv_leq; first by rewrite def_n.
 apply/contraL: lt_n_p2 => lt_pm_m; case/dvdnP: (pdiv_dvd n) => q def_q.
 rewrite -leqNgt [leqRHS]def_q leq_pmul2r // pdiv_min_dvd //.
   by rewrite -[pdiv n]mul1n [ltnRHS]def_q ltn_pmul2r in lt_pm_m.
@@ -1609,7 +1609,7 @@ have [n0 np0 np'0]: [/\ n > 0, np > 0 & np' > 0] by rewrite ltnW ?part_gt0.
 have def_n: n = np * np' by rewrite partnC.
 have lnp0: 0 < logn p n by rewrite lognE p_pr n0 pdiv_dvd.
 pose in_mod k (k0 : k > 0) d := Ordinal (ltn_pmod d k0).
-rewrite {1}def_n totient_coprime // {IHn}(IHn np') ?big_mkord; last first.
+rewrite {1}def_n totient_coprime // {IHn}(IHn np') ?big_mkord.
   by rewrite def_n ltn_Pmull // /np p_part -(expn0 p) ltn_exp2l.
 have ->: totient np = #|[pred d : 'I_np | coprime np d]|.
   rewrite [np in LHS]p_part totient_pfactor //=; set q := p ^ _.
@@ -1617,7 +1617,7 @@ have ->: totient np = #|[pred d : 'I_np | coprime np d]|.
   have def_np: np = p * q by rewrite -expnS prednK // -p_part.
   pose mulp := [fun d : 'I_q => in_mod _ np0 (p * d)].
   rewrite -def_np -{1}[np]card_ord -(cardC [in codom mulp]).
-  rewrite card_in_image => [|[d1 ltd1] [d2 ltd2] /= _ _ []]; last first.
+  rewrite card_in_image => [[d1 ltd1] [d2 ltd2] /= _ _ []|].
     move/eqP; rewrite def_np -!muln_modr ?modn_small //.
     by rewrite eqn_pmul2l // => eq_op12; apply/eqP.
   rewrite card_ord; congr (q + _); apply: eq_card => d /=.
@@ -1629,11 +1629,11 @@ have ->: totient np = #|[pred d : 'I_np | coprime np d]|.
   by exists (Ordinal ltr); apply: val_inj; rewrite /= -def_d modn_small.
 pose h (d : 'I_n) := (in_mod _ np0 d, in_mod _ np'0 d).
 pose h' (d : 'I_np * 'I_np') := in_mod _ n0 (chinese np np' d.1 d.2).
-rewrite -!big_mkcond -sum_nat_const pair_big (reindex_onto h h') => [|[d d'] _].
-  apply: eq_bigl => [[d ltd] /=]; rewrite !inE -val_eqE /= andbC !coprime_modr.
-  by rewrite def_n -chinese_mod // -coprimeMl -def_n modn_small ?eqxx.
-apply/eqP; rewrite /eq_op /= /eq_op /= !modn_dvdm ?dvdn_part //.
-by rewrite chinese_modl // chinese_modr // !modn_small ?eqxx ?ltn_ord.
+rewrite -!big_mkcond -sum_nat_const pair_big (reindex_onto h h') => [[d d'] _|].
+  apply/eqP; rewrite /eq_op /= /eq_op /= !modn_dvdm ?dvdn_part //.
+  by rewrite chinese_modl // chinese_modr // !modn_small ?eqxx ?ltn_ord.
+apply: eq_bigl => [[d ltd] /=]; rewrite !inE -val_eqE /= andbC !coprime_modr.
+by rewrite def_n -chinese_mod // -coprimeMl -def_n modn_small ?eqxx.
 Qed.
 
 Lemma totient_gt1 n : (totient n > 1) = (n > 2).

--- a/boot/seq.v
+++ b/boot/seq.v
@@ -3607,7 +3607,7 @@ Qed.
 Lemma reshapeKl sh s : size s >= sumn sh -> shape (reshape sh s) = sh.
 Proof.
 elim: sh s => [[]|n sh IHsh] //= s sz_s.
-rewrite size_takel; last exact: leq_trans (leq_addr _ _) sz_s.
+rewrite size_takel; first exact: leq_trans (leq_addr _ _) sz_s.
 by rewrite IHsh // -(leq_add2l n) size_drop -maxnE leq_max sz_s orbT.
 Qed.
 
@@ -4289,7 +4289,7 @@ Lemma allpairs_uniq_dep f s t (st := [seq Tagged T y | x <- s, y <- t x]) :
 Proof.
 move=> g Us Ut; rewrite -(map_allpairs g (existT T)) => /map_inj_in_uniq->{f g}.
 elim: s Us => //= x s IHs /andP[s'x Us] in st Ut *; rewrite {st}cat_uniq.
-rewrite {}IHs {Us}// ?andbT => [|x1 s_s1]; last exact/Ut/mem_behead.
+rewrite {}IHs {Us}// ?andbT => [x1 s_s1|]; first exact/Ut/mem_behead.
 have injT: injective (existT T x) by move=> y z /eqP; rewrite eq_Tagged => /eqP.
 rewrite (map_inj_in_uniq (in2W injT)) {injT}Ut ?mem_head // has_sym has_map.
 by apply: contra s'x => /hasP[y _ /allpairsPdep[z [_ [? _ /(congr1 tag)/=->]]]].
@@ -4805,7 +4805,7 @@ suffices /permPl->: perm_eq (tally s) (map (b (tally s)) (unzip1 (tally s))).
   by under eq_map do rewrite /= (permP (tallyK s)).
 elim: (tally s) Ubs => [|[x m] bs IH] //= /andP[bs'x /IH-IHbs {IH}].
 rewrite /tseq /= -/(tseq _) count_cat count_nseq /= eqxx mul1n.
-rewrite (count_memPn _) ?addn0 ?perm_cons; last first.
+rewrite (count_memPn _) ?addn0 ?perm_cons.
   apply: contra bs'x; elim: {b IHbs}bs => //= b bs IHbs.
   by rewrite mem_cat mem_nseq inE andbC; case: (_ == _).
 congr perm_eq: IHbs; apply/eq_in_map=> y bs_y; congr (y, _).
@@ -4875,7 +4875,7 @@ have{s} [n [bs [-> Dn /permPr<- _]]] := permsP s.
 elim: n => [|n IHn] /= in t bs Dn *.
   by rewrite inE (nilP Dn); apply/eqP/perm_nilP.
 rewrite -[bs in tseq bs]cats0 in Dn *; have x0 : T by case: (tseq _) Dn.
-rewrite -[RHS](@andb_idl (last x0 t \in tseq bs)); last first.
+rewrite -[RHS](@andb_idl (last x0 t \in tseq bs)).
   case/lastP: t {IHn} => [|t x] Dt; first by rewrite -(perm_size Dt) in Dn.
   by rewrite -[bs]cats0 -(perm_mem Dt) last_rcons mem_rcons mem_head.
 elim: bs [::] => [|[x [|m]] bs IHbs] //= bs2 in Dn *.
@@ -4894,7 +4894,7 @@ elim: n => //= n IHn in bs Dn Ubs *; rewrite -[bs]cats0 /unzip1 in Dn Ubs.
 elim: bs [::] => [|[x [|m]] bs IHbs] //= bs2 in Dn Ubs *.
   by case/andP: Ubs => _ /IHbs->.
 rewrite /= cons_permsE cat_uniq has_sym andbCA andbC.
-rewrite {}IHbs; first 1 last; first by rewrite (perm_size (perm_tseq bsCA)).
+rewrite {}IHbs; first 1 last; last by rewrite (perm_size (perm_tseq bsCA)).
   by rewrite (perm_uniq (perm_map _ bsCA)).
 rewrite (map_inj_uniq (rcons_injl x)) {}IHn {Dn}//=.
 have: x \notin unzip1 bs by apply: contraL Ubs; rewrite map_cat mem_cat => ->.

--- a/boot/ssreflect.v
+++ b/boot/ssreflect.v
@@ -1,7 +1,6 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From Corelib Require Export ssreflect.
-Global Set SsrOldRewriteGoalsOrder.
 Global Set Asymmetric Patterns.
 Global Set Bullet Behavior "None".
 

--- a/boot/tuple.v
+++ b/boot/tuple.v
@@ -403,7 +403,7 @@ Definition enum : seq (n.-tuple T) :=
 Lemma enumP : Finite.axiom enum.
 Proof.
 case=> /= t t_n; rewrite -(count_map _ (pred1 t)) (pmap_filter (insubK _)).
-rewrite count_filter -(@eq_count _ (pred1 t)) => [|s /=]; last first.
+rewrite count_filter -(@eq_count _ (pred1 t)) => [s /=|].
   by rewrite isSome_insub; case: eqP=> // ->.
 elim: n t t_n => [|m IHm] [|x t] //= {}/IHm; move: (iter m _ _) => em IHm.
 transitivity (x \in T : nat); rewrite // -mem_enum codomE.

--- a/character/character.v
+++ b/character/character.v
@@ -444,8 +444,8 @@ pose W i := oapp val 0 (soc i); pose S := (\sum_i W i)%MS.
 have C'G: [pchar algC]^'.-group G := algC'G_pchar G.
 have [defS dxS]: (S :=: 1%:M)%MS /\ mxdirect S.
   rewrite /S mxdirectE /= !(bigID soc xpredT) /=.
-  rewrite addsmxC big1 => [|i]; last by rewrite /W; case (soc i).
-  rewrite adds0mx_id addnC (@big1 nat) ?add0n => [|i]; last first.
+  rewrite addsmxC big1 => [i|]; first by rewrite /W; case (soc i).
+  rewrite adds0mx_id addnC (@big1 nat) ?add0n => [i|].
     by rewrite /W; case: (soc i); rewrite ?mxrank0.
   have <-: Socle sG = 1%:M := reducible_Socle1 sG (mx_Maschke_pchar rG C'G).
   have [W0 _ | noW] := pickP sG; last first.
@@ -462,9 +462,9 @@ have [defS dxS]: (S :=: 1%:M)%MS /\ mxdirect S.
     by rewrite inE /soc /=; case: pickP => //= Wi; move/eqP.
   rewrite !(reindex standard_irr) {bij_irr}//=.
   have all_soc Wi: soc (standard_irr Wi) by rewrite irrK.
-  rewrite (eq_bigr val) => [|Wi _]; last by rewrite /W irrK.
+  rewrite (eq_bigr val) => [Wi _|]; first by rewrite /W irrK.
   rewrite !(eq_bigl _ _ all_soc); split=> //.
-  rewrite (eq_bigr (mxrank \o val)) => [|Wi _]; last by rewrite /W irrK.
+  rewrite (eq_bigr (mxrank \o val)) => [Wi _|]; first by rewrite /W irrK.
   by rewrite -mxdirectE /= Socle_direct.
 pose modW i : mxmodule rG (W i) :=
   if soc i is Some Wi as oWi return mxmodule rG (oapp val 0 oWi) then
@@ -884,7 +884,7 @@ Lemma char1_eq0 chi : chi \is a character -> (chi 1%g == 0) = (chi == 0).
 Proof.
 case/char_sum_irr=> r ->; apply/idP/idP=> [|/eqP->]; last by rewrite cfunE.
 case: r => [|i r]; rewrite ?big_nil // sum_cfunE big_cons.
-rewrite paddr_eq0 ?sumr_ge0  => // [||j _]; rewrite 1?ltW ?irr1_gt0 //.
+rewrite paddr_eq0 ?sumr_ge0  => // [|j _|]; rewrite 1?ltW ?irr1_gt0 //.
 by rewrite (negbTE (irr1_neq0 i)).
 Qed.
 
@@ -1256,7 +1256,7 @@ Proof. by move=> xG GxG; rewrite /c cast_ordKV enum_rankK_in. Qed.
 Lemma reindex_irr_class R idx (op : @Monoid.com_law R idx) F :
   \big[op/idx]_(xG in classes G) F xG = \big[op/idx]_i F (c i).
 Proof.
-rewrite (reindex c); first by apply: eq_bigl => i; apply: enum_valP.
+rewrite (reindex c); last by apply: eq_bigl => i; apply: enum_valP.
 by exists iC; [apply: in1W; apply: irr_classK | apply: class_IirrK].
 Qed.
 
@@ -1266,7 +1266,7 @@ Let X' := \matrix_(i, j) (#|'C_G[g i]|%:R^-1 * ('chi[G]_j (g i))^*).
 Let XX'_1: X *m X' = 1%:M.
 Proof.
 apply/matrixP=> i j; rewrite !mxE -first_orthogonality_relation mulr_sumr.
-rewrite sum_by_classes => [|u v Gu Gv]; last by rewrite -conjVg !cfunJ.
+rewrite sum_by_classes => [u v Gu Gv|]; first by rewrite -conjVg !cfunJ.
 rewrite reindex_irr_class /=; apply/esym/eq_bigr=> k _.
 rewrite !mxE irr_inv // -/(g k) -divg_index -indexgI /=.
 rewrite (pchar0_natf_div Cpchar) ?dvdn_indexg // index_cent1 invfM invrK.
@@ -1636,7 +1636,7 @@ Qed.
 Lemma TI_cfker_irr : \bigcap_i cfker 'chi[G]_i = [1].
 Proof.
 apply/trivgP; apply: subset_trans cfaithful_reg; rewrite cfkerE ?cfReg_char //.
-rewrite subsetI (bigcap_min 0) //=; last by rewrite cfker_irr0.
+rewrite subsetI (bigcap_min 0) //=; first by rewrite cfker_irr0.
 by apply/bigcapsP=> i _; rewrite bigcap_inf.
 Qed.
 
@@ -2149,7 +2149,7 @@ Proof. by move=> Pi; rewrite !irrEchar cfBigdprodi_charE ?cfBigdprodi_iso. Qed.
 Lemma cfBigdprod_irr chi :
   (forall i, P i -> chi i \in irr (A i)) -> cfBigdprod defG chi \in irr G.
 Proof.
-move=> Nchi; rewrite irrEchar cfBigdprod_char => [|i /Nchi/irrWchar] //=.
+move=> Nchi; rewrite irrEchar cfBigdprod_char => [i /Nchi/irrWchar|] //=.
 by rewrite cfdot_bigdprod big1 // => i /Nchi/irrWnorm.
 Qed.
 
@@ -2165,7 +2165,7 @@ have nz_Phi1: Phi 1%g != 0 by rewrite Phi1_1 oner_eq0.
 have [_ <-] := cfBigdprodK nz_Phi1 Pi.
 rewrite Phi1_1 divr1 -/Phi Phi1 rmorph1.
 rewrite prod_cfunE // in Phi1_1; have := natr_prod_eq1 _ Phi1_1 Pi.
-rewrite -(cfRes1 (A i)) cfBigdprodiK // => ->; first by rewrite scale1r.
+rewrite -(cfRes1 (A i)) cfBigdprodiK // => ->; last by rewrite scale1r.
 by move=> {i Pi} j /Nphi Nphi_j; rewrite Cnat_char1 ?cfBigdprodi_char.
 Qed.
 
@@ -2173,7 +2173,7 @@ Lemma cfBigdprod_Res_lin chi :
   chi \is a linear_char -> cfBigdprod defG (fun i => 'Res[A i] chi) = chi.
 Proof.
 move=> Lchi; apply/cfun_inP=> _ /(mem_bigdprod defG)[x [Ax -> _]].
-rewrite (lin_char_prod Lchi) ?cfBigdprodE // => [|i Pi]; last first.
+rewrite (lin_char_prod Lchi) ?cfBigdprodE // => [i Pi|].
   by rewrite (subsetP (sAG Pi)) ?Ax.
 by apply/eq_bigr=> i Pi; rewrite cfResE ?sAG ?Ax.
 Qed.
@@ -2630,7 +2630,7 @@ transitivity (\prod_W detRepr (socle_repr W) ^+ standard_irr_coef rG W).
   rewrite (reindex _ (socle_of_Iirr_bij _)) unlock /=.
   apply: eq_bigr => i _; congr (_ ^+ _).
   rewrite (cfRepr_sim (mx_rsim_standard rG)) cfRepr_standard.
-  rewrite cfdot_suml (bigD1 i) ?big1 //= => [|j i'j]; last first.
+  rewrite cfdot_suml (bigD1 i) ?big1 //= => [j i'j|].
     by rewrite cfdotZl cfdot_irr (negPf i'j) mulr0.
   by rewrite cfdotZl cfnorm_irr mulr1 addr0 natrK.
 apply/cfun_inP=> x Gx; rewrite prod_cfunE //.
@@ -2703,7 +2703,7 @@ Lemma cfDetIsom aT rT (G : {group aT}) (R : {group rT})
                 (f : {morphism G >-> rT}) (isoGR : isom G R f) phi :
   cfDet (cfIsom isoGR phi) = cfIsom isoGR (cfDet phi).
 Proof.
-rewrite unlock rmorph_prod (reindex (isom_Iirr isoGR)); last first.
+rewrite unlock rmorph_prod (reindex (isom_Iirr isoGR)).
   by exists (isom_Iirr (isom_sym isoGR)) => i; rewrite ?isom_IirrK ?isom_IirrKV.
 apply: eq_bigr=> i; rewrite -!cfDetRepr !irrRepr isom_IirrE rmorphXn cfIsom_iso.
 by rewrite /= ![in cfIsom _]unlock cfDetMorph ?cfRes_char ?cfDetRes ?irr_char.
@@ -2862,10 +2862,10 @@ Qed.
 (* This is Isaacs (2.28). *)
 Lemma cap_cfcenter_irr : \bigcap_i 'Z('chi[G]_i)%CF = 'Z(G).
 Proof.
-apply/esym/eqP; rewrite eqEsubset (introT bigcapsP) /= => [|i _]; last first.
+apply/esym/eqP; rewrite eqEsubset (introT bigcapsP) /= => [i _|].
   rewrite -(quotientSGK _ (normal_sub (cfker_center_normal _))).
-    by rewrite cfcenter_eq_center morphim_center.
-  by rewrite subIset // normal_norm // cfker_normal.
+    by rewrite subIset // normal_norm // cfker_normal.
+  by rewrite cfcenter_eq_center morphim_center.
 set Z := \bigcap_i _.
 have sZG: Z \subset G by rewrite (bigcap_min 0) ?cfcenter_sub.
 rewrite subsetI sZG (sameP commG1P trivgP) -(TI_cfker_irr G).
@@ -2883,7 +2883,7 @@ Proof.
 move=> sHG; rewrite cfun_onE mulrCA natf_indexg // -mulrA mulKf ?neq0CG //.
 rewrite (big_setID H) (setIidPr sHG) /= addrC.
 rewrite (mono_leif (ler_pM2l _)) ?invr_gt0 ?gt0CG // -leifBLR -sumrB.
-rewrite big1 => [|x Hx]; last by rewrite !cfResE ?subrr.
+rewrite big1 => [x Hx|]; first by rewrite !cfResE ?subrr.
 have ->: (support phi \subset H) = (G :\: H \subset [set x | phi x == 0]).
   rewrite subDset setUC -subDset; apply: eq_subset => x.
   by rewrite !inE (andb_idr (contraR _)) // => /cfun0->.
@@ -2935,7 +2935,7 @@ Lemma cfcenter_fful_irr i : cfaithful 'chi[G]_i -> 'Z('chi_i)%CF = 'Z(G).
 Proof.
 move/trivgP=> Ki1; have:= cfcenter_eq_center i; rewrite {}Ki1.
 have inj1: 'injm (@coset gT 1%g) by rewrite ker_coset.
-by rewrite -injm_center; first apply: injm_morphim_inj; rewrite ?norms1.
+by rewrite -injm_center; last apply: injm_morphim_inj; rewrite ?norms1.
 Qed.
 
 (* This is Isaacs (2.32)(b). *)

--- a/character/classfun.v
+++ b/character/classfun.v
@@ -590,7 +590,7 @@ Proof.
 have b_i (i : 'I_#|classes G ::&: A|) : (cfun_base G A)`_i = '1_(enum_val i).
   by rewrite /enum_val -!tnth_nth tnth_map.
 apply/freeP => s S0 i; move/cfunP/(_ (repr (enum_val i))): S0.
-rewrite sum_cfunE (bigD1 i) //= big1 ?addr0 => [|j].
+rewrite sum_cfunE (bigD1 i) //= big1 ?addr0 => [j|]; last first.
   rewrite b_i !cfunE; have /setIdP[/imsetP[x Gx ->] _] := enum_valP i.
   by rewrite cfun_repr cfun_classE Gx class_refl mulr1.
 apply: contraNeq; rewrite b_i !cfunE mulf_eq0 => /norP[_].
@@ -788,7 +788,7 @@ Lemma cfdotElr A B phi psi :
   '[phi, psi] = #|G|%:R^-1 * \sum_(x in A :&: B) phi x * (psi x)^*.
 Proof.
 move=> Aphi Bpsi; rewrite (big_setID G)/= cfdotE (big_setID (A :&: B))/= setIC.
-congr (_ * (_ + _)); rewrite !big1 // => x /setDP[_].
+congr (_ * (_ + _)); rewrite !big1 // => x /setDP[_]; last first.
   by move/cfun0->; rewrite mul0r.
 rewrite inE; case/nandP=> notABx; first by rewrite (cfun_on0 Aphi) ?mul0r.
 by rewrite (cfun_on0 Bpsi) // rmorph0 mulr0.
@@ -971,7 +971,7 @@ without loss ophi: phi / '[phi, psi] = 0.
     by rewrite cfdotBl cfdotZl divfK ?cfnorm_eq0 ?subrr.
   rewrite (canRL (subrK _) (erefl phi1)) rpredDr ?rpredZ ?memv_line //.
   rewrite cfdotDl ophi add0r cfdotZl normrM (ger0_norm (cfnorm_ge0 _)).
-  rewrite exprMn mulrA -cfnormZ cfnormDd; last by rewrite cfdotZr ophi mulr0.
+  rewrite exprMn mulrA -cfnormZ cfnormDd; first by rewrite cfdotZr ophi mulr0.
   by have:= IHo _ ophi; rewrite mulrDl -leifBLR subrr ophi normCK mul0r.
 rewrite ophi normCK mul0r; split; first by rewrite mulr_ge0 ?cfnorm_ge0.
 rewrite eq_sym mulf_eq0 orbC cfnorm_eq0 (negPf nz_psi) /=.
@@ -984,7 +984,7 @@ Lemma cfCauchySchwarz_sqrt phi psi :
 Proof.
 rewrite -(sqrCK (normr_ge0 _)) -sqrtCM ?qualifE/= ?cfnorm_ge0 //.
 rewrite (mono_in_leif (@ler_sqrtC _)) 1?rpredM ?qualifE/= ?cfnorm_ge0 //;
-  [ exact: cfCauchySchwarz | exact: O.. ].
+  [ exact: O.. | exact: cfCauchySchwarz ].
 Qed.
 
 Lemma cf_triangle_leif phi psi :
@@ -992,7 +992,7 @@ Lemma cf_triangle_leif phi psi :
            ?= iff ~~ free (phi :: psi) && (0 <= coord [tuple psi] 0 phi).
 Proof.
 rewrite -(mono_in_leif ler_sqr) ?rpredD ?qualifE/= ?sqrtC_ge0 ?cfnorm_ge0 //;
-  [| exact: O.. ].
+  [ exact: O.. |].
 rewrite andbC sqrrD !sqrtCK addrAC cfnormD (mono_leif (lerD2l _)).
 rewrite -mulr_natr -[_ + _](divfK (negbT (eqC_nat 2 0))) -/('Re _).
 rewrite (mono_leif (ler_pM2r _)) ?ltr0n //.
@@ -1157,7 +1157,7 @@ case/pairwise_orthogonalP=> [/=/andP[notS0 uniqS] oSS].
 rewrite -(in_tupleE S); apply/freeP => a aS0 i.
 have S_i: S`_i \in S by apply: mem_nth.
 have /eqP: '[S`_i, 0]_G = 0 := cfdot0r _.
-rewrite -{2}aS0 raddf_sum /= (bigD1 i) //= big1 => [|j neq_ji]; last 1 first.
+rewrite -{2}aS0 raddf_sum /= (bigD1 i) //= big1 => [j neq_ji|].
   by rewrite cfdotZr oSS ?mulr0 ?mem_nth // eq_sym nth_uniq.
 rewrite addr0 cfdotZr mulf_eq0 conjC_eq0 cfnorm_eq0.
 by case/pred2P=> // Si0; rewrite -Si0 S_i in notS0.
@@ -1927,7 +1927,7 @@ Lemma reindex_dprod R idx (op : Monoid.com_law idx) (F : gT -> R) :
       \big[op/idx]_(k in K) \big[op/idx]_(h in H) F (k * h)%g.
 Proof.
 have /mulgmP/misomP[fM /isomP[injf im_f]] := KxH.
-rewrite pair_big_dep -im_f morphimEdom big_imset; last exact/injmP.
+rewrite pair_big_dep -im_f morphimEdom big_imset; first exact/injmP.
 by apply: eq_big => [][x y]; rewrite ?inE.
 Qed.
 
@@ -2108,7 +2108,7 @@ Lemma cfBigdprodE phi x :
     (forall i, P i -> x i \in A i) ->
   cfBigdprod phi (\prod_(i | P i) x i)%g = \prod_(i | P i) phi i (x i).
 Proof.
-move=> Ax; rewrite prod_cfunE; last by rewrite -(bigdprodW defG) mem_prodg.
+move=> Ax; rewrite prod_cfunE; first by rewrite -(bigdprodW defG) mem_prodg.
 by apply: eq_bigr => i Pi; rewrite cfBigdprodEi.
 Qed.
 
@@ -2125,7 +2125,7 @@ apply/cfun_inP=> x Aix; rewrite cfunE cfResE ?sAG // mulrAC.
 have {1}->: x = (\prod_(j | P j) (if j == i then x else 1))%g.
   rewrite -big_mkcondr (big_pred1 i) ?eqxx // => j /=.
   by apply: andb_idl => /eqP->.
-rewrite cfBigdprodE => [|j _]; last by case: eqP => // ->.
+rewrite cfBigdprodE => [j _|]; first by case: eqP => // ->.
 apply: canLR (mulfK nzPhi) _; rewrite cfBigdprod1 !(bigD1 i Pi) /= eqxx.
 by rewrite mulrCA !mulrA; congr (_ * _); apply: eq_bigr => j /andP[_ /negPf->].
 Qed.
@@ -2146,7 +2146,7 @@ have /fin_all_exists[h1 Dh1] x: exists f, x \in G -> is_hK x f.
     by apply/ffunP=> i; rewrite ffunE; case: ifPn => [/Uf-> | /(supportP Pf1)].
   split; last by rewrite fK; apply/eqP/eq_bigr=> i Pi; rewrite ffunE Pi.
   by apply/familyP=> i; rewrite ffunE !unfold_in; case: ifP => //= /Af.
-rewrite (reindex_onto h h1) /= => [|x /Dh1/(_ (h1 x))]; last first.
+rewrite (reindex_onto h h1) /= => [x /Dh1/(_ (h1 x))|].
   by rewrite eqxx => /andP[_ /eqP].
 apply/eq_big => [f | f /andP[/Dh1<- /andP[/pfamilyP[_ Af] _]]]; last first.
   by rewrite !cfBigdprodE // rmorph_prod -big_split /=.
@@ -2267,12 +2267,12 @@ Proof.
 move=> defG; have [/andP[sKG _] _ mulKH nKH _] := sdprod_context defG.
 rewrite cfIndE //; apply: canLR (mulKf (neq0CG _)) _; rewrite -mulKH mulr_sumr.
 rewrite (set_partition_big _ (rcosets_partition_mul H K)) ?big_imset /=.
-  apply: eq_bigr => y Hy; rewrite rcosetE norm_rlcoset ?(subsetP nKH) //.
-  rewrite -lcosetE mulr_natl big_imset /=; last exact: in2W (mulgI _).
-  by rewrite -sumr_const; apply: eq_bigr => z Kz; rewrite conjgM cfunJ.
-have [{}nKH /isomP[injf _]] := sdprod_isom defG.
-apply: can_in_inj (fun Ky => invm injf (coset K (repr Ky))) _ => y Hy.
-by rewrite rcosetE -val_coset ?(subsetP nKH) // coset_reprK invmE.
+  have [{}nKH /isomP[injf _]] := sdprod_isom defG.
+  apply: can_in_inj (fun Ky => invm injf (coset K (repr Ky))) _ => y Hy.
+  by rewrite rcosetE -val_coset ?(subsetP nKH) // coset_reprK invmE.
+apply: eq_bigr => y Hy; rewrite rcosetE norm_rlcoset ?(subsetP nKH) //.
+rewrite -lcosetE mulr_natl big_imset /=; first exact: in2W (mulgI _).
+by rewrite -sumr_const; apply: eq_bigr => z Kz; rewrite conjgM cfunJ.
 Qed.
 
 Lemma cfInd_on A phi :
@@ -2335,7 +2335,7 @@ have [sHG | not_sHG] := boolP (H \subset G); last first.
   rewrite (cfdotEl _ (cfuni_on _ _)) mulVKf ?neq0CG // big_set1.
   by rewrite cfuniE ?normal1 ?set11 ?mul1r.
 transitivity (#|H|%:R^-1 * \sum_(x in G) phi x * (psi x)^* ).
-  rewrite (big_setID H) /= (setIidPr sHG) addrC big1 ?add0r; last first.
+  rewrite (big_setID H) /= (setIidPr sHG) addrC big1 ?add0r.
     by move=> x /setDP[_ /cfun0->]; rewrite mul0r.
   by congr (_ * _); apply: eq_bigr => x Hx; rewrite cfResE.
 set h' := _^-1; apply: canRL (mulKf (neq0CG G)) _.
@@ -2408,7 +2408,7 @@ have [[injg defR] [_ defS]] := (isomP isoG, isomP isoH).
 rewrite morphimEdom (eq_in_imset eq_hg) -morphimEsub // in defS.
 apply/cfun_inP=> s; rewrite -{1}defR => /morphimP[x _ Gx ->]{s}.
 rewrite cfIsomE ?cfIndE // -defR -{1}defS ?morphimS ?card_injm // morphimEdom.
-congr (_ * _); rewrite big_imset //=; last exact/injmP.
+congr (_ * _); rewrite big_imset //=; first exact/injmP.
 apply: eq_bigr => y Gy; rewrite -morphJ //.
 have [Hxy | H'xy] := boolP (x ^ y \in H); first by rewrite -eq_hg ?cfIsomE.
 by rewrite !cfun0 -?defS // -sub1set -morphim_set1 ?injmSK ?sub1set // groupJ.

--- a/character/inertia.v
+++ b/character/inertia.v
@@ -651,8 +651,8 @@ Proof.
 move=> Dy nHy; have [sHD | not_sHD] := boolP (H \subset D); last first.
   by rewrite !cfMorphEout // rmorph_alg cfConjg1.
 apply/cfun_inP=> x Gx; rewrite !(cfConjgE, cfMorphE) ?memJ_norm ?groupV //.
-  by rewrite morphJ ?morphV ?groupV // (subsetP sHD).
-by rewrite (subsetP (morphim_norm _ _)) ?mem_morphim.
+  by rewrite (subsetP (morphim_norm _ _)) ?mem_morphim.
+by rewrite morphJ ?morphV ?groupV // (subsetP sHD).
 Qed.
 
 Lemma inertia_morph_pre (phi : 'CF(f @* H)) :
@@ -685,7 +685,7 @@ Proof.
 move=> Gy nHy; have [_ defS] := isomP isoH.
 rewrite morphimEdom (eq_in_imset eq_hg) -morphimEsub // in defS.
 apply/cfun_inP=> gx; rewrite -{1}defS => /morphimP[x Gx Hx ->] {gx}.
-rewrite cfConjgE; last by rewrite -defS inE -morphimJ ?(normP nHy).
+rewrite cfConjgE; first by rewrite -defS inE -morphimJ ?(normP nHy).
 by rewrite -morphV -?morphJ -?eq_hg ?cfIsomE ?cfConjgE ?memJ_norm ?groupV.
 Qed.
 
@@ -848,11 +848,11 @@ Lemma cfConjgBigdprodi i (phi : 'CF(A i)) :
    (cfBigdprodi defG phi ^ y = cfBigdprodi defG (phi ^ y))%CF.
 Proof.
 rewrite cfConjgDprodl; try by case: ifP => [/nAy// | _]; rewrite norm1 inE.
-  congr (cfDprodl _ _); case: ifP => [Pi | _].
-    by rewrite cfConjgRes_norm ?nAy.
-  by apply/cfun_inP=> _ /set1P->; rewrite !(cfRes1, cfConjg1).
-rewrite -sub1set norms_gen ?norms_bigcup // sub1set.
-by apply/bigcapP=> j /andP[/nAy].
+  rewrite -sub1set norms_gen ?norms_bigcup // sub1set.
+  by apply/bigcapP=> j /andP[/nAy].
+congr (cfDprodl _ _); case: ifP => [Pi | _].
+  by rewrite cfConjgRes_norm ?nAy.
+by apply/cfun_inP=> _ /set1P->; rewrite !(cfRes1, cfConjg1).
 Qed.
 
 Lemma cfConjgBigdprod phi :
@@ -946,7 +946,7 @@ have AtoB_P s (psi := 'chi_s) (chi := 'Ind[G] psi): s \in calA ->
     by split; rewrite ?char1_ge0 // eq_sym char1_eq0.
   have lb_chi_r: chi 1%g <= 'chi_r 1%g ?= iff (f == e).
     rewrite cfInd1 // -(cfRes1 H) DpsiH -(cfRes1 H 'chi_r) DrH !cfunE sum_cfunE.
-    rewrite (eq_big_seq (fun _ => theta 1%g)) => [|i]; last first.
+    rewrite (eq_big_seq (fun _ => theta 1%g)) => [i|].
       by case/cfclassP=> y _ ->; rewrite cfConjg1.
     rewrite reindex_cfclass //= sumr_const -(eq_card (cfclass_IirrE _ _)).
     rewrite mulr_natl mulrnAr card_cfclass_Iirr //.
@@ -1141,7 +1141,7 @@ have [defKT | ltKT_K] := eqVneq (K :&: T) K; last first.
     by rewrite size_cfclass //= -{2}(setIidPl sKG) -setIA defKT.
   pose phiKt := Tuple (introT eqP t_cast); pose p i := cfIirr (tnth phiKt i).
   have pK i: 'chi_(p i) = (phi ^: K)%CF`_i.
-    rewrite cfIirrE; first by rewrite (tnth_nth 0).
+    rewrite cfIirrE; last by rewrite (tnth_nth 0).
     by have /cfclassP[y _ ->] := mem_tnth i phiKt; rewrite cfConjg_irr ?mem_irr.
   constructor 3; exists p => [i j /(congr1 (tnth (irr L)))/eqP| ].
     by apply: contraTeq; rewrite !pK !nth_uniq ?t_cast ?cfclass_uniq.
@@ -1152,7 +1152,7 @@ have [defKT | ltKT_K] := eqVneq (K :&: T) K; last first.
     rewrite -[t]card_ord -mulrA -(cfRes1 L) DthL cfunE; congr (_ * _).
     rewrite mulr_natl -sumr_const sum_cfunE -t_cast; apply: eq_bigr => i _.
     by have /cfclassP[y _ ->] := mem_nth 0 (valP i); rewrite cfConjg1.
-  rewrite eqn_leq lt0n (contraNneq _ (irr1_neq0 s)); last first.
+  rewrite eqn_leq lt0n (contraNneq _ (irr1_neq0 s)).
     by rewrite Dth1 => ->; rewrite !mul0r.
   rewrite -leC_nat -(ler_pM2r (gt0CiG K L)) -/t -(ler_pM2r (irr1_gt0 p0)).
   rewrite mul1r -Dth1 -cfInd1 //.
@@ -1170,7 +1170,7 @@ have mmLthL i: 'Res[L] 'chi_(mmLth i) = 'Res[L] theta.
   by rewrite scale1r mul1r.
 have [inj_Mphi | /injectivePn[i [j i'j eq_mm_ij]]] := boolP (injectiveb mmLth).
   suffices /eqP e1: e == 1 by constructor 1; rewrite DthL e1 scale1r mem_irr.
-  rewrite eqn_leq lt0n (contraNneq _ (irr1_neq0 s)); last first.
+  rewrite eqn_leq lt0n (contraNneq _ (irr1_neq0 s)).
     by rewrite -(cfRes1 L) DthL cfunE => ->; rewrite !mul0r.
   rewrite -leq_sqr -leC_nat natrX -(ler_pM2r (irr1_gt0 p0)) -mulrA mul1r.
   have ->: e%:R * 'chi_p0 1%g = 'Res[L] theta 1%g by rewrite DthL cfunE.

--- a/character/integral_char.v
+++ b/character/integral_char.v
@@ -134,7 +134,7 @@ transitivity (\sum_(x in zi ^: G) \sum_(y in zj ^: G) aG (x * y)%g).
 pose h2 xy : gT := (xy.1 * xy.2)%g.
 pose h1 xy := enum_rank_in (classes1 G) (h2 xy ^: G).
 rewrite pair_big (partition_big h1 xpredT) //=; apply: eq_bigr => k _.
-rewrite (partition_big h2 [in enum_val k]) /= => [|[x y]]; last first.
+rewrite (partition_big h2 [in enum_val k]) /= => [[x y]|].
   case/andP=> /andP[/= /sKG Gx /sKG Gy] /eqP <-.
   by rewrite enum_rankK_in ?class_refl ?mem_classes ?groupM ?Gx ?Gy.
 rewrite scaler_sumr; apply: eq_bigr => g Kk_g; rewrite scaler_nat.
@@ -349,7 +349,7 @@ have Dalpha: alpha = - 1 / p%:R.
   transitivity (cfReg G g); first by rewrite cfRegE (negPf nt_g).
   rewrite cfReg_sum sum_cfunE (bigD1 0) //= irr0 !cfunE cfun11 cfun1E Gg.
   rewrite mulr1; congr (1 + _); rewrite (bigID p_dv1) /= addrC big_andbC.
-  rewrite big1 => [|i /p_dvd_supp_g chig0]; last by rewrite cfunE chig0 mulr0.
+  rewrite big1 => [i /p_dvd_supp_g chig0|]; first by rewrite cfunE chig0 mulr0.
   rewrite add0r big_andbC mulr_suml; apply: eq_bigr => i _.
   by rewrite mulrAC divfK // cfunE.
 suffices: (p %| 1)%C by rewrite (dvdC_nat p 1) dvdn1 -(subnKC (prime_gt1 p_pr)).
@@ -382,8 +382,8 @@ rewrite ltnS => leGn piGle2; have [simpleG | ] := boolP (simple G); last first.
     move=> m_dv_G; apply: leq_trans piGle2.
     by rewrite uniq_leq_size ?primes_uniq //; apply: pi_of_dvd.
   rewrite (series_sol nsNG) !IHn ?dv_le_pi ?cardSg ?dvdn_quotient //.
-    by apply: leq_trans leGn; apply: ltn_quotient.
-  by apply: leq_trans leGn; apply: proper_card.
+    by apply: leq_trans leGn; apply: proper_card.
+  by apply: leq_trans leGn; apply: ltn_quotient.
 have [->|[p p_pr p_dv_G]] := trivgVpdiv G; first exact: solvable1.
 have piGp: p \in \pi(G) by rewrite mem_primes p_pr cardG_gt0.
 have [P sylP] := Sylow_exists p G; have [sPG pP p'GP] := and3P sylP.
@@ -407,7 +407,7 @@ rewrite unfold_in -if_neg irr1_neq0 Cint_rat_Aint //=.
   by rewrite rpred_div ?rpred_nat // rpred_nat_num ?Cnat_irr1.
 rewrite -[n in n / _]/(_ *+ true) -(eqxx i) -mulr_natr.
 rewrite -first_orthogonality_relation mulVKf ?neq0CG //.
-rewrite sum_by_classes => [|x y Gx Gy]; rewrite -?conjVg ?cfunJ //.
+rewrite sum_by_classes => [x y Gx Gy|]; rewrite -?conjVg ?cfunJ //.
 rewrite mulr_suml rpred_sum // => K /repr_classesP[Gx {1}->].
 by rewrite !mulrA mulrAC rpredM ?Aint_irr ?Aint_class_div_irr1.
 Qed.
@@ -448,7 +448,7 @@ have ->: #|G|%:R = \sum_(x in G) 'chi_i x * 'chi_i (x^-1)%g.
   rewrite -[_%:R]mulr1; apply: canLR (mulVKf (neq0CG G)) _.
   by rewrite first_orthogonality_relation eqxx.
 rewrite (big_setID [set x | 'chi_i x == 0]) /= -setIdE.
-rewrite big1 ?add0r => [| x /setIdP[_ /eqP->]]; last by rewrite mul0r.
+rewrite big1 ?add0r => [x /setIdP[_ /eqP->]|]; first by rewrite mul0r.
 pose h x := (x ^: G * 'Z(G))%g; rewrite (partition_big_imset h).
 rewrite !mulr_suml rpred_sum //= => _ /imsetP[x /setDP[Gx nz_chi_x] ->].
 have: #|x ^: G|%:R * ('chi_i x * 'chi_i x^-1%g) / 'chi_i 1%g \in Aint.
@@ -539,7 +539,7 @@ have [j ->]: exists j, 'chi_i = 'Res 'chi[G]_j.
   rewrite card_Iirr_abelian ?(abelianS sHG) //.
   rewrite -(eqn_pmul2r (indexg_gt0 G H)) Lagrange //; apply/eqP.
   rewrite -sum_nat_const -card_Iirr_abelian // -sum1_card.
-  rewrite (partition_big rH [in codom rH]) /=; last exact: image_f.
+  rewrite (partition_big rH [in codom rH]) /=; first exact: image_f.
   have nsHG: H <| G by rewrite -sub_abelian_normal.
   apply: eq_bigr => _ /codomP[i ->]; rewrite -card_quotient ?normal_norm //.
   rewrite -card_Iirr_abelian ?quotient_abelian //.
@@ -555,7 +555,7 @@ have [j ->]: exists j, 'chi_i = 'Res 'chi[G]_j.
   rewrite -(card_imset _ inj_rQ) -sum1_card; apply: eq_bigl => j.
   rewrite -(inj_eq irr_inj) -!DrH; apply/eqP/imsetP=> [eq_ij | [k _ ->]].
     have [k Dk] := Mlin (conjC_Iirr i) j; exists (quo_Iirr H k) => //.
-    apply/irr_inj; rewrite -DrQ quo_IirrK //.
+    apply/irr_inj; rewrite -DrQ quo_IirrK //; last first.
       by rewrite -Dk conjC_IirrE mulrCA mulrA mulJi mul1r.
     apply/subsetP=> x Hx; have Gx := subsetP sHG x Hx.
     rewrite cfkerEirr inE linG1 -Dk conjC_IirrE; apply/eqP.
@@ -579,9 +579,9 @@ Proof.
 have [p_pr | pr'p] := boolP (prime p); last first.
   have p'n n: (n > 0)%N -> p^'.-nat n.
     by move/p'natEpi->; rewrite mem_primes (negPf pr'p).
-  rewrite irr1_degree natrK => _ /pnat_1-> => [_ _|].
-    by rewrite part_p'nat ?p'n.
-  by rewrite p'n ?irr_degree_gt0.
+  rewrite irr1_degree natrK => _ /pnat_1-> => [|_ _].
+    by rewrite p'n ?irr_degree_gt0.
+  by rewrite part_p'nat ?p'n.
 move=> fful_i /p_natP[a Dchi1] sylP cPP.
 have Dchi1C: 'chi_i 1%g = (p ^ a)%:R by rewrite -Dchi1 irr1_degree natrK.
 have pa_dv_ZiG: (p ^ a %| #|G : 'Z(G)|)%N.
@@ -678,7 +678,7 @@ have{pi1 Zpi1} pi2_ge1: 1 <= pi2.
 have Sgt0: (#|S| > 0)%N by rewrite (cardD1 g) [g \in S]Sg.
 rewrite -mulr_natr -ler_pdivlMr ?ltr0n //.
 have n2chi_ge0 s: s \in S -> 0 <= `|chi s| ^+ 2 by rewrite exprn_ge0.
-rewrite -(expr_ge1 Sgt0); last by rewrite divr_ge0 ?ler0n ?sumr_ge0.
+rewrite -(expr_ge1 Sgt0); first by rewrite divr_ge0 ?ler0n ?sumr_ge0.
 by rewrite (le_trans pi2_ge1) // leif_AGM.
 Qed.
 
@@ -702,7 +702,7 @@ have defS: [pred s in G^# | <[s]> == <[g]>] =i S.
 have resS: {in S, 'chi_i =1 chi}.
   by move=> s /cycle_generator=> g_s; rewrite cfResE ?cycle_subG.
 rewrite !(eq_bigl _ _ defS) sumr_const.
-rewrite (eq_bigr (fun s => `|chi s| ^+ 2)) => [|s /resS-> //].
+rewrite (eq_bigr (fun s => `|chi s| ^+ 2)) => [s /resS-> //|].
 apply: sum_norm2_char_generators => [|s Ss].
   by rewrite cfRes_char ?irr_char.
 by rewrite -resS // nz_chi ?(subsetP sgG) ?cycle_generator.

--- a/character/mxabelem.v
+++ b/character/mxabelem.v
@@ -887,15 +887,15 @@ have nb_irr: #|sS| = (p ^ n.*2 + p.-1)%N.
     apply/eqP; rewrite eqEcard sub1set class_refl cards1.
     by rewrite -index_cent1 (setIidPl _) ?indexgg // sub_cent1.
   move/eqP: (class_formula S); rewrite (bigID [in Zcl]) /=.
-  rewrite (eq_bigr (fun _ => 1)) => [|zS]; last first.
+  rewrite (eq_bigr (fun _ => 1)) => [zS|].
     case/andP=> _ /setIdP[/imsetP[z Sz ->{zS}] /subsetIP[_ cSzS]].
     rewrite (setIidPl _) ?indexgg // sub_cent1 (subsetP cSzS) //.
     exact: mem_repr (class_refl S z).
-  rewrite sum1dep_card setIdE (setIidPr _) 1?cardsE ?cardZcl; last first.
+  rewrite sum1dep_card setIdE (setIidPr _) 1?cardsE ?cardZcl.
     by apply/subsetP=> zS /[!inE] /andP[].
   have pn_gt0: p ^ n.*2 > 0 by rewrite expn_gt0 p_gt0.
   rewrite card_irr_pchar // oSpn expnS -(prednK pn_gt0) mulnS eqn_add2l.
-  rewrite (eq_bigr (fun _ => p)) => [|xS]; last first.
+  rewrite (eq_bigr (fun _ => p)) => [xS|].
     case/andP=> SxS; rewrite inE SxS; case/imsetP: SxS => x Sx ->{xS} notZxS.
     have [y Sy ->] := repr_class S x; apply: p_maximal_index => //.
     apply: cent1_extraspecial_maximal => //; first exact: groupJ.
@@ -926,7 +926,7 @@ have wp1: w ^+ p = 1 by rewrite -irr_modeX // -ozp expg_order irr_mode1.
 have injw: {in 'Z(S) &, injective (irr_mode i0)}.
   move=> x y Zx Zy /= eq_xy; have [[Sx _] [Sy _]] := (setIP Zx, setIP Zy).
   apply: mx_faithful_inj (fful_nlin _ nlin_i0) _ _ Sx Sy _.
-  by rewrite !{1}irr_center_scalar ?eq_xy; first by split.
+  by rewrite !{1}irr_center_scalar ?eq_xy; last by split.
 have prim_w e: 0 < e < p -> p.-primitive_root (w ^+ e).
   case/andP=> e_gt0 lt_e_p; apply/andP; split=> //.
   apply/eqfunP=> -[d ltdp] /=; rewrite unity_rootE -exprM.
@@ -947,11 +947,11 @@ have alpha_i_z i: ((alpha ^+ ephi i) z = z ^+ i.+1)%g.
   transitivity ((a ^+ ephi i) z)%g.
     elim: (ephi i : nat) => // e IHe; rewrite !expgS !permM alphaZ //.
     have Aut_a: a \in Aut 'Z(S) by rewrite defAutZ cycle_id.
-    rewrite -{2}[a](invmK (injm_Zp_unitm z)); last by rewrite im_Zp_unitm -defZ.
+    rewrite -{2}[a](invmK (injm_Zp_unitm z)); first by rewrite im_Zp_unitm -defZ.
     rewrite /= autE ?cycle_id // -/j /= /cyclem.
     rewrite -(autmE (groupX _ Aut_a)) -(autmE (groupX _ Aut_alpha)).
     by rewrite !morphX //= !autmE IHe.
-  rewrite [(a ^+ _)%g](invmK (injm_Zpm a)) /=; last first.
+  rewrite [(a ^+ _)%g](invmK (injm_Zpm a)) /=.
     by rewrite im_Zpm -defAutZ defZ Aut_aut.
   by rewrite autE ?cycle_id //= val_Zp_nat ozp ?modIp'.
 have rphiP i: S :==: autm (groupX (ephi i) Aut_alpha) @* S by rewrite im_autm.
@@ -993,14 +993,14 @@ split=> // [i | ze | i].
 rewrite deg_phi {i}; set d := irr_degree i0.
 apply/eqP; move/eqP: (sum_irr_degree_pchar sS F'S splitF).
 rewrite (bigID [in linS]) /= -/irr_degree.
-rewrite (eq_bigr (fun=> 1)) => [|i]; last by rewrite !inE; move/eqP->.
+rewrite (eq_bigr (fun=> 1)) => [i|]; first by rewrite !inE; move/eqP->.
 rewrite sum1_card nb_lin.
-rewrite (eq_bigl [in codom iphi]) // => [|i]; last first.
+rewrite (eq_bigl [in codom iphi]) // => [i|].
   by rewrite -in_setC -im_iphi.
-rewrite (eq_bigr (fun=> d ^ 2))%N => [|_ /codomP[i ->]]; last first.
+rewrite (eq_bigr (fun=> d ^ 2))%N => [_ /codomP[i ->]|].
   by rewrite deg_phi.
 rewrite sum_nat_const card_image // card_ord oSpn (expnS p) -{3}[p]prednK //.
-rewrite mulSn eqn_add2l eqn_pmul2l; last by rewrite -ltnS prednK.
+rewrite mulSn eqn_add2l eqn_pmul2l; first by rewrite -ltnS prednK.
 by rewrite -muln2 expnM eqn_sqr.
 Qed.
 

--- a/character/mxrepresentation.v
+++ b/character/mxrepresentation.v
@@ -1210,7 +1210,7 @@ Lemma submod_mx_repr : mx_repr G (submod_mx Umod).
 Proof.
 rewrite /submod_mx; split=> [|x y Gx Gy /=].
   by rewrite repr_mx1 mulmx1 val_submodK.
-rewrite -in_submodJ; first by rewrite repr_mxM ?mulmxA.
+rewrite -in_submodJ; last by rewrite repr_mxM ?mulmxA.
 by rewrite mxmodule_trans ?val_submodP.
 Qed.
 
@@ -1323,8 +1323,8 @@ Lemma dom_hom_invmx f :
 Proof.
 move=> injf; set U := dom_hom_mx _; apply/eqmxP.
 rewrite -{1}[U](mulmxKV injf) submxMr; apply/hom_mxP=> x Gx.
-  by rewrite -[_ *m rG x](hom_mxP _) ?mulmxK.
-by rewrite -[_ *m rG x](hom_mxP _) ?mulmxKV.
+  by rewrite -[_ *m rG x](hom_mxP _) ?mulmxKV.
+by rewrite -[_ *m rG x](hom_mxP _) ?mulmxK.
 Qed.
 
 Lemma dom_hom_mx_module f : mxmodule (dom_hom_mx f).
@@ -1359,7 +1359,7 @@ Lemma proj_mx_hom (U V : 'M_n) :
 Proof.
 move=> dxUV modU modV; apply/hom_mxP=> x Gx.
 rewrite -{1}(add_proj_mx dxUV (submx_refl _)) !mulmxDl addrC.
-rewrite {1}[_ *m _]proj_mx_0 ?add0r //; last first.
+rewrite {1}[_ *m _]proj_mx_0 ?add0r //.
   by rewrite mxmodule_trans ?proj_mx_sub.
 by rewrite [_ *m _](proj_mx_id dxUV) // mxmodule_trans ?proj_mx_sub.
 Qed.
@@ -1770,7 +1770,7 @@ have [-> | nzV] := eqVneq V 0; first exact: mxsemisimple0.
 case def_r: r => [| i0 r'] => [|{r' def_r}].
   by rewrite -mxrank_eq0 -defV def_r big_nil mxrank0 in nzV.
 move: defV; rewrite (bigID W_0) /= addsmxC -big_filter !(big_nth i0) !big_mkord.
-rewrite addsmxC big1 ?adds0mx_id => [|i /andP[_ /eqP] //].
+rewrite addsmxC big1 ?adds0mx_id => [i /andP[_ /eqP] //|].
 set tI := 'I_(_); set r_ := nth _ _ => defV.
 have{simW} simWr (i : tI) : mxsimple (W (r_ i)).
   case: i => m /=; set Pr := fun i => _ => lt_m_r /=.
@@ -1860,9 +1860,9 @@ have phiG x: x \in G -> phi *m rG x = rG x *m phi.
   apply: eq_bigr => y Gy; rewrite !mulmxA -repr_mxM ?groupV ?groupM //.
   by rewrite invMg mulKVg repr_mxM ?mulmxA.
 have Uphi: U *m phi = U.
-  rewrite -scalemxAr mulmx_sumr (eq_bigr (fun _ => U)) => [|x Gx].
-    by rewrite sumr_const -scaler_nat !scalerA  mulVf ?scale1r.
-  by rewrite 3!mulmxA mulmxKpV ?repr_mxKV ?Umod ?groupV.
+  rewrite -scalemxAr mulmx_sumr (eq_bigr (fun _ => U)) => [x Gx|].
+    by rewrite 3!mulmxA mulmxKpV ?repr_mxKV ?Umod ?groupV.
+  by rewrite sumr_const -scaler_nat !scalerA  mulVf ?scale1r.
 have tiUker: (U :&: kermx phi = 0)%MS.
   apply/eqP/rowV0P=> v; rewrite sub_capmx => /andP[/submxP[u ->] /sub_kermxP].
   by rewrite -mulmxA Uphi.
@@ -2622,11 +2622,11 @@ Lemma morphpre_mx_abs_irr :
   mx_absolutely_irreducible rGf = mx_absolutely_irreducible rG.
 Proof.
 move=> sGfD; congr (_ && (_ == _)); apply/eqP; rewrite mxrank_leqif_sup //.
-  apply/row_subP=> i; rewrite rowK.
-  case/morphimP: (subsetP sGfD _ (enum_valP i)) => x Dx _ def_i.
-  by rewrite def_i (envelop_mx_id rGf) // !inE Dx -def_i enum_valP.
-apply/row_subP=> i; rewrite rowK (envelop_mx_id rG) //.
-by case/morphpreP: (enum_valP i).
+  apply/row_subP=> i; rewrite rowK (envelop_mx_id rG) //.
+  by case/morphpreP: (enum_valP i).
+apply/row_subP=> i; rewrite rowK.
+case/morphimP: (subsetP sGfD _ (enum_valP i)) => x Dx _ def_i.
+by rewrite def_i (envelop_mx_id rGf) // !inE Dx -def_i enum_valP.
 Qed.
 
 End Morphpre.
@@ -3046,14 +3046,14 @@ split=> [[B eqrUV injB homB] | [f injf homf defV]].
     have [u ->] := submxP (mxmoduleP modU x Gx).
     by rewrite in_submodE -mulmxA -defUf !mulmxA !mulmx1.
   apply/eqmxP; rewrite -mxrank_leqif_eq.
-    by rewrite mxrankMfree ?eqrUV ?row_free_unit.
-  by rewrite -defUf mulmxA val_submodP.
+    by rewrite -defUf mulmxA val_submodP.
+  by rewrite mxrankMfree ?eqrUV ?row_free_unit.
 have eqrUV: \rank U = \rank V by rewrite -defV mxrankMfree ?row_free_unit.
 exists (in_submod V (val_submod 1%:M *m f)) => // [|x Gx].
   rewrite /row_free {6}eqrUV -[_ == _]sub1mx -val_submodS.
-  rewrite in_submodK; last by rewrite -defV submxMr ?val_submodP.
+  rewrite in_submodK; first by rewrite -defV submxMr ?val_submodP.
   by rewrite val_submod1 -defV submxMr ?val_submod1.
-rewrite -in_submodJ; last by rewrite -defV submxMr ?val_submodP.
+rewrite -in_submodJ; first by rewrite -defV submxMr ?val_submodP.
 rewrite -(hom_mxP (submx_trans (val_submodP _) homf)) // -(val_submodJ modU) //.
 by rewrite  mul1mx 2!(mulmxA ((submod_repr _) x)) -val_submodE.
 Qed.
@@ -3112,7 +3112,7 @@ exists (in_submod U (val_factmod 1%:M *m proj_mx U V)) => // [|x Gx].
   rewrite in_submodK ?proj_mx_sub // -{1}[U](proj_mx_id dxUV) //.
   rewrite -{1}(add_sub_fact_mod V U) mulmxDl proj_mx_0 ?val_submodP // add0r.
   by rewrite submxMr // val_factmodS submx1.
-rewrite -in_submodJ ?proj_mx_sub // -(hom_mxP _) //; last first.
+rewrite -in_submodJ ?proj_mx_sub // -(hom_mxP _) //.
   by apply: submx_trans (submx1 _) _; rewrite -addUV proj_mx_hom.
 rewrite mulmxA; congr (_ *m _); rewrite mulmxA -val_factmodE; apply/eqP.
 rewrite eq_sym -subr_eq0 -mulmxBl proj_mx_0 //.
@@ -3415,7 +3415,7 @@ have [X /subsetP sXG [defX1 dxX1]] := Clifford_basis simM.
 pose sMv (W : sH) x := (M *m rG x <= W)%MS; pose Xv := [pred x in X | sMv _ x].
 have sXvG W: {subset Xv W <= G} by move=> x /andP[/sXG].
 have defW W: (\sum_(x in Xv W) M *m rG x :=: W)%MS.
-  apply/eqmxP; rewrite -(geq_leqif (mxrank_leqif_eq _)); last first.
+  apply/eqmxP; rewrite -(geq_leqif (mxrank_leqif_eq _)).
     by apply/sumsmx_subP=> x /andP[].
   rewrite -(leq_add2r (\sum_(W' | W' != W) \rank W')) -((bigD1 W) predT) //=.
   rewrite -(mxdirectP (Socle_direct sH)) /= -/(Socle _) Clifford_Socle1 -defX1.
@@ -3431,9 +3431,9 @@ have dxXv W: mxdirect (\sum_(x in Xv W) M *m rG x).
   by rewrite -mxdirectE mxdirect_addsE /= => /andP[].
 have def_t W: #|Xv W| = t.
   rewrite /t -{1}(Clifford_rank_components W) mulKn 1?(cardD1 W) //.
-  rewrite -defW (mxdirectP (dxXv W)) /= (eq_bigr (fun _ => \rank M)) => [|x].
-    rewrite sum_nat_const mulnK //; last by rewrite lt0n mxrank_eq0; case simM.
-  by move/sXvG=> Gx; rewrite mxrankMfree // row_free_unit repr_mx_unit.
+  rewrite -defW (mxdirectP (dxXv W)) /= (eq_bigr (fun _ => \rank M)) => [x|].
+    by move/sXvG=> Gx; rewrite mxrankMfree // row_free_unit repr_mx_unit.
+  by rewrite sum_nat_const mulnK //; last by rewrite lt0n mxrank_eq0; case simM.
 exists (fun W i => enum_val (cast_ord (esym (def_t W)) i)) => W.
 case: {def_t}t / (def_t W) => sW.
 case: (pickP (Xv W)) => [x0 XvWx0 | XvW0]; last first.
@@ -3662,12 +3662,12 @@ exists (valI *m in_factmod _ 1%:M *m in_submod _ 1%:M) => [||x Gx].
   by rewrite -mxrank_sum_cap addnC.
 - rewrite -kermx_eq0; apply/rowV0P=> u; rewrite (sameP sub_kermxP eqP).
   rewrite mulmxA -in_submodE mulmxA -in_factmodE -(inj_eq val_submod_inj).
-  rewrite linear0 in_submodK ?in_factmod_eq0 => [Vvu|]; last first.
+  rewrite linear0 in_submodK ?in_factmod_eq0 => [|Vvu].
     by rewrite genmxE addsmxC in_factmod_addsK submxMr // mulmx_sub.
   apply: val_submod_inj; apply/eqP; rewrite linear0 -[val_submod u]val_factmodK.
   rewrite val_submodE val_factmodE -mulmxA -val_factmodE -/valI.
   by rewrite in_factmod_eq0 sub_capmx mulmx_sub.
-symmetry; rewrite -{1}in_submodE -{1}in_submodJ; last first.
+symmetry; rewrite -{1}in_submodE -{1}in_submodJ.
    by rewrite genmxE addsmxC in_factmod_addsK -in_factmodE submxMr.
 rewrite -{1}in_factmodE -{1}in_factmodJ // mulmxA in_submodE; congr (_ *m _).
 apply/eqP; rewrite mulmxA -in_factmodE -subr_eq0 -linearB in_factmod_eq0.
@@ -3691,11 +3691,11 @@ exists (v1 *m in_factmod _ 1%:M *m in_submod _ 1%:M) => [||x Gx].
   by rewrite !{1}mxrank_in_factmod eqV12.
 - rewrite -kermx_eq0; apply/rowV0P=> u; rewrite (sameP sub_kermxP eqP) mulmxA.
   rewrite -in_submodE mulmxA -in_factmodE -(inj_eq val_submod_inj) linear0.
-  rewrite in_submodK ?in_factmod_eq0 -?eqU12 => [U1uv1|]; last first.
+  rewrite in_submodK ?in_factmod_eq0 -?eqU12 => [|U1uv1].
     by rewrite genmxE -(in_factmod_addsK U2 V2) submxMr // mulmx_sub.
   apply: val_submod_inj; apply/eqP; rewrite linear0 -[val_submod _]val_factmodK.
   by rewrite in_factmod_eq0 val_factmodE val_submodE -mulmxA -val_factmodE.
-symmetry; rewrite -{1}in_submodE -{1}in_factmodE -{1}in_submodJ; last first.
+symmetry; rewrite -{1}in_submodE -{1}in_factmodE -{1}in_submodJ.
   by rewrite genmxE -(in_factmod_addsK U2 V2) submxMr.
 rewrite -{1}in_factmodJ // mulmxA in_submodE; congr (_ *m _); apply/eqP.
 rewrite mulmxA -in_factmodE -subr_eq0 -linearB in_factmod_eq0 -eqU12.
@@ -3975,7 +3975,7 @@ transitivity (@gring_proj F _ G x (vec_mx 0) 0 0); last first.
   by rewrite !linear0 !mxE.
 rewrite -{}v0 !linear_sum (bigD1 k) //= 2!linearZ /= rowK mxvecK def_k.
 rewrite linear_sum (bigD1 x) ?class_refl //= gring_projE // eqxx.
-rewrite !big1 ?addr0 ?mxE ?mulr1 // => [k' | y /andP[xGy ne_yx]]; first 1 last.
+rewrite !big1 ?addr0 ?mxE ?mulr1 // => [y /andP[xGy ne_yx] | k'].
   by rewrite gring_projE ?(groupCl Gx xGy) // eq_sym (negPf ne_yx).
 rewrite rowK 2!linearZ /= mxvecK -(inj_eq enum_val_inj) def_k eq_sym.
 have [z Gz ->] := imsetP (enum_valP k').
@@ -3989,7 +3989,7 @@ Proof.
 apply/eqmxP/andP; split.
   apply/row_subP=> k; rewrite rowK /gset_mx sub_capmx {1}linear_sum.
   have [x Gx ->{k}] := imsetP (enum_valP k); have sxGG := groupCl Gx.
-  rewrite summx_sub => [|y xGy]; last by rewrite envelop_mx_id ?sxGG.
+  rewrite summx_sub => [y xGy|]; first by rewrite envelop_mx_id ?sxGG.
   rewrite memmx_cent_envelop; apply/centgmxP=> y Gy.
   rewrite {2}(reindex_acts 'J _ Gy) ?astabsJ ?class_norm //=.
   rewrite mulmx_suml mulmx_sumr; apply: eq_bigr => z; move/sxGG=> Gz.
@@ -4006,14 +4006,14 @@ rewrite !linear_sum {xG GxG}def_xG; apply: eq_big  => [y | xy] /=.
 case/imsetP=> y Gy ->{xy}; rewrite linearZ; congr (_ *: _).
 move/(canRL (repr_mxK aG Gy)): (centgmxP cGa y Gy); have Gy' := groupVr Gy.
 move/(congr1 (gring_proj x)); rewrite -mulmxA mulmx_suml !linear_sum.
-rewrite (bigD1 x Gx) big1 => [|z /andP[Gz]]; rewrite linearZ /=; last first.
+rewrite (bigD1 x Gx) big1 => [z /andP[Gz]|]; rewrite linearZ /=.
   by rewrite eq_sym gring_projE // => /negPf->; rewrite scaler0.
 rewrite gring_projE // eqxx scalemx1 (bigD1 (x ^ y)%g) ?groupJ //=.
-rewrite big1 => [|z /andP[Gz]]; rewrite -scalemxAl 2!linearZ /=.
-  rewrite !addr0 -!repr_mxM ?groupM // mulgA mulKVg mulgK => /rowP/(_ 0).
-  by rewrite gring_projE // eqxx scalemx1 !mxE.
-rewrite eq_sym -(can_eq (conjgKV y)) conjgK conjgE invgK.
-by rewrite -!repr_mxM ?gring_projE ?groupM // => /negPf->; rewrite scaler0.
+rewrite big1 => [z /andP[Gz]|]; rewrite -scalemxAl 2!linearZ /=.
+  rewrite eq_sym -(can_eq (conjgKV y)) conjgK conjgE invgK.
+  by rewrite -!repr_mxM ?gring_projE ?groupM // => /negPf->; rewrite scaler0.
+rewrite !addr0 -!repr_mxM ?groupM // mulgA mulKVg mulgK => /rowP/(_ 0).
+by rewrite gring_projE // eqxx scalemx1 !mxE.
 Qed.
 
 Lemma regular_module_ideal m (M : 'M_(m, nG)) :
@@ -4059,7 +4059,7 @@ apply: eq_bigr => x Gx; congr (_ *: _).
 move/rowP/(_ 0): (congr1 (gring_proj x \o gring_mx aG) (cGv x Gx)).
 rewrite /= gring_mxJ // def_v mulmx_suml !linear_sum (bigD1 1%g) //=.
 rewrite repr_mx1 -scalemxAl mul1mx linearZ /= gring_projE // eqxx scalemx1.
-rewrite big1 ?addr0 ?mxE /= => [ | y /andP[Gy nt_y]]; last first.
+rewrite big1 ?addr0 ?mxE /= => [y /andP[Gy nt_y]|].
   rewrite -scalemxAl linearZ -repr_mxM //= gring_projE ?groupM //.
   by rewrite eq_sym eq_mulgV1 mulgK (negPf nt_y) scaler0.
 rewrite (bigD1 x) //= linearZ /= gring_projE // eqxx scalemx1.
@@ -4385,7 +4385,7 @@ Lemma irr_repr'_op0_pchar i j A :
   j != i -> (A \in 'R_j)%MS -> gring_op (irr_repr i) A = 0.
 Proof.
 move=> neq_ij /(irr_comp'_op0_pchar _).
-by move=> ->; [|apply: socle_irr|rewrite irr_reprK_pchar].
+by move=> ->; [apply: socle_irr|rewrite irr_reprK_pchar|].
 Qed.
 
 Lemma op_Wedderburn_id_pchar i : gring_op (irr_repr i) 'e_i = 1%:M.
@@ -4447,9 +4447,9 @@ Proof. by move=> cGG i; apply: mxsimple_abelian_linear (socle_simple i). Qed.
 Lemma linear_irr_comp_pchar i : 'n_i = 1 -> (i :=: socle_base i)%MS.
 Proof.
 move=> ni1; apply/eqmxP; rewrite andbC -mxrank_leqif_eq -/'n_i.
-  rewrite -(mxrankMfree _ gring_free) -genmxE.
-  by rewrite rank_Wedderburn_subring_pchar ni1.
-exact: component_mx_id (socle_simple i).
+  exact: component_mx_id (socle_simple i).
+rewrite -(mxrankMfree _ gring_free) -genmxE.
+by rewrite rank_Wedderburn_subring_pchar ni1.
 Qed.
 
 Lemma Wedderburn_subring_center_pchar i : ('Z('R_i) :=: mxvec 'e_i)%MS.
@@ -4496,7 +4496,7 @@ Proof.
 rewrite -(eqnP classg_base_free) classg_base_center.
 have:= mxdirect_sums_center
   Wedderburn_sum_pchar Wedderburn_direct Wedderburn_ideal.
-move->; rewrite (mxdirectP _) /=; last first.
+move->; rewrite (mxdirectP _) /=.
   apply/mxdirect_sumsP=> i _; apply/eqP; rewrite -submx0.
   rewrite -{2}(mxdirect_sumsP Wedderburn_direct i) // capmxS ?capmxSl //=.
   by apply/sumsmx_subP=> j neji; rewrite (sumsmx_sup j) ?capmxSl.
@@ -4578,7 +4578,7 @@ have splitGq: group_splitting_field (G / G^`(1))%G.
 rewrite -(sum_irr_degree_pchar sGq) // -sum1_card.
 pose rG (j : sGq) := morphim_repr (socle_repr j) nG'G.
 have irrG j: mx_irreducible (rG j) by apply/morphim_mx_irr; apply: socle_irr.
-rewrite (reindex (fun j => irr_comp sG (rG j))) /=.
+rewrite (reindex (fun j => irr_comp sG (rG j))) /=; last first.
   apply: eq_big => [j | j _]; last by rewrite irr_degree_abelian.
   have [_ lin_j _ _] := rsim_irr_comp_pchar sG F'G (irrG j).
   by rewrite inE -lin_j -irr_degreeE irr_degree_abelian.
@@ -4599,7 +4599,7 @@ set u := Sub i lin_i.
 apply: mx_rsim_trans (rsim_irr_comp_pchar sG F'G (irrG _)).
 have [g lin_g inj_g hom_g] := rsim_irr_comp_pchar sGq F'Gq (irrGq u).
 exists g => [||x Gx]; last 1 [have:= hom_g (coset _ x)] || by [].
-by rewrite quo_repr_coset; first by apply; rewrite mem_quotient.
+by rewrite quo_repr_coset; last by apply; rewrite mem_quotient.
 Qed.
 
 Lemma primitive_root_splitting_abelian (z : F) :
@@ -4613,7 +4613,7 @@ case: (pickP [pred x in G | ~~ is_scalar_mx (rG x)]) => [x | scalG].
     by rewrite -order_dvdn order_dvdG.
   case/idPn; rewrite -mxrank_eq0 -(factor_Xn_sub_1 ozG).
   elim: #|G| => [|i IHi]; first by rewrite big_nil horner_mx_C mxrank1.
-  rewrite big_nat_recr => [|//]; rewrite rmorphM mxrankMfree {IHi}//=.
+  rewrite big_nat_recr => [//|]; rewrite rmorphM mxrankMfree {IHi}//=.
   rewrite row_free_unit rmorphB /= horner_mx_X horner_mx_C.
   rewrite (mx_Schur irrG) ?subr_eq0 //; last first.
     by apply: contraNneq nscal_rGx => ->; apply: scalar_mx_is_scalar.
@@ -4890,7 +4890,7 @@ suffices defU: (\sum_i oapp W_ V i :=: U)%MS.
 apply: eqmx_trans defVW; rewrite (bigD1 None) //=; apply/eqmxP.
 have [i0 _ | I0] := pickP I.
   by rewrite (reindex some) ?addsmxS ?defW //; exists (odflt i0) => //; case.
-rewrite big_pred0 //; last by case=> // /I0.
+rewrite big_pred0 //; first by case=> // /I0.
 by rewrite !addsmxS ?sub0mx // -defW big_pred0.
 Qed.
 
@@ -5045,7 +5045,7 @@ exists (in_submod _ (in_factmod U^f valUV^f)) => [||x Gx].
   by case: (\rank (cokermx U)) / (mxrank_map _ _); rewrite map_cokermx.
 - rewrite -kermx_eq0 -submx0; apply/rV_subP=> u.
   rewrite (sameP sub_kermxP eqP) submx0 -val_submod_eq0.
-  rewrite val_submodE -mulmxA -val_submodE in_submodK; last first.
+  rewrite val_submodE -mulmxA -val_submodE in_submodK.
     by rewrite genmxE -(in_factmod_addsK _ V^f) submxMr.
   rewrite in_factmodE mulmxA -in_factmodE in_factmod_eq0.
   move/(submxMr (in_factmod U 1%:M *m in_submod VU 1%:M)^f).
@@ -5053,7 +5053,7 @@ exists (in_submod _ (in_factmod U^f valUV^f)) => [||x Gx].
   rewrite val_factmodK val_submodK map_mx1 mulmx1.
   have ->: in_factmod U U = 0 by apply/eqP; rewrite in_factmod_eq0.
   by rewrite linear0 map_mx0 eqmx0 submx0.
-rewrite {1}in_submodE mulmxA -in_submodE -in_submodJ; last first.
+rewrite {1}in_submodE mulmxA -in_submodE -in_submodJ.
   by rewrite genmxE -(in_factmod_addsK _ V^f) submxMr.
 congr (in_submod _ _); rewrite -in_factmodJ // in_factmodE mulmxA -in_factmodE.
 apply/eqP; rewrite -subr_eq0 -def_rGf -!map_mxM -linearB in_factmod_eq0.
@@ -5327,7 +5327,7 @@ Lemma non_linear_gen_reducible : d > 1 -> mxnonsimple (map_repr gen rG) 1%:M.
 Proof.
 rewrite ltnNge mxminpoly_linear_is_scalar => Anscal.
 pose Af := map_mx gen A; exists (kermx (Af - groot%:M)).
-rewrite submx1 kermx_centg_module /=; last first.
+rewrite submx1 kermx_centg_module /=.
   apply/centgmxP=> z Gz; rewrite mulmxBl [RHS]mulmxBr [in RHS]scalar_mxC.
   by rewrite -!map_mxM 1?(centgmxP cGA).
 rewrite andbC mxrank_ker -subn_gt0 mxrank1 subKn ?rank_leq_row // lt0n.
@@ -5400,7 +5400,7 @@ have rBj: \rank Bj = d.
   have [[] // | nzx /(congr1 (mulmx^~ (mxval x^-1)))] := eqVneq x 0.
   rewrite mul0mx /= -mulmxA -mxvalM divff // mxval1 mulmx1.
   by move/rowP/(_ j)/eqP; rewrite !mxE !eqxx oner_eq0.
-rewrite {1}mulSn -Bfree -{1}rBj {rBj} -mxrank_disjoint_sum.
+rewrite {1}mulSn -Bfree -{1}rBj {rBj} -mxrank_disjoint_sum; last first.
   rewrite mxrankS // addsmx_sub -[nA.+1]/(1 + nA)%N; apply/andP; split.
     apply/row_subP=> k; rewrite row_mul mul_rV_lin1 /=.
     apply: eq_row_sub (mxvec_index (lshift _ 0) k)  _.

--- a/character/vcharacter.v
+++ b/character/vcharacter.v
@@ -428,7 +428,7 @@ suffices def_xi: xi = (-1) ^+ b i *: 'chi_i.
   exists i; rewrite // mem_enum inE -/(b i) orbC.
   by case: (b i) def_xi Sxi => // ->; rewrite scale1r.
 move: Sxi; rewrite [xi]cfun_sum_cfdot (bigD1 i) //.
-rewrite big1 //= ?addr0 => [|j ne_ji]; last first.
+rewrite big1 //= ?addr0 => [j ne_ji|].
   apply/eqP; rewrite scaler_eq0 -normr_eq0 -[_ == 0](expf_eq0 _ 2) normCK.
   by rewrite xi_i'_0 ?eqxx.
 have:= norm_xi_i; rewrite (aut_intr _ (Cint_cfdot_vchar_irr _ _)) //.
@@ -637,7 +637,7 @@ have [[_ sHG regGH][_ tiHG /eqP defNH]] := (normedTI_memJ_P ntiHG, and3P ntiHG).
 suffices /sigW[K defG]: exists K, gval K ><| H == G by exists K; apply/andP.
 pose K1 := G :\: cover (H^# :^: G).
 have oK1: #|K1| = #|G : H|.
-  rewrite cardsD (setIidPr _); last first.
+  rewrite cardsD (setIidPr _).
     rewrite cover_imset; apply/bigcupsP=> x Gx.
     by rewrite sub_conjg conjGid ?groupV // (subset_trans (subsetDl _ _)).
   rewrite (cover_partition (partition_normedTI ntiHG)) -(Lagrange sHG).
@@ -650,7 +650,7 @@ suffices extG i: {j | {in H, 'chi[G]_j =1 'chi[H]_i} & K1 \subset cfker 'chi_j}.
     apply/trivgP; rewrite -(TI_cfker_irr H) /= setIC; apply/bigcapsP=> i _.
     apply/subsetP=> x /setIP[Hx /bigcapP/(_ i isT)/=]; rewrite !cfkerEirr !inE.
     by case: (extG i) => /= j def_j _; rewrite !def_j.
-  exists K; rewrite sdprodE // eqEcard TI_cardMg // mul_subG //=; last first.
+  exists K; rewrite sdprodE // eqEcard TI_cardMg // mul_subG //=.
     by rewrite (bigcap_min (0 : Iirr H)) ?cfker_sub.
   rewrite -(Lagrange sHG) mulnC leq_pmul2r // -oK1 subset_leq_card //.
   by apply/bigcapsP=> i _; case: (extG i).
@@ -665,7 +665,7 @@ have /cfun_onP theta0: theta \in 'CF(H, H^#).
 have RItheta: 'Res ('Ind[G] theta) = theta.
   apply/cfun_inP=> x Hx; rewrite cfResE ?cfIndE // (big_setID H) /= addrC.
   apply: canLR (mulKf (neq0CG H)) _; rewrite (setIidPr sHG) mulr_natl.
-  rewrite big1 ?add0r => [|y /setDP[/regGH tiHy H'y]]; last first.
+  rewrite big1 ?add0r => [y /setDP[/regGH tiHy H'y]|].
     have [-> | ntx] := eqVneq x 1%g; first by rewrite conj1g theta0 ?inE ?eqxx.
     by rewrite theta0 ?tiHy // !inE ntx.
   by rewrite -sumr_const; apply: eq_bigr => y Hy; rewrite cfunJ.
@@ -877,7 +877,7 @@ Lemma cfun_sum_dconstt (phi : 'CF(G)) :
   phi = \sum_(i in dirr_constt phi) '[phi, dchi i] *: dchi i.
 Proof.
 move=> PiZ; rewrite [LHS]cfun_sum_constt.
-rewrite (reindex (to_dirr phi))=> [/= |]; last first.
+rewrite (reindex (to_dirr phi))=> [| /=].
   by exists (@of_irr _)=> //; apply: of_irrK .
 by apply: eq_big => i; rewrite ?irr_constt_to_dirr // cfdot_todirrE.
 Qed.
@@ -888,11 +888,11 @@ Lemma cnorm_dconstt (phi : 'CF(G)) :
 Proof.
 move=> PiZ; rewrite {1 2}(cfun_sum_dconstt PiZ).
 rewrite cfdot_suml; apply: eq_bigr=> i IiD.
-rewrite cfdot_sumr (bigD1 i) //= big1 ?addr0 => [|j /andP [JiD IdJ]].
-  rewrite cfdotZr cfdotZl cfdot_dchi eqxx eq_sym (negPf (ndirr_diff i)).
-  by rewrite subr0 mulr1 aut_natr ?Cnat_dirr.
-rewrite cfdotZr cfdotZl cfdot_dchi eq_sym (negPf IdJ) -natrB ?mulr0 //.
-by rewrite (negPf (contraNneq _ (dirr_constt_oppl JiD))) => // <-.
+rewrite cfdot_sumr (bigD1 i) //= big1 ?addr0 => [j /andP [JiD IdJ]|].
+  rewrite cfdotZr cfdotZl cfdot_dchi eq_sym (negPf IdJ) -natrB ?mulr0 //.
+  by rewrite (negPf (contraNneq _ (dirr_constt_oppl JiD))) => // <-.
+rewrite cfdotZr cfdotZl cfdot_dchi eqxx eq_sym (negPf (ndirr_diff i)).
+by rewrite subr0 mulr1 aut_natr ?Cnat_dirr.
 Qed.
 
 Lemma dirr_small_norm (phi : 'CF(G)) n :
@@ -928,13 +928,13 @@ rewrite addrC (big_setID (dirr_constt (- phi2))) /= cfdotDl; congr (_ + _).
   rewrite (negPf (contraTneq _ p2i)) // => ->.
   by rewrite dirr_constt_oppr dirr_constt_oppl.
 rewrite cfdot_sumr (big_setID (dirr_constt phi1)) setIC /= addrC.
-rewrite big1 ?add0r => [|j /setDP[p2j p1'j]]; last first.
+rewrite big1 ?add0r => [j /setDP[p2j p1'j]|].
   rewrite cfdot_suml big1 // => i /setDP[p1i p2'i].
-  rewrite cfdot_dchi (negPf (contraTneq _ p1i)) => [|-> //].
+  rewrite cfdot_dchi (negPf (contraTneq _ p1i)) => [-> //|].
   rewrite (negPf (contraNneq _ p2'i)) ?subrr // => ->.
   by rewrite dirr_constt_oppr ndirrK.
 rewrite -sumr_const; apply: eq_bigr => i /setIP[p1i p2i]; rewrite cfdot_suml.
-rewrite (bigD1 i) /=; last by rewrite inE dirr_constt_oppr dirr_constt_oppl.
+rewrite (bigD1 i) /=; first by rewrite inE dirr_constt_oppr dirr_constt_oppl.
 rewrite cfnorm_dchi big1 ?addr0 // => j /andP[/setDP[p1j _] i'j].
 rewrite cfdot_dchi (negPf i'j) (negPf (contraTneq _ p1j)) ?subrr // => ->.
 exact: dirr_constt_oppl.

--- a/doc/changelog/04-removed/1545-reworder.md
+++ b/doc/changelog/04-removed/1545-reworder.md
@@ -1,0 +1,7 @@
+- in `ssreflect.v`
+  + `Global Set SsrOldRewriteGoalsOrder`, for a smooth transition, we recommend adding
+    `Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)`
+    in each of your files after requiring `ssreflect.v` (even indirectly), which will enable
+    porting to the new rewrite subgoals order on a file per file basis
+    [note to release managers: this should probably be emphasized in the release notes]
+    ([#1545](https://github.com/math-comp/math-comp/pull/1545)).

--- a/field/algC.v
+++ b/field/algC.v
@@ -1109,7 +1109,7 @@ wlog p_monic : p / p \is monic => [hwlog|].
   have [|r] := hwlog ((lead_coef p)^-1 *: p).
     by rewrite monicE lead_coefZ mulVf ?lead_coef_eq0//.
   rewrite !lead_coefZ mulVf ?lead_coef_eq0//= scale1r.
-  rewrite map_polyZ/= => /(canRL (scalerKV _))->; first by exists r.
+  rewrite map_polyZ/= => /(canRL (scalerKV _))->; last by exists r.
   by rewrite fmorph_eq0 lead_coef_eq0.
 suff: {r : seq algC | p ^^ algRval = \prod_(z <- r) algC_pfactor z}.
   by move=> [r rP]; exists r; rewrite rP (monicP _)// scale1r.

--- a/field/algebraics_fundamentals.v
+++ b/field/algebraics_fundamentals.v
@@ -492,7 +492,7 @@ have add_Rroot xR p c: {yR | extendsR xR yR & has_Rroot xR p c -> root_in yR p}.
     apply: le_trans (le_trans (ler_norm _) (ler_norm_sum _ _ _)) _.
     apply: le_trans (_ : `|dq.[h] * h| <= _); last first.
       by rewrite normrM ler_pM ?normr_ge0 ?MdqP // ?ger0_norm ?lerB ?h_ge0.
-    rewrite horner_poly ger0_norm ?mulr_ge0 ?sumr_ge0 // => [|j _]; last first.
+    rewrite horner_poly ger0_norm ?mulr_ge0 ?sumr_ge0 // => [j _|].
       by rewrite mulr_ge0 ?exprn_ge0 // (le_trans _ (MqPx1 _)).
     rewrite mulr_suml ler_sum // => j _; rewrite normrM -mulrA -exprSr.
     by rewrite ler_pM // normrX ger0_norm.
@@ -654,7 +654,7 @@ have minp_i n (p_i := minPoly (R_ n) (i_ n)): p_i = 'X^2 + 1.
     rewrite minPoly_dvdp ?rpredD ?rpredX ?rpred1 ?polyOverX //.
     rewrite -(fmorph_root (ofQ _)) inQ_K // rmorphD rmorph1 /= map_polyXn.
     by rewrite rootE hornerD hornerXn hornerC Di2 addNr.
-  apply/eqP; rewrite -eqp_monic ?monic_minPoly //; last first.
+  apply/eqP; rewrite -eqp_monic ?monic_minPoly //.
     by rewrite monicE lead_coefE szX2_1 coefD coefXn coefC addr0.
   rewrite -dvdp_size_eqp // eqn_leq dvdp_leq -?size_poly_eq0 ?szX2_1 //= ltnNge.
   by rewrite size_minPoly ltnS leq_eqVlt orbF adjoin_deg_eq1 -sQof2 !inQ_K.
@@ -713,7 +713,7 @@ have /all_sig[n_ FTA] z: {n | z \in sQ (z_ n)}.
     apply/eqP; rewrite eqEsubv; apply/andP; split.
       apply/Fadjoin_seqP; split=> // _ /mapP[w s_w ->].
       by rewrite (subvP (adjoinSl u_z (sub1v _))) // -sQof2 Dz QztE.
-    rewrite /= adjoinC (Fadjoin_idP _) -/Rz; last first.
+    rewrite /= adjoinC (Fadjoin_idP _) -/Rz.
       by rewrite (subvP (adjoinSl _ (sub1v _))) // -sQof2 Dz Dit.
     rewrite /= -adjoin_seq1 adjoin_seqSr //; apply/allP=> /=; rewrite andbT.
     rewrite -(mem_map (fmorph_inj (ofQ _))) -map_comp (eq_map QztE); apply/mapP.
@@ -817,7 +817,7 @@ have /all_sig[n_ FTA] z: {n | z \in sQ (z_ n)}.
     have nz_v: v != 0 by rewrite (memPnC R'v) ?rpred0.
     apply: (IHw (v * w)); last 1 [|] || by rewrite fpredMl // subvP_adjoin.
       by rewrite exprMn rpredM // rpredX.
-    rewrite exprMn fpredMr //=; last by rewrite expf_eq0 (memPnC C'w) ?rpred0.
+    rewrite exprMn fpredMr //=; first by rewrite expf_eq0 (memPnC C'w) ?rpred0.
     by rewrite sqrrD Dit2 expr1n addrC addKr -mulrnAl fpredMl ?rpred_nat.
   pose rect_w2 u v := [/\ u \in Rn, v \in Rn & u + i_t * (v * 2) = w ^+ 2].
   have{Cw2} [u [v [Ru Rv Dw2]]]: {u : Qt & {v | rect_w2 u v}}.
@@ -846,7 +846,7 @@ have /all_sig[n_ FTA] z: {n | z \in sQ (z_ n)}.
     suffices /eqP->: v == 0 by rewrite mul0r addr0.
     by rewrite y2_0 mulr0 eq_sym sqrf_eq0 fmorph_eq0 in px0.
   apply/eqP/esym/(mulIf nz_x2); rewrite -exprMn -rmorphXn -Dw2 rmorphD rmorphM.
-  rewrite /= Dit mulrDl -expr2 mulrA divfK; last by rewrite expf_eq0 in nz_x2.
+  rewrite /= Dit mulrDl -expr2 mulrA divfK; first by rewrite expf_eq0 in nz_x2.
   rewrite mulr_natr addrC sqrrD exprMn Di2 mulN1r -(eqP px0) -mulNr opprB.
   by rewrite -mulrnAl -mulrnAr -rmorphMn -!mulrDl addrAC subrK.
 have inFTA n z: (n_ z <= n)%N -> z = ofQ (z_ n) (inQ (z_ n) z).

--- a/field/algnum.v
+++ b/field/algnum.v
@@ -197,7 +197,7 @@ have Qn_bC (u : {x | x \in Crat_span (map QnC b)}): {y | QnC y = sval u}.
   by rewrite rmorphZ_num (nth_map 0) // -(size_map QnC).
 pose CtoQn x := oapp (fun u => sval (Qn_bC u)) 0 (insub x).
 suffices QnCK: cancel QnC CtoQn by exists CtoQn; rewrite // -(rmorph0 QnC) /=.
-move=> x; rewrite /CtoQn insubT => /= [|Qn_x]; last first.
+move=> x; rewrite /CtoQn insubT => /= [Qn_x|].
   by case: (Qn_bC _) => x1 /= /fmorph_inj.
 rewrite (coord_vbasis (memvf x)) rmorph_sum rpred_sum //= => i _.
 rewrite rmorphZ_num Crat_spanZ ?mem_Crat_span // -/b.
@@ -243,7 +243,7 @@ case: (splitting_field_normal 1%AS x) => rs /eqP Hrs.
 have: root (map_poly (nu \o QnC) (minPoly 1%AS x)) (nu (QnC x)).
   by rewrite fmorph_root root_minPoly.
 rewrite map_Qnum_poly ?minPolyOver // Hrs.
-rewrite [map_poly _ _](_:_ = \prod_(y <- map QnC rs) ('X - y%:P)).
+rewrite [map_poly _ _](_:_ = \prod_(y <- map QnC rs) ('X - y%:P)); last first.
   by rewrite root_prod_XsubC; case/mapP => y _ ?; exists y.
 by rewrite big_map rmorph_prod /=; apply: eq_bigr => i _; rewrite map_polyXsubC.
 Qed.
@@ -391,7 +391,7 @@ have ext1 mu0 x : {mu1 | exists y, x = Sinj mu1 y
     apply: (iffP memv_imgP) => [[yy _ ->] | [yy ->]];
       by exists yy; rewrite ?lfunE ?memvf.
   have algK: is_aspace K.
-    rewrite /is_aspace has_algid1; last first.
+    rewrite /is_aspace has_algid1.
       by apply/memK; exists 1; rewrite rmorph1.
     apply/prodvP=> _ _ /memK[y1 ->] /memK[y2 ->].
     by apply/memK; exists (y1 * y2); rewrite rmorphM.
@@ -477,7 +477,7 @@ pose phi := kHomExtend 1 \1 zn (zn ^+ k).
 have homQn1: kHom 1 1 (\1%VF : 'End(Qn)) by rewrite kHom1.
 have pzn_zk0: root (map_poly \1%VF (minPoly 1 zn)) (zn ^+ k).
   rewrite -(fmorph_root QnC) rmorphXn /= Dz -map_poly_comp.
-  rewrite (@eq_map_poly _ _ _ QnC) => [|a]; last by rewrite /= id_lfunE.
+  rewrite (@eq_map_poly _ _ _ QnC) => [a|]; first by rewrite /= id_lfunE.
   set p1 := map_poly _ _.
   have [q1 Dp1]: exists q1, p1 = pQtoC q1.
     have aP i: (minPoly 1 zn)`_i \in 1%VS.
@@ -501,7 +501,7 @@ have [nu Dnu] := extend_algC_subfield_aut QnC phiRM.
 exists nu => _ /(prim_rootP prim_z)[i ->].
 rewrite rmorphXn /= exprAC -Dz -Dnu /= -{1}[zn]hornerX /phi.
 rewrite (kHomExtend_poly homQn1) ?polyOverX //.
-rewrite map_polyE map_id_in => [|?]; last by rewrite id_lfunE.
+rewrite map_polyE map_id_in => [?|]; first by rewrite id_lfunE.
 by rewrite polyseqK hornerX rmorphXn.
 Qed.
 
@@ -520,7 +520,7 @@ case/dvdpP_rat_int=> qz [a nz_a Dq] [r].
 move/(congr1 (fun q1 => lead_coef (a *: pZtoQ q1))).
 rewrite rmorphM scalerAl -Dq lead_coefZ lead_coefM /=.
 have /monicP->: pZtoQ pz \is monic by rewrite -(map_monic QtoC) pZtoQtoC -Dp.
-rewrite (monicP mon_q) mul1r mulr1 lead_coef_map_inj //; last exact: intr_inj.
+rewrite (monicP mon_q) mul1r mulr1 lead_coef_map_inj //; first exact: intr_inj.
 rewrite Dq => ->; apply/polyOverP=> i; rewrite !(coefZ, coef_map).
 by rewrite -rmorphM /= rmorph_int.
 Qed.

--- a/field/closed_field.v
+++ b/field/closed_field.v
@@ -165,10 +165,10 @@ Lemma lead_coefTP (k : tF -> fF) :
 Proof.
 move=> kP p e; elim: p => [|a p IHp]/= in k kP e *.
   by rewrite lead_coef0 kP.
-rewrite IHp; last by move=> *; rewrite //= -kP.
+rewrite IHp; first by move=> *; rewrite //= -kP.
 rewrite GRing.eval_If /= lead_coef_eq0.
 case p'0: (_ == _); first by rewrite (eqP p'0) mul0r add0r lead_coefC -kP.
-rewrite lead_coefDl ?lead_coefMX // polyseqC size_mul ?p'0 //; last first.
+rewrite lead_coefDl ?lead_coefMX // polyseqC size_mul ?p'0 //.
   by rewrite -size_poly_eq0 size_polyX.
 rewrite size_polyX addnC /=; case: (_ == _)=> //=.
 by rewrite ltnS lt0n size_poly_eq0 p'0.
@@ -288,17 +288,17 @@ Proof.
 move=> Pk q sq cq c qq r n e /=.
 elim: n c qq r k Pk e => [|n Pn] c qq r k Pk e; rewrite sizeTP.
   case ltrq : (_ < _); first by rewrite /= ltrq /= -Pk.
-  rewrite lead_coefTP => [|a p]; rewrite [in LHS]Pk; [|symmetry].
-    rewrite ?(eval_mulpT,eval_amulXnT,eval_sumpT,eval_opppT) //=.
-    by rewrite ltrq //= !mul_polyC ?(mul0r,add0r,scale0r).
-  by rewrite [in LHS]Pk ?(eval_mulpT,eval_amulXnT,eval_sumpT, eval_opppT).
+  rewrite lead_coefTP => [a p|]; rewrite [in LHS]Pk; [symmetry|].
+    by rewrite [in LHS]Pk ?(eval_mulpT,eval_amulXnT,eval_sumpT, eval_opppT).
+  rewrite ?(eval_mulpT,eval_amulXnT,eval_sumpT,eval_opppT) //=.
+  by rewrite ltrq //= !mul_polyC ?(mul0r,add0r,scale0r).
 case ltrq : (_<_); first by rewrite /= ltrq Pk.
-rewrite lead_coefTP.
+rewrite lead_coefTP; last first.
   rewrite Pn ?(eval_mulpT,eval_amulXnT,eval_sumpT,eval_opppT) //=.
   by rewrite ltrq //= !mul_polyC ?(mul0r,add0r,scale0r).
 rewrite -/redivp_rec_loopT => x e'.
-rewrite Pn; last by move=> *; rewrite Pk.
-symmetry; rewrite Pn; last by move=> *; rewrite Pk.
+rewrite Pn; first by move=> *; rewrite Pk.
+symmetry; rewrite Pn; first by move=> *; rewrite Pk.
 rewrite Pk ?(eval_lift,eval_mulpT,eval_amulXnT,eval_sumpT,eval_opppT).
 by rewrite mul_polyC ?(mul0r,add0r).
 Qed.
@@ -337,8 +337,8 @@ Lemma redivpTP (k : nat * polyF * polyF -> fF) :
 Proof.
 move=> Pk p q e /=; rewrite isnullP unlock /=.
 case q0 : (eval_poly e q == 0) => /=; first by rewrite Pk /= mul0r add0r polyC0.
-rewrite !sizeTP lead_coefTP /=; last by move=> *; rewrite !redivp_rec_loopTP.
-rewrite redivp_rec_loopTP /=; last by move=> *; rewrite Pk.
+rewrite !sizeTP lead_coefTP /=; first by move=> *; rewrite !redivp_rec_loopTP.
+rewrite redivp_rec_loopTP /=; first by move=> *; rewrite Pk.
 by rewrite mul0r add0r polyC0 redivp_rec_loopP.
 Qed.
 
@@ -454,7 +454,7 @@ Proof.
 move=> Pk p q n e; elim: n => [|n Pn] /= in k Pk p q e *.
   rewrite isnullP /=.
   by case: (_ == _); rewrite Pk /= mul0r add0r ?(polyC0, polyC1).
-rewrite /rcoprimep rgcdpTP ?sizeTP ?eval_lift => * /=.
+rewrite /rcoprimep rgcdpTP ?sizeTP ?eval_lift => * /=; last first.
   case: (_ == _);
   by do ?[rewrite /= ?(=^~Pk, redivpTP, rgcdpTP, sizeTP, Pn, eval_lift) //==> *].
 do ?[rewrite /= ?(=^~Pk, redivpTP, rgcdpTP, sizeTP, Pn, eval_lift) //==> *].

--- a/field/cyclotomic.v
+++ b/field/cyclotomic.v
@@ -81,16 +81,16 @@ have dv_n k: (n %/ gcdn k n %| n)%N.
 have [uDn _ inDn] := divisors_correct n_gt0.
 have defDn: divisors n = map val (map (@inord n) (divisors n)).
   by rewrite -map_comp map_id_in // => d; rewrite inDn => /in_d.
-rewrite defDn big_map big_uniq /=; last first.
+rewrite defDn big_map big_uniq /=.
   by rewrite -(map_inj_uniq val_inj) -defDn.
 pose h (k : 'I_n) : 'I_n.+1 := inord (n %/ gcdn k n).
 rewrite -(factor_Xn_sub_1 prim_z) big_mkord.
-rewrite (partition_big h (dvdn^~ n)) /= => [|k _]; last by rewrite in_d ?dv_n.
+rewrite (partition_big h (dvdn^~ n)) /= => [k _|]; first by rewrite in_d ?dv_n.
 apply: eq_big => d; first by rewrite -(mem_map val_inj) -defDn inDn.
 set q := (n %/ d)%N => d_dv_n.
 have [q_gt0 d_gt0]: (0 < q /\ 0 < d)%N by apply/andP; rewrite -muln_gt0 divnK.
 have fP (k : 'I_d): (q * k < n)%N by rewrite divn_mulAC ?ltn_divLR ?ltn_pmul2l.
-rewrite (reindex (fun k => Ordinal (fP k))); last first.
+rewrite (reindex (fun k => Ordinal (fP k))).
   have f'P (k : 'I_n): (k %/ q < d)%N by rewrite ltn_divLR // mulnC divnK.
   exists (fun k => Ordinal (f'P k)) => [k _ | k /eqnP/=].
     by apply: val_inj; rewrite /= mulKn.
@@ -178,7 +178,7 @@ have [r def_zn]: exists r, cyclotomic z n = pZtoC r.
     rewrite map_polyZ mapXn1 Dr0 Dr -scalerAl scalerKV ?intr_eq0 //.
     by rewrite rmorphM.
   by rewrite zprimitiveZ // zprimitive_monic ?monicXnsubC ?mapXn1.
-rewrite floorpK; last by apply/polyOverP=> i; rewrite def_zn coef_map /=.
+rewrite floorpK; first by apply/polyOverP=> i; rewrite def_zn coef_map /=.
 pose f e (k : 'I_n) := Ordinal (ltn_pmod (k * e) n_gt0).
 have [e Dz0] := prim_rootP prim_z (prim_expr_order prim_z0).
 have co_e_n: coprime e n by rewrite -(prim_root_exp_coprime e prim_z) -Dz0.
@@ -236,7 +236,7 @@ without loss{nz_af} [mon_f mon_g]: af f g Df Dfg / f \is monic /\ g \is monic.
   by rewrite !(intz, =^~ scaler_int) !monicE !lead_coefZ mulrC cfg1.
 have{af} Df: pQtoC pf = pZtoC f.
   have:= congr1 lead_coef Df.
-  rewrite lead_coefZ lead_coef_map_inj //; last exact: intr_inj.
+  rewrite lead_coefZ lead_coef_map_inj //; first exact: intr_inj.
   rewrite !(monicP _) // mulr1 Df => <-; rewrite scale1r -map_poly_comp.
   by apply: eq_map_poly => b; rewrite /= rmorph_int.
 have [/size1_polyC Dg | g_gt1] := leqP (size g) 1.
@@ -273,7 +273,7 @@ rewrite prime_coprime // (dvdn_pcharf (pchar_Fp p_pr)) => /co_fg {co_fg}.
 have pcharFpX: p \in [pchar {poly 'F_p}] by rewrite (rmorph_pchar polyC) ?pchar_Fp.
 rewrite -(coprimep_pexpr _ _ (prime_gt0 p_pr)) -(pFrobenius_autE pcharFpX).
 rewrite -[g]comp_polyXr map_comp_poly -horner_map /= pFrobenius_autE -rmorphXn.
-rewrite -!map_poly_comp (@eq_map_poly _ _ _ (polyC \o *~%R 1)); last first.
+rewrite -!map_poly_comp (@eq_map_poly _ _ _ (polyC \o *~%R 1)).
   by move=> a; rewrite /= !rmorph_int.
 rewrite map_poly_comp -[_.[_]]map_comp_poly /= => co_fg.
 suffices: coprimep (pZtoC f) (pZtoC (g \Po 'X^p)).

--- a/field/falgebra.v
+++ b/field/falgebra.v
@@ -843,7 +843,7 @@ Qed.
 
 Fact agenv_is_aspace U : is_aspace (agenv U).
 Proof.
-rewrite /is_aspace has_algid1; last by rewrite memvE agenvEl addvSl.
+rewrite /is_aspace has_algid1; first by rewrite memvE agenvEl addvSl.
 by rewrite agenv_modl // [V in (_ <= V)%VS]agenvEl addvSr.
 Qed.
 Canonical agenv_aspace U : {aspace aT} := ASpace (agenv_is_aspace U).
@@ -1123,7 +1123,7 @@ Proof. by rewrite aimg_agen limgD limg_span. Qed.
 Fact ker_sub_ahom_is_aspace (f g : ahom aT rT) :
   is_aspace (lker (ahval f - ahval g)).
 Proof.
-rewrite /is_aspace has_algid1; last by apply/eqlfunP; rewrite !rmorph1.
+rewrite /is_aspace has_algid1; first by apply/eqlfunP; rewrite !rmorph1.
 apply/prodvP=> a b /eqlfunP Dfa /eqlfunP Dfb.
 by apply/eqlfunP; rewrite !rmorphM /= Dfa Dfb.
 Qed.

--- a/field/fieldext.v
+++ b/field/fieldext.v
@@ -401,10 +401,10 @@ Qed.
 Lemma Fadjoin_eq_sum : <<K; x>>%VS = sumKx.
 Proof.
 apply/esym/eqP; rewrite eqEdim eq_leq ?andbT.
-  apply/subv_sumP=> i _; rewrite -agenvM prodvS ?subv_adjoin //.
-  by rewrite -expv_line (subv_trans (subX_agenv _ _)) ?agenvS ?addvSr.
-rewrite dim_Fadjoin -[n]card_ord -sum_nat_const (directvP Fadjoin_sum_direct).
-by apply: eq_bigr => i _; rewrite /= dim_cosetv.
+  rewrite dim_Fadjoin -[n]card_ord -sum_nat_const (directvP Fadjoin_sum_direct).
+  by apply: eq_bigr => i _; rewrite /= dim_cosetv.
+apply/subv_sumP=> i _; rewrite -agenvM prodvS ?subv_adjoin //.
+by rewrite -expv_line (subv_trans (subX_agenv _ _)) ?agenvS ?addvSr.
 Qed.
 
 Lemma Fadjoin_poly_eq v : v \in <<K; x>>%VS -> (Fadjoin_poly K x v).[x] = v.
@@ -475,8 +475,8 @@ set p := minPoly K x; apply: (iffP idP) => [Kx | Dp]; last first.
   suffices ->: x = - p`_0 by rewrite rpredN (polyOverP minPolyOver).
   by rewrite Dp coefB coefX coefC add0r opprK.
 rewrite (@all_roots_prod_XsubC _ p [:: x]) /= ?root_minPoly //.
-  by rewrite big_seq1 (monicP (monic_minPoly K x)) scale1r.
-by apply/eqP; rewrite size_minPoly eqSS adjoin_deg_eq1.
+  by apply/eqP; rewrite size_minPoly eqSS adjoin_deg_eq1.
+by rewrite big_seq1 (monicP (monic_minPoly K x)) scale1r.
 Qed.
 
 Lemma root_small_adjoin_poly p :
@@ -698,7 +698,7 @@ Qed.
 
 Fact aspaceOver_suproof E : is_aspace (vspaceOver E).
 Proof.
-rewrite /is_aspace has_algid1; last by rewrite mem_vspaceOver (@mem1v _ L).
+rewrite /is_aspace has_algid1; first by rewrite mem_vspaceOver (@mem1v _ L).
 by apply/prodvP=> u v; rewrite !mem_vspaceOver; apply: memvM.
 Qed.
 Canonical aspaceOver E := ASpace (aspaceOver_suproof E).
@@ -745,7 +745,7 @@ Lemma aspaceOverP (E_F : {subfield L_F}) :
 Proof.
 have [V [defEF modV memV]] := vspaceOverP E_F.
 have algE: has_algid V && (V * V <= V)%VS.
-  rewrite has_algid1; last by rewrite -memV mem1v.
+  rewrite has_algid1; first by rewrite -memV mem1v.
   by apply/prodvP=> u v; rewrite -!memV; apply: memvM.
 by exists (ASpace algE); rewrite -sup_field_module; split; first apply: val_inj.
 Qed.
@@ -853,7 +853,7 @@ Qed.
 
 Fact baseAspace_suproof (E : {subfield L}) : is_aspace (baseVspace E).
 Proof.
-rewrite /is_aspace has_algid1; last by rewrite mem_baseVspace (mem1v E).
+rewrite /is_aspace has_algid1; first by rewrite mem_baseVspace (mem1v E).
 by apply/prodvP=> u v; rewrite !mem_baseVspace; apply: memvM.
 Qed.
 Canonical baseAspace E := ASpace (baseAspace_suproof E).

--- a/field/finfield.v
+++ b/field/finfield.v
@@ -104,9 +104,9 @@ Proof.
 set n := #|F|; set oppX := - 'X; set pF := LHS.
 have le_oppX_n: size oppX <= n by rewrite size_polyN size_polyX finNzRing_gt1.
 have: size pF = (size (enum F)).+1 by rewrite -cardE size_polyDl size_polyXn.
-move/all_roots_prod_XsubC->; last by rewrite uniq_rootsE enum_uniq.
-  by rewrite big_enum lead_coefDl ?size_polyXn // lead_coefXn scale1r.
-by apply/allP=> x _; rewrite rootE !hornerE expf_card subrr.
+move/all_roots_prod_XsubC->; [|by rewrite uniq_rootsE enum_uniq|].
+  by apply/allP=> x _; rewrite rootE !hornerE expf_card subrr.
+by rewrite big_enum lead_coefDl ?size_polyXn // lead_coefXn scale1r.
 Qed.
 
 Lemma finPcharP : {p | prime p & p \in [pchar F]}.
@@ -718,7 +718,7 @@ have ->: #|u ^: G|%:R = \prod_(d < n.+1 | d %| n) (aq d / aq d ^+ (d %| m)).
   rewrite -index_cent1 natf_indexg ?subsetT //= setTI prodf_div prod_aq // -oG.
   congr (_ / _); rewrite big_mkcond oCu -prod_aq //= big_mkcond /=.
   by apply: eq_bigr => d _; case: ifP => [/dvdn_trans->| _]; rewrite ?if_same.
-rewrite (bigD1 ord_max) //= [n %| m](contraNF _ Z'u) => [|n_dv_m]; last first.
+rewrite (bigD1 ord_max) //= [n %| m](contraNF _ Z'u) => [n_dv_m|].
   rewrite -sub_cent1 subEproper eq_sym eqEcard subsetT oG oCu leq_sub2r //.
   by rewrite leq_exp2l // dvdn_leq.
 rewrite divr1 dvdC_mulr //; apply/rpred_prod => d /andP[/Zaq-Zaqd _].

--- a/field/galois.v
+++ b/field/galois.v
@@ -619,7 +619,7 @@ have Df1 u: inLz (f1 u) = f (inLz u).
   elim/last_ind: r1 {u}(inLz u) => [|r1 y IHr1] u.
     by rewrite Fadjoin_nil => _ Fu; rewrite fFid // (subvP (sub1v _)).
   rewrite all_rcons adjoin_rcons => /andP[rr1 ry] /Fadjoin_polyP[pu r1pu ->].
-  rewrite (kHom_horner homLf) -defLz; last exact: seqv_sub_adjoin; last first.
+  rewrite (kHom_horner homLf) -defLz; [|exact: seqv_sub_adjoin|].
     by apply: polyOverS r1pu; apply/subvP/adjoin_seqSr/allP.
   apply: rpred_horner.
     by apply/polyOverP=> i; rewrite coef_map /= defLz IHr1 ?(polyOverP r1pu).
@@ -1213,7 +1213,7 @@ have x_ (i : 'I_n): {x | x \in 'Gal(<<K; a>> / K) & x a = r`_i}.
   by rewrite splitKa root_prod_XsubC mem_nth.
 have /card_image <-: injective (fun i => s2val (x_ i)).
   move=> i j /eqP; case: (x_ i) (x_ j) => y /= galEy Dya [z /= galEx Dza].
-  rewrite gal_adjoin_eq // Dya Dza nth_uniq // => [/(i =P j)//|].
+  rewrite gal_adjoin_eq // Dya Dza nth_uniq // => [|/(i =P j)//].
   by rewrite -separable_prod_XsubC -splitKa; apply: separable_generatorP.
 apply/eqP/eq_card=> x; apply/codomP/idP=> [[i ->] | galEx]; first by case: x_.
 have /(nthP 0) [i ltin Dxa]: x a \in r.
@@ -1293,7 +1293,7 @@ rewrite -fixedKE; apply/polyOverP => i; apply/fixedFieldP=> [|x galEx].
   rewrite (polyOverP _) // big_map rpred_prod // => b _.
   by rewrite polyOverXsubC memv_gal.
 rewrite -coef_map rmorph_prod; congr (_ : {poly _})`_i.
-symmetry; rewrite (perm_big (map x r)) /= ?(big_map x).
+symmetry; rewrite (perm_big (map x r)) /= ?(big_map x); last first.
   by apply: eq_bigr => b _; rewrite rmorphB /= map_polyX map_polyC.
 have Uxr: uniq (map x r) by rewrite map_inj_uniq //; apply: fmorph_inj.
 have /uniq_min_size: {subset map x r <= r}.
@@ -1364,7 +1364,7 @@ transitivity (\prod_(j < i.+1) (x ^+ j)%g a).
   by apply: eq_bigr => j _; rewrite expgSr galM ?lfunE.
 have [/modn_small->//||->] := ltngtP i.+1 n; first by rewrite ltnNge ltn_ord.
 rewrite modnn big_ord0; apply: etrans normEa1; rewrite /galNorm DgalE -im_Zpm.
-rewrite morphimEdom big_imset /=; last exact/injmP/injm_Zpm.
+rewrite morphimEdom big_imset /=; first exact/injmP/injm_Zpm.
 by apply: eq_bigl => j /=; rewrite mem_Zp ?order_gt1.
 Qed.
 

--- a/field/qfpoly.v
+++ b/field/qfpoly.v
@@ -92,7 +92,7 @@ Proof. by rewrite /mk_monic !hI. Qed.
 Lemma coprimep_unit (p : {poly %/ h}) : p != 0%R -> coprimep hQ p.
 Proof.
 move=> pNZ.
-rewrite irreducible_poly_coprime //; last first.
+rewrite irreducible_poly_coprime //.
   by case: hI; rewrite mk_monicE.
 apply: contra pNZ => H; case: eqP => // /eqP /dvdp_leq /(_ H).
 by rewrite leqNgt size_mk_monic.

--- a/field/separable.v
+++ b/field/separable.v
@@ -86,8 +86,8 @@ have [g_p]: g %| p /\ g %| p^`() by rewrite dvdp_gcdr ?dvdp_gcdl.
 pose c := lead_coef g ^+ scalp p g; have nz_c: c != 0 by rewrite lcn_neq0.
 have Dcp: c *: p = p %/ g * g by rewrite Pdiv.Idomain.divpK.
 rewrite nz_g andbT leqNgt -(dvdpZr _ _ nz_c) -derivZ Dcp derivM.
-rewrite dvdp_addr; last by rewrite dvdp_mull.
-rewrite Gauss_dvdpr; last by rewrite sq'p // mulrC -Dcp dvdpZl.
+rewrite dvdp_addr; first by rewrite dvdp_mull.
+rewrite Gauss_dvdpr; first by rewrite sq'p // mulrC -Dcp dvdpZl.
 by apply: contraL => /nz_der1p nz_g'; rewrite gtNdvdp ?nz_g' ?lt_size_deriv.
 Qed.
 
@@ -256,7 +256,7 @@ move=> nz_q qy_0 /pcharf0P pcharF0.
 without loss{nz_q} sep_q: q qy_0 / separable_poly q.
   move=> IHq; apply: IHq (make_separable nz_q).
   have /dvdpP[q1 Dq] := dvdp_gcdl q q^`().
-  rewrite {1}Dq mulpK ?gcdp_eq0; last by apply/nandP; left.
+  rewrite {1}Dq mulpK ?gcdp_eq0; first by apply/nandP; left.
   have [n [r nz_ry Dr]] := multiplicity_XsubC (q ^ iota) y.
   rewrite map_poly_eq0 nz_q /= in nz_ry.
   case: n => [|n] in Dr; first by rewrite Dr mulr1 (negPf nz_ry) in qy_0.
@@ -343,7 +343,7 @@ Lemma Derivation_exp x m : x \in E -> D (x ^+ m) = x ^+ m.-1 *+ m * D x.
 Proof.
 move=> Ex; case: m; first by rewrite expr0 mulr0n mul0r Derivation1.
 elim=> [|m IHm]; first by rewrite mul1r.
-rewrite exprS (Derivation_mul derD) //; last by apply: rpredX.
+rewrite exprS (Derivation_mul derD) //; first by apply: rpredX.
 by rewrite mulrC IHm mulrA mulrnAr -exprS -mulrDl.
 Qed.
 
@@ -422,7 +422,7 @@ rewrite comp_polyE size_poly_eq -?Dn ?fn1 ?oner_eq0 //.
 have pr_p := pcharf_prime pcharLp; have p_gt0 := prime_gt0 pr_p.
 apply/polyP=> i; rewrite coef_sum.
 have [[{}i ->] | p'i] := altP (@dvdnP p i); last first.
-  rewrite big1 => [|j _]; last first.
+  rewrite big1 => [j _|].
     rewrite coefZ -exprM coefXn [_ == _](contraNF _ p'i) ?mulr0 // => /eqP->.
     by rewrite dvdn_mulr.
   rewrite (dvdn_pcharf pcharLp) in p'i; apply: mulfI p'i _ _ _.
@@ -431,7 +431,7 @@ have [ltri | leir] := leqP r.+1 i.
   rewrite nth_default ?sz_f ?Dn ?ltn_pmul2r ?big1 // => j _.
   rewrite coefZ -exprM coefXn mulnC gtn_eqF ?mulr0 //.
   by rewrite ltn_pmul2l ?(leq_trans _ ltri).
-rewrite (bigD1 (Sub i _)) //= big1 ?addr0 => [|j i'j]; last first.
+rewrite (bigD1 (Sub i _)) //= big1 ?addr0 => [j i'j|].
   by rewrite coefZ -exprM coefXn mulnC eqn_pmul2l // mulr_natr mulrb ifN_eqC.
 by rewrite coef_poly leir coefZ -exprM coefXn mulnC eqxx mulr1.
 Qed.
@@ -593,7 +593,7 @@ have KyxEqKx: (<< <<K; q.[x]>>; x>> = <<K; x>>)%VS.
   apply/FadjoinP/andP; rewrite memv_adjoin andbT.
   by apply/FadjoinP/andP; rewrite subv_adjoin mempx_Fadjoin.
 have /[!KyxEqKx] derDx := extendDerivationP derD sepFyx.
-rewrite -horner_comp (Derivation_horner derDx) ?memv_adjoin //; last first.
+rewrite -horner_comp (Derivation_horner derDx) ?memv_adjoin //.
   by apply: (polyOverSv (subv_adjoin _ _)); apply: polyOver_comp.
 set Dx_p := map_poly _; have Dx_p_0 t: t \is a polyOver K -> (Dx_p t).[x] = 0.
   move/polyOverP=> Kt; congr (_.[x] = 0): (horner0 x); apply/esym/polyP => i.

--- a/fingroup/action.v
+++ b/fingroup/action.v
@@ -803,7 +803,7 @@ Proof.
 move=> GactS; have sGD := acts_dom GactS.
 transitivity (\sum_(a in G) \sum_(x in 'Fix_(S | to)[a]) 1%N).
   by apply: eq_bigr => a _; rewrite -sum1_card.
-rewrite (exchange_big_dep [in S]) /= => [|a x _]; last by case/setIP.
+rewrite (exchange_big_dep [in S]) /= => [a x _|]; first by case/setIP.
 rewrite (set_partition_big _ (orbit_partition GactS)) -sum_nat_const /=.
 apply: eq_bigr => _ /imsetP[x Sx ->].
 rewrite -(card_orbit_in_stab x sGD) -sum_nat_const.
@@ -1078,7 +1078,7 @@ Lemma astab_trans_gcore G S u :
   [transitive G, on S | to] -> u \in S -> 'C(S | to) = gcore 'C[u | to] G.
 Proof.
 move=> transG Su; apply/eqP; rewrite eqEsubset.
-rewrite gcore_max ?astabS ?sub1set //=; last first.
+rewrite gcore_max ?astabS ?sub1set //=.
   exact: subset_trans (atrans_acts transG) (astab_norm _ _).
 apply/subsetP=> x cSx; apply/astabP=> uy.
 case/(atransP2 transG Su) => y Gy ->{uy}.
@@ -1444,7 +1444,7 @@ move=> cSH /subsetIP[sGD nHG].
 apply/eqP; rewrite eqEsubset !subsetI !subsetIl /= -!astabCin ?quotientS //.
 have cfixH F: H \subset 'C(S :&: F | to).
   by rewrite (subset_trans cSH) // astabS ?subsetIl.
-rewrite andbC astab_mod ?quotientS //=; last by rewrite astabCin ?subsetIr.
+rewrite andbC astab_mod ?quotientS //=; first by rewrite astabCin ?subsetIr.
 by rewrite -(quotientSGK nHG) //= -astab_mod // astabCin ?quotientS ?subsetIr.
 Qed.
 
@@ -2382,7 +2382,7 @@ Qed.
 Lemma morph_gacent A : A \subset D1 -> h @* 'C_(|to1)(A) = 'C_(|to2)(f @* A).
 Proof.
 have [[_ defD2] [injh defR2]] := (isomP iso_f, isomP iso_h).
-move=> sAD1; rewrite !gacentE //; last by rewrite -defD2 morphimS.
+move=> sAD1; rewrite !gacentE //; first by rewrite -defD2 morphimS.
 rewrite morphimEsub ?subsetIl // -{1}defR2 morphimEdom.
 exact: (morph_afix (gact_stable to1) (injmP injh)).
 Qed.

--- a/fingroup/automorphism.v
+++ b/fingroup/automorphism.v
@@ -159,7 +159,7 @@ Hypothesis injf : 'injm f.
 Lemma morphim_fixP A : A \subset G -> reflect (f @* A = A) (f @* A \subset A).
 Proof.
 rewrite /morphim => sAG; have:= eqEcard (f @: A) A.
-rewrite (setIidPr sAG) card_in_imset ?leqnn ?andbT  => [<-|]; first exact: eqP.
+rewrite (setIidPr sAG) card_in_imset ?leqnn ?andbT  => [|<-]; last exact: eqP.
 by move/injmP: injf; apply: sub_in2; apply/subsetP.
 Qed.
 

--- a/fingroup/fingroup.v
+++ b/fingroup/fingroup.v
@@ -1791,7 +1791,7 @@ Proof. by move=> tiGH; rewrite mul_cardG tiGH cards1 muln1. Qed.
 Lemma cardMg_TI G H : #|G| * #|H| <= #|G * H| -> G :&: H = 1.
 Proof.
 move=> leGH; apply: card_le1_trivg.
-rewrite -(@leq_pmul2l #|G * H|); first by rewrite -mul_cardG muln1.
+rewrite -(@leq_pmul2l #|G * H|); last by rewrite -mul_cardG muln1.
 by apply: leq_trans leGH; rewrite muln_gt0 !cardG_gt0.
 Qed.
 
@@ -1875,7 +1875,7 @@ have B_1 n : 1 \in B ^+ n.
   by elim: n => [|n IHn]; rewrite ?set11 // expgS mulUg mul1g inE IHn.
 case: (pickP (fun i : 'I_N => B ^+ i.+1 \subset B ^+ i)) => [n fixBn | no_fix].
   exists n; apply/eqP; rewrite eqEsubset BsubG andbT.
-  rewrite -[B ^+ n]gen_set_id ?genS ?subsetUr //.
+  rewrite -[B ^+ n]gen_set_id ?genS ?subsetUr //; last first.
     by apply: subset_trans fixBn; rewrite expgS mulUg subsetU ?mulg_subl ?orbT.
   rewrite /group_set B_1 /=.
   elim: {2}(n : nat) => [|m IHm]; first by rewrite mulg1.
@@ -1923,7 +1923,7 @@ Proof. by rewrite -genJ conjUg. Qed.
 
 Lemma genD1 A x : x \in <<A :\ x>> -> <<A :\ x>> = <<A>>.
 Proof.
-move=> gA'x; apply/eqP; rewrite eqEsubset genS; last by rewrite subsetDl.
+move=> gA'x; apply/eqP; rewrite eqEsubset genS; first by rewrite subsetDl.
 rewrite gen_subG; apply/subsetP=> y Ay.
 by case: (y =P x) => [-> //|]; move/eqP=> nyx; rewrite mem_gen // !inE nyx.
 Qed.
@@ -1993,7 +1993,7 @@ Proof. by rewrite joingC joing1G. Qed.
 Lemma genM_join G H : <<G * H>> = G <*> H.
 Proof.
 apply/eqP; rewrite eqEsubset gen_subG /= -{1}[G <*> H]mulGid.
-rewrite genS; last by rewrite subUset mulG_subl mulG_subr.
+rewrite genS; first by rewrite subUset mulG_subl mulG_subr.
 by rewrite mulgSS ?(sub_gen, subsetUl, subsetUr).
 Qed.
 

--- a/fingroup/gproduct.v
+++ b/fingroup/gproduct.v
@@ -379,7 +379,7 @@ Lemma index_sdprodr G A B M :
   A ><| B = G -> M \subset B -> #|B : M| =  #|G : A <*> M|.
 Proof.
 move=> defG; case/sdprodP: defG (defG) => [[K H -> ->] mulKH nKH _] defG sMH.
-rewrite -!divgS //=; last by rewrite -genM_join gen_subG -mulKH mulgS.
+rewrite -!divgS //=; first by rewrite -genM_join gen_subG -mulKH mulgS.
 by rewrite -(sdprod_card defG) -(sdprod_card (sdprod_subr defG sMH)) divnMl.
 Qed.
 
@@ -584,7 +584,7 @@ Lemma cprod_modl A B G H :
   A \* B = G -> A \subset H -> A \* (B :&: H) = G :&: H.
 Proof.
 case/cprodP=> [[U V -> -> {A B}]] defG cUV sUH.
-by rewrite cprodE; [rewrite group_modl ?defG | rewrite subIset ?cUV].
+by rewrite cprodE; [rewrite subIset ?cUV | rewrite group_modl ?defG].
 Qed.
 
 Lemma cprod_modr A B G H :
@@ -596,13 +596,13 @@ Lemma bigcprodYP (I : finType) (P : pred I) (H : I -> {group gT}) :
           (\big[cprod/1]_(i | P i) H i == (\prod_(i | P i) H i)%G).
 Proof.
 apply: (iffP eqP) => [defG i j Pi Pj neq_ij | cHH].
-  rewrite (bigD1 j) // (bigD1 i) /= ?cprodA in defG; last exact/andP.
+  rewrite (bigD1 j) // (bigD1 i) /= ?cprodA in defG; first exact/andP.
   by case/cprodP: defG => [[K _ /cprodP[//]]].
 set Q := P; have sQP: subpred Q P by []; have [n leQn] := ubnP #|Q|.
 elim: n => // n IHn in (Q) leQn sQP *.
 have [i Qi | Q0] := pickP Q; last by rewrite !big_pred0.
 rewrite (cardD1x Qi) add1n ltnS !(bigD1 i Qi) /= in leQn *.
-rewrite {}IHn {n leQn}// => [|j /andP[/sQP //]].
+rewrite {}IHn {n leQn}// => [j /andP[/sQP //]|].
 rewrite bigprodGE cprodEY // gen_subG; apply/bigcupsP=> j /andP[neq_ji Qj].
 by rewrite cHH ?sQP.
 Qed.
@@ -774,7 +774,7 @@ set Q := P; have sQP: subpred Q P by []; have [n leQn] := ubnP #|Q|.
 elim: n => // n IHn in (Q) leQn sQP *.
 have [i Qi | Q0] := pickP Q; last by rewrite !big_pred0.
 rewrite (cardD1x Qi) add1n ltnS !(bigD1 i Qi) /= in leQn *.
-rewrite {}IHn {n leQn}// => [|j /andP[/sQP //]].
+rewrite {}IHn {n leQn}// => [j /andP[/sQP //]|].
 apply/dprodYP; apply: subset_trans (dxG i (sQP i Qi)); rewrite !bigprodGE.
 by apply: genS; apply/bigcupsP=> j /andP[Qj ne_ji]; rewrite (bigcup_max j) ?sQP.
 Qed.
@@ -783,7 +783,7 @@ Lemma dprod_modl A B G H :
   A \x B = G -> A \subset H -> A \x (B :&: H) = G :&: H.
 Proof.
 case/dprodP=> [[U V -> -> {A B}]] defG cUV trUV sUH.
-rewrite dprodEcp; first by apply: cprod_modl; rewrite ?cprodE.
+rewrite dprodEcp; last by apply: cprod_modl; rewrite ?cprodE.
 by rewrite setIA trUV (setIidPl _) ?sub1G.
 Qed.
 
@@ -948,7 +948,7 @@ Proof.
 elim/big_rec2: _ G => [|i fB B Pi def_fB] G sGD defG.
   by rewrite -defG morphim1.
 case/cprodP: defG (defG) => [[Hi Gi -> defB] _ _]; rewrite defB => defG.
-rewrite (def_fB Gi) //; first exact: morphim_cprod.
+rewrite (def_fB Gi) //; last exact: morphim_cprod.
 by apply: subset_trans sGD; case/cprod_normal2: defG => _ /andP[].
 Qed.
 
@@ -959,7 +959,7 @@ Proof.
 move=> sGD injf; elim/big_rec2: _ G sGD => [|i fB B Pi def_fB] G sGD defG.
   by rewrite -defG morphim1.
 case/dprodP: defG (defG) => [[Hi Gi -> defB] _ _ _]; rewrite defB => defG.
-rewrite (def_fB Gi) //; first exact: injm_dprod.
+rewrite (def_fB Gi) //; last exact: injm_dprod.
 by apply: subset_trans sGD; case/dprod_normal2: defG => _ /andP[].
 Qed.
 
@@ -1273,7 +1273,7 @@ suff -> : \big[dprod/1]_i groupXn1 (H i) = (\prod_i groupXn1 (H i))%G.
   by rewrite comm_prodG//=; apply: in2W; apply: set1gXn_commute.
 apply/eqP; apply/bigdprodYP => i //= _; rewrite subsetD.
 apply/andP; split.
-  rewrite comm_prodG; last by apply: in2W; apply: set1gXn_commute.
+  rewrite comm_prodG; first by apply: in2W; apply: set1gXn_commute.
   apply/centsP => _ /prodsgP[/= h_ h_P ->] _ /set1gXnP [h hH ->].
   apply/ffunP => j; rewrite !ffunE/=.
   rewrite (big_morph _ (@dffunM j) (_ : _ = 1)) ?ffunE//.
@@ -1281,7 +1281,7 @@ apply/andP; split.
   rewrite big1 ?mulg1 ?mul1g// => j neq_ji.
   by have /set1gXnP[? _ ->] := h_P j neq_ji; rewrite ffunE dfwith_out.
 rewrite -setI_eq0 -subset0; apply/subsetP => /= x; rewrite !inE.
-rewrite comm_prodG; last by apply: in2W; apply: set1gXn_commute.
+rewrite comm_prodG; first by apply: in2W; apply: set1gXn_commute.
 move=> /and3P[+ + /set1gXnP [h _ x_h]]; rewrite {x}x_h.
 move=> /prodsgP[x_ x_P /ffunP/(_ i)]; rewrite ffunE dfwith_in => {h}->.
 apply: contra_neqT => _; apply/ffunP => j; rewrite !ffunE/=.
@@ -1300,7 +1300,7 @@ Qed.
 Lemma setXn_gen H : (forall i, 1 \in H i) -> 
   <<setXn H>> = setXn (fun i => <<H i>>).
 Proof.
-move=> H1; apply/eqP; rewrite eqEsubset gen_subG setXnS/=; last first.
+move=> H1; apply/eqP; rewrite eqEsubset gen_subG setXnS/=.
   by move=> ?; rewrite subset_gen.
 rewrite -[in X in X \subset _]setXn_prod; under eq_bigr do
    rewrite -morphim_dfung1 morphim_gen ?subsetT// morphim_dfung1.
@@ -1426,7 +1426,7 @@ Lemma sdpair_setact (G : {set rT}) a : G \subset R -> a \in D ->
   sdpair1 @* (to^~ a @: G) = (sdpair1 @* G) :^ sdpair2 a.
 Proof.
 move=> sGR Da; have GtoR := subsetP sGR; apply/eqP.
-rewrite eqEcard cardJg !(card_injm injm_sdpair1) //; last first.
+rewrite eqEcard cardJg !(card_injm injm_sdpair1) //.
   by apply/subsetP=> _ /imsetP[x Gx ->]; rewrite gact_stable ?GtoR.
 rewrite (card_imset _ (act_inj _ _)) leqnn andbT.
 apply/subsetP=> _ /morphimP[xa Rxa /imsetP[x Gx def_xa ->]].
@@ -1558,7 +1558,7 @@ Canonical pprodm_morphism := Morphism pprodmM.
 Lemma morphim_pprodm A B :
   A \subset H -> B \subset K -> f @* (A * B) = fH @* A * fK @* B.
 Proof.
-move=> sAH sBK; rewrite [f @* _]morphimEsub /=; last first.
+move=> sAH sBK; rewrite [f @* _]morphimEsub /=.
   by rewrite norm_joinEr // mulgSS.
 apply/setP=> y; apply/imsetP/idP=> [[_ /mulsgP[x a Ax Ba ->] ->{y}] |].
   have Hx := subsetP sAH x Ax; have Ka := subsetP sBK a Ba.

--- a/fingroup/morphism.v
+++ b/fingroup/morphism.v
@@ -544,7 +544,7 @@ Lemma ltn_morphim A : [1] \proper 'ker_A f -> #|f @* A| < #|A|.
 Proof.
 case/properP; rewrite sub1set => /setIP[A1 _] [x /setIP[Ax kx] x1].
 rewrite (cardsD1 1 A) A1 ltnS -{1}(setD1K A1) morphimU morphim1.
-rewrite (setUidPr _) ?sub1set; last first.
+rewrite (setUidPr _) ?sub1set.
   by rewrite -(mker kx) mem_morphim ?(dom_ker kx) // inE x1.
 by rewrite (leq_trans (leq_imset_card _ _)) ?subset_leq_card ?subsetIr.
 Qed.
@@ -574,7 +574,7 @@ Proof. by move=> nsGf nsHf /morphim_injG->. Qed.
 Lemma morphim_gen A : A \subset D -> f @* <<A>> = <<f @* A>>.
 Proof.
 move=> sAD; apply/eqP.
-rewrite eqEsubset andbC gen_subG morphimS; last exact: subset_gen.
+rewrite eqEsubset andbC gen_subG morphimS; first exact: subset_gen.
 by rewrite sub_morphim_pre gen_subG // -sub_morphim_pre // subset_gen.
 Qed.
 
@@ -589,7 +589,7 @@ Lemma morphpre_gen R :
   1 \in R -> R \subset f @* D -> f @*^-1 <<R>> = <<f @*^-1 R>>.
 Proof.
 move=> R1 sRfD; apply/eqP.
-rewrite eqEsubset andbC gen_subG morphpreS; last exact: subset_gen.
+rewrite eqEsubset andbC gen_subG morphpreS; first exact: subset_gen.
 rewrite -{1}(morphpreK sRfD) -morphim_gen ?subsetIl // morphimGK //=.
   by rewrite sub_gen // setIS // preimsetS ?sub1set.
 by rewrite gen_subG subsetIl.
@@ -601,7 +601,7 @@ Lemma morphimR A B :
   A \subset D -> B \subset D -> f @* [~: A, B] = [~: f @* A, f @* B].
 Proof.
 move/subsetP=> sAD /subsetP sBD.
-rewrite morphim_gen; last first; last congr <<_>>.
+rewrite morphim_gen; last congr <<_>>.
   by apply/subsetP=> _ /imset2P[x y Ax By ->]; rewrite groupR; auto.
 apply/setP=> fz; apply/morphimP/imset2P=> [[z _] | [fx fy]].
   case/imset2P=> x y Ax By -> -> {z fz}.
@@ -1060,7 +1060,7 @@ Canonical factm_morphism := Morphism factm_morphM.
 
 Lemma morphim_factm (A : {set aT}) : ff @* (q @* A) = f @* A.
 Proof.
-rewrite -morphim_comp /= {1}/morphim /= morphimGK //; last first.
+rewrite -morphim_comp /= {1}/morphim /= morphimGK //.
   by rewrite (subset_trans sKqKf) ?subsetIl.
 apply/setP=> y; apply/morphimP/morphimP;
   by case=> x Gx Ax ->{y}; exists x; rewrite //= factmE.

--- a/fingroup/perm.v
+++ b/fingroup/perm.v
@@ -268,22 +268,23 @@ rewrite -ffactnn -{2}(card_sig [in A]) /= -card_inj_ffuns_on.
 pose fT (f : ffA) := [ffun x => oapp f x (insub x)].
 pose pfT f := insubd (1 : {perm T}) (fT f).
 pose fA s : ffA := [ffun u => s (val u)].
-rewrite -!sum1dep_card -sum1_card (reindex_onto fA pfT) => [|f].
-  apply: eq_bigl => p; rewrite andbC; apply/idP/and3P=> [onA | []]; first split.
-  - apply/eqP; suffices fTAp: fT (fA p) = pval p.
-      by apply/permP=> x; rewrite -!pvalE insubdK fTAp //; apply: (valP p).
-    apply/ffunP=> x; rewrite ffunE pvalE.
-    by case: insubP => [u _ <- | /out_perm->] //=; rewrite ffunE.
-  - by apply/forallP=> [[x Ax]]; rewrite ffunE /= perm_closed.
-  - by apply/injectiveP=> u v; rewrite !ffunE => /perm_inj; apply: val_inj.
-  move/eqP=> <- _ _; apply/subsetP=> x; rewrite !inE -pvalE val_insubd fun_if.
-  by rewrite if_arg ffunE; case: insubP; rewrite // pvalE perm1 if_same eqxx.
-case/andP=> /forallP-onA /injectiveP-f_inj.
-apply/ffunP=> u; rewrite ffunE -pvalE insubdK; first by rewrite ffunE valK.
-apply/injectiveP=> {u} x y; rewrite !ffunE.
-case: insubP => [u _ <-|]; case: insubP => [v _ <-|] //=; first by move/f_inj->.
-  by move=> Ay' def_y; rewrite -def_y [_ \in A]onA in Ay'.
-by move=> Ax' def_x; rewrite def_x [_ \in A]onA in Ax'.
+rewrite -!sum1dep_card -sum1_card (reindex_onto fA pfT) => [f|].
+  case/andP=> /forallP-onA /injectiveP-f_inj.
+  apply/ffunP=> u; rewrite ffunE -pvalE insubdK; last by rewrite ffunE valK.
+  apply/injectiveP=> {u} x y; rewrite !ffunE.
+  case: insubP => [u _ <-|]; case: insubP => [v _ <-|] //=.
+  - by move/f_inj->.
+  - by move=> Ay' def_y; rewrite -def_y [_ \in A]onA in Ay'.
+  by move=> Ax' def_x; rewrite def_x [_ \in A]onA in Ax'.
+apply: eq_bigl => p; rewrite andbC; apply/idP/and3P=> [onA | []]; first split.
+- apply/eqP; suffices fTAp: fT (fA p) = pval p.
+    by apply/permP=> x; rewrite -!pvalE insubdK fTAp //; apply: (valP p).
+  apply/ffunP=> x; rewrite ffunE pvalE.
+  by case: insubP => [u _ <- | /out_perm->] //=; rewrite ffunE.
+- by apply/forallP=> [[x Ax]]; rewrite ffunE /= perm_closed.
+- by apply/injectiveP=> u v; rewrite !ffunE => /perm_inj; apply: val_inj.
+move/eqP=> <- _ _; apply/subsetP=> x; rewrite !inE -pvalE val_insubd fun_if.
+by rewrite if_arg ffunE; case: insubP; rewrite // pvalE perm1 if_same eqxx.
 Qed.
 
 End Theory.
@@ -597,7 +598,7 @@ Implicit Types s t : 'S_n.
 
 Lemma card_Sn : #|'S_(n)| = n`!.
 Proof.
-rewrite (eq_card (B := perm_on [set : 'I_n])).
+rewrite (eq_card (B := perm_on [set : 'I_n])); last first.
   by rewrite card_perm /= cardsE /= card_ord.
 move=> p; rewrite inE unfold_in /perm_on /=.
 by apply/esym/subsetP => i _; rewrite in_set.
@@ -655,7 +656,7 @@ elim: {k}(k : nat) {1 3}k (erefl (k : nat)) => [|m IHm] k def_k.
   by rewrite (_ : k = ord0) ?lift_perm1 ?odd_perm1 //; apply: val_inj.
 have le_mn: m < n.+1 by [rewrite -def_k ltnW]; pose j := Ordinal le_mn.
 rewrite -(mulg1 1)%g -(lift_permM _ j) odd_permM {}IHm // addbC.
-rewrite (_ : _ 1 = tperm j k); first by rewrite odd_tperm neq_ltn/= def_k leqnn.
+rewrite (_ : _ 1 = tperm j k); last by rewrite odd_tperm neq_ltn/= def_k leqnn.
 apply/permP=> i; case: (unliftP j i) => [i'|] ->; last first.
   by rewrite lift_perm_id tpermL.
 apply: ord_inj; rewrite lift_perm_lift !permE /= eq_sym -if_neg neq_lift.

--- a/fingroup/quotient.v
+++ b/fingroup/quotient.v
@@ -843,7 +843,7 @@ case/andP=> sHK nHK chHG.
 have nsHG := char_normal chHG; have [sHG nHG] := andP nsHG.
 case/charP; rewrite quotientSGK // => sKG /= chKG.
 apply/charP; split=> // f injf Gf; apply/morphim_fixP => //.
-rewrite -(quotientSGK _ sHK); last by rewrite -morphimIim Gf subIset ?nHG.
+rewrite -(quotientSGK _ sHK); first by rewrite -morphimIim Gf subIset ?nHG.
 have{chHG} Hf: f @* H = H by case/charP: chHG => _; apply.
 set q := quotm_morphism f nsHG; have{injf}: 'injm q by apply: injm_quotm.
 have: q @* _ = _ := morphim_quotm _ _ _; move: q; rewrite Hf => q im_q injq.
@@ -860,7 +860,7 @@ Implicit Types L M : {group rT}.
 
 Lemma card_morphim G : #|f @* G| = #|D :&: G : 'ker f|.
 Proof.
-rewrite -morphimIdom -indexgI -card_quotient; last first.
+rewrite -morphimIdom -indexgI -card_quotient.
   by rewrite normsI ?normG ?subIset ?ker_norm.
 by apply: esym (card_isog _); rewrite first_isog_loc ?subsetIl.
 Qed.

--- a/order/order.v
+++ b/order/order.v
@@ -3455,7 +3455,7 @@ Lemma sorted_filter_gt x s :
   sorted <=%O s -> [seq y <- s | x < y] = drop (count (<= x) s) s.
 Proof.
 move=> s_sorted; rewrite count_le_gt -[LHS]revK -filter_rev.
-rewrite (@sorted_filter_lt _ T^d); first by rewrite take_rev revK count_rev.
+rewrite (@sorted_filter_lt _ T^d); last by rewrite take_rev revK count_rev.
 by rewrite rev_sorted.
 Qed.
 
@@ -3463,7 +3463,7 @@ Lemma sorted_filter_ge x s :
   sorted <=%O s -> [seq y <- s | x <= y] = drop (count (< x) s) s.
 Proof.
 move=> s_sorted; rewrite count_lt_ge -[LHS]revK -filter_rev.
-rewrite (@sorted_filter_le _ T^d); first by rewrite take_rev revK count_rev.
+rewrite (@sorted_filter_le _ T^d); last by rewrite take_rev revK count_rev.
 by rewrite rev_sorted.
 Qed.
 

--- a/order/preorder.v
+++ b/order/preorder.v
@@ -3660,7 +3660,7 @@ Proof. by move=> x; apply: enum_rankK_in. Qed.
 
 Lemma enum_valK_in x0 A Ax0 : cancel enum_val (@enum_rank_in x0 A Ax0).
 Proof.
-move=> x; apply: ord_inj; rewrite insubdK; last first.
+move=> x; apply: ord_inj; rewrite insubdK.
   by rewrite cardE [_ \in _]index_mem mem_nth // -cardE.
 by rewrite index_uniq ?enum_uniq // -cardE.
 Qed.

--- a/solvable/abelian.v
+++ b/solvable/abelian.v
@@ -333,7 +333,7 @@ Proof.
 case/cprodP=> [[K H -> ->{A B}] <- cKH].
 apply/eqP; rewrite eqn_dvd dvdn_lcm !exponentS ?mulG_subl ?mulG_subr //=.
 apply/exponentP=> _ /imset2P[x y Kx Hy ->].
-rewrite -[1]mulg1 expgMn; last by red; rewrite -(centsP cKH).
+rewrite -[1]mulg1 expgMn; first by red; rewrite -(centsP cKH).
 congr (_ * _); apply/eqP; rewrite -order_dvdn.
   by rewrite (dvdn_trans (dvdn_exponent Kx)) ?dvdn_lcml.
 by rewrite (dvdn_trans (dvdn_exponent Hy)) ?dvdn_lcmr.
@@ -462,7 +462,7 @@ apply/idP/andP=> [abelG | []].
 case/and3P=> pH cHH expHp; case/and3P=> pK cKK expKp.
 rewrite -defG /abelem pgroupM pH pK abelianM cHH cKK cHK /=.
 apply/exponentP=> _ /imset2P[x y Hx Ky ->].
-rewrite expgMn; last by red; rewrite -(centsP cHK).
+rewrite expgMn; first by red; rewrite -(centsP cHK).
 by rewrite (exponentP expHp) // (exponentP expKp) // mul1g.
 Qed.
 
@@ -690,10 +690,10 @@ Proof.
 move=> p_pr; apply: (iffP (pmaxElemP p G E)) => [[] | defE].
   case/pElemP=> sEG abelE maxE; have [_ cEE eE] := and3P abelE.
   apply/setP=> x; rewrite !inE -andbA; apply/and3P/idP=> [[Gx cEx xp] | Ex].
-    rewrite -(maxE (<[x]> <*> E)%G) ?joing_subr //.
+    rewrite -(maxE (<[x]> <*> E)%G) ?joing_subr //; last first.
       by rewrite -cycle_subG joing_subl.
     rewrite inE join_subG cycle_subG Gx sEG /=.
-    rewrite (cprod_abelem _ (cprodEY _)); last by rewrite centsC cycle_subG.
+    rewrite (cprod_abelem _ (cprodEY _)); first by rewrite centsC cycle_subG.
     by rewrite cycle_abelem ?p_pr ?orbT // order_dvdn xp.
   by rewrite (subsetP sEG) // (subsetP cEE) // (exponentP eE).
 split=> [|H]; last first.
@@ -773,8 +773,8 @@ Qed.
 Lemma p_rank_abelem p G : p.-abelem G -> 'r_p(G) = logn p #|G|.
 Proof.
 move=> abelG; apply/eqP; rewrite eqn_leq andbC (bigmax_sup G)//.
-  by apply/bigmax_leqP=> E /[1!inE] /andP[/lognSg->].
-by rewrite inE subxx.
+  by rewrite inE subxx.
+by apply/bigmax_leqP=> E /[1!inE] /andP[/lognSg->].
 Qed.
 
 Lemma p_rankS p A B : A \subset B -> 'r_p(A) <= 'r_p(B).
@@ -973,7 +973,7 @@ Lemma injm_Ldiv n A : f @* 'Ldiv_n(A) = 'Ldiv_n(f @* A).
 Proof.
 apply/eqP; rewrite eqEsubset morphim_Ldiv.
 rewrite -[f @* 'Ldiv_n(A)](morphpre_invm injf).
-rewrite -sub_morphim_pre; last by rewrite subIset ?morphim_sub.
+rewrite -sub_morphim_pre; first by rewrite subIset ?morphim_sub.
 rewrite injmI ?injm_invm // setISS ?morphim_LdivT //.
 by rewrite sub_morphim_pre ?morphim_sub // morphpre_invm.
 Qed.
@@ -1105,7 +1105,7 @@ Proof.
 move=> defG; apply/eqP; rewrite eqn_leq -leq_subLR andbC.
 have [_ defKH cKH tiKH] := dprodP defG; have nKH := cents_norm cKH.
 rewrite {1}(isog_p_rank (quotient_isog nKH tiKH)) /= -quotientMidl defKH.
-rewrite p_rank_quotient; last by rewrite -defKH mul_subG ?normG.
+rewrite p_rank_quotient; first by rewrite -defKH mul_subG ?normG.
 have [[E EpE] [F EpF]] := (p_rank_witness p K, p_rank_witness p H).
 have [[sEK abelE <-] [sFH abelF <-]] := (pnElemP EpE, pnElemP EpF).
 have defEF: E \x F = E <*> F.
@@ -1149,7 +1149,7 @@ Qed.
 Lemma Ohm_cont rT G (f : {morphism G >-> rT}) :
   f @* 'Ohm_n(G) \subset 'Ohm_n(f @* G).
 Proof.
-rewrite morphim_gen ?genS //; last by rewrite -gen_subG Ohm_sub.
+rewrite morphim_gen ?genS //; first by rewrite -gen_subG Ohm_sub.
 apply/subsetP=> fx /morphimP[x Gx]; rewrite inE Gx /=.
 case/OhmPredP=> p p_pr xpn_1 -> {fx}.
 rewrite inE morphimEdom imset_f //=; apply/OhmPredP; exists p => //.
@@ -1181,26 +1181,26 @@ Lemma Ohm_p_cycle p x :
   p.-elt x -> 'Ohm_n(<[x]>) = <[x ^+ (p ^ (logn p #[x] - n))]>.
 Proof.
 move=> p_x; apply/eqP; rewrite (OhmE p_x) eqEsubset cycle_subG mem_gen.
-  rewrite gen_subG andbT; apply/subsetP=> y /LdivP[x_y ypn].
-  case: (leqP (logn p #[x]) n) => [|lt_n_x].
-    by rewrite -subn_eq0 => /eqP->.
-  have p_pr: prime p by move: lt_n_x; rewrite lognE; case: (prime p).
-  have def_y: <[y]> = <[x ^+ (#[x] %/ #[y])]>.
-    apply: congr_group; apply/set1P.
-    by rewrite -cycle_sub_group ?cardSg ?inE ?cycle_subG ?x_y /=.
-  rewrite -cycle_subG def_y cycle_subG -{1}(part_pnat_id p_x) p_part.
-  rewrite -{1}(subnK (ltnW lt_n_x)) expnD -muln_divA ?order_dvdn ?ypn //.
-  by rewrite expgM mem_cycle.
-rewrite !inE mem_cycle -expgM -expnD addnC -maxnE -order_dvdn.
-by rewrite -{1}(part_pnat_id p_x) p_part dvdn_exp2l ?leq_maxr.
+  rewrite !inE mem_cycle -expgM -expnD addnC -maxnE -order_dvdn.
+  by rewrite -{1}(part_pnat_id p_x) p_part dvdn_exp2l ?leq_maxr.
+rewrite gen_subG andbT; apply/subsetP=> y /LdivP[x_y ypn].
+case: (leqP (logn p #[x]) n) => [|lt_n_x].
+  by rewrite -subn_eq0 => /eqP->.
+have p_pr: prime p by move: lt_n_x; rewrite lognE; case: (prime p).
+have def_y: <[y]> = <[x ^+ (#[x] %/ #[y])]>.
+  apply: congr_group; apply/set1P.
+  by rewrite -cycle_sub_group ?cardSg ?inE ?cycle_subG ?x_y /=.
+rewrite -cycle_subG def_y cycle_subG -{1}(part_pnat_id p_x) p_part.
+rewrite -{1}(subnK (ltnW lt_n_x)) expnD -muln_divA ?order_dvdn ?ypn //.
+by rewrite expgM mem_cycle.
 Qed.
 
 Lemma Ohm_dprod A B G : A \x B = G -> 'Ohm_n(A) \x 'Ohm_n(B) = 'Ohm_n(G).
 Proof.
 case/dprodP => [[H K -> ->{A B}]] <- cHK tiHK.
-rewrite dprodEY //; last first.
-- by apply/trivgP; rewrite -tiHK setISS ?Ohm_sub.
+rewrite dprodEY //.
 - by rewrite (subset_trans (subset_trans _ cHK)) ?centS ?Ohm_sub.
+- by apply/trivgP; rewrite -tiHK setISS ?Ohm_sub.
 apply/eqP; rewrite -(cent_joinEr cHK) eqEsubset join_subG /=.
 rewrite !OhmS ?joing_subl ?joing_subr //= cent_joinEr //= -genM_join genS //.
 apply/subsetP=> _ /setIdP[/imset2P[x y Hx Ky ->] /OhmPredP[p p_pr /eqP]].
@@ -1259,7 +1259,7 @@ Proof.
 move=> pG cGG; rewrite (MhoE pG); rewrite gen_set_id //; apply/group_setP.
 split=> [|xn yn]; first by apply/imsetP; exists 1; rewrite ?expg1n.
 case/imsetP=> x Gx ->; case/imsetP=> y Gy ->.
-by rewrite -expgMn; [apply: imset_f; rewrite groupM | apply: (centsP cGG)].
+by rewrite -expgMn; [apply: (centsP cGG) | apply: imset_f; rewrite groupM].
 Qed.
 
 Lemma trivg_Mho G : 'Mho^n(G) == 1 -> 'Ohm_n(G) == G.
@@ -1275,7 +1275,7 @@ Qed.
 Lemma Mho_p_cycle p x : p.-elt x -> 'Mho^n(<[x]>) = <[x ^+ (p ^ n)]>.
 Proof.
 move=> p_x.
-apply/eqP; rewrite (MhoE p_x) eqEsubset cycle_subG mem_gen; last first.
+apply/eqP; rewrite (MhoE p_x) eqEsubset cycle_subG mem_gen.
   by apply: imset_f; apply: cycle_id.
 rewrite gen_subG andbT; apply/subsetP=> _ /imsetP[_ /cycleP[k ->] ->].
 by rewrite -expgM mulnC expgM mem_cycle.
@@ -1283,21 +1283,21 @@ Qed.
 
 Lemma Mho_cprod A B G : A \* B = G -> 'Mho^n(A) \* 'Mho^n(B) = 'Mho^n(G).
 Proof.
-case/cprodP => [[H K -> ->{A B}]] <- cHK; rewrite cprodEY //; last first.
+case/cprodP => [[H K -> ->{A B}]] <- cHK; rewrite cprodEY //.
   by rewrite (subset_trans (subset_trans _ cHK)) ?centS ?Mho_sub.
 apply/eqP; rewrite -(cent_joinEr cHK) eqEsubset join_subG /=.
 rewrite !MhoS ?joing_subl ?joing_subr //= cent_joinEr // -genM_join.
 apply: genS; apply/subsetP=> xypn /imsetP[_ /setIdP[/imset2P[x y Hx Ky ->]]].
 move/constt_p_elt; move: (pdiv _) => p <- ->.
 have cxy: commute x y by red; rewrite -(centsP cHK).
-rewrite consttM // expgMn; last exact: commuteX2.
+rewrite consttM // expgMn; first exact: commuteX2.
 by rewrite mem_mulg ?Mho_p_elt ?groupX ?p_elt_constt.
 Qed.
 
 Lemma Mho_dprod A B G : A \x B = G -> 'Mho^n(A) \x 'Mho^n(B) = 'Mho^n(G).
 Proof.
 case/dprodP => [[H K -> ->{A B}]] defG cHK tiHK.
-rewrite dprodEcp; first by apply: Mho_cprod; rewrite cprodE.
+rewrite dprodEcp; last by apply: Mho_cprod; rewrite cprodE.
 by apply/trivgP; rewrite -tiHK setISS ?Mho_sub.
 Qed.
 
@@ -1516,7 +1516,7 @@ Proof.
 move=> cGG; have nilG := abelian_nil cGG; case p_pr: (prime p); last first.
   by apply/eqP; rewrite lognE p_pr eqn0Ngt p_rank_gt0 mem_primes p_pr.
 case/dprodP: (Ohm_dprod 1 (nilpotent_pcoreC p nilG)) => _ <- _ /TI_cardMg->.
-rewrite mulnC logn_Gauss; last first.
+rewrite mulnC logn_Gauss.
   rewrite prime_coprime // -p'natE // -/(pgroup _ _).
   exact: pgroupS (Ohm_sub _ _) (pcore_pgroup _ _).
 rewrite -(p_rank_Sylow (nilpotent_pcore_Hall p nilG)) -p_rank_Ohm1.
@@ -1562,8 +1562,8 @@ rewrite leq_eqVlt => /predU1P[{xp_yp m IHm leym}oy | ltpy]; last first.
     by move/IHm; apply; rewrite groupMr // groupV groupX ?cycle_id.
   apply: leq_ltn_trans (leq_trans ltpy leym).
   rewrite dvdn_leq ?prime_gt0 // order_dvdn expgMn.
-    by rewrite expgVn def_yp mulgV.
-  by apply: (centsP cGG); rewrite ?groupV ?groupX.
+    by apply: (centsP cGG); rewrite ?groupV ?groupX.
+  by rewrite expgVn def_yp mulgV.
 pose Y := <[y]>; have nsYG: Y <| G by rewrite -sub_abelian_normal ?cycle_subG.
 have [sYG nYG] := andP nsYG; have nYx := subsetP nYG x Gx.
 have GxY: coset Y x \in G / Y by rewrite mem_morphim.
@@ -1604,7 +1604,7 @@ have ltKm: #|K| < m.
   by rewrite subsetI subxx cycle_subG.
 case/splitsP: (IHm _ _ ltKm (abelemS sKG abelG) (subsetIr H K)) => L.
 case/complP=> tiHKL defK; apply/splitsP; exists L; rewrite inE.
-rewrite -subG1 -tiHKL -setIA setIS; last by rewrite subsetI -defK mulG_subr /=.
+rewrite -subG1 -tiHKL -setIA setIS; first by rewrite subsetI -defK mulG_subr /=.
 by rewrite -(setIidPr sHG) -defG -group_modl ?cycle_subG //= setIC -mulgA defK.
 Qed.
 
@@ -1693,8 +1693,8 @@ have{lnOx} lnOy i: lnO i <[x]> = lnO i <[y]>.
   have co_yx': coprime #[y] #[x.`_p^'] by rewrite !order_constt coprime_partC.
   have defX: <[y]> \x <[x.`_p^']> = <[x]>.
     rewrite dprodE ?coprime_TIg //.
-      by rewrite -cycleM ?consttC //; apply: (centsP cXX); apply: mem_cycle.
-    by apply: (sub_abelian_cent2 cXX); rewrite cycle_subG mem_cycle.
+      by apply: (sub_abelian_cent2 cXX); rewrite cycle_subG mem_cycle.
+    by rewrite -cycleM ?consttC //; apply: (centsP cXX); apply: mem_cycle.
   rewrite -(lnOx i _ _ _ defX) addnC {1}/lnO lognE.
   case: and3P => // [[p_pr _ /idPn[]]]; rewrite -p'natE //.
   exact: pgroupS (Ohm_sub _ _) (p_elt_constt _ _).
@@ -1791,11 +1791,11 @@ case p_x: (p_group <[x]>); last first.
   rewrite -(dprod_card (Ohm_dprod n def_x)) -(dprod_card (Mho_dprod n def_x)).
   rewrite mulnCA -mulnA mulnCA mulnA.
   rewrite !{}IHm ?(dprod_card def_x) ?(leq_trans _ lexm) {m lexm}//.
-    rewrite /order -(dprod_card def_x) -!orderE !order_constt ltn_Pmull //.
-    rewrite p_part -(expn0 p) ltn_exp2l 1?lognE ?prime_gt1 ?pdiv_prime //.
-    by rewrite order_gt0 pdiv_dvd.
-  rewrite proper_card // properEneq cycle_subG mem_cycle andbT.
-  by apply: contra (negbT p'x); move/eqP <-; apply: p_elt_constt.
+    rewrite proper_card // properEneq cycle_subG mem_cycle andbT.
+    by apply: contra (negbT p'x); move/eqP <-; apply: p_elt_constt.
+  rewrite /order -(dprod_card def_x) -!orderE !order_constt ltn_Pmull //.
+  rewrite p_part -(expn0 p) ltn_exp2l 1?lognE ?prime_gt1 ?pdiv_prime //.
+  by rewrite order_gt0 pdiv_dvd.
 case/p_groupP: p_x => p p_pr p_x.
 rewrite (Ohm_p_cycle n p_x) (Mho_p_cycle n p_x) -!orderE.
 set k := logn p #[x]; have ox: #[x] = (p ^ k)%N by rewrite -card_pgroup.
@@ -1905,7 +1905,7 @@ rewrite leq_pmul2l //; apply: contraLR.
 rewrite eqn_dvd dvdn_exponent //= -ltnNge => lt_x_e.
 rewrite (leq_trans (ltn_Pmull (prime_gt1 p_pr) _)) ?expn_gt0 ?prime_gt0 //.
 rewrite -expnS dvdn_leq // ?gcdn_gt0 ?order_gt0 // dvdn_gcd.
-rewrite pfactor_dvdn // dvdn_exp2l.
+rewrite pfactor_dvdn // dvdn_exp2l; last first.
   by rewrite -[ltnRHS]subn0 ltn_sub2l // lognE p_pr order_gt0 p_dv_x.
 rewrite ltn_sub2r // ltnNge -(dvdn_Pexp2l _ _ (prime_gt1 p_pr)) -!p_part.
 by rewrite !part_pnat_id // (pnat_dvd (exponent_dvdn G)).
@@ -2013,7 +2013,7 @@ Lemma exponent_dprod_homocyclic p K H G :
 Proof.
 move=> defG pG homG ntK; have [homK _] := dprod_homocyclic defG pG homG.
 have [] := abelian_type_dprod_homocyclic defG pG homG.
-by rewrite abelian_type_homocyclic // -['r(K)]prednK ?rank_gt0 => [[]|].
+by rewrite abelian_type_homocyclic // -['r(K)]prednK ?rank_gt0 => [|[]].
 Qed.
 
 End AbelianStructure.

--- a/solvable/alt.v
+++ b/solvable/alt.v
@@ -171,7 +171,7 @@ pose A3 := [set x : {perm T} | #[x] == 3]; suffices oA3: #|A :&: A3| = 8.
   rewrite -(([set P] =P 'Syl_2(A)) _) ?cards1 // eqEsubset sub1set inE sylP.
   by apply/subsetP=> Q sylQ; rewrite inE -val_eqE /= !sQ2 // inE.
 rewrite -[8]/(4 * 2)%N -{}oQ3 -sum1_card -sum_nat_const.
-rewrite (partition_big (fun x => <[x]>%G) [in 'Syl_3(A)]) => [|x]; last first.
+rewrite (partition_big (fun x => <[x]>%G) [in 'Syl_3(A)]) => [x|].
   by case/setIP=> Ax; rewrite /= !inE pHallE p_part cycle_subG Ax oA.
 apply: eq_bigr => Q; rewrite inE pHallE oA p_part -?natTrecE //=.
 case/andP=> sQA /eqP oQ; have:= oQ.
@@ -353,7 +353,7 @@ have{le_p_n} lt_p1_n: #|[set x | p1 x != x]| < n.
 transitivity (p1 (+) true); last first.
   by rewrite odd_permM odd_tperm -Hx1 inE eq_sym addbK.
 have ->: p = p1 * tperm x1 (p x1) by rewrite -tpermV mulgK.
-rewrite morphM; last 2 first; first by rewrite 2!inE; apply/astab1P.
+rewrite morphM; last 2 first; last by rewrite 2!inE; apply/astab1P.
   by rewrite 2!inE; apply/astab1P; rewrite -[RHS]p1x_x permM px_x.
 rewrite odd_permM IHn //=; congr (_ (+) _).
 pose x2 : T' := Sub x1 nx1x; pose px2 : T' := Sub (p x1) npx1x.
@@ -378,7 +378,7 @@ apply/isogP; exists [morphism of restrm sSd rfd] => /=; last first.
   have dz': rgd z x == x by rewrite rgd_x.
   move=> kz; exists (rgd z); last by rewrite /= rfd_rgd.
     by rewrite 2!inE (sameP astab1P eqP).
-  rewrite 4!inE /= (sameP astab1P eqP) dz' -rfd_odd; last exact/eqP.
+  rewrite 4!inE /= (sameP astab1P eqP) dz' -rfd_odd; first exact/eqP.
   by rewrite rfd_rgd mker // ?set11.
 apply/injmP=> x1 y1 /=.
 case/setIP=> Hax1; move/astab1P; rewrite /= /aperm => Hx1.

--- a/solvable/burnside_app.v
+++ b/solvable/burnside_app.v
@@ -21,8 +21,8 @@ Lemma burnside_formula : forall (gT : finGroupType) s (G : {group gT}),
 Proof.
 move=> gT s G Us sG sT to.
 rewrite big_uniq // -(card_uniqP Us) (eq_card sG) -Frobenius_Cauchy.
-  by apply: eq_big => // p _; rewrite setTI.
-by apply/actsP=> ? _ ?; rewrite !inE.
+  by apply/actsP=> ? _ ?; rewrite !inE.
+by apply: eq_big => // p _; rewrite setTI.
 Qed.
 
 Arguments burnside_formula {gT}.
@@ -262,7 +262,7 @@ Canonical iso_group := Group group_set_iso.
 
 Lemma card_rot : #|rot| = 4.
 Proof.
-rewrite -[4]/(size [:: id1; r1; r2; r3]) -(card_uniqP _).
+rewrite -[4]/(size [:: id1; r1; r2; r3]) -(card_uniqP _); last first.
   by apply: eq_card => x; rewrite rot_is_rot !inE -!orbA.
 by apply: map_uniq (fun p : {perm square} => p c0) _ _; rewrite /= !permE.
 Qed.
@@ -368,7 +368,8 @@ Lemma card_n2 : forall x y z t : square, uniq [:: x; y; z; t] ->
   #|[set p : col_squares | (p x == p y) && (p z == p t)]| = (n ^ 2)%N.
 Proof.
 move=> x y z t Uxt; rewrite -[n]card_ord.
-pose f (p : col_squares) := (p x, p z); rewrite -(@card_in_image _ _ f).
+pose f (p : col_squares) := (p x, p z).
+rewrite -(@card_in_image _ _ f); last first.
   rewrite -mulnn -card_prod; apply: eq_card => [] [c d] /=; apply/imageP.
   rewrite (cat_uniq [::x; y]) in Uxt; case/and3P: Uxt => _.
   rewrite /= !orbF !andbT => /norP[] /[!inE] nxzt nyzt _.
@@ -387,7 +388,7 @@ Lemma card_n :
    = n.
 Proof.
 rewrite -[n]card_ord /coin0 /coin1 /coin2 /coin3.
-pose f (p : col_squares) := p c3; rewrite -(@card_in_image _ _ f).
+pose f (p : col_squares) := p c3; rewrite -(@card_in_image _ _ f); last first.
   apply: eq_card => c /=; apply/imageP.
   exists ([ffun => c] : col_squares); last by rewrite /f ffunE.
   by rewrite /= inE !ffunE !eqxx.
@@ -399,18 +400,18 @@ Qed.
 
 Lemma burnside_app2 : (square_coloring_number2 * 2 = n ^ 4 + n ^ 2)%N.
 Proof.
-rewrite (burnside_formula [:: id1; sh]) => [||p]; last first.
-- by rewrite !inE.
+rewrite (burnside_formula [:: id1; sh]) => [|p|].
 - by rewrite /= inE diff_id_sh.
+- by rewrite !inE.
 by rewrite 2!big_cons big_nil addn0 {1}card_Fid F_Sh card_n2.
 Qed.
 
 Lemma burnside_app_rot :
   (square_coloring_number4 * 4 = n ^ 4 + n ^ 2 + 2 * n)%N.
 Proof.
-rewrite (burnside_formula [:: id1; r1; r2; r3]) => [||p]; last first.
-- by rewrite !inE !orbA.
+rewrite (burnside_formula [:: id1; r1; r2; r3]) => [|p|].
 - by apply: map_uniq (fun p : {perm square} => p c0) _ _; rewrite /= !permE.
+- by rewrite !inE !orbA.
 rewrite !big_cons big_nil /= addn0 {1}card_Fid F_r1 F_r2 F_r3.
 by rewrite card_n card_n2 //= [n + _]addnC !addnA addn0.
 Qed.
@@ -431,17 +432,17 @@ move/eqn_pmul2l <-; rewrite -expnS -card_Fid Fid cardsT.
 rewrite -{1}[n]card_ord -cardX.
 pose pk k := [ffun i => k (if i == y then x else i) : colors].
 rewrite -(@card_image _ _ (fun k : col_squares => (k y, pk k))).
-  apply/eqP; apply: eq_card => ck /=; rewrite inE /= [_ \in _]inE.
-  apply/eqP/imageP; last first.
-    by case=> k _ -> /=; rewrite !ffunE if_same eqxx.
-  case: ck => c k /= kxy.
-  exists [ffun i => if i == y then c else k i]; first by rewrite inE.
-  rewrite !ffunE eqxx; congr (_, _); apply/ffunP=> i; rewrite !ffunE.
-  case Eiy: (i == y); last by rewrite Eiy.
-  by rewrite (negbTE nxy) (eqP Eiy).
-move=> k1 k2 [Eky Epk]; apply/ffunP=> i.
-have{Epk}: pk k1 i = pk k2 i by rewrite Epk.
-by rewrite !ffunE; case: eqP => // ->.
+  move=> k1 k2 [Eky Epk]; apply/ffunP=> i.
+  have{Epk}: pk k1 i = pk k2 i by rewrite Epk.
+  by rewrite !ffunE; case: eqP => // ->.
+apply/eqP; apply: eq_card => ck /=; rewrite inE /= [_ \in _]inE.
+apply/eqP/imageP; last first.
+  by case=> k _ -> /=; rewrite !ffunE if_same eqxx.
+case: ck => c k /= kxy.
+exists [ffun i => if i == y then c else k i]; first by rewrite inE.
+rewrite !ffunE eqxx; congr (_, _); apply/ffunP=> i; rewrite !ffunE.
+case Eiy: (i == y); last by rewrite Eiy.
+by rewrite (negbTE nxy) (eqP Eiy).
 Qed.
 
 Lemma F_Sd2 : 'Fix_to[sd2] = [set x | coin0 x == coin2 x].
@@ -454,10 +455,10 @@ Lemma burnside_app_iso :
   (square_coloring_number8 * 8 = n ^ 4 + 2 * n ^ 3 + 3 * n ^ 2 + 2 * n)%N.
 Proof.
 pose iso_list := [:: id1; r1; r2; r3; sh; sv; sd1; sd2].
-rewrite (burnside_formula iso_list) => [||p]; last first.
-- by rewrite /= !inE.
+rewrite (burnside_formula iso_list) => [|p|].
 - apply: map_uniq (fun p : {perm square} => (p c0, p c1)) _ _.
   by rewrite /= !permE.
+- by rewrite /= !inE.
 rewrite !big_cons big_nil {1}card_Fid F_r1 F_r2 F_r3 F_Sh F_Sv F_Sd1 F_Sd2.
 rewrite card_n !card_n3 // !card_n2 //= !addnA !addn0.
 by rewrite [LHS]addn.[ACl 1 * 7 * 8 * 3 * 5 * 6 * 2 * 4].
@@ -1141,7 +1142,7 @@ Proof.
 move=> x y z t Uxt; rewrite -[n]card_ord.
 case: (uniq4_uniq6 Uxt) => u [v Uxv].
 pose ff (p : col_cubes) := (p x, p z, p u, p v).
-rewrite -(@card_in_image _ _ ff); first last.
+rewrite -(@card_in_image _ _ ff).
   move=> p1 p2 /[!inE] /andP[p1y p1t] /andP[p2y p2t] [px pz] pu pv.
   have eqp12 : all (fun i => p1 i == p2 i) [:: x; y; z; t; u; v].
    by rewrite /= -(eqP p1y) -(eqP p1t) -(eqP p2y) -(eqP p2t) px pz pu pv !eqxx.
@@ -1168,7 +1169,7 @@ Proof.
 move=> x y z t Uxt; rewrite -[n]card_ord.
 case: (uniq4_uniq6 Uxt) => u [v Uxv].
 pose ff (p : col_cubes) := (p x, p u, p v);
-    rewrite -(@card_in_image _ _ ff); first last.
+    rewrite -(@card_in_image _ _ ff).
   move=> p1 p2 /[!inE]; rewrite -!andbA.
   move=> /and3P[/eqP p1xy /eqP p1yz /eqP p1zt].
   move=> /and3P[/eqP p2xy /eqP p2yz /eqP p2zt] [px pu] pv.
@@ -1192,7 +1193,7 @@ Lemma card_n2_3 : forall x y z t u v: cube, uniq [:: x; y; z; t; u; v] ->
 Proof.
 move=> x y z t u v  Uxv; rewrite -[n]card_ord .
 pose ff (p : col_cubes) := (p x, p t).
-rewrite -(@card_in_image _ _ ff); first last.
+rewrite -(@card_in_image _ _ ff).
   move=> p1 p2 /[!inE]; rewrite -!andbA.
   move=> /and4P[/eqP p1xy /eqP p1yz /eqP p1tu /eqP p1uv].
   move=> /and4P[/eqP p2xy/eqP  p2yz /eqP p2tu /eqP p2uv] [px pu].
@@ -1214,7 +1215,7 @@ Lemma card_n3s : forall x y z t u v: cube, uniq [:: x; y; z; t; u; v] ->
 Proof.
 move=> x y z t u v Uxv; rewrite -[n]card_ord .
 pose ff (p : col_cubes) := (p x, p z, p u).
-rewrite -(@card_in_image _ _ ff); first last.
+rewrite -(@card_in_image _ _ ff).
   move=> p1 p2 /[!inE]; rewrite -!andbA.
   move=> /and3P[/eqP p1xy /eqP p1zt /eqP p1uv].
   move=> /and3P[/eqP p2xy /eqP p2zt /eqP p2uv] [px pz] pu.
@@ -1243,13 +1244,13 @@ Proof.
 pose iso_list := [:: id3; s05; s14; s23; r05; r14; r23; r50; r41; r32;
                      r024; r042; r012; r021; r031; r013; r043; r034;
                      s1; s2; s3; s4; s5; s6].
-rewrite (burnside_formula iso_list); last first.
-- by move=> p; rewrite !inE /= !(eq_sym _ p).
+rewrite (burnside_formula iso_list).
 - apply: map_uniq (fun p : {perm cube} => (p F0, p F1)) _ _.
   have bsr : (fun p : {perm cube} => (p F0, p F1)) =1
              (fun p => (nth F0 p F0, nth F0 p F1)) \o sop.
     by move=> x; rewrite /= -2!sop_spec.
   by rewrite (eq_map bsr) map_comp  -(eqP Lcorrect); vm_compute.
+- by move=> p; rewrite !inE /= !(eq_sym _ p).
 rewrite !big_cons big_nil {1}card_Fid3 /= F_s05 F_s14 F_s23 F_r05 F_r14 F_r23
   F_r50 F_r41 F_r32 F_r024 F_r042 F_r012 F_r021 F_r031 F_r013 F_r043  F_r034
   F_s1  F_s2 F_s3 F_s4 F_s5 F_s6.

--- a/solvable/center.v
+++ b/solvable/center.v
@@ -202,8 +202,8 @@ have cKH: H \subset 'C(K) by rewrite centsC.
 apply/imset2P/and3P=> [[x y /setIP[Hx cHx] /setIP[Ky cKy] ->{z}]| []].
   by rewrite imset2_f ?groupM // ?(subsetP cHK) ?(subsetP cKH).
 case/imset2P=> x y Hx Ky ->{z}.
-rewrite groupMr => [cHx|]; last exact: subsetP Ky.
-rewrite groupMl => [cKy|]; last exact: subsetP Hx.
+rewrite groupMr => [|cHx]; first exact: subsetP Ky.
+rewrite groupMl => [|cKy]; first exact: subsetP Hx.
 by exists x y; rewrite ?inE ?Hx ?Ky.
 Qed.
 
@@ -399,7 +399,7 @@ Lemma setI_im_cpair : CH :&: CK = 'Z(CH).
 Proof.
 apply/eqP; rewrite eqEsubset setIS //=.
 rewrite subsetI center_sub -injm_center //.
-rewrite (eq_in_morphim _ eq_cpairZ); first by rewrite morphim_comp morphimS.
+rewrite (eq_in_morphim _ eq_cpairZ); last by rewrite morphim_comp morphimS.
 by rewrite !(setIidPr _) // -sub_morphim_pre.
 Qed.
 
@@ -476,7 +476,7 @@ apply: andb_id2l => /= injfH; apply: andb_idr => _.
 rewrite !im_ifactm // -(morphimIdom gH) setI_im_cpair -injm_center //.
 rewrite morphim_ifactm // eqEsubset subsetI morphimS //=.
 rewrite {1}injm_center // setIS //=.
-rewrite (eq_in_morphim _ eq_fHK); first by rewrite morphim_comp morphimS.
+rewrite (eq_in_morphim _ eq_fHK); last by rewrite morphim_comp morphimS.
 by rewrite !(setIidPr _) // -sub_morphim_pre.
 Qed.
 
@@ -636,7 +636,7 @@ Qed.
 Lemma ncprod1 : G_ 1 \isog G.
 Proof.
 case: ncprodS => gz isoZ; rewrite isog_sym /= -im_cpair.
-rewrite mulGSid /=; first by rewrite sub_isog ?injm_cpairg1.
+rewrite mulGSid /=; last by rewrite sub_isog ?injm_cpairg1.
 rewrite -{3}center_ncprod0 injm_center ?injm_cpair1g //.
 by rewrite -cpair_center_id center_sub.
 Qed.

--- a/solvable/cyclic.v
+++ b/solvable/cyclic.v
@@ -278,7 +278,7 @@ apply/idP/idP=> [/cyclicP[x defG] | coKH]; last by rewrite -defKH cyclicM.
 rewrite /coprime -dvdn1 -(@dvdn_pmul2l m) ?lcmn_gt0 ?cardG_gt0 //.
 rewrite muln_lcm_gcd muln1 -TI_cardMg // defKH defG order_dvdn.
 have /mulsgP[y z Ky Hz ->]: x \in K * H by rewrite defKH defG cycle_id.
-rewrite -[1]mulg1 expgMn; last exact/commute_sym/(centsP cKH).
+rewrite -[1]mulg1 expgMn; first exact/commute_sym/(centsP cKH).
 apply/eqP; congr (_ * _); apply/eqP; rewrite -order_dvdn.
   exact: dvdn_trans (order_dvdG Ky) (dvdn_lcml _ _).
 exact: dvdn_trans (order_dvdG Hz) (dvdn_lcmr _ _).
@@ -331,7 +331,7 @@ apply/eqP; rewrite eq_expg_mod_order.
 have [x_le1 | x_gt1] := leqP #[x] 1.
   suffices: #[y] %| 1 by rewrite dvdn1 => /eqP->; rewrite !modn1.
   by rewrite (dvdn_trans dvd_y_x) // dvdn1 order_eq1 -cycle_eq1 trivg_card_le1.
-rewrite -(expg_znat i (cycle_id x)) invmE /=; last by rewrite /Zp x_gt1 inE.
+rewrite -(expg_znat i (cycle_id x)) invmE /=; first by rewrite /Zp x_gt1 inE.
 by rewrite val_Zp_nat // modn_dvdm.
 Qed.
 
@@ -679,7 +679,7 @@ Proof.
 have [lea1 | lt1a] := leqP #[a] 1.
   rewrite /order card_le1_trivg // cards1 (@eq_card1 _ 1) // => x.
   by rewrite !inE -cycle_eq1 eq_sym.
-rewrite -(card_injm (injm_invm (injm_Zpm a))) /= ?im_Zpm; last first.
+rewrite -(card_injm (injm_invm (injm_Zpm a))) /= ?im_Zpm.
   by apply/subsetP=> x /[1!inE]; apply: cycle_generator.
 rewrite -card_units_Zp // cardsE card_sub morphim_invmE; apply: eq_card => /= d.
 by rewrite !inE /= qualifE /= /Zp lt1a inE /= generator_coprime {1}Zp_cast.
@@ -704,7 +704,7 @@ Proof.
 pose h (x : gT) : 'I_#|G|.+1 := inord #[x].
 symmetry; rewrite -{1}sum1_card (partition_big h xpredT) //=.
 apply: eq_bigr => d _; set Gd := finset _.
-rewrite -sum_nat_const sum1dep_card -sum1_card (_ : finset _ = Gd); last first.
+rewrite -sum_nat_const sum1dep_card -sum1_card (_ : finset _ = Gd).
   apply/setP=> x /[!inE]; apply: andb_id2l => Gx.
   by rewrite /eq_op /= inordK // ltnS subset_leq_card ?cycle_subG.
 rewrite (partition_big_imset cycle) {}/Gd; apply: eq_bigr => C /=.
@@ -726,7 +726,7 @@ apply: eq_bigr => d _; rewrite -{2}ox1; case: ifP => [|ndv_dG]; last first.
   rewrite eq_card0 // => C; apply/imsetP=> [[x /setIdP[Gx oxd] _{C}]].
   by rewrite -(eqP oxd) order_dvdG in ndv_dG.
 move/cycle_sub_group; set Gd := [set _] => def_Gd.
-rewrite (_ : _ @: _ = @gval _ @: Gd); first by rewrite imset_set1 cards1 mul1n.
+rewrite (_ : _ @: _ = @gval _ @: Gd); last by rewrite imset_set1 cards1 mul1n.
 apply/setP=> C; apply/idP/imsetP=> [| [gC GdC ->{C}]].
   case/imsetP=> x /setIdP[_ oxd] ->; exists <[x]>%G => //.
   by rewrite -def_Gd inE -Zp_cycle subsetT.

--- a/solvable/extraspecial.v
+++ b/solvable/extraspecial.v
@@ -143,8 +143,8 @@ rewrite [@gtype _]unlock; apply: intro_isoGrp => [|rT H].
   have Gy: y \in G by rewrite -cycle_subG joing_subr.
   rewrite eqEsubset subsetT -im_sdpair mulG_subG /= -/G; apply/andP; split.
     apply/subsetP=> u /morphimP[[i j] _ _ def_u].
-    suffices ->: u = z ^+ i * x ^+ j. 
-      rewrite groupMl; apply/groupX; first exact: Gx.
+    suffices ->: u = z ^+ i * x ^+ j.
+      rewrite groupMl; apply/groupX; last exact: Gx.
       by apply/groupR; first exact: Gx.
     rewrite def_zi def_xi !natr_Zp -morphM ?inE // def_u.
     by congr (sdpair1 _ (_, _)); rewrite ?mulg1 ?mul1g.
@@ -247,7 +247,8 @@ rewrite cent_joinEr ?(sub_abelian_cent2 cGzGz) ?cycle_subG ?mem_quotient //.
 have oZx: #|<[coset 'Z(G) x]>| = p.
   rewrite -orderE (nt_prime_order p_pr) ?expGz ?mem_quotient //.
   by apply: contra notZx; move/eqP=> Zx; rewrite coset_idr ?(subsetP nZG).
-rewrite TI_cardMg ?oZx -?orderE ?(nt_prime_order p_pr) ?expGz ?mem_quotient //.
+rewrite TI_cardMg ?oZx -?orderE ?(nt_prime_order p_pr) ?expGz ?mem_quotient //;
+    last first.
   apply: contra not_cxy; move/eqP=> Zy.
   rewrite -cent_cycle (subsetP _ y (coset_idr _ Zy)) ?(subsetP nZG) //.
   by rewrite subIset ?centS ?orbT ?cycle_subG.
@@ -294,7 +295,7 @@ elim: n => [|n IHn].
   by rewrite (dvdn_trans (exponent_dvdn _)) ?card_pX1p2n.
 case: pX1p2S => gz isoZ; rewrite -im_cpair /=.
 apply/exponentP=> xy; case/imset2P=> x y C1x C2y ->{xy}.
-rewrite expgMn; last by red; rewrite -(centsP (im_cpair_cent isoZ)).
+rewrite expgMn; first by red; rewrite -(centsP (im_cpair_cent isoZ)).
 rewrite (exponentP _ y C2y) ?exponent_injm ?injm_cpair1g // mulg1.
 by rewrite (exponentP _ x C1x) ?exponent_injm ?injm_cpairg1 // exponent_pX1p2.
 Qed.
@@ -472,7 +473,7 @@ have defY: <[x]> \x E = Y.
     rewrite prime_TIg -?orderE ?ox // -(quotientSGK _ sZE) ?quotient_cycle //.
     rewrite (sameP setIidPl eqP) eq_sym -defEt tiXEt -quotient_cycle //.
     by rewrite -subG1 quotient_sub1 // cycle_subG.
-  rewrite dprodE //; last 1 first.
+  rewrite dprodE //.
     by rewrite cent_cycle (subset_trans sEY) //= -/Y -defCx subsetIr.
   rewrite -[Y](quotientGK nsZY) -defYt cosetpreM -quotient_cycle //.
   rewrite quotientK // -(normC nZX) defEt quotientGK ?(normalS _ sEY) //.
@@ -607,9 +608,9 @@ have oQ: #|'Q_(2 ^ 3)| = 8 by rewrite card_quaternion.
 have pQ: 2.-group 'Q_8 by rewrite /pgroup oQ.
 case: DnQ_P => gz isoZ.
 rewrite -im_cpair cardMg_divn setI_im_cpair cpair_center_id.
-rewrite -injm_center//; last exact: injm_cpair1g.
+rewrite -injm_center//; first exact: injm_cpair1g.
 rewrite (card_injm (injm_cpairg1 _))//= (card_injm (injm_cpair1g _))//.
-rewrite (card_injm (injm_cpair1g _))//; last exact: center_sub.
+rewrite (card_injm (injm_cpair1g _))//; first exact: center_sub.
 rewrite oQ card_pX1p2n // (card_center_extraspecial pQ Q8_extraspecial).
 by rewrite -muln_divA // mulnC -(expnD 2 2).
 Qed.
@@ -623,7 +624,7 @@ Proof.
 case: DnQ_P (DnQ_pgroup n) => gz isoZ pDnQ.
 have [injDn injQ] := (injm_cpairg1 isoZ, injm_cpair1g isoZ).
 have [n0 | n_gt0] := posnP n.
-  rewrite -im_cpair mulSGid; first exact: injm_extraspecial Q8_extraspecial.
+  rewrite -im_cpair mulSGid; last exact: injm_extraspecial Q8_extraspecial.
   apply/setIidPl; rewrite setI_im_cpair -injm_center //=.
   by congr (_ @* _); rewrite n0 center_ncprod0.
 apply: (cprod_extraspecial pDnQ (im_cpair_cprod isoZ) (setI_im_cpair _)).
@@ -730,7 +731,7 @@ right; case: DnQ_P => gz isoZ; rewrite (isog_cprod_by _ defG) //; first 1 last.
 rewrite /= -morphimIim; case/cprodP: defDn => _ defDn cDn1E.
 rewrite setICA setIA -defDn -group_modr ?morphimS ?subsetT //.
 rewrite /= im_fR (setIC R) ziER -center_prod // defZE -defZR.
-rewrite mulSGid /=; last first.
+rewrite mulSGid /=.
   by rewrite -{1}im_fR -injm_center // -cpairg1_center !morphimS ?center_sub.
 rewrite -injm_center ?subsetT // -injmI // setI_im_cpair.
 by rewrite -injm_center // cpairg1_center injm_center // im_fR mulGid.

--- a/solvable/extremal.v
+++ b/solvable/extremal.v
@@ -317,10 +317,10 @@ have [t At mt]: {t | t \in A & m t = -1}%R.
   by rewrite coprimenP // ltnW.
 have ot: #[t] = 2.
   apply/eqP; rewrite eqn_leq order_gt1 dvdn_leq ?order_dvdn //=.
-    apply/eqP; move/(congr1 m); apply/eqP; rewrite mt m1 eq_sym -subr_eq0.
-    rewrite opprK -val_eqE /= Zp_cast ?modn_small // /q oG ltnW //.
-    by rewrite (leq_trans (_ : 2 ^ 2 <= p ^ 2)) ?leq_sqr ?leq_exp2l.
-  by apply/eqP; apply: inj_m; rewrite ?groupX ?group1 ?mX // mt -signr_odd.
+    by apply/eqP; apply: inj_m; rewrite ?groupX ?group1 ?mX // mt -signr_odd.
+  apply/eqP; move/(congr1 m); apply/eqP; rewrite mt m1 eq_sym -subr_eq0.
+  rewrite opprK -val_eqE /= Zp_cast ?modn_small // /q oG ltnW //.
+  by rewrite (leq_trans (_ : 2 ^ 2 <= p ^ 2)) ?leq_sqr ?leq_exp2l.
 exists t; split=> //.
 case G4: (~~ odd p && (n == 1%N)).
   case: (even_prime p_pr) G4 => [p2 | -> //]; rewrite p2 /=; move/eqP=> n1.
@@ -371,9 +371,9 @@ have p_s: p.-elt s by rewrite /p_elt os pnatX ?pnat_id.
 have defS1: 'Ohm_1(<[s]>) = <[s0]>.
   apply/eqP; rewrite eq_sym eqEcard cycle_subG -orderE os0.
   rewrite (Ohm1_cyclic_pgroup_prime _ p_s) ?cycle_cyclic ?leqnn ?cycle_eq1 //=.
-    rewrite (OhmE _ p_s) mem_gen ?groupX //= !inE mem_cycle //.
-    by rewrite -order_dvdn os0 ?dvdnn.
-  by apply/eqP=> s1; rewrite -os0 /s0 s1 expg1n order1 in p_gt1.
+    by apply/eqP=> s1; rewrite -os0 /s0 s1 expg1n order1 in p_gt1.
+  rewrite (OhmE _ p_s) mem_gen ?groupX //= !inE mem_cycle //.
+  by rewrite -order_dvdn os0 ?dvdnn.
 case: (even_prime p_pr) => [p2 | oddp]; last first.
   rewrite {+}/e0 oddp subn0 in s0 os0 ms0 os ms defS1 *.
   have [f defF] := cyclicP cycF; have defP: P = <[s]>.
@@ -389,7 +389,7 @@ rewrite G4; exists s; split=> //; last first.
   rewrite ms0 mt eq_sym mulrN1 -subr_eq0 opprK -natrD -addSnnS.
   by rewrite prednK ?expn_gt0 // addnn -mul2n -expnS -p2 -oG pchar_Zp.
 suffices TIst: <[s]> :&: <[t]> = 1.
-  rewrite dprodE //; last by rewrite (sub_abelian_cent2 cAA) ?cycle_subG.
+  rewrite dprodE //; first by rewrite (sub_abelian_cent2 cAA) ?cycle_subG.
   apply/eqP; rewrite eqEcard mulG_subG !cycle_subG As At oA.
   by rewrite TI_cardMg // -!orderE os ot p2 mul1n /= -expnSr prednK.
 rewrite setIC; apply: prime_TIg; first by rewrite -orderE ot.
@@ -591,16 +591,16 @@ suffices{k k_gt0 le_k_n2} defGn2: <[x ^+ p]> \x <[y]> = 'Ohm_(n.-2)(G).
   rewrite pfactorK ?(pfactorK 1) // (eqnP k_gt0) expg1 -expgM -expnS.
   rewrite -subSn // -subSS def_n1 def_n => -> /=; rewrite ?add1n subnSK // subn2.
   by apply/eqP; rewrite eqEsubset OhmS ?Ohm_sub //= -{1}Ohm_id OhmS ?Ohm_leq.
-rewrite dprodEY //=; last by apply/trivgP; rewrite -tiXY setSI ?cycleX.
+rewrite dprodEY //=; first by apply/trivgP; rewrite -tiXY setSI ?cycleX.
 apply/eqP; rewrite eqEsubset join_subG !cycle_subG /= [in y \in _]def_n.
 rewrite (subsetP (Ohm_leq G (ltn0Sn _)) y) //= (OhmE _ pG) -/r.
-rewrite mem_gen /=; last by rewrite !inE -order_dvdn oxp groupX /=.
+rewrite mem_gen /=; first by rewrite !inE -order_dvdn oxp groupX /=.
 rewrite gen_subG /= cent_joinEr // -defXY; apply/subsetP=> uv; case/setIP.
 case/imset2P=> u v Xu Yv ->{uv}; rewrite /r inE def_n expnS expgM.
 case/lcosetP: (XYp u v Xu Yv) => _ /cycleP[j ->] ->.
 case/cycleP: Xu => i ->{u}; rewrite -!(expgM, expgD) -order_dvdn ox.
 rewrite (mulnC r) /r {1}def_n expnSr mulnA -mulnDl -mulnA -expnS.
-rewrite subnSK  // subn2 /q -def_n1 expnS dvdn_pmul2r // dvdn_addl.
+rewrite subnSK  // subn2 /q -def_n1 expnS dvdn_pmul2r // dvdn_addl; last first.
   by case/dvdnP=> k ->; rewrite mulnC expgM mem_mulg ?mem_cycle.
 case: (ltngtP n 3) => [|n_gt3|n3]; first by rewrite ltnNge n_gt2.
   by rewrite -subnSK // expnSr mulnA dvdn_mull.
@@ -1013,7 +1013,7 @@ have defG': G^`(1) = <[x ^+ 2]>.
   by rewrite -def2q -def2r mulnA mulnK.
 have defG1: 'Mho^1(G) = <[x ^+ 2]>.
   apply/eqP; rewrite (MhoE _ pG) eqEsubset !gen_subG sub1set andbC.
-  rewrite mem_gen; last exact: imset_f.
+  rewrite mem_gen; first exact: imset_f.
   apply/subsetP=> z2; case/imsetP=> z Gz ->{z2}.
   case Xz: (z \in X); last by rewrite -{1}(oX' z) ?expg_order ?group1 // inE Xz.
   by case/cycleP: Xz => i ->; rewrite expgAC mem_cycle.
@@ -1035,7 +1035,7 @@ have def_tG: {in G :\: X, forall t, t ^: G = <[x ^+ 2]> :* t}.
   by rewrite defJt ?groupV ?mem_cycle // expgVn invgK expgAC.
 have defMt: {in G :\: X, forall t, <[x ^+ 2]> ><| <[t]> = <<t ^: G>>}.
   move=> t X't; have [Gt notXt] := setDP X't.
-  rewrite sdprodEY ?cycle_subG ?(subsetP (nXiG 2)) //; first 1 last.
+  rewrite sdprodEY ?cycle_subG ?(subsetP (nXiG 2)) //.
     rewrite setIC prime_TIg -?orderE ?oX' // cycle_subG.
     by apply: contra notXt; apply: subsetP; rewrite cycleX.
   apply/eqP; have: t \in <<t ^: G>> by rewrite mem_gen ?class_refl.
@@ -1065,7 +1065,7 @@ have defX': yG :|: xyG = G :\: X.
 split.
 - by rewrite ?sdprodE // setIC // prime_TIg ?cycle_subG // -orderE ?oX'.
 - rewrite defG'; split=> //.
-  apply/eqP; rewrite eqn_leq (leq_trans (nil_class_pgroup pG)); last first.
+  apply/eqP; rewrite eqn_leq (leq_trans (nil_class_pgroup pG)).
     by rewrite oG pfactorK // geq_max leqnn -(subnKC n_gt1).
   rewrite -(subnKC n_gt1) subn2 ltnNge.
   rewrite (sameP (lcn_nil_classP _ (pgroup_nil pG)) eqP).
@@ -1090,7 +1090,7 @@ split.
 rewrite eqn_leq n_gt1; case: leqP n2_abelG => //= n_gt2 _.
 have ->: 'Z(G) = <[x ^+ r]>.
   apply/eqP; rewrite eqEcard andbC -orderE oxr -{1}(setIidPr (center_sub G)).
-  rewrite cardG_gt1 /= meet_center_nil ?(pgroup_nil pG) //; last first.
+  rewrite cardG_gt1 /= meet_center_nil ?(pgroup_nil pG) //.
     by rewrite -cardG_gt1 oG (leq_trans _ ltqm).
   apply/subsetP=> t; case/setIP=> Gt cGt.
   case X't: (t \in G :\: X).
@@ -1177,7 +1177,7 @@ have oX': {in G :\: X, forall z, #[z] = 4}.
   by move=> t X't /=; rewrite (@orderXprime _ 2 2) // X'2.
 have defZ: 'Z(G) = <[x ^+ r]>.
   apply/eqP; rewrite eqEcard andbC -orderE oxr -{1}(setIidPr (center_sub G)).
-  rewrite cardG_gt1 /= meet_center_nil ?(pgroup_nil pG) //; last first.
+  rewrite cardG_gt1 /= meet_center_nil ?(pgroup_nil pG) //.
     by rewrite -cardG_gt1 oG (leq_trans _ ltqm).
   apply/subsetP=> z; case/setIP=> Gz cGz; have [Gv _]:= setDP U'v.
   case Uvz: (z \in <[u]> :* v).
@@ -1214,7 +1214,7 @@ have defG': G^`(1) = <[x ^+ 2]>.
   by rewrite -def2q -def2r mulnA mulnK.
 have defG1: 'Mho^1(G) = <[x ^+ 2]>.
   apply/eqP; rewrite (MhoE _ pG) eqEsubset !gen_subG sub1set andbC.
-  rewrite mem_gen; last exact: imset_f.
+  rewrite mem_gen; first exact: imset_f.
   apply/subsetP=> z2; case/imsetP=> z Gz ->{z2}.
   case Xz: (z \in X).
     by case/cycleP: Xz => i ->; rewrite -expgM mulnC expgM mem_cycle.
@@ -1247,7 +1247,7 @@ have sMtG: {in G :\: X, forall t, <<t ^: G>> \subset G}.
 have oMt: {in G :\: X, forall t, #|<<t ^: G>>| = q}.
   move=> t X't; have [Gt notXt] := setDP X't.
   rewrite -defMt // -(Lagrange (joing_subl _ _)) -orderE ox2 -def2r mulnC.
-  congr (_ * r)%N; rewrite -card_quotient /=; last first.
+  congr (_ * r)%N; rewrite -card_quotient /=.
     by rewrite defMt // (subset_trans _ (nXiG 2)) ?sMtG.
   rewrite joingC quotientYidr ?(subset_trans _ (nXiG 2)) ?cycle_subG //.
   rewrite quotient_cycle ?(subsetP (nXiG 2)) //= -defPhi.
@@ -1271,7 +1271,7 @@ have defX': yG :|: xyG = G :\: X.
   by rewrite /yG /xyG !def_tG // !card_rcoset addnn -mul2n -orderE ox2 def2r.
 rewrite pprodE //; split=> // [|||n_gt3].
 - rewrite defG'; split=> //; apply/eqP; rewrite eqn_leq.
-  rewrite (leq_trans (nil_class_pgroup pG)); last first.
+  rewrite (leq_trans (nil_class_pgroup pG)).
     by rewrite oG pfactorK // -(subnKC n_gt2).
   rewrite -(subnKC (ltnW n_gt2)) subn2 ltnNge.
   rewrite (sameP (lcn_nil_classP _ (pgroup_nil pG)) eqP).
@@ -1305,7 +1305,7 @@ have isoMt: {in G :\: X, forall z, <<z ^: G>> \isog 'Q_q}.
   move=> z X'z /=; rewrite isogEcard card_quaternion ?oMt // leqnn andbT.
   rewrite Grp_quaternion //; apply/existsP; exists (x ^+ 2, z) => /=.
   rewrite defMt // -/q -/r !xpair_eqE -!expgM def2r -order_dvdn ox dvdnn.
-  rewrite -expnS prednK; last by rewrite -subn2 subn_gt0.
+  rewrite -expnS prednK; first by rewrite -subn2 subn_gt0.
   by rewrite X'2 // def_xr !eqxx /= invXX' ?mem_cycle.
 rewrite !isoMt //; split=> // C; case/cyclicP=> z ->{C} sCG iCG.
 rewrite [X]defU // defU -?cycle_subG //.
@@ -1364,7 +1364,7 @@ have def2r1: (2 * (2 ^ (n - 3)).-1).+1 = r.-1.
   by rewrite /r -(subnKC n_gt3).
 have defZ: 'Z(G) = <[x ^+ r]>.
   apply/eqP; rewrite eqEcard andbC -orderE oxr -{1}(setIidPr (center_sub G)).
-  rewrite cardG_gt1 /= meet_center_nil ?(pgroup_nil pG) //; last first.
+  rewrite cardG_gt1 /= meet_center_nil ?(pgroup_nil pG) //.
     by rewrite -cardG_gt1 oG (leq_trans _ ltqm).
   apply/subsetP=> z /setIP[Gz cGz].
   case X'z: (z \in G :\: X).
@@ -1392,7 +1392,7 @@ have defG': G^`(1) = <[x ^+ 2]>.
   by rewrite -def2q -def2r mulnA mulnK.
 have defG1: 'Mho^1(G) = <[x ^+ 2]>.
   apply/eqP; rewrite (MhoE _ pG) eqEsubset !gen_subG sub1set andbC.
-  rewrite mem_gen; last exact: imset_f.
+  rewrite mem_gen; first exact: imset_f.
   apply/subsetP=> z2; case/imsetP=> z Gz ->{z2}.
   case Xz: (z \in X).
     by case/cycleP: Xz => i ->; rewrite -expgM mulnC expgM mem_cycle.
@@ -1434,7 +1434,7 @@ have sMtG: {in G :\: X, forall t, <<t ^: G>> \subset G}.
 have oMt: {in G :\: X, forall t, #|<<t ^: G>>| = q}.
   move=> t X't; have [Gt notXt] := setDP X't.
   rewrite -defMt // -(Lagrange (joing_subl _ _)) -orderE ox2 -def2r mulnC.
-  congr (_ * r)%N; rewrite -card_quotient /=; last first.
+  congr (_ * r)%N; rewrite -card_quotient /=.
     by rewrite defMt // (subset_trans _ (nXiG 2)) ?sMtG.
   rewrite joingC quotientYidr ?(subset_trans _ (nXiG 2)) ?cycle_subG //.
   rewrite quotient_cycle ?(subsetP (nXiG 2)) //= -defPhi -orderE.
@@ -1459,7 +1459,7 @@ have defX': yG :|: xyG = G :\: X.
 split.
 - by rewrite sdprodE // setIC prime_TIg ?cycle_subG // -orderE oy.
 - rewrite defG'; split=> //.
-  apply/eqP; rewrite eqn_leq (leq_trans (nil_class_pgroup pG)); last first.
+  apply/eqP; rewrite eqn_leq (leq_trans (nil_class_pgroup pG)).
     by rewrite oG pfactorK // -(subnKC n_gt3).
   rewrite -(subnKC (ltnW (ltnW n_gt3))) subn2 ltnNge.
   rewrite (sameP (lcn_nil_classP _ (pgroup_nil pG)) eqP).
@@ -1833,7 +1833,7 @@ case=> [[n_gt23 xy] | [p2 Z_xxy]].
 have{i def_yp p_i} Zy2: y ^+ 2 \in Z.
   rewrite defZ (OhmE _ pX) -groupV -p2 def_yp mem_gen // !inE groupX //= p2.
   rewrite expgS -{2}def_yp -(mulKg y y) -conjgE -conjXg -conjVg def_yp conjXg.
-  rewrite -expgMn //; last by apply: (centsP cXX); rewrite ?memJ_norm.
+  rewrite -expgMn //; first by apply: (centsP cXX); rewrite ?memJ_norm.
   by rewrite -order_dvdn (dvdn_trans (order_dvdG Z_xxy)) ?oZ.
 rewrite !cycle_traject !orderE oZ p2 !inE !mulg1 /= in Z_xxy Zy2 *.
 rewrite -eq_invg_mul eq_sym -[r]prednK // expgS (inj_eq (mulgI _)) in Z_xxy.
@@ -2101,7 +2101,7 @@ case/semidihedral_classP: cG => n n_gt3 isoG.
 have [[x y] genG [oy _]] := generators_semidihedral n_gt3 isoG.
 case/semidihedral_structure: genG => // _ _ [_ _ [defG1 _] _] _ [isoG1 _ _].
 case/idPn: (n_gt3); rewrite -(ltn_predK n_gt3) ltnS -leqNgt -(@leq_exp2l 2) //.
-rewrite -card_2dihedral //; last by rewrite -(subnKC n_gt3).
+rewrite -card_2dihedral //; first by rewrite -(subnKC n_gt3).
 by rewrite -(card_isog isoG1) /= -defG1 oG1p p2.
 Qed.
 
@@ -2127,7 +2127,7 @@ have cHsHs: abelian (H / Z).
   rewrite sub_der1_abelian //= (OhmE _ pU) genS //= -/U.
   apply/subsetP=> _ /imset2P[h k Hh Hk ->].
   have Uhk: [~ h, k] \in U by rewrite (subsetP sHG_U) ?mem_commg ?(subsetP sHG).
-  rewrite inE Uhk inE -commXg; last by red; rewrite -(centsP cHU).
+  rewrite inE Uhk inE -commXg; first by red; rewrite -(centsP cHU).
   apply/commgP; red; rewrite (centsP cHU) // (subsetP sPhiH_U) //.
   by rewrite (Phi_joing pH) mem_gen // inE orbC (Mho_p_elt 1) ?(mem_p_elt pH).
 have nsZH: Z <| H by rewrite sub_center_normal.
@@ -2209,7 +2209,7 @@ have{defE'} sEG_E': [~: E, G] \subset E^`(1).
   apply/subsetP=> _ /imset2P[g e Gg Ee ->].
   have He: e \in H by rewrite (subsetP sKH) ?(subsetP sEK).
   have Uge: [~ g, e] \in U by rewrite (subsetP sHG_U) ?mem_commg.
-  rewrite inE Uge inE -commgX; last by red; rewrite -(centsP cHU).
+  rewrite inE Uge inE -commgX; first by red; rewrite -(centsP cHU).
   have sZ_ZG: Z \subset 'Z(G).
     have charZ: Z \char G := gFchar_trans _ charU.
     have/implyP:= meet_center_nil (pgroup_nil pG) (char_normal charZ).
@@ -2291,7 +2291,7 @@ case/modular_group_structure: genM => // _ [defZM _ oZM] _ _.
 have:= n_gt2; rewrite leq_eqVlt eq_sym !xpair_eqE andbC.
 case: eqP => [n3 _ _ | _ /= n_gt3 defOhmM].
   have eqZU1: Z = 'Mho^1(U) by apply/eqP; rewrite eqEcard sZU1 oZ oU1 n3 /=.
-  rewrite (setIidPl _) in defM; first by rewrite -defM oM n3 pfactorK in R_gt_3.
+  rewrite (setIidPl _) in defM; last by rewrite -defM oM n3 pfactorK in R_gt_3.
   by rewrite -eqZU1 subIset ?centS ?orbT.
 have{defOhmM} [|defM2 _] := defOhmM 2; first by rewrite -subn1 ltn_subRL.
 do [set xpn3 := x ^+ _; set X2 := <[_]>] in defM2.
@@ -2299,7 +2299,7 @@ have oX2: #|X2| = (p ^ 2)%N.
   by rewrite -orderE (orderXexp _ ox) -{1}(subnKC n_gt2) addSn addnK.
 have sZX2: Z \subset X2.
   have cycXp: cyclic <[x ^+ p]> := cycle_cyclic _.
-  rewrite -(cardSg_cyclic cycXp) /=; first by rewrite oZ oX2 dvdn_mull.
+  rewrite -(cardSg_cyclic cycXp) /=; last by rewrite oZ oX2 dvdn_mull.
     rewrite -defZM subsetI (subset_trans (Ohm_sub _ _)) //=.
     by rewrite (subset_trans sZU1) // centsC defM subsetIr.
   by rewrite /xpn3 -subnSK //expnS expgM cycleX.
@@ -2311,18 +2311,18 @@ have [cEX2 cYE]: X2 \subset 'C(E) /\ E \subset 'C(<[y]>).
  by apply/andP; rewrite centsC -subsetI -centM defM2.
 have pN: p.-group N := pgroupS (subsetIl _ _) pG.
 have defN2: (E <*> X2) \x <[y]> = 'Ohm_2(N).
-  rewrite dprodE ?centY ?subsetI 1?centsC ?cYE //=; last first.
+  rewrite dprodE ?centY ?subsetI 1?centsC ?cYE //=.
     rewrite -cycle_subG in My; rewrite joingC cent_joinEl //= -/X2.
     rewrite -(setIidPr My) setIA -group_modl ?cycle_subG ?groupX //.
     by rewrite mulGSid // (subset_trans _ sZX2) // -defZE -tiER setIS.
   apply/eqP; rewrite cent_joinEr // -mulgA defM2 eqEsubset mulG_subG.
-  rewrite OhmS ?andbT; last by rewrite -defN mulG_subr.
+  rewrite OhmS ?andbT; first by rewrite -defN mulG_subr.
   have expE: exponent E %| p ^ 2 by rewrite exponent_special ?(pgroupS sEG).
-  rewrite /= (OhmE 2 pN) sub_gen /=; last 1 first.
+  rewrite /= (OhmE 2 pN) sub_gen /=.
     by rewrite subsetI -defN mulG_subl sub_LdivT expE.
   rewrite -cent_joinEl // -genM_join genS // -defN.
   apply/subsetP=> _ /setIP[/imset2P[e z Ee Mz ->]].
-  rewrite inE expgMn; last by red; rewrite -(centsP cME).
+  rewrite inE expgMn; first by red; rewrite -(centsP cME).
   rewrite (exponentP expE) // mul1g => zp2; rewrite mem_mulg //=.
   by rewrite (OhmE 2 (pgroupS sMR pR)) mem_gen // !inE Mz.
 have{defN2} defZN2: X2 \x <[y]> = 'Z('Ohm_2(N)).

--- a/solvable/finmodule.v
+++ b/solvable/finmodule.v
@@ -278,14 +278,14 @@ have GrH x: x \in G -> rH x \in G.
   move=> Gx; case/rcosetP: (HrH x) => y Hy ->.
   by rewrite groupM // (subsetP sHG).
 have rH_Pmul x y: x \in P -> rH (x * y) = pQ x * rH y.
-  by move=> Px; rewrite /rH mulgA -pQmul; first by rewrite /pP rPmul ?mulgA.
+  by move=> Px; rewrite /rH mulgA -pQmul; last by rewrite /pP rPmul ?mulgA.
 have rH_Hmul h y: h \in H -> rH (h * y) = rH y.
   by move=> Hh; rewrite rH_Pmul ?(subsetP sHP) // -(mulg1 h) pQhq ?mul1g.
 pose mu x y := fmod ((rH x * rH y)^-1 * rH (x * y)).
 pose nu y := (\sum_(Px in rcosets P G) mu (repr Px) y)%R.
 have rHmul: {in G &, forall x y, rH (x * y) = rH x * rH y * val (mu x y)}.
   move=> x y Gx Gy; rewrite /= fmodK ?mulKVg // -mem_lcoset lcoset_sym.
-  rewrite -norm_rlcoset; last by rewrite nHG ?GrH ?groupM.
+  rewrite -norm_rlcoset; first by rewrite nHG ?GrH ?groupM.
   by rewrite (rcoset_eqP (HrH _)) -rcoset_mul ?nHG ?GrH // mem_mulg.
 have actrH a x: x \in G -> (a ^@ rH x = a ^@ x)%R.
   move=> Gx; apply: val_inj; rewrite /= !fmvalJ ?nHG ?GrH //.
@@ -335,7 +335,7 @@ exists (Morphism fM @* G)%G; apply/complP; split.
   rewrite -{1}(mulgKV y (rH y)) groupMl -?mem_rcoset // => Hy.
   by rewrite -(mulg1 y) /f nu_Hmul // rH_Hmul //; apply: (morph1 (Morphism fM)).
 apply/setP=> x; apply/mulsgP/idP=> [[h y Hh fy ->{x}] | Gx].
-  rewrite groupMl; last exact: (subsetP sHG).
+  rewrite groupMl; first exact: (subsetP sHG).
   case/morphimP: fy => z _ Gz ->{h Hh y}.
   by rewrite /= /f groupMl ?GrH // (subsetP sHG) ?fmodP.
 exists (x * (f x)^-1) (f x); last first; first by rewrite mulgKV.
@@ -367,11 +367,11 @@ apply/eqP; rewrite eq_sym eqEcard; apply/andP; split; last first.
   by rewrite cardJg -(leq_pmul2l (cardG_gt0 H)) -!TI_cardMg // eqHL eqHK.
 apply/subsetP=> _ /imsetP[x Kx ->]; rewrite conjgE mulgA (conjgC _ x).
 have Gx: x \in G by rewrite sKG.
-rewrite conjVg -mulgA -fmvalJ ?nHG // -fmvalN -fmvalA (_ : _ + _ = nu x)%R.
-  by rewrite val_nu // mulKVg groupV mem_remgr // eqHL groupV.
+rewrite conjVg -mulgA -fmvalJ ?nHG // -fmvalN -fmvalA (_ : _ + _ = nu x)%R;
+  last by rewrite val_nu // mulKVg groupV mem_remgr // eqHL groupV.
 rewrite actZr -!mulNrn -mulrnDl actr_sum.
 rewrite addrC (reindex_acts _ (actsRs_rcosets _ K) Kx) -sumrB /= -/Q.
-rewrite (eq_bigr (fun _ => nu x)) => [|_ /imsetP[y Ky ->]]; last first.
+rewrite (eq_bigr (fun _ => nu x)) => [_ /imsetP[y Ky ->]|].
   rewrite !rcosetE -rcosetM QeqLP.
   case: repr_rcosetP => z /setIP[Lz _]; case: repr_rcosetP => t /setIP[Lt _].
   rewrite !nu_cocycle ?groupM ?(sKG y) // ?sLG //.
@@ -379,7 +379,7 @@ rewrite (eq_bigr (fun _ => nu x)) => [|_ /imsetP[y Ky ->]]; last first.
 apply: val_inj; rewrite sumr_const !fmvalZ.
 rewrite -{2}(expgK coHiPG (fmodP (nu x))); congr (_ ^+ _ ^+ _).
 rewrite -[#|_|]divgS ?subsetIl // -(divnMl (cardG_gt0 H)).
-rewrite -!TI_cardMg //; last by rewrite setIA setIAC (setIidPl sHP).
+rewrite -!TI_cardMg //; first by rewrite setIA setIAC (setIidPl sHP).
 by rewrite group_modl // eqHK (setIidPr sPG) divgS.
 Qed.
 
@@ -440,7 +440,7 @@ Proof.
 move=> s t Gs Gt /=.
 rewrite [transfer t](reindex_acts 'Rs _ Gs) ?actsRs_rcosets //= -big_split /=.
 apply: eq_bigr => _ /rcosetsP[x Gx ->]; rewrite !rcosetE -!rcosetM.
-rewrite -zmodMgE -morphM -?mem_rcoset; first by rewrite !mulgA mulgKV rcosetM.
+rewrite -zmodMgE -morphM -?mem_rcoset; last by rewrite !mulgA mulgKV rcosetM.
   by rewrite rcoset_repr rcosetM mem_rcoset mulgK mem_repr_rcoset.
 by rewrite rcoset_repr (rcosetM _ _ t) mem_rcoset mulgK mem_repr_rcoset.
 Qed.
@@ -564,8 +564,8 @@ have trY: is_transversal Y HG G.
     have HGgHyg: H :* y * <[g]> \in HG :* <[g]>.
       by rewrite mem_mulg ?set11 // -rcosetE imset_f ?(subsetP sYG).
     rewrite !(def_pblock tiX HGgHyg) //.
-      by rewrite -[x'](mulgK (g ^+ j)) mem_mulg // groupV mem_cycle.
-    by rewrite -[x](mulgK (g ^+ i)) mem_mulg ?rcoset_refl // groupV mem_cycle.
+      by rewrite -[x](mulgK (g ^+ i)) mem_mulg ?rcoset_refl // groupV mem_cycle.
+    by rewrite -[x'](mulgK (g ^+ j)) mem_mulg // groupV mem_cycle.
   apply/set1P; rewrite /y eq_xx'; congr (_ * _ ^+ _) => //; apply/eqP.
   rewrite -(@nth_uniq _ (H :* x) (traj x)) ?size_traj // ?eq_xx' //.
   by rewrite !nth_traj ?(rcoset_eqP Hy_x'gj) // -eq_xx'.
@@ -575,7 +575,7 @@ have rYE x i : x \in X -> i < n_ x -> rY (H :* x :* g ^+ i) = x * g ^+ i.
   apply/esym/def_pblock; last exact: rcoset_refl; first by case/and3P: partHG.
   by rewrite -rcosetE imset_f ?groupM ?groupX // sXG.
 rewrite (transfer_indep trY Gg) /V -/rY (set_partition_big _ partHGg) /=.
-rewrite -defHgX big_imset /=; last first.
+rewrite -defHgX big_imset /=.
   apply/imset_injP; rewrite defHgX (card_transversal trX) defHGg.
   by rewrite (card_in_imset injHGg).
 apply eq_bigr=> x Xx; rewrite Hgr_eq (eq_bigl _ _ (pcyc_eq x)) -big_uniq //=.
@@ -587,10 +587,10 @@ elim: {1 3}n 0%N (addn0 n) => [|m IHm] i def_i /=.
   rewrite -(mulgA _ _ g) -rcosetM -expgSr -[(H :* x) :* _]rcosetE.
   rewrite -actpermE morphX ?inE // permX // -{2}def_n n_eq iter_porbit mulgA.
   by rewrite -[H :* x]rcoset1 (rYE _ 0) ?mulg1.
-rewrite big_cons rYE //; last by rewrite def_n -def_i ltnS leq_addl.
+rewrite big_cons rYE //; first by rewrite def_n -def_i ltnS leq_addl.
 rewrite permE /= rcosetE -rcosetM -(mulgA _ _ g) -expgSr.
 rewrite addSnnS in def_i; rewrite IHm //.
-rewrite rYE //; last by rewrite def_n -def_i ltnS leq_addl.
+rewrite rYE //; first by rewrite def_n -def_i ltnS leq_addl.
 by rewrite mulgV [fmalpha 1]morph1 add0r.
 Qed.
 

--- a/solvable/frobenius.v
+++ b/solvable/frobenius.v
@@ -498,7 +498,7 @@ apply/normedTI_memJ_P; rewrite setD_eq0 subG1 sHG -defKH -(normC nKH).
 split=> // z _ /setD1P[ntz Hz] /mulsgP[y x Hy Kx ->]; rewrite groupMl // !inE.
 rewrite conjg_eq1 ntz; apply/idP/idP=> [Hzxy | Hx]; last by rewrite !in_group.
 apply: (subsetP (sub1G H)); have Hzy: z ^ y \in H by apply: groupJ.
-rewrite -(regG (z ^ y)); last by apply/setD1P; rewrite conjg_eq1.
+rewrite -(regG (z ^ y)); first by apply/setD1P; rewrite conjg_eq1.
 rewrite inE Kx cent1C (sameP cent1P commgP) -in_set1 -[[set 1]]tiKH inE /=.
 rewrite andbC groupM ?groupV -?conjgM //= commgEr groupMr //.
 by rewrite memJ_norm ?(subsetP nKH) ?groupV.
@@ -599,7 +599,7 @@ apply/setP=> x /[!inE]; have [-> | ntx] := eqVneq; first exact: group1.
 rewrite /= -(cover_partition partG) /cover.
 have neKHy y: gval K <> H^# :^ y.
   by move/setP/(_ 1); rewrite group1 conjD1g setD11.
-rewrite big_setU1 /= ?inE; last by apply/imsetP=> [[y _ /neKHy]].
+rewrite big_setU1 /= ?inE; first by apply/imsetP=> [[y _ /neKHy]].
 have [nsKG sHG _ _ tiKH] := sdprod_context defG; have [sKG nKG]:= andP nsKG.
 symmetry; case Kx: (x \in K) => /=.
   apply/set0Pn=> [[v /setIP[Sv]]]; have [y Gy ->] := atransP2 transG Su Sv.
@@ -632,11 +632,11 @@ apply/Frobenius_semiregularP; first exact: quotient_coprime_sdprod.
 move=> _ /(subsetP (quotientD1 _ _))/morphimP[x nNx H1x ->].
 rewrite -cent_cycle -quotient_cycle //=.
 rewrite -strongest_coprime_quotient_cent ?cycle_subG //.
-- by rewrite cent_cycle quotientS1 ?regH.
 - by rewrite subIset ?sNK.
 - rewrite (coprimeSg (subsetIl N _)) ?(coprimeSg sNK) ?(coprimegS _ coKH) //.
   by rewrite cycle_subG; case/setD1P: H1x.
-by rewrite orbC abelian_sol ?cycle_abelian.
+- by rewrite orbC abelian_sol ?cycle_abelian.
+- by rewrite cent_cycle quotientS1 ?regH.
 Qed.
 
 Section InjmFrobenius.
@@ -695,7 +695,7 @@ have: n %| #|'Ldiv_(p * n)(G)|.
   have: p * n %| #|G| by rewrite oG dvdn_pmul2r ?pdiv_dvd.
   move/IHm=> IH; apply: dvdn_trans (IH _); first exact: dvdn_mull.
   by rewrite oG divnMr.
-rewrite -(cardsID 'Ldiv_n()) dvdn_addl.
+rewrite -(cardsID 'Ldiv_n()) dvdn_addl; last first.
   rewrite -setIA ['Ldiv_n(_)](setIidPr _) //.
   by apply/subsetP=> x; rewrite !inE -!order_dvdn; apply: dvdn_mull.
 rewrite -setIDA; set A := _ :\: _.
@@ -711,21 +711,22 @@ have pA x: x \in A -> (#[x]`_p = n`_p * p)%N.
 rewrite -(partnC p n_gt0) Gauss_dvd ?coprime_partC //; apply/andP; split.
   rewrite -sum1_card (partition_big_imset (@cycle _)) /=.
   apply: dvdn_sum => _ /imsetP[x /setIP[Gx Ax] ->].
-  rewrite (eq_bigl (generator <[x]>)) => [|y].
-    rewrite sum1dep_card -totient_gen -[#[x]](partnC p) //.
-    rewrite totient_coprime ?coprime_partC // dvdn_mulr // .
-    by rewrite (pA x Ax) p_part // -expnSr totient_pfactor // dvdn_mull.
-  rewrite /generator eq_sym andbC; case xy: {+}(_ == _) => //.
-  rewrite !inE -!order_dvdn in Ax *.
-  by rewrite -cycle_subG /order -(eqP xy) cycle_subG Gx.
+  rewrite (eq_bigl (generator <[x]>)) => [y|].
+    rewrite /generator eq_sym andbC; case xy: {+}(_ == _) => //.
+    rewrite !inE -!order_dvdn in Ax *.
+    by rewrite -cycle_subG /order -(eqP xy) cycle_subG Gx.
+  rewrite sum1dep_card -totient_gen -[#[x]](partnC p) //.
+  rewrite totient_coprime ?coprime_partC // dvdn_mulr // .
+  by rewrite (pA x Ax) p_part // -expnSr totient_pfactor // dvdn_mull.
 rewrite -sum1_card (partition_big_imset (fun x => x.`_p ^: G)) /=.
 apply: dvdn_sum => _ /imsetP[x /setIP[Gx Ax] ->].
 set y := x.`_p; have oy: #[y] = (n`_p * p)%N by rewrite order_constt pA.
-rewrite (partition_big (fun x => x.`_p) [in y ^: G]) /= => [|z]; last first.
+rewrite (partition_big (fun x => x.`_p) [in y ^: G]) /= => [z|].
   by case/andP=> _ /eqP <-; rewrite /= class_refl.
 pose G' := ('C_G[y] / <[y]>)%G; pose n' := gcdn #|G'| n`_p^'.
 have n'_gt0: 0 < n' by rewrite gcdn_gt0 cardG_gt0.
-rewrite (eq_bigr (fun _ => #|'Ldiv_n'(G')|)) => [|_ /imsetP[a Ga ->]].
+rewrite (eq_bigr (fun _ => #|'Ldiv_n'(G')|)) => [_ /imsetP[a Ga ->]|];
+    last first.
   rewrite sum_nat_const -index_cent1 indexgI.
   rewrite -(dvdn_pmul2l (cardG_gt0 'C_G[y])) mulnA LagrangeI.
   have oCy: #|'C_G[y]| = (#[y] * #|G'|)%N.
@@ -742,7 +743,7 @@ rewrite (eq_bigr (fun _ => #|'Ldiv_n'(G')|)) => [|_ /imsetP[a Ga ->]].
   by rewrite cardSg ?subsetIl // dvdn_mul ?pdiv_dvd.
 pose h := [fun z => coset <[y]> (z ^ a^-1)].
 pose h' := [fun Z : coset_of <[y]> => (y * (repr Z).`_p^') ^ a].
-rewrite -sum1_card (reindex_onto h h') /= => [|Z]; last first.
+rewrite -sum1_card (reindex_onto h h') /= => [Z|].
   rewrite conjgK coset_kerl ?cycle_id ?morph_constt ?repr_coset_norm //.
   rewrite /= coset_reprK 2!inE -order_dvdn dvdn_gcd => /and3P[_ _ p'Z].
   by apply: constt_p_elt (pnat_dvd p'Z _); apply: part_pnat.
@@ -755,28 +756,28 @@ apply: eq_bigl => z; apply/andP/andP=> [[]|[]].
   have G'z: h z \in G' by rewrite mem_morphim //= inE groupJ // groupV.
   rewrite inE G'z inE -order_dvdn dvdn_gcd order_dvdG //=.
   rewrite /order -morphim_cycle // -quotientE card_quotient ?cycle_subG //.
-  rewrite -(@dvdn_pmul2l #[y]) // Lagrange; last first.
+  rewrite -(@dvdn_pmul2l #[y]) // Lagrange.
     by rewrite /= cycleJ cycle_subG mem_conjgV -zp_ya mem_cycle.
   rewrite oy mulnAC partnC // [#|_|]orderJ; split.
     by rewrite !inE -!order_dvdn mulnC in Az; case/andP: Az.
   set Z := coset _ _; have NZ := repr_coset_norm Z; have:= coset_reprK Z.
   case/kercoset_rcoset=> {NZ}// _ /cycleP[i ->] ->{Z}.
-  rewrite consttM; last exact/commute_sym/commuteX/cent1P.
+  rewrite consttM; first exact/commute_sym/commuteX/cent1P.
   rewrite (constt1P _) ?p_eltNK 1?p_eltX ?p_elt_constt // mul1g.
   by rewrite conjMg consttJ conjgKV -zp_ya consttC.
 rewrite 2!inE -order_dvdn; set Z := coset _ _ => /andP[Cz n'Z] /eqP def_z.
 have Nz: z ^ a^-1 \in 'N(<[y]>).
-  rewrite -def_z conjgK groupMr; first by rewrite -(cycle_subG y) normG.
+  rewrite -def_z conjgK groupMr; last by rewrite -(cycle_subG y) normG.
   by rewrite groupX ?repr_coset_norm.
 have{Cz} /setIP[Gz Cz]: z ^ a^-1 \in 'C_G[y].
   case/morphimP: Cz => u Nu Cu /kercoset_rcoset[] // _ /cycleP[i ->] ->.
   by rewrite groupMr // groupX // inE groupX //; apply/cent1P.
 have{def_z} zp_ya: z.`_p = y ^ a.
   rewrite -def_z consttJ consttM.
-    rewrite constt_p_elt ?p_elt_constt //.
-    by rewrite (constt1P _) ?p_eltNK ?p_elt_constt ?mulg1.
-  apply: commute_sym; apply/cent1P.
-  by rewrite -def_z conjgK groupMl // in Cz; apply/cent1P.
+    apply: commute_sym; apply/cent1P.
+    by rewrite -def_z conjgK groupMl // in Cz; apply/cent1P.
+  rewrite constt_p_elt ?p_elt_constt //.
+  by rewrite (constt1P _) ?p_eltNK ?p_elt_constt ?mulg1.
 have ozp: (#[z ^ a^-1]`_p)%N = #[y] by rewrite -order_constt consttJ zp_ya conjgK.
 split; rewrite zp_ya // -class_lcoset lcoset_id // eqxx andbT.
 rewrite -(conjgKV a z) !inE groupJ //= -!order_dvdn orderJ; apply/andP; split.

--- a/solvable/gfunctor.v
+++ b/solvable/gfunctor.v
@@ -401,13 +401,13 @@ have sFK: 'ker (restrm sDF (coset (F2 _ G))) \subset K.
   rewrite {}/K !ker_restrm ker_comp /= subsetI subsetIl !ker_coset /=.
   by rewrite -sub_morphim_pre ?subsetIl // morphimIdom ?morphimF.
 have sOF := gFsub F1 (G / F2 _ G); have sGG: G \subset G by [].
-rewrite -sub_quotient_pre; last first.
+rewrite -sub_quotient_pre.
   by apply: subset_trans (nF2 _ _); rewrite morphimS ?gFmod_closed.
 suffices im_fact H : F2 _ G \subset gval H -> H \subset G ->
   factm sFK sGG @* (H / F2 _ G) = f @* H / F2 _ (f @* G).
 - rewrite -2?im_fact ?gFmod_closed ?gFsub //.
-    by rewrite cosetpreK morphimF /= ?morphim_restrm ?setIid.
-  by rewrite -sub_quotient_pre ?normG //= trivg_quotient sub1G.
+    by rewrite -sub_quotient_pre ?normG //= trivg_quotient sub1G.
+  by rewrite cosetpreK morphimF /= ?morphim_restrm ?setIid.
 move=> sFH sHG; rewrite -(morphimIdom _ (H / _)) /= {2}morphim_restrm /= setIid.
 rewrite -morphimIG ?ker_coset // -(morphim_restrm sDF) morphim_factm.
 by rewrite morphim_restrm morphim_comp -quotientE morphimIdom.
@@ -423,7 +423,7 @@ Variables F1 F2 : GFunctor.pmap.
 Lemma gFmod_hereditary : GFunctor.hereditary (F1 %% F2).
 Proof.
 move=> gT H G sHG; set FGH := _ :&: H; have nF2H := gFnorm F2 H.
-rewrite -sub_quotient_pre; last exact: subset_trans (subsetIr _ _) _.
+rewrite -sub_quotient_pre; first exact: subset_trans (subsetIr _ _) _.
 pose rH := restrm nF2H (coset (F2 _ H)); pose rHM := [morphism of rH].
 have rnorm_simpl: rHM @* H = H / F2 _ H by rewrite morphim_restrm setIid.
 have nF2G := subset_trans sHG (gFnorm F2 G).

--- a/solvable/gseries.v
+++ b/solvable/gseries.v
@@ -505,7 +505,7 @@ move=> nVG nsVU; apply/mingroupP/mingroupP; case=> /andP[->] /=.
   rewrite quotient_norms //; split=> // H /andP[ntH nHG] sHU.
   by apply: minUV (sHU); rewrite ntH -(cosetpreK H) actsQ // norm_quotient_pre.
 rewrite sub_quotient_pre // => nUG minU; rewrite astabsQ //.
-rewrite (subset_trans nUG); last first.
+rewrite (subset_trans nUG).
   by rewrite subsetI subsetIl /= -{2}(quotientGK nsVU) morphpre_norm.
 split=> // H /andP[ntH nHG] sHU.
 rewrite -{1}(cosetpreK H) astabsQ ?normal_cosetpre ?subsetI ?nVG //= in nHG.

--- a/solvable/hall.v
+++ b/solvable/hall.v
@@ -76,12 +76,12 @@ case/inv_quotientS=> //= ZK quoZK sZZK sZKG.
 have nZZK: Z <| ZK by apply: normalS nZG.
 have cardZK: #|ZK| = (#|Z| * #|G : H|)%N.
   rewrite -(Lagrange sZZK); congr (_ * _)%N.
-  rewrite -card_quotient -?quoZK; last by case/andP: nZZK.
+  rewrite -card_quotient -?quoZK; first by case/andP: nZZK.
   rewrite -(divgS sHG) -(Lagrange sZG) -(Lagrange sZH) divnMl //.
   rewrite -!card_quotient ?normal_norm //= -/Gbar -/Hbar.
   by rewrite -eqHKbar (TI_cardMg tiHKbar) mulKn.
 have: [splits ZK, over Z].
-  rewrite (Gaschutz_split nZZK _ sZZK) ?center_abelian //; last first.
+  rewrite (Gaschutz_split nZZK _ sZZK) ?center_abelian //.
     rewrite -divgS // cardZK mulKn ?cardG_gt0 //.
     by case/andP: hallH => _; apply: coprimeSg.
   by apply/splitsP; exists 1%G; rewrite inE -subG1 subsetIr mulg1 eqxx.
@@ -89,7 +89,7 @@ case/splitsP=> K /complP[tiZK eqZK].
 have sKZK: K \subset ZK by rewrite -(mul1g K) -eqZK mulSg ?sub1G.
 have tiHK: H :&: K = 1.
   apply/trivgP; rewrite /= -(setIidPr sKZK) setIA -tiZK setSI //.
-  rewrite -quotient_sub1; last by rewrite subIset 1?normal_norm.
+  rewrite -quotient_sub1; first by rewrite subIset 1?normal_norm.
   by rewrite /= quotientGI //= -quoZK tiHKbar.
 apply/splitsP; exists K; rewrite inE tiHK ?eqEcard subxx leqnn /=.
 rewrite mul_subG ?(subset_trans sKZK) //= TI_cardMg //.
@@ -120,9 +120,9 @@ have [coKM coHMK]: coprime #|M| #|K| /\ coprime #|H / M| #|K|.
   by apply/andP; rewrite -coprimeMl card_quotient ?nMsG ?Lagrange.
 have oKM (K' : {group gT}): K' \subset G -> #|K'| = #|K| -> #|K' / M| = #|K|.
   move=> sK'G oK'.
-  rewrite -quotientMidr -?norm_joinEl ?card_quotient ?nMsG //; last first.
+  rewrite -quotientMidr -?norm_joinEl ?card_quotient ?nMsG //.
     by rewrite gen_subG subUset sK'G.
-  rewrite -divgS /=; last by rewrite -gen_subG genS ?subsetUr.
+  rewrite -divgS /=; first by rewrite -gen_subG genS ?subsetUr.
   by rewrite norm_joinEl ?nMsG // coprime_cardMg ?mulnK // oK' coprime_sym.
 have [xb]: exists2 xb, xb \in H / M & K1 / M = (K / M) :^ xb.
   apply: IHn; try by rewrite (quotient_sol, morphim_norms, oKM K) ?(oKM K1).
@@ -282,10 +282,10 @@ have coMK: coprime #|M| #|K|.
   by rewrite coprime_sym (pnat_coprime piK) //; apply: (pHall_pgroup hallM).
 case: (SchurZassenhaus_trans_sol _ nMK sK1G1 coMK) => [||x Mx defK1].
 - exact: solvableS solG.
-- apply/eqP; rewrite -(eqn_pmul2l (cardG_gt0 M)) -TI_cardMg //; last first.
+- apply/eqP; rewrite -(eqn_pmul2l (cardG_gt0 M)) -TI_cardMg //.
     by apply/trivgP; rewrite -trMH /= setIA subsetIl.
   rewrite -coprime_cardMg // defG1; apply/eqP; congr #|(_ : {set _})|.
-  rewrite group_modl; last by rewrite -defG1 mulG_subl.
+  rewrite group_modl; first by rewrite -defG1 mulG_subl.
   by apply/setIidPr; rewrite defG gen_subG subUset sKG.
 exists x^-1; first by rewrite groupV (subsetP sMG).
 by rewrite -(_ : K1 :^ x^-1 = K) ?(conjSg, subsetIl) // defK1 conjsgK.
@@ -424,7 +424,7 @@ have nGN_N: G :&: N <| N.
 have NG_AG : G * N = A <*> G.
   by apply: Hall_Frattini_arg hallH => //; apply/andP.
 have iGN_A: #|N : G :&: N| = #|A|.
-  rewrite -card_quotient //; last by case/andP: nGN_N.
+  rewrite -card_quotient //; first by case/andP: nGN_N.
   rewrite (card_isog (second_isog nGN)) /= -quotientMidr (normC nGN) NG_AG.
   rewrite card_quotient // -divgS //= joingC norm_joinEr //.
   by rewrite coprime_cardMg // mulnC mulnK.
@@ -565,8 +565,8 @@ have sGA_H: [~: G, A] \subset H.
   rewrite gen_subG defG.
   apply/subsetP=> _ /imset2P[_ a /imset2P[x y Kx Hy ->] Aa ->].
   rewrite commMgJ (([~ x, a] =P 1) _) ?(conj1g, mul1g).
-    by rewrite groupMl ?groupV // memJ_norm ?(subsetP nHA).
-  by rewrite subsetI sKG in cKA; apply/commgP/(centsP cKA).
+    by rewrite subsetI sKG in cKA; apply/commgP/(centsP cKA).
+  by rewrite groupMl ?groupV // memJ_norm ?(subsetP nHA).
 apply: pcore_max; last first.
   by rewrite /(_ <| G) /=  commg_norml commGC commg_subr nGA.
 by case/and3P: hallH => _ piH _; apply: pgroupS piH.
@@ -637,7 +637,7 @@ have sXMG: XM \subset G by rewrite join_subG sXG.
 have hallY: pi.-Hall(XM) Y.
   have sYXM: Y \subset XM by rewrite subsetIr.
   have piY: pi.-group Y by apply: pgroupS piH; apply: subsetIl.
-  rewrite /pHall sYXM piY -divgS // -(_ : Y * M = XM).
+  rewrite /pHall sYXM piY -divgS // -(_ : Y * M = XM); last first.
     by rewrite coprime_cardMg ?co_pi_M // mulKn //.
   rewrite /= setIC group_modr ?joing_subr //=; apply/setIidPl.
   rewrite ((H * M =P G) _) // eqEcard mul_subG //= coprime_cardMg ?co_pi_M //.

--- a/solvable/jordanholder.v
+++ b/solvable/jordanholder.v
@@ -203,15 +203,15 @@ have i1 : perm_eq (mksrepr G N1 :: mkfactors N1 st1)
   rewrite perm_cons -[mksrepr _ _ :: _]/(mkfactors N1 [:: N & sN]).
   apply: Hi=> //; rewrite /comps ?lst1 //= lsN csN andbT /=.
   rewrite -quotient_simple.
-    by rewrite -(isog_simple iso2) quotient_simple.
-  by rewrite (normalS (subsetIl N1 N2) (normal_sub nN1G)).
+    by rewrite (normalS (subsetIl N1 N2) (normal_sub nN1G)).
+  by rewrite -(isog_simple iso2) quotient_simple.
 have i2 : perm_eq (mksrepr G N2 :: mkfactors N2 st2)
                   [:: mksrepr G N2, mksrepr N2 N & mkfactors N sN].
   rewrite perm_cons -[mksrepr _ _ :: _]/(mkfactors N2 [:: N & sN]).
   apply: Hi=> //; rewrite /comps ?lst2 //= lsN csN andbT /=.
   rewrite -quotient_simple.
-    by rewrite -(isog_simple iso1) quotient_simple.
-  by rewrite (normalS (subsetIr N1 N2) (normal_sub nN2G)).
+    by rewrite (normalS (subsetIr N1 N2) (normal_sub nN2G)).
+  by rewrite -(isog_simple iso1) quotient_simple.
 pose fG1 := [:: mksrepr G N1, mksrepr N1 N & mkfactors N sN].
 pose fG2 := [:: mksrepr G N2, mksrepr N2 N & mkfactors N sN].
 have i3 : perm_eq fG1 fG2.
@@ -261,8 +261,8 @@ Proof.
 move=> aAN1 aAN2.
 apply/subsetP=> x Ax; rewrite !inE Ax /=; apply/subsetP=> y Ny /[1!inE].
 case/setIP: Ny=> N1y N2y; rewrite inE ?astabs_act  ?N1y ?N2y //.
-- by move/subsetP: aAN2; move/(_ x Ax).
 - by move/subsetP: aAN1; move/(_ x Ax).
+- by move/subsetP: aAN2; move/(_ x Ax).
 Qed.
 
 Lemma gastabsP (S : {set rT}) (a : aT) :
@@ -626,8 +626,8 @@ have nNN2 : N <| N2.
 have aN : [ acts A, on N1 :&: N2 | to].
   apply/subsetP=> x Ax; rewrite !inE Ax /=; apply/subsetP=> y Ny; rewrite inE.
   case/setIP: Ny=> N1y N2y. rewrite inE ?astabs_act  ?N1y ?N2y //.
-    by move/subsetP: aN2; move/(_ x Ax).
-  by move/subsetP: aN1; move/(_ x Ax).
+    by move/subsetP: aN1; move/(_ x Ax).
+  by move/subsetP: aN2; move/(_ x Ax).
 have i1 : perm_eq (mksrepr G N1 :: mkfactors N1 st1)
                   [:: mksrepr G N1, mksrepr N1 N & mkfactors N sN].
   rewrite perm_cons -[mksrepr _ _ :: _]/(mkfactors N1 [:: N & sN]).
@@ -636,8 +636,8 @@ have i1 : perm_eq (mksrepr G N1 :: mkfactors N1 st1)
   apply: asimpleI => //.
     by apply: subset_trans (normal_norm nN2G); apply: normal_sub.
   rewrite -quotientMidl (maxainvM _ _ maxN_2) //.
-    by apply: maxainv_asimple_quo.
-  by move=> e; apply: neN12.
+    by move=> e; apply: neN12.
+  by apply: maxainv_asimple_quo.
 have i2 : perm_eq (mksrepr G N2 :: mkfactors N2 st2)
                   [:: mksrepr G N2, mksrepr N2 N & mkfactors N sN].
   rewrite perm_cons -[mksrepr _ _ :: _]/(mkfactors N2 [:: N & sN]).

--- a/solvable/maximal.v
+++ b/solvable/maximal.v
@@ -75,7 +75,7 @@ move/bigdprodWY: defF => <- {F}; elim: r rp => [_|q r IHr] /=.
   by rewrite big_nil gen0 pgroup1 normal1.
 rewrite inE eq_sym big_cons -joingE -joing_idr => /norP[qp /IHr {IHr}].
 set F := <<_>> => /andP[p'F nsFG].
-rewrite norm_joinEl /= -/F; last exact/gFsub_trans/normal_norm.
+rewrite norm_joinEl /= -/F; first exact/gFsub_trans/normal_norm.
 by rewrite pgroupM p'F normalM ?pcore_normal //= (pi_pgroup (pcore_pgroup q G)).
 Qed.
 
@@ -345,7 +345,7 @@ Lemma Phi_cprod G H K :
   p.-group G -> H \* K = G -> 'Phi(H) \* 'Phi(K) = 'Phi(G).
 Proof.
 move=> pG defG; have [_ /mulG_sub[sHG sKG] cHK] := cprodP defG.
-rewrite cprodEY /=; last by rewrite (centSS (Phi_sub _) (Phi_sub _)).
+rewrite cprodEY /=; first by rewrite (centSS (Phi_sub _) (Phi_sub _)).
 rewrite !(Phi_joing (pgroupS _ pG)) //=.
 have /cprodP[_ <- /cent_joinEr <-] := der_cprod 1 defG.
 have /cprodP[_ <- /cent_joinEr <-] := Mho_cprod 1 defG.
@@ -434,7 +434,7 @@ Lemma FittingEgen G :
   'F(G) = <<\bigcup_(p < #|G|.+1 | (p : nat) \in \pi(G)) 'O_p(G)>>.
 Proof.
 apply/eqP; rewrite eqEsubset gen_subG /=.
-rewrite -{1}(bigdprodWY (erefl 'F(G))) (big_nth 0) big_mkord genS.
+rewrite -{1}(bigdprodWY (erefl 'F(G))) (big_nth 0) big_mkord genS; last first.
   by apply/bigcupsP=> p _; rewrite -p_core_Fitting pcore_sub.
 apply/bigcupsP=> [[i /= lti]] _; set p := nth _ _ i.
 have pi_p: p \in \pi(G) by rewrite mem_nth.
@@ -571,11 +571,11 @@ pose Iok (I : {set {perm gT}}) :=
   (I \subset Aut G) &&
   [exists (M : {group gT} | M <| G), \big[dprod/1]_(f in I) f @: H == M].
 have defH: (1 : {perm gT}) @: H = H.
-  apply/eqP; rewrite eqEcard card_imset ?leqnn; last exact: perm_inj.
+  apply/eqP; rewrite eqEcard card_imset ?leqnn; first exact: perm_inj.
   by rewrite andbT; apply/subsetP=> _ /imsetP[x Hx ->]; rewrite perm1.
 have [|I] := @maxset_exists _ Iok 1.
-  rewrite /Iok sub1G; apply/existsP; exists H.
-  by rewrite /normal sHG nHG (big_pred1 1) => [|f]; rewrite ?defH /= ?inE.
+  rewrite /Iok sub1G; apply/existsP; exists H; last first.
+  by rewrite /normal sHG nHG (big_pred1 1) => [f|]; rewrite ?defH /= ?inE.
 case/maxsetP=> /andP[Aut_I /exists_eq_inP[M /andP[sMG nMG] defM]] maxI.
 rewrite sub1set=> ntI; case/eqVproper: sMG => [defG | /andP[sMG not_sGM]].
   exists H; split=> //; last by exists I; rewrite ?defM.
@@ -621,7 +621,7 @@ have cfHM: M \subset 'C(autm Af @* H).
   rewrite centsC (sameP commG1P trivgP) -tifHM subsetI commg_subl commg_subr.
   by rewrite (subset_trans sMG) // (subset_trans sfHG).
 exists (autm Af @* H <*> M)%G; rewrite /normal /= join_subG sMG sfHG normsY //=.
-rewrite (bigD1 f) ?inE ?eqxx // (eq_bigl [in I]) /= => [|g]; last first.
+rewrite (bigD1 f) ?inE ?eqxx // (eq_bigl [in I]) /= => [g|].
   by rewrite /= !inE andbC; case: eqP => // ->.
 by rewrite defM -(autmE Af) -morphimEsub // dprodE // cent_joinEr ?eqxx.
 Qed.
@@ -681,7 +681,7 @@ Qed.
 Lemma Fitting_pcore pi G : 'F('O_pi(G)) = 'O_pi('F(G)).
 Proof.
 apply/eqP; rewrite eqEsubset.
-rewrite (subset_trans _ (pcoreS _ (Fitting_sub _))); last first.
+rewrite (subset_trans _ (pcoreS _ (Fitting_sub _))).
   by rewrite subsetI Fitting_sub Fitting_max ?Fitting_nil ?gFnormal_trans.
 rewrite (subset_trans _ (FittingS (pcore_sub _ _))) // subsetI pcore_sub.
 by rewrite pcore_max ?pcore_pgroup ?gFnormal_trans.
@@ -729,7 +729,7 @@ have Zxy: [~ x, y] \in 'Z(G) by rewrite -defG' mem_commg.
 have Zxp: x ^+ p \in 'Z(G).
   rewrite -defPhi (Phi_joing pG) (MhoE 1 pG) joing_idr mem_gen // !inE.
   by rewrite expn1 orbC (imset_f (natexp^~ p)).
-rewrite mem_morphpre /= ?defG' ?Zxy // inE -commXg; last first.
+rewrite mem_morphpre /= ?defG' ?Zxy // inE -commXg.
   by red; case/setIP: Zxy => _ /centP->.
 by apply/commgP; red; case/setIP: Zxp => _ /centP->.
 Qed.
@@ -769,7 +769,7 @@ have{sZ2G'_Z} sG'Z: G^`(1) \subset 'Z(G).
   rewrite -quotient_der ?gFnorm // -quotientGI ?ucn_subS ?quotientS1 //=.
   by rewrite ucn1.
 have sCG': 'C_G(A) \subset G^`(1).
-  rewrite -quotient_sub1 //; last by rewrite subIset ?gFnorm.
+  rewrite -quotient_sub1 //; first by rewrite subIset ?gFnorm.
   rewrite (subset_trans (quotient_subcent _ G A)) //= -[G in G / _]defG.
   have nGA: A \subset 'N(G) by rewrite -commg_subl defG.
   rewrite quotientR ?gFnorm_trans ?normG //.
@@ -1057,7 +1057,7 @@ have defG: E * R = G.
   have cGx_x: <[x]> \subset 'C_G[x] by rewrite cycle_subG inE Gx cent1id.
   have nsRcx := p_maximal_normal (pgroupS sCxG pG) maxR.
   rewrite (norm_joinEr (subset_trans cGx_x (normal_norm nsRcx))).
-  rewrite (mulg_normal_maximal nsRcx) //=; last first.
+  rewrite (mulg_normal_maximal nsRcx) //=.
     by rewrite centY !cent_cycle cycle_subG !in_setI Gx cent1id cent1C.
   have nsCxG := p_maximal_normal pG maxCx.
   have syG: <[y]> \subset G by rewrite cycle_subG.
@@ -1308,7 +1308,7 @@ exists (sdprodm_morphism defE fMact).
 rewrite im_sdprodm injm_sdprodm injm_idm -card_im_injm im_idm fK.
 have [_ -> _ ->] := sdprodP defE; rewrite !eqxx; split=> //= u Zu.
 rewrite sdprodmEl ?(subsetP sZK) ?defZ // -(autE injg gZ Zu).
-rewrite -[aut _ _](invmK (injm_Zp_unitm z)); first by rewrite permE Zu.
+rewrite -[aut _ _](invmK (injm_Zp_unitm z)); last by rewrite permE Zu.
 by rewrite im_Zp_unitm Aut_aut.
 Qed.
 
@@ -1349,7 +1349,7 @@ Lemma exponent_Ohm1_class2 H :
   odd p -> p.-group H -> nil_class H <= 2 -> exponent 'Ohm_1(H) %| p.
 Proof.
 move=> odd_p pH; rewrite nil_class2 => sH'Z; apply/exponentP=> x /=.
-rewrite (OhmE 1 pH) expn1 gen_set_id => {x} [/LdivP[] //|].
+rewrite (OhmE 1 pH) expn1 gen_set_id => {x} [|/LdivP[] //].
 apply/group_setP; split=> [|x y]; first by rewrite !inE group1 expg1n //=.
 case/LdivP=> Hx xp1 /LdivP[Hy yp1]; rewrite !inE groupM //=.
 have [_ czH]: [~ y, x] \in H /\ centralises [~ y, x] H.
@@ -1373,7 +1373,7 @@ Proof.
 move/pgroup_nil=> nilG; rewrite /abelian.
 case/maxgroupP=> /andP[nsAG abelA] maxA; have [sAG nAG] := andP nsAG.
 rewrite inE nsAG eqEsubset /= andbC subsetI abelA normal_sub //=.
-rewrite -quotient_sub1; last by rewrite subIset 1?normal_norm.
+rewrite -quotient_sub1; first by rewrite subIset 1?normal_norm.
 apply/trivgP; apply: (TI_center_nil (quotient_nil A nilG)).
   by rewrite quotient_normal // /normal subsetIl normsI ?normG ?norms_cent.
 apply/trivgP/subsetP=> _ /setIP[/morphimP[x Nx /setIP[_ Cx]] ->].
@@ -1411,7 +1411,7 @@ apply/subsetP=> w /imset2P[u v].
 rewrite /= -groupV -(groupV _ v) /= astabQR //= -/Z !inE (groupV 'C(Z)).
 case/and4P=> cZu _ _ sRuZ /and4P[cZv' _ _ sRvZ] ->{w}.
 apply/centP=> a Aa; rewrite /commute -!mulgA (commgCV v) (mulgA u).
-rewrite (centP cZu); last by rewrite (subsetP sRvZ) ?mem_commg ?set11 ?groupV.
+rewrite (centP cZu); first by rewrite (subsetP sRvZ) ?mem_commg ?set11 ?groupV.
 rewrite 2!(mulgA v^-1) mulKVg 4!mulgA invgK (commgC u^-1) mulgA.
 rewrite -(mulgA _ _ v^-1) -(centP cZv') ?(subsetP sRuZ) ?mem_commg ?set11//.
 by rewrite -!mulgA invgK mulKVg !mulKg.
@@ -1453,7 +1453,7 @@ have sXW: <[x]> \subset W.
 have{nil_classY pY sXW sZY sZCA} defW: W = <[x]> * Z.
   rewrite -[W](setIidPr (Ohm_sub _ _)) /= -/Y {1}defY -group_modl //= -/Y -/W.
   congr (_ * _); apply/eqP; rewrite eqEsubset {1}[Z](OhmE 1 pA).
-  rewrite subsetI setIAC subIset //; first by rewrite sZCA -[Z]Ohm_id OhmS.
+  rewrite subsetI setIAC subIset //; last by rewrite sZCA -[Z]Ohm_id OhmS.
   rewrite sub_gen ?setIS //; apply/subsetP=> w Ww; rewrite inE.
   by apply/eqP; apply: exponentP w Ww; apply: exponent_Ohm1_class2.
 have{sXG sAG} sXAG: XA \subset G by rewrite join_subG sXG.
@@ -1525,7 +1525,7 @@ rewrite groupM //= => nt_xyp; pose XY := <[x]> <*> <[y]>.
 have{yp1 nt_xyp} defXY: XY = U.
   have sXY_U: XY \subset U by rewrite join_subG !cycle_subG Ux Uy.
   rewrite [XY]minU //= eqEsubset Ohm_sub (OhmE 1 (pgroupS _ pU)) //.
-  rewrite /= joing_idl joing_idr genS; last first.
+  rewrite /= joing_idl joing_idr genS.
     by rewrite subsetI subset_gen subUset !sub1set !inE xp1 yp1.
   apply: contra nt_xyp => /exponentP-> //.
   by rewrite groupMl mem_gen // (set21, set22).
@@ -1540,8 +1540,8 @@ have{genXp minU xp1 sVU ltVU} expVp: exponent V %| p.
   by rewrite inE -order_dvdn (dvdn_trans (order_dvdG Vv)) // cardJg order_dvdn.
 have{A pA defA1 sX'A V expVp} Zxy: [~ x, y] \in Z.
   rewrite -defA1 (OhmE 1 pA) mem_gen // !inE (exponentP expVp).
-    by rewrite (subsetP sX'A) //= mem_commg ?(subsetP sUX).
-  by rewrite groupMl -1?[x^-1]conjg1 mem_gen // imset2_f // ?groupV cycle_id.
+    by rewrite groupMl -1?[x^-1]conjg1 mem_gen // imset2_f // ?groupV cycle_id.
+  by rewrite (subsetP sX'A) //= mem_commg ?(subsetP sUX).
 have{Zxy sUX cZX} cXYxy: [~ x, y] \in 'C(XY).
   by rewrite centsC in cZX; rewrite defXY (subsetP (centS sUX)) ?(subsetP cZX).
 rewrite -defU1 exponent_Ohm1_class2 // nil_class2 -defXY der1_joing_cycles //.
@@ -1565,23 +1565,23 @@ have sKG := char_sub chK; have nKG := char_normal chK.
 exists K; split=> //; apply/eqP; rewrite eqEsubset andbC setSI //=.
 have chZ: 'Z(K) \char G by [apply: subcent_char]; have nZG := char_norm chZ.
 have chC: 'C_G(K) \char G by apply: subcent_char chK.
-rewrite -quotient_sub1; last by rewrite subIset // char_norm.
+rewrite -quotient_sub1; first by rewrite subIset // char_norm.
 apply/trivgP; apply: (TI_center_nil (quotient_nil _ (pgroup_nil pG))).
   by rewrite quotient_normal ?norm_normalI ?norms_cent ?normal_norm.
 apply: TI_Ohm1; apply/trivgP; rewrite -trivg_quotient -sub_cosetpre_quo //.
-rewrite morphpreI quotientGK /=; last first.
+rewrite morphpreI quotientGK /=.
   by apply: normalS (char_normal chZ); rewrite ?subsetIl ?setSI.
 set X := _ :&: _; pose gX := [group of X].
 have sXG: X \subset G by rewrite subIset ?subsetIl.
 have cXK: K \subset 'C(gX) by rewrite centsC 2?subIset // subxx orbT.
 rewrite subsetI centsC cXK andbT -(mul1g K) -mulSG mul1g -(cent_joinEr cXK).
 rewrite [_ <*> K]maxK ?joing_subr //= andbC (cent_joinEr cXK).
-rewrite -center_prod // (subset_trans _ (mulG_subr _ _)).
+rewrite -center_prod // (subset_trans _ (mulG_subr _ _)); last first.
   rewrite charM 1?charI ?(char_from_quotient (normal_cosetpre _)) //.
   by rewrite cosetpreK !gFchar_trans.
-rewrite (@Phi_mulg p) ?(pgroupS _ pG) // subUset commGC commMG; last first.
+rewrite (@Phi_mulg p) ?(pgroupS _ pG) // subUset commGC commMG.
   by rewrite normsR ?(normsG sKG) // cents_norm // centsC.
-rewrite !mul_subG 1?commGC //.
+rewrite !mul_subG 1?commGC //; last first.
   apply: subset_trans (commgS _ (subsetIr _ _)) _.
   rewrite -quotient_cents2 ?subsetIl // centsC // cosetpreK //.
   exact/gFsub_trans/subsetIr.

--- a/solvable/nilpotent.v
+++ b/solvable/nilpotent.v
@@ -172,7 +172,7 @@ Lemma lcn_cprod n A B G : A \* B = G -> 'L_n(A) \* 'L_n(B) = 'L_n(G).
 Proof.
 case: n => // n /cprodP[[H K -> ->{A B}] defG cHK].
 have sL := subset_trans (lcn_sub _ _); rewrite cprodE ?(centSS _ _ cHK) ?sL //.
-symmetry; elim: n => // n; rewrite lcnSn => ->; rewrite commMG /=; last first.
+symmetry; elim: n => // n; rewrite lcnSn => ->; rewrite commMG /=.
   by apply: subset_trans (commg_normr _ _); rewrite sL // -defG mulG_subr.
 rewrite -!(commGC G) -defG -{1}(centC cHK).
 rewrite !commMG ?normsR ?lcn_norm ?cents_norm // 1?centsC //.
@@ -182,7 +182,7 @@ Qed.
 Lemma lcn_dprod n A B G : A \x B = G -> 'L_n(A) \x 'L_n(B) = 'L_n(G).
 Proof.
 move=> defG; have [[K H defA defB] _ _ tiAB] := dprodP defG.
-rewrite !dprodEcp // in defG *; first exact: lcn_cprod.
+rewrite !dprodEcp // in defG *; last exact: lcn_cprod.
 by rewrite defA defB; apply/trivgP; rewrite -tiAB defA defB setISS ?lcn_sub.
 Qed.
 
@@ -442,7 +442,7 @@ Qed.
 Lemma ucn_dprod n A B G : A \x B = G -> 'Z_n(A) \x 'Z_n(B) = 'Z_n(G).
 Proof.
 move=> defG; have [[K H defA defB] _ _ tiAB] := dprodP defG.
-rewrite !dprodEcp // in defG *; first exact: ucn_cprod.
+rewrite !dprodEcp // in defG *; last exact: ucn_cprod.
 by rewrite defA defB; apply/trivgP; rewrite -tiAB defA defB setISS ?ucn_sub.
 Qed.
 
@@ -785,7 +785,7 @@ have -> : (morphm fm @* setXn G)%g = setXn (fun i => G (lift ord0 i)).
   exists w; last by apply/ffunP => i; rewrite morphmE ffunE/= wl.
   apply/setXnP => i.
   case: (unliftP ord0 i) => [j|]->; rewrite ?wl ?w0 ?vG//.
-rewrite IHn ?andbT//; last by move=> i; apply: solG.
+rewrite IHn ?andbT//; first by move=> i; apply: solG.
 pose k (x : gT ord0) : prod_group_gT :=
   [ffun i : 'I_n.+1 =>
      match (ord0 =P i) return (gT i) : Type with

--- a/solvable/pgroup.v
+++ b/solvable/pgroup.v
@@ -425,7 +425,7 @@ Proof.
 apply/idP/idP=> [pi_xm | /dvdnP[q ->{m}]]; last first.
   rewrite mulnC; apply: pnat_dvd (part_pnat pi #[x]).
   by rewrite order_dvdn -expgM mulnC mulnA partnC // -order_dvdn dvdn_mulr.
-rewrite -(@Gauss_dvdr _ #[x ^+ m]); last first.
+rewrite -(@Gauss_dvdr _ #[x ^+ m]).
   by rewrite coprime_sym (pnat_coprime pi_xm) ?part_pnat.
 apply: (@dvdn_trans #[x]); first by rewrite -{2}[#[x]](partnC pi) ?dvdn_mull.
 by rewrite order_dvdn mulnC expgM expg_order.
@@ -505,7 +505,7 @@ Proof. by rewrite -{1}(consttC pi^' x) consttNK mulgK p_elt_constt. Qed.
 
 Lemma order_constt pi (x : gT) : #[x.`_pi] = (#[x]`_pi)%N.
 Proof.
-rewrite -{2}(consttC pi x) orderM; [|exact: commuteX2|]; last first.
+rewrite -{2}(consttC pi x) orderM; [exact: commuteX2| |].
   by apply: (@pnat_coprime pi); apply: p_elt_constt.
 by rewrite partnM // part_pnat_id ?part_p'nat ?muln1 //; apply: p_elt_constt.
 Qed.
@@ -544,7 +544,7 @@ Qed.
 Lemma sub_in_constt pi1 pi2 x :
   {in \pi(#[x]), {subset pi1 <= pi2}} -> x.`_pi2.`_pi1 = x.`_pi1.
 Proof.
-move=> pi12; rewrite -{2}(consttC pi2 x) consttM; last exact: commuteX2.
+move=> pi12; rewrite -{2}(consttC pi2 x) consttM; first exact: commuteX2.
 rewrite (constt1P _ x.`_pi2^' _) ?mulg1 //.
 apply: sub_in_pnat (p_elt_constt _ x) => p; rewrite order_constt => pi_p.
 by apply/contra/pi12; rewrite -[#[x]](partnC pi2^') // primesM // pi_p.
@@ -559,7 +559,7 @@ elim: _.+1 => [|p IHp].
   by rewrite big_nil; apply/constt1P; apply/pgroupP.
 rewrite big_nat_recr //= -{}IHp -(consttC (lp p) x.`__); congr (_ * _).
   by rewrite sub_in_constt // => q _; apply: leqW.
-set y := _.`__; rewrite -(consttC p y) (constt1P p^' _ _) ?mulg1.
+set y := _.`__; rewrite -(consttC p y) (constt1P p^' _ _) ?mulg1; last first.
   by rewrite 2?sub_in_constt // => q _; move/eqnP->; rewrite !inE ?ltnn.
 rewrite /p_elt pnatNK !order_constt -partnI.
 apply: sub_in_pnat (part_pnat _ _) => q _.
@@ -771,7 +771,7 @@ Proof. by move=> Dx; apply: pnat_dvd; apply: morph_order. Qed.
 Lemma morph_constt pi x : x \in D -> f x.`_pi = (f x).`_pi.
 Proof.
 move=> Dx; rewrite -{2}(consttC pi x) morphM ?groupX //.
-rewrite consttM; last by rewrite !morphX //; apply: commuteX2.
+rewrite consttM; first by rewrite !morphX //; apply: commuteX2.
 have: pi.-elt (f x.`_pi) by rewrite morph_p_elt ?groupX ?p_elt_constt //.
 have: pi^'.-elt (f x.`_pi^') by rewrite morph_p_elt ?groupX ?p_elt_constt //.
 by move/constt1P->; move/constt_p_elt->; rewrite mulg1.
@@ -1019,7 +1019,7 @@ have sFK: 'ker (restrm sDF (coset (F _ G))) \subset K.
   rewrite -sub_morphim_pre ?subsetIl //.
   by rewrite morphimIdom !ker_coset (setIidPr _) ?pmorphimF ?gFsub.
 have sOF := pcore_sub pi (G / F _ G); have sDD: D :&: G \subset D :&: G by [].
-rewrite -sub_morphim_pre -?quotientE; last first.
+rewrite -sub_morphim_pre -?quotientE.
   by apply: subset_trans (gFnorm F _); rewrite morphimS ?pcore_mod_sub.
 suffices im_fact (H : {group gT}) : F _ G \subset H -> H \subset G ->
   factm sFK sDD @* (H / F _ G) = f @* H / F _ (f @* G).
@@ -1158,9 +1158,9 @@ apply: (@quotient_inj _ (pseries_group pi1s G)).
 - by rewrite /= /(_ <| _) pseries_norm2 -cats1 pseries_sub_catl.
 rewrite /= cat_rcons -(IHpi (pi :: pi2s)) {1}quotient_pseries IHpi.
 apply/eqP; rewrite quotient_pseries eqEsubset !pcore_max ?pcore_pgroup //=.
-  rewrite -quotient_pseries morphim_normal // /(_ <| _) pseries_norm2.
-  by rewrite -cat_rcons pseries_sub_catl.
-by rewrite gFnormal_trans ?quotient_normal ?gFnormal.
+  by rewrite gFnormal_trans ?quotient_normal ?gFnormal.
+rewrite -quotient_pseries morphim_normal // /(_ <| _) pseries_norm2.
+by rewrite -cat_rcons pseries_sub_catl.
 Qed.
 
 Lemma pseries_char_catl pi1s pi2s gT (G : {group gT}) :
@@ -1178,9 +1178,9 @@ apply: (@quotient_inj _ (pseries_group pi2s G)).
 - by rewrite /= /(_ <| _) pseries_norm2 -cats1 pseries_sub_catl.
 rewrite /= -Epis {1}quotient_pseries Epis quotient_pseries.
 apply/eqP; rewrite eqEsubset !pcore_max ?pcore_pgroup //=.
-  rewrite -quotient_pseries morphim_normal // /(_ <| _) pseries_norm2.
-  by rewrite pseries_sub_catr.
-by rewrite gFnormal_trans ?morphim_normal ?gFnormal.
+  by rewrite gFnormal_trans ?morphim_normal ?gFnormal.
+rewrite -quotient_pseries morphim_normal // /(_ <| _) pseries_norm2.
+by rewrite pseries_sub_catr.
 Qed.
 
 Lemma pseries_char_catr pi1s pi2s gT (G : {group gT}) :
@@ -1257,27 +1257,27 @@ Proof. by rewrite -(pHallNK pi G H); apply: sdprod_pcore_HallP. Qed.
 Lemma pcoreI pi rho G : 'O_[predI pi & rho](G) = 'O_pi('O_rho(G)).
 Proof.
 apply/eqP; rewrite eqEsubset !pcore_max //.
+- by apply: sub_pgroup (pcore_pgroup _ _) => p /andP[].
+- apply/andP; split; first by apply: sub_pcore => p /andP[].
+  by rewrite gFnorm_trans ?normsG ?gFsub.
 - rewrite /pgroup pnatI -!pgroupE.
   by rewrite pcore_pgroup (pgroupS (pcore_sub pi _))// pcore_pgroup.
 - by rewrite !gFnormal_trans.
-- by apply: sub_pgroup (pcore_pgroup _ _) => p /andP[].
-apply/andP; split; first by apply: sub_pcore => p /andP[].
-by rewrite gFnorm_trans ?normsG ?gFsub.
 Qed.
 
 Lemma bigcap_p'core pi G :
   G :&: \bigcap_(p < #|G|.+1 | (p : nat) \in pi) 'O_p^'(G) = 'O_pi^'(G).
 Proof.
 apply/eqP; rewrite eqEsubset subsetI pcore_sub pcore_max /=.
-- by apply/bigcapsP=> p pi_p; apply: sub_pcore => r; apply: contraNneq => ->.
 - apply/pgroupP=> q q_pr qGpi'; apply: contraL (eqxx q) => /= pi_q.
   apply: (pgroupP (pcore_pgroup q^' G)) => //.
   have qG: q %| #|G| by rewrite (dvdn_trans qGpi') // cardSg ?subsetIl.
   have ltqG: q < #|G|.+1 by rewrite ltnS dvdn_leq.
   rewrite (dvdn_trans qGpi') ?cardSg ?subIset //= orbC.
   by rewrite (bigcap_inf (Ordinal ltqG)).
-rewrite /normal subsetIl normsI ?normG // norms_bigcap //.
-by apply/bigcapsP => p _; apply: gFnorm.
+- rewrite /normal subsetIl normsI ?normG // norms_bigcap //.
+  by apply/bigcapsP => p _; apply: gFnorm.
+- by apply/bigcapsP=> p pi_p; apply: sub_pcore => r; apply: contraNneq => ->.
 Qed.
 
 Lemma coprime_pcoreC (rT : finGroupType) pi G (R : {group rT}) :

--- a/solvable/primitive_action.v
+++ b/solvable/primitive_action.v
@@ -62,7 +62,7 @@ apply/forallP/maximal_eqP=> /= [primG | [_ maxCx] Q].
   have defH: 'N_(G)(X | to) = H.
     have trH: [transitive H, on X | to] by apply/imsetP; exists x.
     have sHN: H \subset 'N_G(X | to) by rewrite subsetI sHG atrans_acts.
-    move/(subgroup_transitiveP Xx sHN): (trH) => /= <-.
+    move/(subgroup_transitiveP Xx sHN): (trH) => /= <-; last first.
       by rewrite mulSGid //= setIAC subIset ?sCH.
     apply/imsetP; exists x => //; apply/eqP.
     by rewrite eqEsubset imsetS // acts_sub_orbit ?subsetIr.

--- a/solvable/sylow.v
+++ b/solvable/sylow.v
@@ -64,7 +64,7 @@ move=> pM sMR /mingroupP[/andP[ntM nMG] minM].
 have /andP[sGpG nGpG]: 'O_p(G) <| G := gFnormal _ G.
 have sGD := acts_dom nMG; have sGpD: 'O_p(G) \subset D := gFsub_trans _ sGD.
 rewrite subsetI sGpG -gacentC //=; apply/setIidPl; apply: minM (subsetIl _ _).
-rewrite nontrivial_gacent_pgroup ?pcore_pgroup //=; last first.
+rewrite nontrivial_gacent_pgroup ?pcore_pgroup //=.
   by split; rewrite ?gFsub_trans.
 by apply: subset_trans (acts_subnorm_subgacent sGpD nMG); rewrite subsetI subxx.
 Qed.
@@ -144,8 +144,8 @@ have sylP: p.-Sylow(G) P.
     rewrite p_part lognE p_pr /= -trivg_card1; apply/idPn=> ntP.
     by case/pgroup_pdiv: pP p_pr => // ->.
   rewrite -(LagrangeI G 'N(P)) /= mulnC partnM ?cardG_gt0 // part_p'nat.
-    by rewrite mul1n (card_Hall (sylS P S_P)).
-  by rewrite p'natE // -indexgI -oSiN // /dvdn oS1.
+    by rewrite p'natE // -indexgI -oSiN // /dvdn oS1.
+  by rewrite mul1n (card_Hall (sylS P S_P)).
 have eqS Q: maxp G Q = p.-Sylow(G) Q.
   apply/idP/idP=> [S_Q|]; last exact: Hall_max.
   have{} S_Q: Q \in S by rewrite inE.
@@ -285,10 +285,10 @@ Qed.
 Lemma Sylow_gen G : <<\bigcup_(P : {group gT} | Sylow G P) P>> = G.
 Proof.
 set T := [set P : {group gT} | Sylow G P].
-rewrite -{2}(@Sylow_transversal_gen T G) => [|P | q _].
-- by congr <<_>>; apply: eq_bigl => P; rewrite inE.
+rewrite -{2}(@Sylow_transversal_gen T G) => [P | q _|].
 - by rewrite inE => /and3P[].
-by case: (Sylow_exists q G) => P sylP; exists P; rewrite // inE (p_Sylow sylP).
+- by case: (Sylow_exists q G) => P sylP; exists P; rewrite // inE (p_Sylow sylP).
+- by congr <<_>>; apply: eq_bigl => P; rewrite inE.
 Qed.
 
 End MoreSylow.
@@ -408,8 +408,8 @@ Lemma nilpotent_Hall_pcore pi G H :
 Proof.
 move=> nilG hallH; have maxH := Hall_max hallH; apply/eqP.
 rewrite eqEsubset pcore_max ?(pHall_pgroup hallH) //.
-  by rewrite (normal_sub_max_pgroup maxH) ?pcore_pgroup ?pcore_normal.
-exact: nilpotent_maxp_normal maxH.
+  exact: nilpotent_maxp_normal maxH.
+by rewrite (normal_sub_max_pgroup maxH) ?pcore_pgroup ?pcore_normal.
 Qed.
 
 Lemma nilpotent_pcore_Hall pi G : nilpotent G -> pi.-Hall(G) 'O_pi(G).
@@ -425,10 +425,10 @@ Proof.
 move=> nilG; have trO: 'O_pi(G) :&: 'O_pi^'(G) = 1.
   by apply: coprime_TIg; apply: (@pnat_coprime pi); apply: pcore_pgroup.
 rewrite dprodE //.
-  apply/eqP; rewrite eqEcard mul_subG ?pcore_sub // (TI_cardMg trO).
-  by rewrite !(card_Hall (nilpotent_pcore_Hall _ _)) // partnC ?leqnn.
-rewrite (sameP commG1P trivgP) -trO subsetI commg_subl commg_subr.
-by rewrite !gFsub_trans ?gFnorm.
+  rewrite (sameP commG1P trivgP) -trO subsetI commg_subl commg_subr.
+  by rewrite !gFsub_trans ?gFnorm.
+apply/eqP; rewrite eqEcard mul_subG ?pcore_sub // (TI_cardMg trO).
+by rewrite !(card_Hall (nilpotent_pcore_Hall _ _)) // partnC ?leqnn.
 Qed.
 
 Lemma sub_nilpotent_cent2 H K G :
@@ -646,8 +646,8 @@ have [y2 Ny2 Dy2]: exists2 y2, y2 \in 'N_(P :&: E)(D) & y2 \notin D.
   case/subsetPn: sNN => z /setIP[Pz NNz]; rewrite 2!inE Pz.
   case/subsetPn=> y Dzy Dy; exists y => //; apply: subsetP Dzy.
   rewrite -setIA setICA subsetI sub_conjg (normsP nEG) ?groupV //.
-    by rewrite sDE -(normP NNz); rewrite conjSg subsetI sDP.
-  by apply: subsetP Pz; apply: (subset_trans (pHall_sub sylP)).
+    by apply: subsetP Pz; apply: (subset_trans (pHall_sub sylP)).
+  by rewrite sDE -(normP NNz); rewrite conjSg subsetI sDP.
 suff{Dy2} Dy2D: y2 |: D = D by rewrite -Dy2D setU11 in Dy2.
 apply: maxD; last by rewrite subsetUr.
 case/setIP: Ny2 => PEy2 Ny2; case/setIP: Ny1 => Ey1 Ny1.


### PR DESCRIPTION
Mathcomp was doing `Global Set SsrOldRewriteGoalsOrder` in `boot/ssreflect.v`, let's try to remove it and add the set command to each file that needs porting, thus easing the porting process on a file per file basis. The current PR also ports mathcomp itself. This
* removes 161 `last first`
* adds 50 `last first`

which seems to indicate that, even on code written with the old order, the new one is beneficial.

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).

#### Overlays

* [x] https://github.com/math-comp/algebra-tactics/pull/129
* [x] https://github.com/rocq-community/apery/pull/42
* [x] https://github.com/rocq-community/coqeal/pull/118
* [x] https://github.com/rocq-community/bits/pull/30
* [x] https://github.com/proux01/coquelicot/tree/mc1545
* [x] https://github.com/math-comp/Abel/pull/103
* [x] https://github.com/arthuraa/deriving/pull/38
* [x] https://github.com/arthuraa/extructures/pull/37
* [x] https://github.com/rocq-community/fourcolor/pull/76
* [x] https://github.com/rocq-community/gaia/pull/29
* [x] https://github.com/rocq-community/graph-theory/pull/49
* [x] https://github.com/math-comp/analysis/pull/1860
* [x] https://github.com/math-comp/finmap/pull/152
* [x] https://github.com/math-comp/multinomials/pull/119
* [x] https://github.com/math-comp/real-closed/pull/83
* [x] https://github.com/rocq-community/tarjan/pull/35
* [x] https://github.com/jasmin-lang/coqword/pull/36
* [x] https://github.com/math-comp/mczify/pull/67
* [x] https://github.com/math-comp/odd-order/pull/78
* [x] https://github.com/QuickChick/QuickChick/pull/427
* [x] https://github.com/rocq-community/reglang/pull/79
* [x] ~https://gitlab.inria.fr/coqinterval/interval/-/merge_requests/15~
* [x] https://github.com/SSProve/ssprove/pull/108
* [x] https://github.com/SSProve/ssprove/pull/110
* [x] https://github.com/affeldt-aist/infotheo/pull/207
* [ ] https://github.com/imdea-software/fcsl-pcm/pull/57
