### PR TITLE
fix a typo: lteifW -> lteifS

### DIFF
--- a/order/preorder.v
+++ b/order/preorder.v
@@ -1390,8 +1390,8 @@ Proof. by case: C1 C2 => [][] //= _ /ltW. Qed.
 Lemma lteifW C x y : x < y ?<= if C -> x <= y.
 Proof. by case: C => // /ltW. Qed.
 
-#[deprecated(since="mathcomp 2.6.0", use=lteifW)]
-Notation ltrW_lteif := lteifW.
+#[deprecated(since="mathcomp 2.6.0", use=lteifS)]
+Notation ltrW_lteif := lteifS.
 
 (* min and max *)
 


### PR DESCRIPTION
##### Motivation for this change

This PR fixes a typo in a deprecation warning in `preorder.v`.
(See also PR #1494 ).

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
