### PR TITLE
Revert "Remove [POrder of T by <:] and [Order of T by <:]"

### DIFF
--- a/algebra/interval_inference.v
+++ b/algebra/interval_inference.v
@@ -462,8 +462,7 @@ Section POrder.
 Context d (T : porderType d) (f : interval int -> T -> bool) (i : Itv.t).
 Local Notation itv := (Itv.def f i).
 HB.instance Definition _ := [isSub for @Itv.r T f i].
-HB.instance Definition _ := [Choice of itv by <:].
-HB.instance Definition _ := [SubChoice_isSubPOrder of itv by <: with d].
+HB.instance Definition _ : Order.POrder d itv := [POrder of itv by <:].
 End POrder.
 
 Section Order.

--- a/doc/changelog/04-removed/1584-remove_DeprecatedSubOrder.md
+++ b/doc/changelog/04-removed/1584-remove_DeprecatedSubOrder.md
@@ -1,3 +1,0 @@
-- in `order.v`
-  + notations `[POrder of T by <:]` and `[Order of T by <:]`
-    ([#1584](https://github.com/math-comp/math-comp/pull/1584)).

--- a/order/order.v
+++ b/order/order.v
@@ -456,6 +456,10 @@ From mathcomp Require Export preorder.
 (* [SubChoice_isSubOrder of U by <: with disp] ==                             *)
 (* [SubChoice_isSubOrder of U by <:] == orderType mixin for a subType whose   *)
 (*                          base type is an orderType                         *)
+(*   [POrder of U by <:] == porderType mixin for a subType whose base type is *)
+(*                          a porderType                                      *)
+(*    [Order of U by <:] == orderType mixin for a subType whose base type is  *)
+(*                          an orderType                                      *)
 (*                                                                            *)
 (* We provide expected instances of ordered types for bool, nat (for leq and  *)
 (* and dvdn), 'I_n, 'I_n.+1 (with a top and bottom), nat for dvdn,            *)
@@ -5338,6 +5342,12 @@ End Total.
 
 Module Exports.
 HB.reexport DeprecatedSubOrder.
+Notation "[ 'POrder' 'of' T 'by' <: ]" :=
+  (POrder.copy T%type (sub_type T%type))
+  (format "[ 'POrder'  'of'  T  'by'  <: ]") : form_scope.
+Notation "[ 'Order' 'of' T 'by' <: ]" :=
+  (Total.copy T%type (sub_type T%type))
+  (only parsing) : form_scope.
 End Exports.
 End DeprecatedSubOrder.
 HB.export DeprecatedSubOrder.Exports.


### PR DESCRIPTION
##### Motivation for this change

This reverts commit 9a3de5c573f0a87511cede9aaf85522210f98fea.

See https://github.com/math-comp/math-comp/wiki/Minutes-2026%E2%80%9005%E2%80%9013

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
