### PR TITLE
Cleanup `Require Import`s in `algebra/`

### DIFF
--- a/algebra/archimedean.v
+++ b/algebra/archimedean.v
@@ -2,7 +2,9 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import fintype bigop order ssralg poly ssrnum ssrint.
+From mathcomp Require Import fintype bigop nmodule order algebra divalg.
+From mathcomp Require Import decfield poly orderedzmod numdomain numfield.
+From mathcomp Require Import ssrint.
 
 (******************************************************************************)
 (*                           Archimedean structures                           *)
@@ -140,7 +142,7 @@ Arguments int_num {R} : simpl never.
 Notation trunc := truncn (only parsing).
 
 Module Def.
-Export ssrnum.Num.Def.
+Export Num.Def.
 
 Notation truncn := truncn.
 #[deprecated(since="mathcomp 2.4.0", use=truncn)]
@@ -181,7 +183,7 @@ HB.instance Definition _ :=
     intArchimedean.intrP intArchimedean.natrP.
 
 Module Import Theory.
-Export ssrnum.Num.Theory.
+Export Num.Theory.
 
 Section ArchiNumDomainTheory.
 

--- a/algebra/countalg.v
+++ b/algebra/countalg.v
@@ -2,7 +2,7 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import bigop ssralg.
+From mathcomp Require Import bigop nmodule algebra divalg decfield.
 
 (*****************************************************************************)
 (*     The algebraic part of the algebraic hierarchy for countable types     *)

--- a/algebra/finalg.v
+++ b/algebra/finalg.v
@@ -3,7 +3,7 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
 From mathcomp Require Import fintype finset fingroup morphism perm action.
-From mathcomp Require Import ssralg countalg.
+From mathcomp Require Import nmodule algebra divalg decfield countalg.
 
 (*****************************************************************************)
 (*      The algebraic part of the algebraic hierarchy for finite types       *)

--- a/algebra/intdiv.v
+++ b/algebra/intdiv.v
@@ -2,8 +2,9 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
-From mathcomp Require Import div choice fintype tuple bigop prime order perm.
-From mathcomp Require Import ssralg poly polydiv ssrnum ssrint zmodp matrix.
+From mathcomp Require Import div choice fintype tuple bigop prime nmodule order.
+From mathcomp Require Import perm algebra divalg poly polydiv zmodp matrix.
+From mathcomp Require Import orderedzmod numdomain ssrint.
 
 (******************************************************************************)
 (* This file provides various results on divisibility of integers.            *)

--- a/algebra/matrix.v
+++ b/algebra/matrix.v
@@ -2,8 +2,8 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import fintype finfun bigop finset order fingroup perm.
-From mathcomp Require Import ssralg countalg finalg zmodp.
+From mathcomp Require Import fintype finfun bigop finset nmodule fingroup perm.
+From mathcomp Require Import order algebra divalg countalg finalg zmodp.
 
 (******************************************************************************)
 (* Basic concrete linear algebra : definition of type for matrices, and all   *)

--- a/algebra/mxalgebra.v
+++ b/algebra/mxalgebra.v
@@ -1,9 +1,10 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq choice.
-From mathcomp Require Import fintype finfun bigop finset fingroup perm order.
-From mathcomp Require Import div prime binomial ssralg finalg zmodp matrix.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
+From mathcomp Require Import choice fintype finfun bigop prime finset binomial.
+From mathcomp Require Import nmodule fingroup perm order algebra divalg finalg.
+From mathcomp Require Import zmodp matrix.
 
 (*****************************************************************************)
 (* In this file we develop the rank and row space theory of matrices, based  *)

--- a/algebra/mxpoly.v
+++ b/algebra/mxpoly.v
@@ -1,9 +1,10 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat choice seq.
-From mathcomp Require Import div fintype tuple finfun bigop fingroup perm.
-From mathcomp Require Import ssralg zmodp matrix mxalgebra poly polydiv.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
+From mathcomp Require Import choice fintype tuple finfun bigop fingroup perm.
+From mathcomp Require Import nmodule algebra divalg decfield matrix mxalgebra.
+From mathcomp Require Import poly polydiv.
 
 (******************************************************************************)
 (*   This file provides basic support for formal computation with matrices,   *)

--- a/algebra/mxred.v
+++ b/algebra/mxred.v
@@ -1,8 +1,8 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
-From mathcomp Require Import choice fintype finfun bigop fingroup perm order.
-From mathcomp Require Import ssralg zmodp matrix mxalgebra poly polydiv mxpoly.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype finfun bigop nmodule order algebra divalg.
+From mathcomp Require Import poly polydiv matrix mxalgebra mxpoly.
 
 (*****************************************************************************)
 (* In this file, we prove diagonalization theorems. For this purpose, we     *)

--- a/algebra/poly.v
+++ b/algebra/poly.v
@@ -3,7 +3,7 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq choice.
 From mathcomp Require Import fintype bigop finset tuple div binomial.
-From mathcomp Require Import ssralg countalg.
+From mathcomp Require Import nmodule algebra divalg decfield countalg.
 
 (******************************************************************************)
 (* This file provides a library for univariate polynomials over ring          *)

