### PR TITLE
Finalise the renaming from `addr_closed` to `nmod_closed`

### DIFF
--- a/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
+++ b/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
@@ -2830,7 +2830,7 @@ End AlgebraTheory.
 
 Module ClosedExports.
 
-Notation addr_closed := nmod_closed.
+Notation nmod_closed := nmod_closed.
 Notation oppr_closed := oppr_closed.
 Notation zmod_closed := zmod_closed.
 Notation mulr_closed := mulr_closed.
@@ -2845,14 +2845,14 @@ Notation subalg_closed := subalg_closed.
 
 Coercion zmod_closed0D : zmod_closed >-> nmod_closed.
 Coercion zmod_closedN : zmod_closed >-> oppr_closed.
-Coercion semiring_closedD : semiring_closed >-> addr_closed.
+Coercion semiring_closedD : semiring_closed >-> nmod_closed.
 Coercion semiring_closedM : semiring_closed >-> mulr_closed.
 Coercion smulr_closedM : smulr_closed >-> mulr_closed.
 Coercion smulr_closedN : smulr_closed >-> oppr_closed.
 Coercion subring_closedB : subring_closed >-> zmod_closed.
 Coercion subring_closedM : subring_closed >-> smulr_closed.
 Coercion subring_closed_semi : subring_closed >-> semiring_closed.
-Coercion subsemimod_closedD : subsemimod_closed >-> addr_closed.
+Coercion subsemimod_closedD : subsemimod_closed >-> nmod_closed.
 Coercion subsemimod_closedZ : subsemimod_closed >-> scaler_closed.
 Coercion linear_closedB : linear_closed >-> subr_closed.
 Coercion submod_closedB : submod_closed >-> zmod_closed.

--- a/algebra/algebraic_hierarchy/ssralg.v
+++ b/algebra/algebraic_hierarchy/ssralg.v
@@ -796,7 +796,11 @@ Definition char0_natf_div := pchar0_natf_div.
 Definition fmorph_char := fmorph_pchar.
 End Theory.
 
-Module AllExports. HB.reexport. End AllExports.
+Module AllExports.
+#[deprecated(since="mathcomp 2.6.0", use=nmod_closed)]
+Notation addr_closed := nmod_closed.
+HB.reexport.
+End AllExports.
 
 End GRing.
 

--- a/algebra/matrix.v
+++ b/algebra/matrix.v
@@ -4132,14 +4132,13 @@ Proof. exact: mxOver_const. Qed.
 
 Section mxOverAdd.
 Variable addS : addrClosed M.
-Fact mxOver_add_subproof : addr_closed (@mxOver m n _ addS).
+Fact mxOver_nmod_closed : nmod_closed (@mxOver m n _ addS).
 Proof.
 split=> [|p q Sp Sq]; first by rewrite mxOver0 // ?rpred0.
 by apply/mxOverP=> i j; rewrite mxE rpredD // !(mxOverP _).
 Qed.
 HB.instance Definition _ :=
-  GRing.isAddClosed.Build 'M[M]_(m, n) (mxOver_pred addS)
-    mxOver_add_subproof.
+  GRing.isAddClosed.Build 'M[M]_(m, n) (mxOver_pred addS) mxOver_nmod_closed.
 End mxOverAdd.
 
 Section mxOverOpp.

--- a/algebra/numeric_hierarchy/numdomain.v
+++ b/algebra/numeric_hierarchy/numdomain.v
@@ -144,7 +144,7 @@ Proof. by move=> y z; rewrite !ler_def ![_ + z]addrC addrKA. Qed.
 
 HB.instance Definition _ := Add_isHomo.Build R ler_wD2l.
 
-Fact real_addr_closed : addr_closed (@Num.real R).
+Fact real_nmod_closed : nmod_closed (@Num.real R).
 Proof.
 split=> [|x y Rx Ry]; first by rewrite realE lexx.
 without loss{Rx} x_ge0: x y Ry / 0 <= x.
@@ -154,7 +154,7 @@ case/orP: Ry => [y_ge0 | y_le0]; first by rewrite realE -nnegrE rpredD.
 by rewrite realE -[y]opprK orbC -oppr_ge0 opprB !subr_ge0 ger_leVge ?oppr_ge0.
 Qed.
 HB.instance Definition _ := GRing.isAddClosed.Build R Num.real
-  real_addr_closed.
+  real_nmod_closed.
 
 Fact comparabler_trans : transitive (Num.comparable : rel R).
 Proof.

--- a/algebra/numeric_hierarchy/orderedzmod.v
+++ b/algebra/numeric_hierarchy/orderedzmod.v
@@ -721,10 +721,10 @@ Lemma ltr_nMn2l x :
   x < 0 -> {mono (@GRing.natmul R x) : m n / (n < m)%N >-> m < n}.
 Proof. by move=> x_lt0; apply: leW_nmono (ler_nMn2l _). Qed.
 
-Fact nneg_addr_closed : addr_closed (@Num.nneg R).
+Fact nneg_nmod_closed : nmod_closed (@Num.nneg R).
 Proof. by split; [apply: lexx | apply: addr_ge0]. Qed.
 HB.instance Definition _ := GRing.isAddClosed.Build R nneg_num_pred
