### PR TITLE
sub normedZmodType

### DIFF
--- a/algebra/numeric_hierarchy/numdomain.v
+++ b/algebra/numeric_hierarchy/numdomain.v
@@ -17,12 +17,16 @@ From mathcomp Require Import orderedzmod.
 (*                                                                            *)
 (*  semiNormedZmodType == Zmodule with a semi-norm                            *)
 (*                        The HB class is called SemiNormedZmodule.           *)
-(*  normedZmodType == Zmodule with a norm                                     *)
-(*                    The HB class is called NormedZmodule.                   *)
-(*   numDomainType == Integral domain with an order and a norm                *)
-(*                    The HB class is called NumDomain.                       *)
-(*  realDomainType == Num domain where all elements are positive or negative  *)
-(*                    The HB class is called RealDomain.                      *)
+(*      normedZmodType == Zmodule with a norm                                 *)
+(*                        The HB class is called NormedZmodule.               *)
+(* subNormedZmodType S == join of normedZmodType M and subType (S : pred M)   *)
+(*                        such that val preserves the norm                    *)
+(*                        The HB class is called SubNormedZmodule.            *)
+(*       numDomainType == Integral domain with an order and a norm            *)
+(*                        The HB class is called NumDomain.                   *)
+(*      realDomainType == Num domain where all elements are positive or       *)
+(*                        negative                                            *)
+(*                        The HB class is called RealDomain.                  *)
 (*                                                                            *)
 (* Over these structures, we have the following operations:                   *)
 (*             `|x| == norm of x                                              *)
@@ -72,6 +76,17 @@ HB.mixin Record SemiNormedZmodule_isPositiveDefinite
 HB.structure Definition NormedZmodule (R : porderZmodType) :=
   { M of SemiNormedZmodule_isPositiveDefinite R M & SemiNormedZmodule R M }.
 Arguments norm {R M} x : rename.
+
+HB.mixin Record Zmodule_isSubNormed (R : porderZmodType) (M : normedZmodType R)
+   (S : pred M) U & SubType M S U & NormedZmodule R U := {
+  norm_valE : forall x : U, norm ((val : U -> M) x) = norm x
+}.
+
+#[short(type="subNormedZmodType")]
+HB.structure Definition SubNormedZmodule (R : porderZmodType)
+    (M : normedZmodType R) (S : pred M) :=
+  { U of SubChoice M S U & Num.NormedZmodule R U & GRing.SubZmodule M S U
+       & Zmodule_isSubNormed R M S U }.
 
 HB.factory Record Zmodule_isNormed (R : porderZmodType) M
          & GRing.Zmodule M := {

--- a/doc/changelog/01-added/1579-subnormedzmodtype.md
+++ b/doc/changelog/01-added/1579-subnormedzmodtype.md
@@ -1,0 +1,5 @@
+- in `numdomain.v`:
+  + mixin `Zmodule_isSubNormed`
+  + structure `SubNormedZmodule`
+  + notation `subNormedZmodType`
+    (* [1579](https://github.com/math-comp/math-comp/pull/1579) *)


### PR DESCRIPTION
##### Motivation for this change

Addition of a mixin and a structure for sub `normedZmodType`, currently used in the Hahn-Banach [PR](https://github.com/math-comp/analysis/pull/1889) as discussed during the [2026-04-15 meeting](https://github.com/math-comp/math-comp/wiki/Minutes-2026%E2%80%9004%E2%80%9015).

fyi @mkerjean

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
