### PR TITLE
Add endless and dense orders

### DIFF
--- a/order/order.v
+++ b/order/order.v
@@ -1170,6 +1170,22 @@ HB.structure Definition TPOrder d := { T of hasTop d T & POrder d T }.
 #[short(type="tbPOrderType")]
 HB.structure Definition TBPOrder d := { T of hasTop d T & BPOrder d T }.
 
+#[short(type="lowerEndlessPOrderType")]
+HB.structure Definition LowerEndlessPOrder d :=
+  { T of hasNoBottom d T & POrder d T }.
+#[short(type="upperEndlessPOrderType")]
+HB.structure Definition UpperEndlessPOrder d :=
+  { T of hasNoTop d T & POrder d T }.
+#[short(type="endlessPOrderType")]
+HB.structure Definition EndlessPOrder d :=
+  { T of hasNoTop d T & LowerEndlessPOrder d T }.
+#[short(type="densePOrderType")]
+HB.structure Definition DensePOrder d :=
+  { T of Preorder_isDense d T & POrder d T }.
+#[short(type="endlessDensePOrderType")]
+HB.structure Definition EndlessDensePOrder d :=
+  { T of EndlessPOrder d T & DensePOrder d T }.
+
 Module POrderExports.
 Arguments le_trans {d s} [_ _ _].
 End POrderExports.
@@ -1378,6 +1394,26 @@ HB.structure Definition TTotal d := { T of Total d T & hasTop d T }.
 
 #[short(type="tbOrderType")]
 HB.structure Definition TBTotal d := { T of BTotal d T & hasTop d T }.
+
+#[short(type="lowerEndlessOrderType")]
+HB.structure Definition LowerEndlessOrder d :=
+  { T of hasNoBottom d T & Total d T }.
+
+#[short(type="upperEndlessOrderType")]
+HB.structure Definition UpperEndlessOrder d :=
+  { T of hasNoTop d T & Total d T }.
+
+#[short(type="endlessOrderType")]
+HB.structure Definition EndlessOrder d :=
+  { T of hasNoTop d T & LowerEndlessOrder d T }.
+
+#[short(type="denseOrderType")]
+HB.structure Definition DenseOrder d :=
+  { T of Preorder_isDense d T & Total d T }.
+
+#[short(type="endlessDenseOrderType")]
+HB.structure Definition EndlessDenseOrder d :=
+  { T of EndlessOrder d T & DenseOrder d T }.
 
 #[key="T", primitive]
 HB.mixin Record DistrLattice_hasRelativeComplement d T & DistrLattice d T := {

--- a/order/preorder.v
+++ b/order/preorder.v
@@ -706,12 +706,43 @@ HB.mixin Record hasTop d T & Preorder d T := {
   lex1 : forall x, le x top;
 }.
 
+#[key="T", primitive]
+HB.mixin Record hasNoBottom d T & Preorder d T := {
+  lt_nobottom : forall x : T, exists y : T, lt y x;
+}.
+
+#[key="T", primitive]
+HB.mixin Record hasNoTop d T & Preorder d T := {
+  lt_notop : forall x : T, exists y : T, lt x y;
+}.
+
+#[key="T", primitive]
+HB.mixin Record Preorder_isDense d T & Preorder d T := {
+  lt_dense : forall x y : T, lt x y -> exists z : T, (lt x z) && (lt z y);
+}.
+
 #[short(type="bPreorderType")]
 HB.structure Definition BPreorder d := { T of hasBottom d T & Preorder d T }.
 #[short(type="tPreorderType")]
 HB.structure Definition TPreorder d := { T of hasTop d T & Preorder d T }.
 #[short(type="tbPreorderType")]
 HB.structure Definition TBPreorder d := { T of hasTop d T & BPreorder d T }.
+
+#[short(type="lowerEndlessPreorderType")]
+HB.structure Definition LowerEndlessPreorder d :=
+  { T of hasNoBottom d T & Preorder d T }.
+#[short(type="upperEndlessPreorderType")]
+HB.structure Definition UpperEndlessPreorder d :=
+  { T of hasNoTop d T & Preorder d T }.
+#[short(type="endlessPreorderType")]
+HB.structure Definition EndlessPreorder d :=
+  { T of hasNoTop d T & LowerEndlessPreorder d T }.
+#[short(type="densePreorderType")]
+HB.structure Definition DensePreorder d :=
+  { T of Preorder_isDense d T & Preorder d T }.
+#[short(type="endlessDensePreorderType")]
+HB.structure Definition EndlessDensePreorder d :=
+  { T of EndlessPreorder d T & DensePreorder d T }.
 
 Section PreorderDef.
 
@@ -963,6 +994,27 @@ HB.structure Definition FinTPreorder d := { T of FinPreorder d T & hasTop d T }.
 
 #[short(type="finTBPreorderType")]
 HB.structure Definition FinTBPreorder d := { T of FinBPreorder d T & hasTop d T }.
+
+#[short(type="finLowerEndlessPreorderType")]
+HB.structure Definition FinLowerEndlessPreorder d :=
+  { T of FinPreorder d T & hasNoBottom d T }.
+
+#[short(type="finUpperEndlessPreorderType")]
+HB.structure Definition FinUpperEndlessPreorder d :=
+  { T of FinPreorder d T & hasNoTop d T }.
+
+#[short(type="finEndlessPreorderType")]
+HB.structure Definition FinEndlessPreorder d :=
+  { T of FinLowerEndlessPreorder d T & hasNoTop d T }.
+
+#[short(type="finDensePreorderType")]
+HB.structure Definition FinDensePreorder d :=
+  { T of FinPreorder d T & Preorder_isDense d T }.
+
+(* example: {x,y,z} with x < y < z < x *)
+#[short(type="finEndlessDensePreorderType")]
+HB.structure Definition FinEndlessDensePreorder d :=
+  { T of FinEndlessPreorder d T & FinDensePreorder d T }.
 
 (********)
 (* DUAL *)


### PR DESCRIPTION
This PR adds endless and dense mixins to the preorder structure and its extensions.
An important instance is `(R : realFieldType)`.

To be used in https://github.com/math-comp/analysis/pull/1848

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
