### PR TITLE
This PR reintroduces the factory `SubPzRing_isSubComPzRing` so that

### DIFF
--- a/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
+++ b/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
@@ -3235,7 +3235,7 @@ HB.structure Definition SubComPzRing (R : pzRingType) S :=
 HB.factory Record SubPzRing_isSubComPzRing (R : comPzRingType) S U
     & SubPzRing R S U := {}.
 
-HB.builders Context R S U of SubPzRing_isSubComPzRing R S U.
+HB.builders Context R S U & SubPzRing_isSubComPzRing R S U.
 HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
 HB.end.
 

--- a/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
+++ b/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
@@ -3231,6 +3231,14 @@ HB.end.
 HB.structure Definition SubComPzRing (R : pzRingType) S :=
   {U of SubPzRing R S U & ComPzRing U}.
 
+(* It will be possible to remove this factory after the release of MathComp 2.7.0 *)
+HB.factory Record SubPzRing_isSubComPzRing (R : comPzRingType) S U
+    of SubPzRing R S U := {}.
+
+HB.builders Context R S U of SubPzRing_isSubComPzRing R S U.
+HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
+HB.end.
+
 #[short(type="subComNzRingType")]
 HB.structure Definition SubComNzRing (R : nzRingType) S :=
   {U of SubNzRing R S U & ComNzRing U}.

--- a/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
+++ b/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
@@ -3233,7 +3233,7 @@ HB.structure Definition SubComPzRing (R : pzRingType) S :=
 
 (* It will be possible to remove this factory after the release of MathComp 2.7.0 *)
 HB.factory Record SubPzRing_isSubComPzRing (R : comPzRingType) S U
-    of SubPzRing R S U := {}.
+    & SubPzRing R S U := {}.
 
 HB.builders Context R S U of SubPzRing_isSubComPzRing R S U.
 HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.

--- a/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
+++ b/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
@@ -3231,14 +3231,6 @@ HB.end.
 HB.structure Definition SubComPzRing (R : pzRingType) S :=
   {U of SubPzRing R S U & ComPzRing U}.
 
-(* It will be possible to remove this factory after the release of MathComp 2.7.0 *)
-HB.factory Record SubPzRing_isSubComPzRing (R : comPzRingType) S U
-    & SubPzRing R S U := {}.
-
-HB.builders Context R S U & SubPzRing_isSubComPzRing R S U.
-HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
-HB.end.
-
 #[short(type="subComNzRingType")]
 HB.structure Definition SubComNzRing (R : nzRingType) S :=
   {U of SubNzRing R S U & ComNzRing U}.

--- a/algebra/algebraic_hierarchy/ssralg.v
+++ b/algebra/algebraic_hierarchy/ssralg.v
@@ -802,6 +802,14 @@ Notation addr_closed := nmod_closed.
 HB.reexport.
 End AllExports.
 
+(* It will be possible to remove this factory after the release of MathComp 2.7.0 *)
+HB.factory Record SubPzRing_isSubComPzRing (R : comPzRingType) S U
+    & SubPzRing R S U := {}.
+
+HB.builders Context R S U & SubPzRing_isSubComPzRing R S U.
+HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
+HB.end.
+
 End GRing.
 
 Export AllExports.
@@ -867,11 +875,3 @@ Notation "[ 'char' R ]" := (GRing.pchar R) : ring_scope.
 Notation has_char0 R := (GRing.pchar R =i pred0).
 #[deprecated(since="mathcomp 2.4.0", use=pFrobenius_aut)]
 Notation Frobenius_aut chRp := (pFrobenius_aut chRp).
-
-(* It will be possible to remove this factory after the release of MathComp 2.7.0 *)
-HB.factory Record SubPzRing_isSubComPzRing (R : comPzRingType) S U
-    & SubPzRing R S U := {}.
-
-HB.builders Context R S U & SubPzRing_isSubComPzRing R S U.
-HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
-HB.end.

--- a/algebra/algebraic_hierarchy/ssralg.v
+++ b/algebra/algebraic_hierarchy/ssralg.v
@@ -867,3 +867,11 @@ Notation "[ 'char' R ]" := (GRing.pchar R) : ring_scope.
 Notation has_char0 R := (GRing.pchar R =i pred0).
 #[deprecated(since="mathcomp 2.4.0", use=pFrobenius_aut)]
 Notation Frobenius_aut chRp := (pFrobenius_aut chRp).
+
+(* It will be possible to remove this factory after the release of MathComp 2.7.0 *)
+HB.factory Record SubPzRing_isSubComPzRing (R : comPzRingType) S U
+    & SubPzRing R S U := {}.
+
+HB.builders Context R S U & SubPzRing_isSubComPzRing R S U.
+HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
+HB.end.


### PR DESCRIPTION
MathComp-Analysis can use this construction and compile with 2.5.0 and 2.6.0

See https://github.com/math-comp/analysis/pull/1949/

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
