### PR TITLE
enable `le_itv` on `Itv.def`

### DIFF
--- a/algebra/interval_inference.v
+++ b/algebra/interval_inference.v
@@ -462,7 +462,8 @@ Section POrder.
 Context d (T : porderType d) (f : interval int -> T -> bool) (i : Itv.t).
 Local Notation itv := (Itv.def f i).
 HB.instance Definition _ := [isSub for @Itv.r T f i].
-HB.instance Definition _ : Order.POrder d itv := [POrder of itv by <:].
+HB.instance Definition _ : Order.SubPOrder d (Itv.spec f i) d itv :=
+  Order.SubPOrder.copy itv (sub_type itv).
 End POrder.
 
 Section Order.

--- a/doc/changelog/01-added/1604-master.md
+++ b/doc/changelog/01-added/1604-master.md
@@ -1,0 +1,3 @@
+- in `interval_inference.v`
+  + `SubPOrder` instance on `Itv.def`
+    ([#1604](https://github.com/math-comp/math-comp/pull/1604)).


### PR DESCRIPTION
##### Motivation for this change

This PR adds an instantiation of `Itv.def` as `Order.SubPOrder` so that
one can use `le_itv` on elements of intervals.

Without this addition, one cannot :
```
Section test.
Context d (T : porderType d) (f : interval int -> T -> bool) (i : Itv.t).
Local Notation itv := (Itv.def f i).
Local Open Scope order_scope.
Variables x y : itv.
Goal (x <= y) = (\val x <= \val y).
by rewrite Order.le_val.
Qed.
End test.
```

(do I need to write changelog for this change?)

Co-authored-by: @CohenCyril 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
