### PR TITLE
Remove the big `\min^d` and `\max^d` notations from `order.v`

### DIFF
--- a/doc/changelog/01-added/1578-cleanup-order-doc.md
+++ b/doc/changelog/01-added/1578-cleanup-order-doc.md
@@ -1,3 +1,3 @@
 - in `order/preorder.v`
-  + notations `\max_<range>`, `\min_<range>`, `\max^d_<range>`, `\min^d_<range>`
+  + notations `\max_<range>` and `\min_<range>`
     ([#1578](https://github.com/math-comp/math-comp/pull/1578)).

--- a/doc/changelog/02-changed/1590-deduplicate-bigminmax.md
+++ b/doc/changelog/02-changed/1590-deduplicate-bigminmax.md
@@ -1,0 +1,4 @@
+- in `order.v`
+  + moved the notations `\max^d_<range>` and `\min^d_<range>` to `preorder.v`
+    ([#1578](https://github.com/math-comp/math-comp/pull/1578) and
+     [#1590](https://github.com/math-comp/math-comp/pull/1590)).

--- a/order/order.v
+++ b/order/order.v
@@ -1520,8 +1520,6 @@ Local Notation "\bot" := dual_bottom.
 Local Notation "\top" := dual_top.
 Local Notation join := dual_join.
 Local Notation meet := dual_meet.
-Local Notation min := dual_min.
-Local Notation max := dual_max.
 
 Notation "\join^d_ ( i <- r | P ) F" :=
   (\big[join / \bot]_(i <- r | P%B) F%O) : order_scope.
@@ -1597,56 +1595,6 @@ Notation "\meet^d_ ( i 'in' A | P ) F" :=
  (\big[meet / \top]_(i in A | P%B) F%O) : order_scope.
 Notation "\meet^d_ ( i 'in' A ) F" :=
  (\big[meet / \top]_(i in A) F%O) : order_scope.
-
-Notation "\min^d_ i F" :=
-  (\big[min/top]_i F) : order_scope.
-Notation "\min^d_ ( i <- r | P ) F" :=
-  (\big[min/top]_(i <- r | P%B) F%O) : order_scope.
-Notation "\min^d_ ( i < r ) F" :=
-  (\big[min/top]_(i <- r) F%O) : order_scope.
-Notation "\min^d_ ( m <= i < n | P ) F" :=
-  (\big[min/top]_(m <= i < n | P%B) F%O) : order_scope.
-Notation "\min^d_ ( m <= i < n ) F" :=
-  (\big[min/top]_(m <= i < n) F%O) : order_scope.
-Notation "\min^d_ ( i | P ) F" :=
-  (\big[min/top]_(i | P%B) F%O) : order_scope.
-Notation "\min^d_ ( i : t | P ) F" :=
-  (\big[min/top]_(i : t | P%B) F%O) (only parsing) : order_scope.
-Notation "\min^d_ ( i : t ) F" :=
-  (\big[min/top]_(i : t) F%O) (only parsing) : order_scope.
-Notation "\min^d_ ( i < n | P ) F" :=
-  (\big[min/top]_(i < n | P%B) F%O) : order_scope.
-Notation "\min^d_ ( i < n ) F" :=
-  (\big[min/top]_(i < n) F%O) : order_scope.
-Notation "\min^d_ ( i 'in' A | P ) F" :=
-  (\big[min/top]_(i in A | P%B) F%O) : order_scope.
-Notation "\min^d_ ( i 'in' A ) F" :=
-  (\big[min/top]_(i in A) F%O) : order_scope.
-
-Notation "\max^d_ i F" :=
-  (\big[max/bottom]_i F%O) : order_scope.
-Notation "\max^d_ ( i <- r | P ) F" :=
-  (\big[max/bottom]_(i <- r | P%B) F%O) : order_scope.
-Notation "\max^d_ ( i < r ) F" :=
-  (\big[max/bottom]_(i <- r) F%O) : order_scope.
-Notation "\max^d_ ( m <= i < n | P ) F" :=
-  (\big[max/bottom]_(m <= i < n | P%B) F%O) : order_scope.
-Notation "\max^d_ ( m <= i < n ) F" :=
-  (\big[max/bottom]_(m <= i < n) F%O) : order_scope.
-Notation "\max^d_ ( i | P ) F" :=
-  (\big[max/bottom]_(i | P%B) F%O) : order_scope.
-Notation "\max^d_ ( i : t | P ) F" :=
-  (\big[max/bottom]_(i : t | P%B) F%O) (only parsing) : order_scope.
-Notation "\max^d_ ( i : t ) F" :=
-  (\big[max/bottom]_(i : t) F%O) (only parsing) : order_scope.
-Notation "\max^d_ ( i < n | P ) F" :=
-  (\big[max/bottom]_(i < n | P%B) F%O) : order_scope.
-Notation "\max^d_ ( i < n ) F" :=
-  (\big[max/bottom]_(i < n) F%O) : order_scope.
-Notation "\max^d_ ( i 'in' A | P ) F" :=
-  (\big[max/bottom]_(i in A | P%B) F%O) : order_scope.
-Notation "\max^d_ ( i 'in' A ) F" :=
-  (\big[max/bottom]_(i in A) F%O) : order_scope.
 
 End DualSyntax.
 

--- a/order/order.v
+++ b/order/order.v
@@ -1571,31 +1571,6 @@ Notation "\meet^d_ ( i 'in' A | P ) F" :=
 Notation "\meet^d_ ( i 'in' A ) F" :=
  (\big[meet / \top]_(i in A) F%O) : order_scope.
 
-Notation "\meet^d_ ( i <- r | P ) F" :=
-  (\big[meet / \top]_(i <- r | P%B) F%O) : order_scope.
-Notation "\meet^d_ ( i <- r ) F" :=
-  (\big[meet / \top]_(i <- r) F%O) : order_scope.
-Notation "\meet^d_ ( i | P ) F" :=
-  (\big[meet / \top]_(i | P%B) F%O) : order_scope.
-Notation "\meet^d_ i F" :=
-  (\big[meet / \top]_i F%O) : order_scope.
-Notation "\meet^d_ ( i : I | P ) F" :=
-  (\big[meet / \top]_(i : I | P%B) F%O) (only parsing) : order_scope.
-Notation "\meet^d_ ( i : I ) F" :=
-  (\big[meet / \top]_(i : I) F%O) (only parsing) : order_scope.
-Notation "\meet^d_ ( m <= i < n | P ) F" :=
- (\big[meet / \top]_(m <= i < n | P%B) F%O) : order_scope.
-Notation "\meet^d_ ( m <= i < n ) F" :=
- (\big[meet / \top]_(m <= i < n) F%O) : order_scope.
-Notation "\meet^d_ ( i < n | P ) F" :=
- (\big[meet / \top]_(i < n | P%B) F%O) : order_scope.
-Notation "\meet^d_ ( i < n ) F" :=
- (\big[meet / \top]_(i < n) F%O) : order_scope.
-Notation "\meet^d_ ( i 'in' A | P ) F" :=
- (\big[meet / \top]_(i in A | P%B) F%O) : order_scope.
-Notation "\meet^d_ ( i 'in' A ) F" :=
- (\big[meet / \top]_(i in A) F%O) : order_scope.
-
 End DualSyntax.
 
 (*

--- a/order/preorder.v
+++ b/order/preorder.v
@@ -1039,6 +1039,10 @@ Notation "x ><^d y" := (~~ (><^d%O x y)) : order_scope.
 Notation "\bot^d" := dual_bottom : order_scope.
 Notation "\top^d" := dual_top : order_scope.
 
+(* The following Local Notations are here to define the \min^d_ and \max^d_   *)
+(* notations below. Do not remove them.                                       *)
+Local Notation bot := dual_bottom.
+Local Notation top := dual_top.
 Local Notation min := dual_min.
 Local Notation max := dual_max.
 
@@ -1068,29 +1072,29 @@ Notation "\min^d_ ( i 'in' A ) F" :=
   (\big[min/top]_(i in A) F%O) : order_scope.
 
 Notation "\max^d_ i F" :=
-  (\big[max/bottom]_i F%O) : order_scope.
+  (\big[max/bot]_i F%O) : order_scope.
 Notation "\max^d_ ( i <- r | P ) F" :=
-  (\big[max/bottom]_(i <- r | P%B) F%O) : order_scope.
+  (\big[max/bot]_(i <- r | P%B) F%O) : order_scope.
 Notation "\max^d_ ( i < r ) F" :=
-  (\big[max/bottom]_(i <- r) F%O) : order_scope.
+  (\big[max/bot]_(i <- r) F%O) : order_scope.
 Notation "\max^d_ ( m <= i < n | P ) F" :=
-  (\big[max/bottom]_(m <= i < n | P%B) F%O) : order_scope.
+  (\big[max/bot]_(m <= i < n | P%B) F%O) : order_scope.
 Notation "\max^d_ ( m <= i < n ) F" :=
-  (\big[max/bottom]_(m <= i < n) F%O) : order_scope.
+  (\big[max/bot]_(m <= i < n) F%O) : order_scope.
 Notation "\max^d_ ( i | P ) F" :=
-  (\big[max/bottom]_(i | P%B) F%O) : order_scope.
+  (\big[max/bot]_(i | P%B) F%O) : order_scope.
 Notation "\max^d_ ( i : t | P ) F" :=
-  (\big[max/bottom]_(i : t | P%B) F%O) (only parsing) : order_scope.
+  (\big[max/bot]_(i : t | P%B) F%O) (only parsing) : order_scope.
 Notation "\max^d_ ( i : t ) F" :=
-  (\big[max/bottom]_(i : t) F%O) (only parsing) : order_scope.
+  (\big[max/bot]_(i : t) F%O) (only parsing) : order_scope.
 Notation "\max^d_ ( i < n | P ) F" :=
-  (\big[max/bottom]_(i < n | P%B) F%O) : order_scope.
+  (\big[max/bot]_(i < n | P%B) F%O) : order_scope.
 Notation "\max^d_ ( i < n ) F" :=
-  (\big[max/bottom]_(i < n) F%O) : order_scope.
+  (\big[max/bot]_(i < n) F%O) : order_scope.
 Notation "\max^d_ ( i 'in' A | P ) F" :=
-  (\big[max/bottom]_(i in A | P%B) F%O) : order_scope.
+  (\big[max/bot]_(i in A | P%B) F%O) : order_scope.
 Notation "\max^d_ ( i 'in' A ) F" :=
-  (\big[max/bottom]_(i in A) F%O) : order_scope.
+  (\big[max/bot]_(i in A) F%O) : order_scope.
 
 End DualSyntax.
 


### PR DESCRIPTION
##### Motivation for this change

We added them to `preorder.v` in #1578, but we didn't notice that they were already defined in `order.v`. So, let's remove the latter to deduplicate them.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~ (they are not documented in `order.v`)
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
