### PR TITLE
fix already merged PR #1587

### DIFF
--- a/algebra/algebraic_hierarchy/ssralg.v
+++ b/algebra/algebraic_hierarchy/ssralg.v
@@ -645,6 +645,14 @@ HB.instance Definition _ := isMonoidMorphism.Build R S f
 
 HB.end.
 
+(* It will be possible to remove this factory after the release of MathComp 2.7.0 *)
+HB.factory Record SubPzRing_isSubComPzRing (R : comPzRingType) S U
+    & SubPzRing R S U := {}.
+
+HB.builders Context R S U & SubPzRing_isSubComPzRing R S U.
+HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
+HB.end.
+
 #[warning="-deprecated-reference-since-mathcomp-2.5.0",
   deprecated(since="mathcomp 2.5.0", use=rmorphism_monoidP)]
 Definition rmorphismMP (R S : pzSemiRingType) (f : {rmorphism R -> S}) :
@@ -801,14 +809,6 @@ Module AllExports.
 Notation addr_closed := nmod_closed.
 HB.reexport.
 End AllExports.
-
-(* It will be possible to remove this factory after the release of MathComp 2.7.0 *)
-HB.factory Record SubPzRing_isSubComPzRing (R : comPzRingType) S U
-    & SubPzRing R S U := {}.
-
-HB.builders Context R S U & SubPzRing_isSubComPzRing R S U.
-HB.instance Definition _ := SubSemiRing_isSubComSemiRing.Build R S U.
-HB.end.
 
 End GRing.
 


### PR DESCRIPTION
PR #1587 put a factory into the `GRing` module but it was ill placed.
By putting it in the right place, that indeed fixes the problem in this MathComp-Analysis PR: https://github.com/math-comp/analysis/pull/1949

I have tested by locally recompiling MathComp and its dependencies,
I should have done that for the first PR (which I only tested by changing MCA),
my bad, sorry for the noise

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