--- a/algebra/polyXY.v
+++ b/algebra/polyXY.v
@@ -2,9 +2,8 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype choice ssrnat seq.
-From mathcomp Require Import fintype tuple finfun bigop fingroup perm div.
-From mathcomp Require Import ssralg zmodp matrix mxalgebra.
-From mathcomp Require Import poly polydiv mxpoly binomial.
+From mathcomp Require Import choice fintype bigop nmodule algebra divalg.
+From mathcomp Require Import poly polydiv matrix mxpoly.
 
 (******************************************************************************)
 (* This file provides additional primitives and theory for bivariate          *)

--- a/algebra/polydiv.v
+++ b/algebra/polydiv.v
@@ -1,7 +1,7 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import fintype bigop ssralg poly.
+From mathcomp Require Import fintype bigop nmodule algebra divalg decfield poly.
 
 (******************************************************************************)
 (* This file provides a library for the basic theory of Euclidean and pseudo- *)

--- a/algebra/qpoly.v
+++ b/algebra/qpoly.v
@@ -1,8 +1,8 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import fintype tuple bigop binomial finset finfun ssralg.
-From mathcomp Require Import countalg finalg poly polydiv perm fingroup matrix.
-From mathcomp Require Import mxalgebra mxpoly vector countalg.
+From mathcomp Require Import fintype tuple finfun bigop finset nmodule algebra.
+From mathcomp Require Import divalg countalg finalg poly polydiv.
+From mathcomp Require Import matrix mxalgebra mxpoly vector.
 
 (******************************************************************************)
 (* This file defines the algebras R[X]/<p> and their theory.                  *)

--- a/algebra/rat.v
+++ b/algebra/rat.v
@@ -1,10 +1,11 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import prime fintype finfun bigop order tuple ssralg.
-From mathcomp Require Import countalg div ssrnum ssrint archimedean poly zmodp.
-From mathcomp Require Import polydiv intdiv matrix mxalgebra vector.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
+From mathcomp Require Import choice fintype tuple finfun bigop prime nmodule.
+From mathcomp Require Import order algebra divalg countalg poly polydiv.
+From mathcomp Require Import zmodp matrix mxalgebra vector orderedzmod.
+From mathcomp Require Import numdomain numfield ssrint intdiv archimedean.
 
 (******************************************************************************)
 (* This file defines a datatype for rational numbers and equips it with a     *)

--- a/algebra/sesquilinear.v
+++ b/algebra/sesquilinear.v
@@ -1,7 +1,8 @@
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
-From mathcomp Require Import choice fintype tuple bigop ssralg finset fingroup.
-From mathcomp Require Import zmodp poly order ssrnum matrix mxalgebra vector.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype tuple bigop order nmodule algebra divalg.
+From mathcomp Require Import orderedzmod numdomain numfield.
+From mathcomp Require Import matrix mxalgebra vector.
 
 (******************************************************************************)
 (*                            Sesquilinear forms                              *)

--- a/algebra/spectral.v
+++ b/algebra/spectral.v
@@ -1,8 +1,8 @@
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype choice ssrnat.
-From mathcomp Require Import seq div fintype bigop ssralg finset fingroup zmodp.
-From mathcomp Require Import poly polydiv order ssrnum matrix mxalgebra vector.
-From mathcomp Require Import mxpoly mxred sesquilinear.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype bigop nmodule order algebra divalg.
+From mathcomp Require Import poly matrix mxalgebra mxpoly mxred.
+From mathcomp Require Import orderedzmod numdomain numfield sesquilinear.
 
 (******************************************************************************)
 (*                             Spectral theory                                *)

--- a/algebra/ssrint.v
+++ b/algebra/ssrint.v
@@ -2,8 +2,8 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat choice seq.
-From mathcomp Require Import fintype finfun bigop order ssralg countalg ssrnum.
-From mathcomp Require Import poly.
+From mathcomp Require Import fintype finfun bigop order nmodule algebra divalg.
+From mathcomp Require Import countalg poly orderedzmod numdomain numfield.
 
 (******************************************************************************)
 (* This file develops a basic theory of signed integers, defining:            *)

--- a/algebra/vector.v
+++ b/algebra/vector.v
@@ -2,8 +2,8 @@
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
-From mathcomp Require Import fintype bigop finfun tuple.
-From mathcomp Require Import ssralg matrix mxalgebra zmodp.
+From mathcomp Require Import fintype tuple finfun bigop nmodule algebra divalg.
+From mathcomp Require Import matrix mxalgebra.
 
 (******************************************************************************)
 (*                    Finite dimensional vector spaces                        *)

--- a/algebra/zmodp.v
+++ b/algebra/zmodp.v
@@ -3,7 +3,7 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool choice eqtype ssrnat seq.
 From mathcomp Require Import div fintype bigop finset prime fingroup perm.
-From mathcomp Require Import ssralg countalg finalg.
+From mathcomp Require Import nmodule algebra divalg decfield countalg finalg.
 
 (******************************************************************************)
 (*  Definition of the additive group and ring Zp, represented as 'I_p         *)


### PR DESCRIPTION
##### Motivation for this change

It does ~two things~ the following:
- removing `Require Import`s of `ssralg` and `ssrnum` (they should eventually be deprecated),
- ~removing the dependency from `orderedzmod` to `algebra`.~

~The latter change currently has the issue that `nmodule.v` does not provide the equivalent of `GRing.Theory`.~

**EDIT:** I opened another PR for the latter change: #1560.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- ~[ ] added changelog entries with `doc/changelog/make-entry.sh`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