-  nneg_addr_closed.
+  nneg_nmod_closed.
 
 Fact real_oppr_closed : oppr_closed (@Num.real R).
 Proof. by move=> x; rewrite /= !realE oppr_ge0 orbC -!oppr_ge0 opprK. Qed.
@@ -839,7 +839,7 @@ Proof.
 by move=> /ge_comparable + /le_comparable => /comparabler_trans/[apply].
 Qed.
 
-Fact real_addr_closed : addr_closed (@Num.real R).
+Fact real_nmod_closed : nmod_closed (@Num.real R).
 Proof.
 split=> [|x y Rx Ry]; first by rewrite realE lexx.
 without loss{Rx} x_ge0: x y Ry / 0 <= x.
@@ -849,7 +849,7 @@ case/orP: Ry => [y_ge0 | y_le0]; first by rewrite realE -nnegrE rpredD.
 by rewrite realE -[y]opprK orbC -oppr_ge0 opprB !subr_ge0 ger_leVge ?oppr_ge0.
 Qed.
 HB.instance Definition _ := GRing.isAddClosed.Build R real_num_pred
-  real_addr_closed.
+  real_nmod_closed.
 
 Lemma ler_leVge x y : x <= 0 -> y <= 0 -> (x <= y) || (y <= x).
 Proof. by rewrite -!oppr_ge0 => /(ger_leVge _) /[apply]; rewrite !lerN2. Qed.

--- a/algebra/poly.v
+++ b/algebra/poly.v
@@ -1010,13 +1010,13 @@ Proof.
 by rewrite qualifE /= polyseqC; case: eqP => [->|] /=; rewrite ?andbT ?rpred0.
 Qed.
 
-Fact polyOver_addr_closed : addr_closed (polyOver S).
+Fact polyOver_nmod_closed : nmod_closed (polyOver S).
 Proof.
 split=> [|p q Sp Sq]; first exact: polyOver0.
 by apply/polyOverP=> i; rewrite coefD rpredD ?(polyOverP _).
 Qed.
 HB.instance Definition _ := GRing.isAddClosed.Build {poly R} (polyOver_pred S)
-  polyOver_addr_closed.
+  polyOver_nmod_closed.
 
 End PolyOverAdd.
 

--- a/character/character.v
+++ b/character/character.v
@@ -844,13 +844,13 @@ Proof. by rewrite -irr0 irr_char. Qed.
 Lemma cfun0_char : (0 : 'CF(G)) \is a character.
 Proof. by apply/forallP=> i; rewrite linear0 rpred0. Qed.
 
-Fact add_char : addr_closed (@character G).
+Fact char_nmod_closed : nmod_closed (@character G).
 Proof.
 split=> [|chi xi /forallP-Nchi /forallP-Nxi]; first exact: cfun0_char.
 by apply/forallP=> i; rewrite linearD rpredD /=.
 Qed.
 HB.instance Definition _ := GRing.isAddClosed.Build (classfun G) character_pred
-  add_char.
+  char_nmod_closed.
 
 Lemma char_sum_irrP {phi} :
   reflect (exists n, phi = \sum_i (n i)%:R *: 'chi_i) (phi \is a character).

--- a/doc/changelog/03-renamed/1551-addr_closed.md
+++ b/doc/changelog/03-renamed/1551-addr_closed.md
@@ -1,0 +1,26 @@
+- in `rings_modules_and_algebras.v`
+  + `addr_closed` -> `nmod_closed`
+  + Note that the deprecation abbreviation for the legacy `addr_closed` is
+    declared only in `ssralg.v`
+    ([#1551](https://github.com/math-comp/math-comp/pull/1551)).
+
+- in `orderedzmod.v`
+  + `nneg_addr_closed` -> `nneg_nmod_closed`
+  + `real_addr_closed` -> `real_nmod_closed`
+    ([#1551](https://github.com/math-comp/math-comp/pull/1551)).
+
+- in `numdomain.v`
+  + `real_addr_closed` -> `real_nmod_closed`
+    ([#1551](https://github.com/math-comp/math-comp/pull/1551)).
+
+- in `matrix.v`
+  + `mxOver_add_subproof` -> `mxOver_nmod_closed`
+    ([#1551](https://github.com/math-comp/math-comp/pull/1551)).
+
+- in `poly.v`
+  + `polyOver_addr_closed` -> `polyOver_nmod_closed`
+    ([#1551](https://github.com/math-comp/math-comp/pull/1551)).
+
+- in `character.v`
+  + `add_char` -> `char_nmod_closed`
+    ([#1551](https://github.com/math-comp/math-comp/pull/1551)).


### PR DESCRIPTION
##### Motivation for this change

Until the introduction of `nmodule.v`, `addr_closed` meant "closed under + and 0", but now it means "closed under +". The old `addr_closed` was renamed to `nmod_closed` in e54479b (#1256), but it looks like it was only halfway done. See https://github.com/math-comp/math-comp/pull/1548#discussion_r2881154479.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
