### PR TITLE
Adapt to rocq-prover/rocq#21987 (secvar status)

### DIFF
--- a/field/finfield.v
+++ b/field/finfield.v
@@ -392,7 +392,7 @@ Implicit Types (a b : F) (x y : L) (K E : {subfield L}).
 
 Let galL K : galois K {:L}.
 Proof.
-without loss {K} ->: K / K = 1%AS.
+without loss ->: K / K = 1%AS.
   by move=> IH_K; apply: galoisS (IH_K _ (erefl _)); rewrite sub1v subvf.
 apply/splitting_galoisField; pose finL := FinFieldExtType L.
 exists ('X^#|finL| - 'X); split; first by rewrite rpredB 1?rpredX ?polyOverX.
@@ -406,7 +406,7 @@ Qed.
 Fact galLgen K :
   {alpha | generator 'Gal({:L} / K) alpha & forall x, alpha x = x ^+ order K}.
 Proof.
-without loss{K} ->: K / K = 1%AS; last rewrite /order dimv1 expn1.
+without loss ->: K / K = 1%AS; last rewrite /order dimv1 expn1.
   case/(_ 1%AS)=> // alpha /eqP-defGalL; rewrite /order dimv1 expn1 => Dalpha.
   exists (alpha ^+ \dim K)%g => [|x]; last first.
     elim: (\dim K) => [|n IHn]; first by rewrite gal_id.

--- a/field/separable.v
+++ b/field/separable.v
@@ -645,7 +645,7 @@ move=> pcharLp; apply/idP/idP=> [sepKx | /Fadjoin_poly_eq]; last first.
   - by rewrite rootE !hornerE horner_comp hornerXn Dx subrr.
   rewrite unlock !(derivE, deriv_comp) -mulr_natr -rmorphMn /= mL0.
   by rewrite !mulr0 subr0 coprimep1.
-without loss{e} ->: e x sepKx / e = 0.
+without loss ->: e x sepKx / e = 0.
   move=> IH; elim: {e}e.+1 => [|e]; [exact: memv_adjoin | apply: subvP].
   apply/FadjoinP/andP; rewrite subv_adjoin expnSr exprM (IH 0) //.
   by have /adjoin_separableP-> := sepKx; rewrite ?rpredX ?memv_adjoin.


### PR DESCRIPTION
Not sure what's going on, it says "no such hypothesis". backtrace says the error is from clear.
Are we doing `clear` twice somehow?
(I don't know how to read ssr tactics)

