### PR TITLE
spectral: spectral theorem for real symmetric matrices

### DIFF
--- a/algebra/archimedean.v
+++ b/algebra/archimedean.v
@@ -87,10 +87,10 @@ Bind Scope ring_scope with ArchiNumField.sort.
 End ArchiNumFieldExports.
 HB.export ArchiNumFieldExports.
 
-(* Join structures: since [numClosedFieldType] and [rcfType] now both inherit  *)
-(* [Num.ConjField] (and the intermediate [Num.NumFieldConj]), the archimedean  *)
-(* closed and real-closed fields share the conjugation mixins; HB requires a   *)
-(* common ancestor combining the archimedean [floorCeil] mixin with them.      *)
+(* Join structures: since [numClosedFieldType] and [rcfType] now both inherit *)
+(* [Num.ConjField] (and the intermediate [Num.NumFieldConj]), the archimedean *)
+(* closed and real-closed fields share the conjugation mixins; HB requires a  *)
+(* common ancestor combining the archimedean [floorCeil] mixin with them.     *)
 HB.structure Definition ArchiNumFieldConj :=
   { R of NumDomain_hasFloorCeilTruncn R & Num.NumFieldConj R }.
 

--- a/algebra/archimedean.v
+++ b/algebra/archimedean.v
@@ -87,6 +87,16 @@ Bind Scope ring_scope with ArchiNumField.sort.
 End ArchiNumFieldExports.
 HB.export ArchiNumFieldExports.
 
+(* Join structures: since [numClosedFieldType] and [rcfType] now both inherit  *)
+(* [Num.ConjField] (and the intermediate [Num.NumFieldConj]), the archimedean  *)
+(* closed and real-closed fields share the conjugation mixins; HB requires a   *)
+(* common ancestor combining the archimedean [floorCeil] mixin with them.      *)
+HB.structure Definition ArchiNumFieldConj :=
+  { R of NumDomain_hasFloorCeilTruncn R & Num.NumFieldConj R }.
+
+HB.structure Definition ArchiConjField :=
+  { R of NumDomain_hasFloorCeilTruncn R & Num.ConjField R }.
+
 #[short(type="archiClosedFieldType")]
 HB.structure Definition ArchiClosedField :=
   { R of NumDomain_hasFloorCeilTruncn R & Num.ClosedField R }.

--- a/algebra/numeric_hierarchy/numfield.v
+++ b/algebra/numeric_hierarchy/numfield.v
@@ -126,14 +126,15 @@ HB.mixin Record NumField_hasImaginary R & NumField R := {
 (* [sqrtC] is available).  Field order is preserved so that existing          *)
 (* [NumField_isImaginary.Build] calls (which infer the data fields from the   *)
 (* proof fields) keep working.                                                *)
-HB.factory Record NumField_isImaginary R of GRing.ClosedField R & NumField R
+HB.factory Record NumField_isImaginary R & GRing.ClosedField R & NumField R
 := {
   imaginaryF : R;
   conjF : {rmorphism R -> R};
   sqrCiF : imaginaryF ^+ 2 = - 1;
   normCKF : forall x, `|x| ^+ 2 = x * conjF x;
 }.
-HB.builders Context R of NumField_isImaginary R.
+HB.builders Context R & NumField_isImaginary R.
+  #[warnings="-HB.no-new-instance"]
   HB.instance Definition _ := NumField_hasImaginary.Build R sqrCiF.
   HB.instance Definition _ := NumField_hasConj.Build R normCKF.
 
@@ -218,8 +219,9 @@ HB.mixin Record RealField_hasPolyIvt R & RealField R := {
 HB.factory Record RealField_isClosed R & RealField R := {
   poly_ivtF : real_closed_axiom R
 }.
-HB.builders Context R of RealField_isClosed R.
+HB.builders Context R & RealField_isClosed R.
 
+#[warnings="-HB.no-new-instance"]
 HB.instance Definition _ := RealField_hasPolyIvt.Build R poly_ivtF.
 
 Let conjid : {rmorphism R -> R} := idfun.

--- a/algebra/numeric_hierarchy/numfield.v
+++ b/algebra/numeric_hierarchy/numfield.v
@@ -85,19 +85,106 @@ Bind Scope ring_scope with NumField.sort.
 End NumFieldExports.
 HB.export NumFieldExports.
 
-HB.mixin Record NumField_isImaginary R & NumField R := {
-  imaginary : R;
+HB.mixin Record NumField_hasConj R & NumField R := {
   conj_subdef : {rmorphism R -> R};
-  sqrCi : imaginary ^+ 2 = - 1;
   normCK_subdef : forall x, `|x| ^+ 2 = x * conj_subdef x;
 }.
+
+HB.mixin Record NumField_hasSqrt R & NumField R := {
+  sqrtr_subdef : R -> R;
+  sqrtr_ge0_subdef : forall x, 0 <= sqrtr_subdef x;
+  sqr_sqrtr_subdef : forall x, 0 <= x -> sqrtr_subdef x ^+ 2 = x;
+  ler0_sqrtr_subdef : forall x, x <= 0 -> sqrtr_subdef x = 0;
+}.
+
+(* Intermediate ancestor carrying only the conjugation: declared before       *)
+(* [ConjField] so that a [numClosedFieldType] (which gains [NumField_hasConj]  *)
+(* via the factory but only later acquires [NumField_hasSqrt] from [sqrtC])    *)
+(* shares [NumField_hasConj] through this structure rather than through        *)
+(* [ConjField].                                                                *)
+HB.structure Definition NumFieldConj :=
+  { R of NumField_hasConj R & NumField R }.
+
+#[short(type="conjFieldType")]
+HB.structure Definition ConjField :=
+  { R of NumField_hasConj R & NumField_hasSqrt R & NumField R }.
+
+HB.mixin Record NumField_hasImaginary R & NumField R := {
+  imaginary : R;
+  sqrCi : imaginary ^+ 2 = - 1;
+}.
+
+(* The historical [NumField_isImaginary] mixin is now an HB factory: it       *)
+(* rebuilds the imaginary unit ([NumField_hasImaginary]) and the conjugation  *)
+(* ([NumField_hasConj]) so that a [numClosedFieldType] gains the              *)
+(* [conjFieldType] structure (the square root is provided separately, after   *)
+(* [sqrtC] is available).  Field order is preserved so that existing          *)
+(* [NumField_isImaginary.Build] calls (which infer the data fields from the   *)
+(* proof fields) keep working.                                                *)
+HB.factory Record NumField_isImaginary R of GRing.ClosedField R & NumField R
+:= {
+  imaginaryF : R;
+  conjF : {rmorphism R -> R};
+  sqrCiF : imaginaryF ^+ 2 = - 1;
+  normCKF : forall x, `|x| ^+ 2 = x * conjF x;
+}.
+HB.builders Context R of NumField_isImaginary R.
+  HB.instance Definition _ := NumField_hasImaginary.Build R sqrCiF.
+  HB.instance Definition _ := NumField_hasConj.Build R normCKF.
+
+  (* [conjF] fixes real elements, ported from [CrealE]. *)
+  Let conjFreal x : (x \is Num.real) = (conjF x == x).
+  Proof.
+  rewrite realEsqr ger0_def normrX normCKF.
+  by have [-> | /mulfI/inj_eq-> //] := eqVneq x 0; rewrite rmorph0 !eqxx.
+  Qed.
+
+  Fact cl_sqrtr_subproof (x : R) :
+    exists2 y, 0 <= y & (if 0 <= x then y ^+ 2 == x else y == 0) : bool.
+  Proof.
+  case x_ge0: (0 <= x); last by exists 0.
+  have x_real : x \is Num.real := ger0_real x_ge0.
+  pose z := sval (sig_eqW (@GRing.solve_monicpoly _ 2 (nth 0 [:: x]) isT)).
+  have Dz : z ^+ 2 = x.
+    rewrite /z; case: sig_eqW => /= w ->.
+    by rewrite !big_ord_recl big_ord0 /= mulr1 mul0r !addr0.
+  have cjz : conjF z ^+ 2 = z ^+ 2.
+    by rewrite -rmorphXn Dz; apply/eqP; rewrite -conjFreal.
+  exists `|z|; first by rewrite normr_ge0.
+  have /orP[/eqP cjzz|/eqP cjzNz] : (conjF z == z) ||
+      (conjF z == - z) by rewrite -eqf_sqr cjz eqxx.
+    by rewrite real_normK ?Dz// realEsqr Dz x_ge0.
+  have nz2 : `|z| ^+ 2 = - x by rewrite normCKF cjzNz mulrN -expr2 Dz.
+  have x0 : x = 0.
+    by apply: le_anti; rewrite x_ge0 andbT -oppr_ge0 -nz2 exprn_ge0.
+  by rewrite nz2 x0 oppr0.
+  Qed.
+  Definition cl_sqrtr x := s2val (sig2W (cl_sqrtr_subproof x)).
+  Fact cl_sqrtr_ge0 x : 0 <= cl_sqrtr x.
+  Proof. by rewrite /cl_sqrtr; case: (sig2W _). Qed.
+  Fact cl_sqr_sqrtr x : 0 <= x -> cl_sqrtr x ^+ 2 = x.
+  Proof.
+  rewrite /cl_sqrtr => x_ge0.
+  by case: (sig2W _) => /= y _; rewrite x_ge0 => /eqP.
+  Qed.
+  Fact cl_ler0_sqrtr x : x <= 0 -> cl_sqrtr x = 0.
+  Proof.
+  rewrite /cl_sqrtr; case: (sig2W _) => y /= _.
+  case: ifP => [x0 /eqP sq xle0|_ /eqP//].
+  have x_eq0 : x = 0 by apply: le_anti; rewrite x0 xle0.
+  by move: sq; rewrite x_eq0 => /eqP; rewrite sqrf_eq0 => /eqP.
+  Qed.
+  HB.instance Definition _ :=
+    NumField_hasSqrt.Build R cl_sqrtr_ge0 cl_sqr_sqrtr cl_ler0_sqrtr.
+HB.end.
 
 #[short(type="numClosedFieldType")]
 HB.structure Definition ClosedField :=
   { R of NumField_isImaginary R & GRing.ClosedField R & NumField R }.
 
-Definition conj {C : numClosedFieldType} : C -> C := @conj_subdef C.
-#[export] HB.instance Definition _ C := GRing.RMorphism.on (@conj C).
+Definition conj {R : conjFieldType} : R -> R := @conj_subdef R.
+#[export] HB.instance Definition _ (R : conjFieldType) :=
+  GRing.RMorphism.on (@conj R).
 #[deprecated(since="mathcomp 2.5.0", use=conj)]
 Notation conj_op := conj (only parsing).
 
@@ -115,9 +202,52 @@ Bind Scope ring_scope with RealField.sort.
 End RealFieldExports.
 HB.export RealFieldExports.
 
-HB.mixin Record RealField_isClosed R & RealField R := {
+HB.mixin Record RealField_hasPolyIvt R & RealField R := {
   poly_ivt_subproof : real_closed_axiom R
 }.
+
+(* The historical [RealField_isClosed] mixin is now an HB factory: besides the *)
+(* intermediate value property it rebuilds the (trivial) conjugation [conj=id] *)
+(* and the square root of nonnegative elements, so that an [rcfType] is        *)
+(* endowed with the [conjFieldType] structure.                                 *)
+HB.factory Record RealField_isClosed R & RealField R := {
+  poly_ivtF : real_closed_axiom R
+}.
+HB.builders Context R of RealField_isClosed R.
+
+HB.instance Definition _ := RealField_hasPolyIvt.Build R poly_ivtF.
+
+Let conjid : {rmorphism R -> R} := idfun.
+Fact rcf_normCK (x : R) : `|x| ^+ 2 = x * conjid x.
+Proof. by rewrite real_normK ?num_real// expr2. Qed.
+HB.instance Definition _ := NumField_hasConj.Build R rcf_normCK.
+
+Fact rcf_sqrtr_subproof (x : R) :
+  exists2 y, 0 <= y & (if 0 <= x then y ^+ 2 == x else y == 0) : bool.
+Proof.
+case x_ge0: (0 <= x); last by exists 0.
+have le0x1 : 0 <= x + 1 by rewrite -nnegrE rpredD ?rpred1.
+have [|y /andP[y_ge0 _]] := @poly_ivtF ('X^2 - x%:P) _ _ le0x1.
+  rewrite !hornerE expr0n/= sub0r oppr_le0 x_ge0/= subr_ge0.
+  by rewrite -[leLHS]mul1r ler_pM// (lerDl, lerDr).
+by rewrite rootE !hornerE subr_eq0; exists y.
+Qed.
+Definition rcf_sqrtr x := s2val (sig2W (rcf_sqrtr_subproof x)).
+Fact rcf_sqrtr_ge0 x : 0 <= rcf_sqrtr x.
+Proof. by rewrite /rcf_sqrtr; case: (sig2W _). Qed.
+Fact rcf_sqr_sqrtr x : 0 <= x -> rcf_sqrtr x ^+ 2 = x.
+Proof.
+by rewrite /rcf_sqrtr => x_ge0; case: (sig2W _) => /= y _; rewrite x_ge0 => /eqP.
+Qed.
+Fact rcf_ler0_sqrtr x : x <= 0 -> rcf_sqrtr x = 0.
+Proof.
+rewrite /rcf_sqrtr; case: (sig2W _) => y /= _.
+by have [//|_ /eqP//|->] := ltrgt0P x; rewrite mulf_eq0 orbb => /eqP.
+Qed.
+HB.instance Definition _ :=
+  NumField_hasSqrt.Build R rcf_sqrtr_ge0 rcf_sqr_sqrtr rcf_ler0_sqrtr.
+
+HB.end.
 
 #[short(type="rcfType")]
 HB.structure Definition RealClosedField :=
@@ -151,7 +281,7 @@ Module Import Def.
 Export Num.Def.
 
 Notation conjC := conj.
-Definition sqrtr {R} x := s2val (sig2W (@sqrtr_subproof R x)).
+Definition sqrtr {R : conjFieldType} (x : R) := sqrtr_subdef x.
 
 End Def.
 
@@ -167,6 +297,59 @@ End Syntax.
 Module Export Theory.
 
 Export Num.Theory.
+
+Section ConjFieldTheory.
+
+Variable R : conjFieldType.
+Implicit Types a x y z : R.
+
+Definition normCK : forall x, `|x| ^+ 2 = x * x^* := normCK_subdef.
+
+Lemma normCKC x : `|x| ^+ 2 = x^* * x. Proof. by rewrite normCK mulrC. Qed.
+
+Lemma conjCK : involutive (@conj R).
+Proof.
+have JE x : x^* = `|x|^+2 / x.
+  have [->|x_neq0] := eqVneq x 0; first by rewrite rmorph0 invr0 mulr0.
+  by apply: (canRL (mulfK _)) => //; rewrite mulrC -normCK.
+move=> x; have [->|x_neq0] := eqVneq x 0; first by rewrite !rmorph0.
+rewrite !JE normrM normrV ?unitfE// exprMn normrX normr_id.
+by rewrite exprVn -mulrA -invfM mulrA -expr2 divKf// 2!sqrf_eq0 normr_eq0.
+Qed.
+
+Lemma mul_conjC_ge0 x : 0 <= x * x^*.
+Proof. by rewrite -normCK exprn_ge0. Qed.
+
+Lemma mul_conjC_gt0 x : (0 < x * x^* ) = (x != 0).
+Proof.
+have [->|x_neq0] := eqVneq; first by rewrite rmorph0 mulr0.
+by rewrite -normCK exprn_gt0 ?normr_gt0.
+Qed.
+
+Lemma mul_conjC_eq0 x : (x * x^* == 0) = (x == 0).
+Proof. by rewrite -normCK expf_eq0 normr_eq0. Qed.
+
+Lemma conjC_ge0 x : (0 <= x^* ) = (0 <= x).
+Proof.
+wlog suffices: x / 0 <= x -> 0 <= x^*.
+  by move=> IH; apply/idP/idP=> /IH; rewrite ?conjCK.
+rewrite [in X in X -> _]le0r => /predU1P[-> | x_gt0]; first by rewrite rmorph0.
+by rewrite -(pmulr_rge0 _ x_gt0) mul_conjC_ge0.
+Qed.
+
+(* Square Root theory *)
+
+Lemma sqrtr_ge0 a : 0 <= sqrt a.
+Proof. exact: sqrtr_ge0_subdef. Qed.
+Hint Resolve sqrtr_ge0 : core.
+
+Lemma sqr_sqrtr a : 0 <= a -> sqrt a ^+ 2 = a.
+Proof. exact: sqr_sqrtr_subdef. Qed.
+
+Lemma ler0_sqrtr a : a <= 0 -> sqrt a = 0.
+Proof. exact: ler0_sqrtr_subdef. Qed.
+
+End ConjFieldTheory.
 
 Section NumFieldTheory.
 
@@ -554,20 +737,7 @@ Lemma poly_ivt : real_closed_axiom R. Proof. exact: poly_ivt. Qed.
 
 (* Square Root theory *)
 
-Lemma sqrtr_ge0 a : 0 <= sqrt a.
-Proof. by rewrite /sqrt; case: (sig2W _). Qed.
 Hint Resolve sqrtr_ge0 : core.
-
-Lemma sqr_sqrtr a : 0 <= a -> sqrt a ^+ 2 = a.
-Proof.
-by rewrite /sqrt => a_ge0; case: (sig2W _) => /= x _; rewrite a_ge0 => /eqP.
-Qed.
-
-Lemma ler0_sqrtr a : a <= 0 -> sqrt a = 0.
-Proof.
-rewrite /sqrtr; case: (sig2W _) => x /= _.
-by have [//|_ /eqP//|->] := ltrgt0P a; rewrite mulf_eq0 orbb => /eqP.
-Qed.
 
 Lemma ltr0_sqrtr a : a < 0 -> sqrt a = 0.
 Proof. by move=> /ltW; apply: ler0_sqrtr. Qed.
@@ -579,7 +749,7 @@ Variant sqrtr_spec a : R -> bool -> bool -> R -> Type :=
 Lemma sqrtrP a : sqrtr_spec a a (0 <= a) (a < 0) (sqrt a).
 Proof.
 have [a_ge0|a_lt0] := ger0P a.
-  by rewrite -{1 2}[a]sqr_sqrtr //; constructor.
+  by rewrite -{1 2}[a]sqr_sqrtr //; constructor; apply: sqrtr_ge0.
 by rewrite ltr0_sqrtr //; constructor.
 Qed.
 
@@ -630,7 +800,7 @@ Qed.
 Lemma ler_wsqrtr : {homo @sqrt R : a b / a <= b}.
 Proof.
 move=> a b /= le_ab; case: (boolP (0 <= a))=> [pa|]; last first.
-  by rewrite -ltNge; move/ltW; rewrite -sqrtr_eq0; move/eqP->.
+  by rewrite -ltNge; move/ltW; rewrite -sqrtr_eq0 => /eqP->; apply: sqrtr_ge0.
 rewrite -(@ler_pXn2r R 2) ?nnegrE ?sqrtr_ge0 //.
 by rewrite !sqr_sqrtr // (le_trans pa).
 Qed.
@@ -671,21 +841,9 @@ Section ClosedFieldTheory.
 Variable C : numClosedFieldType.
 Implicit Types a x y z : C.
 
-Definition normCK : forall x, `|x| ^+ 2 = x * x^* := normCK_subdef.
-
 Definition sqrCi : 'i ^+ 2 = -1 :> C := sqrCi.
 
 Lemma mulCii : 'i * 'i = -1 :> C. Proof. exact: sqrCi. Qed.
-
-Lemma conjCK : involutive (@conj C).
-Proof.
-have JE x : x^* = `|x|^+2 / x.
-  have [->|x_neq0] := eqVneq x 0; first by rewrite rmorph0 invr0 mulr0.
-  by apply: (canRL (mulfK _)) => //; rewrite mulrC -normCK.
-move=> x; have [->|x_neq0] := eqVneq x 0; first by rewrite !rmorph0.
-rewrite !JE normrM normfV exprMn normrX normr_id.
-by rewrite exprVn -mulrA -invfM mulrA -expr2 divKf// 2!sqrf_eq0 normr_eq0.
-Qed.
 
 Let Re2 z := z + z^*.
 Definition nnegIm z := (0 <= 'i * (z^* - z)).
@@ -742,28 +900,6 @@ Proof. by rewrite ['Im _]unlock. Qed.
 
 Let nz2 : 2 != 0 :> C. Proof. by rewrite pnatr_eq0. Qed.
 
-Lemma normCKC x : `|x| ^+ 2 = x^* * x. Proof. by rewrite normCK mulrC. Qed.
-
-Lemma mul_conjC_ge0 x : 0 <= x * x^*.
-Proof. by rewrite -normCK exprn_ge0. Qed.
-
-Lemma mul_conjC_gt0 x : (0 < x * x^* ) = (x != 0).
-Proof.
-have [->|x_neq0] := eqVneq; first by rewrite rmorph0 mulr0.
-by rewrite -normCK exprn_gt0 ?normr_gt0.
-Qed.
-
-Lemma mul_conjC_eq0 x : (x * x^* == 0) = (x == 0).
-Proof. by rewrite -normCK expf_eq0 normr_eq0. Qed.
-
-Lemma conjC_ge0 x : (0 <= x^* ) = (0 <= x).
-Proof.
-wlog suffices: x / 0 <= x -> 0 <= x^*.
-  by move=> IH; apply/idP/idP=> /IH; rewrite ?conjCK.
-rewrite [in X in X -> _]le0r => /predU1P[-> | x_gt0]; first by rewrite rmorph0.
-by rewrite -(pmulr_rge0 _ x_gt0) mul_conjC_ge0.
-Qed.
-
 Lemma conjC_nat n : (n%:R)^* = n%:R :> C. Proof. exact: rmorph_nat. Qed.
 Lemma conjC0 : 0^* = 0 :> C. Proof. exact: rmorph0. Qed.
 Lemma conjC1 : 1^* = 1 :> C. Proof. exact: rmorph1. Qed.
@@ -794,7 +930,7 @@ Lemma conj_normC z : `|z|^* = `|z|.
 Proof. by rewrite conj_Creal ?normr_real. Qed.
 
 Lemma CrealJ : {mono (@conj C) : x / x \is Num.real}.
-Proof. by apply: (homo_mono1 conjCK) => x xreal; rewrite conj_Creal. Qed.
+Proof. by apply: (homo_mono1 (@conjCK C)) => x xreal; rewrite conj_Creal. Qed.
 
 Lemma geC0_conj x : 0 <= x -> x^* = x.
 Proof. by move=> /ger0_real/CrealP. Qed.
@@ -1405,7 +1541,7 @@ Notation "'i" := imaginary : ring_scope.
 Notation "'Re z" := (Re z) : ring_scope.
 Notation "'Im z" := (Im z) : ring_scope.
 
-Arguments conjCK {C} x.
+Arguments conjCK {R} x.
 Arguments sqrCK {C} [x] le0x.
 Arguments sqrCK_P {C x}.
 

--- a/algebra/numeric_hierarchy/numfield.v
+++ b/algebra/numeric_hierarchy/numfield.v
@@ -23,6 +23,11 @@ From mathcomp Require Import divalg decfield poly orderedzmod numdomain.
 (*                    The HB class is called RealField.                       *)
 (*         rcfType == A Real Field with the real closed axiom                 *)
 (*                    The HB class is called RealClosedField.                 *)
+(*   conjFieldType == numField with an involutive conjugation `conj`          *)
+(*                    s.t. `|x|^2 = x * conj x`, and a square root of         *)
+(*                    nonnegative elements; common ancestor of rcfType        *)
+(*                    and numClosedFieldType.                                 *)
+(*                    The HB class is called ConjField.                       *)
 (*                                                                            *)
 (* Over these structures, we have the following operation:                    *)
 (*       Num.sqrt x == in a real-closed field, a positive square root of x if *)
@@ -98,10 +103,10 @@ HB.mixin Record NumField_hasSqrt R & NumField R := {
 }.
 
 (* Intermediate ancestor carrying only the conjugation: declared before       *)
-(* [ConjField] so that a [numClosedFieldType] (which gains [NumField_hasConj]  *)
-(* via the factory but only later acquires [NumField_hasSqrt] from [sqrtC])    *)
-(* shares [NumField_hasConj] through this structure rather than through        *)
-(* [ConjField].                                                                *)
+(* [ConjField] so that a [numClosedFieldType] (which gains [NumField_hasConj] *)
+(* via the factory but only later acquires [NumField_hasSqrt] from [sqrtC])   *)
+(* shares [NumField_hasConj] through this structure rather than through       *)
+(* [ConjField].                                                               *)
 HB.structure Definition NumFieldConj :=
   { R of NumField_hasConj R & NumField R }.
 
@@ -206,10 +211,10 @@ HB.mixin Record RealField_hasPolyIvt R & RealField R := {
   poly_ivt_subproof : real_closed_axiom R
 }.
 
-(* The historical [RealField_isClosed] mixin is now an HB factory: besides the *)
-(* intermediate value property it rebuilds the (trivial) conjugation [conj=id] *)
-(* and the square root of nonnegative elements, so that an [rcfType] is        *)
-(* endowed with the [conjFieldType] structure.                                 *)
+(* The historical [RealField_isClosed] mixin is now an HB factory: besides    *)
+(* the intermediate value property it rebuilds the (trivial) conjugation      *)
+(* [conj=id] and the square root of nonnegative elements, so that an          *)
+(* [rcfType] is endowed with the [conjFieldType] structure.                   *)
 HB.factory Record RealField_isClosed R & RealField R := {
   poly_ivtF : real_closed_axiom R
 }.
@@ -237,7 +242,8 @@ Fact rcf_sqrtr_ge0 x : 0 <= rcf_sqrtr x.
 Proof. by rewrite /rcf_sqrtr; case: (sig2W _). Qed.
 Fact rcf_sqr_sqrtr x : 0 <= x -> rcf_sqrtr x ^+ 2 = x.
 Proof.
-by rewrite /rcf_sqrtr => x_ge0; case: (sig2W _) => /= y _; rewrite x_ge0 => /eqP.
+rewrite /rcf_sqrtr => x_ge0.
+by case: (sig2W _) => /= y _; rewrite x_ge0 => /eqP.
 Qed.
 Fact rcf_ler0_sqrtr x : x <= 0 -> rcf_sqrtr x = 0.
 Proof.

--- a/algebra/sesquilinear.v
+++ b/algebra/sesquilinear.v
@@ -154,7 +154,7 @@ Proof. by move: f => [? [? ? []]]. Qed.
 End InvolutiveTheory.
 
 Section conjC_involutive.
-Variable C : numClosedFieldType.
+Variable C : conjFieldType.
 
 Let conjCfun_involutive : involutive (@conjC C). Proof. exact: conjCK. Qed.
 
@@ -163,7 +163,7 @@ HB.instance Definition _ :=
 
 End conjC_involutive.
 
-Lemma map_mxCK {C : numClosedFieldType} m n (A : 'M[C]_(m, n)) :
+Lemma map_mxCK {C : conjFieldType} m n (A : 'M[C]_(m, n)) :
   (A ^ conjC) ^ conjC = A.
 Proof. by apply/matrixP=> i j; rewrite !mxE conjCK. Qed.
 
@@ -1039,7 +1039,7 @@ Arguments mem_orthovPn {F eps theta vT form V u}.
 Arguments mem_orthovP {F eps theta vT form V u}.
 
 Section DotVectTheory.
-Variables (C : numClosedFieldType).
+Variables (C : conjFieldType).
 Variable (U : lmodType C) (form : {dot U for conjC}).
 
 Local Notation "''[' u , v ]" := (form u%R v%R) : ring_scope.
@@ -1058,15 +1058,6 @@ Proof. by rewrite -dnorm_geiff0 eq_sym. Qed.
 Lemma dnorm_gt0 u : (0 < '[u]) = (u != 0).
 Proof. by rewrite lt_def dnorm_eq0 dnorm_ge0 andbT. Qed.
 
-Lemma sqrt_dnorm_ge0 u : 0 <= sqrtC '[u].
-Proof. by rewrite sqrtC_ge0 dnorm_ge0. Qed.
-
-Lemma sqrt_dnorm_eq0 u : (sqrtC '[u] == 0) = (u == 0).
-Proof. by rewrite sqrtC_eq0 dnorm_eq0. Qed.
-
-Lemma sqrt_dnorm_gt0 u : (sqrtC '[u] > 0) = (u != 0).
-Proof. by rewrite sqrtC_gt0 dnorm_gt0. Qed.
-
 Lemma dnormZ a u : '[a *: u]= `|a| ^+ 2 * '[u].
 Proof. by rewrite linearZl_LR linearZr_LR/= mulrA normCK. Qed.
 
@@ -1077,6 +1068,25 @@ Lemma dnormB u v : let d := '[u, v] in '[u - v] = '[u] + '[v] - (d + d^*).
 Proof. by rewrite hnormB mul1r. Qed.
 
 End DotVectTheory.
+
+Section DotVectTheoryClosed.
+Variables (C : numClosedFieldType).
+Variable (U : lmodType C) (form : {dot U for conjC}).
+
+Local Notation "''[' u , v ]" := (form u%R v%R) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+
+Lemma sqrt_dnorm_ge0 u : 0 <= sqrtC '[u].
+Proof. by rewrite sqrtC_ge0 dnorm_ge0. Qed.
+
+Lemma sqrt_dnorm_eq0 u : (sqrtC '[u] == 0) = (u == 0).
+Proof. by rewrite sqrtC_eq0 dnorm_eq0. Qed.
+
+Lemma sqrt_dnorm_gt0 u : (sqrtC '[u] > 0) = (u != 0).
+Proof. by rewrite sqrtC_gt0 dnorm_gt0. Qed.
+
+End DotVectTheoryClosed.
+
 #[global]
 Hint Extern 0 (is_true (0 <= Dot.sort _ _ _
   (* NB: This Hint is assuming ^*, a more precise pattern would be welcome *)))
@@ -1655,10 +1665,10 @@ Notation symmetricmx := (hermitianmx _ false idfun).
 Notation skewmx := (hermitianmx _ true idfun).
 Notation hermsymmx := (hermitianmx _ false conjC).
 
-Lemma hermitian1mx_subproof {C : numClosedFieldType} n : (1%:M : 'M[C]_n) \is hermsymmx.
+Lemma hermitian1mx_subproof {C : conjFieldType} n : (1%:M : 'M[C]_n) \is hermsymmx.
 Proof.
-by rewrite qualifE /= expr0 scale1r tr_scalar_mx map_scalar_mx/= conjC1.
+by rewrite qualifE /= expr0 scale1r tr_scalar_mx map_scalar_mx/= (rmorph1 conjC).
 Qed.
 
-Canonical hermitian1mx {C : numClosedFieldType} n :=
+Canonical hermitian1mx {C : conjFieldType} n :=
   HermitianMx (@hermitian1mx_subproof C n).

--- a/algebra/sesquilinear.v
+++ b/algebra/sesquilinear.v
@@ -1665,9 +1665,11 @@ Notation symmetricmx := (hermitianmx _ false idfun).
 Notation skewmx := (hermitianmx _ true idfun).
 Notation hermsymmx := (hermitianmx _ false conjC).
 
-Lemma hermitian1mx_subproof {C : conjFieldType} n : (1%:M : 'M[C]_n) \is hermsymmx.
+Lemma hermitian1mx_subproof {C : conjFieldType} n :
+  (1%:M : 'M[C]_n) \is hermsymmx.
 Proof.
-by rewrite qualifE /= expr0 scale1r tr_scalar_mx map_scalar_mx/= (rmorph1 conjC).
+rewrite qualifE /= expr0 scale1r tr_scalar_mx map_scalar_mx/=.
+by rewrite (rmorph1 conjC).
 Qed.
 
 Canonical hermitian1mx {C : conjFieldType} n :=

--- a/algebra/spectral.v
+++ b/algebra/spectral.v
@@ -876,7 +876,7 @@ HB.instance Definition _ := Num.isNumRing.Build realsubfield
 End Num.
 
 Definition realsubpfactor (x : C) : {poly realsubfield} :=
-  if x \is Num.real =P true is ReflectT xR then 'X - (Realsub xR)%:P else
+  if (x \is Num.real) =P true is ReflectT xR then 'X - (Realsub xR)%:P else
   'X^2 - (Realsub (Creal_Re x) *+ 2) *: 'X + ((Realsub (normr_real x))^+2)%:P.
 Notation Cpfactor x := (realsubpfactor x ^^ realsubval).
 

--- a/algebra/spectral.v
+++ b/algebra/spectral.v
@@ -416,8 +416,10 @@ Lemma add_proj_ortho p m n (U : 'M_(p, n)) (W : 'M_(m, n)) :
 Proof.
 rewrite -[W in LHS](@add_proj_mx _ _ _ <<U>>%MS U^!%MS W)//.
 rewrite !mulmxDl proj_ortho_id ?proj_ortho_sub //.
-rewrite proj_ortho_0 ?proj_mx_sub // addr0.
-rewrite proj_ortho_0 ?ortho_id ?proj_ortho_sub // add0r.
+rewrite [_ *m proj_mx U^!%MS _ *m proj_ortho U]proj_ortho_0 ?proj_mx_sub //.
+rewrite addr0.
+rewrite [_ *m proj_mx <<U>>%MS _ *m proj_ortho U^!%MS]proj_ortho_0
+  ?ortho_id ?proj_ortho_sub // add0r.
 by rewrite proj_ortho_id ?proj_mx_sub// add_proj_mx.
 Qed.
 

--- a/algebra/spectral.v
+++ b/algebra/spectral.v
@@ -90,7 +90,7 @@ Notation "M ^t*" := (M ^t conjC) (at level 29, left associativity)
   : sesquilinear_scope.
 Notation realmx := (mxOver Num.real).
 
-Lemma trmxCK {C : numClosedFieldType} m n (A : 'M[C]_(m, n)) : A ^t* ^t* = A.
+Lemma trmxCK {C : conjFieldType} m n (A : 'M[C]_(m, n)) : A ^t* ^t* = A.
 Proof. by apply/matrixP=> i j; rewrite !mxE conjCK. Qed.
 
 Section realmx.
@@ -172,7 +172,7 @@ by rewrite !mxOverM// => /(_ isT isT isT isT) [-> ->].
 Qed.
 
 Section unitarymx.
-Context {C : numClosedFieldType}.
+Context {C : conjFieldType}.
 
 Definition unitarymx {m n} := [qualify X : 'M[C]_(m, n) | X *m X ^t* == 1%:M].
 Fact unitarymx_key m n : pred_key (@unitarymx m n). Proof. by []. Qed.
@@ -267,12 +267,18 @@ Proof. by move=> Asym Areal; rewrite hermitian_normalmx// realsym_hermsym. Qed.
 End normalmx.
 
 Local Notation dotmx_def := (form_of_matrix (@conjC _) 1%:M).
-Definition dotmx (C : numClosedFieldType) n (u v : 'rV[C]_n) :=
+Definition dotmx (C : conjFieldType) n (u v : 'rV[C]_n) :=
   dotmx_def u%R v%R.
 
-Section Spectral.
-Variable (C : numClosedFieldType).
+Section ConjSpectral.
+Variable (C : conjFieldType).
 Set Default Proof Using "C".
+
+Lemma sqrtr_gt0_dnorm (a : C) : 0 <= a -> (0 < sqrtr a) = (0 < a).
+Proof.
+move=> a_ge0; rewrite lt0r sqrtr_ge0 lt0r a_ge0 !andbT.
+by rewrite -(sqr_sqrtr a_ge0) sqrf_eq0 sqr_sqrtr.
+Qed.
 
 (**
 TODO: bug report
@@ -471,8 +477,8 @@ have [v /and4P [vBn v_neq0 dAv_ge0 dAsub]] :
         by rewrite (submx_trans _ vBn) // proj_ortho_sub.
       rewrite (submx_trans (proj_ortho_sub _ _)) //.
       by rewrite -{1}[B]addr0 addmx_sub_adds ?sub0mx.
-  pose c := (sqrtC '[BoSn])^-1; have c_gt0 : c > 0.
-    by rewrite invr_gt0 sqrtC_gt0 lt_def ?dnorm_eq0 ?dnorm_ge0 BoSn_neq0.
+  pose c := (sqrtr '[BoSn])^-1; have c_gt0 : c > 0.
+    by rewrite invr_gt0 sqrtr_gt0_dnorm ?dnorm_ge0// lt_def ?dnorm_eq0 ?dnorm_ge0 BoSn_neq0.
   exists BoSn; apply/and4P; split => //.
   - by rewrite orthomx_sym ?proj_ortho_sub // /gtr_eqF.
   - rewrite -pBE linearDl/=.
@@ -480,16 +486,16 @@ have [v /and4P [vBn v_neq0 dAv_ge0 dAsub]] :
     by rewrite orthomx_proj_mx_ortho // orthomx_sym.
   - by rewrite -pBE addmx_sub_adds // proj_ortho_sub.
 wlog nv_eq1 : v vBn v_neq0 dAv_ge0 dAsub / '[v] = 1.
-  pose c := (sqrtC '[v])^-1.
-  have c_gt0 : c > 0 by rewrite invr_gt0 sqrtC_gt0 ?dnorm_gt0.
+  pose c := (sqrtr '[v])^-1.
+  have c_gt0 : c > 0 by rewrite invr_gt0 sqrtr_gt0_dnorm ?dnorm_ge0// dnorm_gt0.
   have [c_ge0 c_eq0F] := (ltW c_gt0, gt_eqF c_gt0).
   move=> /(_ (c *: v)); apply.
   - by rewrite orthomxZ ?c_eq0F.
   - by rewrite scaler_eq0 c_eq0F.
   - by rewrite linearZr mulr_ge0 // conjC_ge0.
   - by rewrite (submx_trans dAsub) // addsmxS // eqmx_scale // c_eq0F.
-  - rewrite dnormZ normfV ger0_norm ?sqrtC_ge0 ?dnorm_ge0 //.
-    by rewrite exprVn rootCK ?mulVf // dnorm_eq0.
+  - rewrite dnormZ normfV ger0_norm ?sqrtr_ge0 ?dnorm_ge0 //.
+    by rewrite exprVn sqr_sqrtr ?dnorm_ge0 ?mulVf // dnorm_eq0.
 exists (col_mx B v).
   apply/row_unitarymxP => i j.
   case: (split_ordP i) (split_ordP j) => [] i' -> [] j' ->;
@@ -572,6 +578,18 @@ move=> [:nsV]; rewrite !(orthomx1P _) -?scalar_mx_block //;
   [abstract: nsV|]; last by rewrite orthomx_sym.
 by do 2!rewrite eqmx_schmidt_free ?eq_row_base ?row_base_free // orthomx_sym.
 Qed.
+
+End ConjSpectral.
+
+Section Spectral.
+Variable (C : numClosedFieldType).
+
+Local Notation "''[' u , v ]" := (dotmx u v) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+Local Notation "B ^!" :=
+  (orthomx conjC (mx_of_hermitian (hermitian1mx _)) B) :
+    matrix_set_scope.
+Local Notation "A '_|_ B" := (A%MS <= B^!)%MS : bool_scope.
 
 Lemma cotrigonalization n (As : seq 'M[C]_n) :
   {in As &, forall A B, comm_mx A B} ->

--- a/algebra/spectral.v
+++ b/algebra/spectral.v
@@ -1,7 +1,8 @@
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
 From mathcomp Require Import fintype bigop nmodule order.
-From mathcomp Require Import rings_modules_and_algebras divalg poly matrix.
+From mathcomp Require Import rings_modules_and_algebras divalg poly polydiv.
+From mathcomp Require Import matrix.
 From mathcomp Require Import mxalgebra mxpoly mxred orderedzmod numdomain.
 From mathcomp Require Import numfield sesquilinear.
 
@@ -758,3 +759,263 @@ by move=> /esym/CrealP.
 Qed.
 
 End Spectral.
+
+Local Notation "p ^^ f" := (map_poly f p)
+  (at level 30, f at level 30, format "p  ^^  f").
+
+Section RealSubfield.
+
+Variable (C : numClosedFieldType).
+
+Record realsubfield :=
+  Realsub { realsubval : C; realsubvalP : realsubval \is Num.real }.
+
+HB.instance Definition _ := [isSub for realsubval].
+HB.instance Definition _ := [Choice of realsubfield by <:].
+HB.instance Definition _ :=
+  [SubChoice_isSubIntegralDomain of realsubfield by <:].
+HB.instance Definition _ :=
+  [SubIntegralDomain_isSubField of realsubfield by <:].
+HB.instance Definition _ : Order.isPOrder ring_display realsubfield :=
+  Order.CancelPartial.Pcan _ valK.
+Lemma total_realsubfield :
+  total (<=%O : rel (realsubfield : porderType _)).
+Proof. by move=> x y; apply/real_leVge/valP/valP. Qed.
+HB.instance Definition _ :=
+  Order.POrder_isTotal.Build _ realsubfield total_realsubfield.
+
+Lemma realsubval_is_zmod_morphism : zmod_morphism realsubval.
+Proof. by []. Qed.
+Lemma realsubval_is_monoid_morphism : monoid_morphism realsubval.
+Proof. by []. Qed.
+HB.instance Definition _ :=
+  GRing.isZmodMorphism.Build realsubfield C realsubval
+  realsubval_is_zmod_morphism.
+HB.instance Definition _ :=
+  GRing.isMonoidMorphism.Build realsubfield C realsubval
+  realsubval_is_monoid_morphism.
+
+Definition realsubfield_norm (x : realsubfield) : realsubfield :=
+  Realsub (normr_real (val x)).
+Lemma realsubfield_ler_norm_add x y :
+  realsubfield_norm (x + y) <= (realsubfield_norm x + realsubfield_norm y).
+Proof. exact: ler_normD. Qed.
+Lemma realsubfield_normr0_eq0 x : realsubfield_norm x = 0 -> x = 0.
+Proof. by move=> /(congr1 val)/normr0_eq0 ?; apply/val_inj. Qed.
+Lemma realsubfield_normrMn x n :
+  realsubfield_norm (x *+ n) = realsubfield_norm x *+ n.
+Proof. by apply/val_inj; rewrite /= !rmorphMn/= normrMn. Qed.
+Lemma realsubfield_normrN x : realsubfield_norm (- x) = realsubfield_norm x.
+Proof. by apply/val_inj; apply: normrN. Qed.
+
+Section Num.
+
+Section withz.
+Let z : realsubfield := 0.
+Lemma realsubfield_addr_gt0 (x y : realsubfield) : z < x -> z < y -> z < x + y.
+Proof. exact: addr_gt0. Qed.
+Lemma realsubfield_ger_leVge (x y : realsubfield) :
+  z <= x -> z <= y -> (x <= y) || (y <= x).
+Proof. exact: ger_leVge. Qed.
+Lemma realsubfield_normrM : {morph realsubfield_norm : x y / x * y}.
+Proof. by move=> *; apply/val_inj; apply: normrM. Qed.
+Lemma realsubfield_ler_def (x y : realsubfield) :
+  (x <= y) = (realsubfield_norm (y - x) == y - x).
+Proof. by apply: ler_def. Qed.
+End withz.
+
+HB.instance Definition _ := Num.Zmodule_isNormed.Build _ realsubfield
+  realsubfield_ler_norm_add realsubfield_normr0_eq0
+  realsubfield_normrMn realsubfield_normrN.
+HB.instance Definition _ := Num.isNumRing.Build realsubfield
+  realsubfield_addr_gt0 realsubfield_ger_leVge
+  realsubfield_normrM realsubfield_ler_def.
+End Num.
+
+Definition realsubpfactor (x : C) : {poly realsubfield} :=
+  if x \is Num.real =P true is ReflectT xR then 'X - (Realsub xR)%:P else
+  'X^2 - (Realsub (Creal_Re x) *+ 2) *: 'X + ((Realsub (normr_real x))^+2)%:P.
+Notation Cpfactor x := (realsubpfactor x ^^ realsubval).
+
+Lemma realsubpfactorRE (x : C) (xR : x \is Num.real) :
+  realsubpfactor x = 'X - (Realsub xR)%:P.
+Proof.
+rewrite /realsubpfactor; case: eqP xR => //= p1 p2.
+by rewrite (bool_irrelevance p1 p2).
+Qed.
+
+Lemma CpfactorRE (x : C) : x \is Num.real ->
+  Cpfactor x = 'X - x%:P.
+Proof. by move=> xR; rewrite realsubpfactorRE map_polyXsubC. Qed.
+
+Lemma realsubpfactorCE (x : C) : x \isn't Num.real ->
+  realsubpfactor x =
+  'X^2 - (Realsub (Creal_Re x) *+ 2) *: 'X + ((Realsub (normr_real x))^+2)%:P.
+Proof. by rewrite /realsubpfactor; case: eqP => // p; rewrite p. Qed.
+
+Lemma CpfactorCE (x : C) : x \isn't Num.real ->
+  Cpfactor x = ('X - x%:P) * ('X - x^*%:P).
+Proof.
+move=> xNR; rewrite realsubpfactorCE//=.
+rewrite rmorphD /= rmorphB/= !map_polyZ !map_polyXn/= map_polyX.
+rewrite (map_polyC realsubval)/=.
+rewrite mulrBl !mulrBr -!addrA; congr (_ + _).
+rewrite opprD addrA opprK -opprD -rmorphM/= -normCK; congr (- _ + _).
+rewrite mulrC !mul_polyC -scalerDl.
+rewrite [x in RHS]Crect conjC_rect ?Creal_Re ?Creal_Im//.
+by rewrite addrACA addNr addr0.
+Qed.
+
+Lemma CpfactorE x :
+  Cpfactor x = ('X - x%:P) * ('X - x^*%:P) ^+ (x \isn't Num.real).
+Proof.
+by have [/CpfactorRE|/CpfactorCE] := boolP (_ \is _); rewrite ?mulr1.
+Qed.
+
+Lemma size_Cpfactor x : size (Cpfactor x) = (x \isn't Num.real).+2.
+Proof.
+have [xR|xNR] := boolP (_ \is _); first by rewrite CpfactorRE// size_XsubC.
+by rewrite CpfactorCE// size_mul ?size_XsubC ?polyXsubC_eq0.
+Qed.
+
+Lemma size_realsubpfactor x : size (realsubpfactor x) = (x \isn't Num.real).+2.
+Proof. by have := size_Cpfactor x; rewrite size_map_poly. Qed.
+
+Lemma Cpfactor_eq0 x : (Cpfactor x == 0) = false.
+Proof. by rewrite -size_poly_eq0 size_Cpfactor. Qed.
+
+Lemma realsubpfactor_eq0 x : (realsubpfactor x == 0) = false.
+Proof. by rewrite -size_poly_eq0 size_realsubpfactor. Qed.
+
+Lemma CpfactorCgt0 x y : x \isn't Num.real -> y \is Num.real ->
+  (Cpfactor x).[y] > 0.
+Proof.
+move=> xNR yR; rewrite CpfactorCE// hornerM !hornerXsubC.
+rewrite [x]Crect conjC_rect ?Creal_Re ?Creal_Im// !opprD !addrA opprK.
+rewrite -subr_sqr exprMn sqrCi mulN1r opprK ltr_wpDl//.
+- by rewrite real_exprn_even_ge0// ?rpredB// ?Creal_Re.
+by rewrite real_exprn_even_gt0 ?Creal_Im ?orTb//=; apply/eqP/Creal_ImP.
+Qed.
+
+Lemma realsubpfactorR_mul_gt0 (x a b : C) :
+    x \is Num.real -> a \is Num.real -> b \is Num.real ->
+    a <= b ->
+    ((Cpfactor x).[a] * (Cpfactor x).[b] <= 0) =
+  (a <= x <= b).
+Proof.
+move=> xR aR bR ab; rewrite !CpfactorRE// !hornerXsubC.
+have [lt_xa|lt_ax|->]/= := real_ltgtP xR aR; last first.
+- by rewrite subrr mul0r lexx ab.
+- by rewrite nmulr_rle0 ?subr_lt0 ?subr_ge0.
+rewrite pmulr_rle0 ?subr_gt0// subr_le0.
+by apply: negbTE; rewrite -real_ltNge// (lt_le_trans lt_xa).
+Qed.
+
+Lemma monic_Cpfactor x : Cpfactor x \is monic.
+Proof. by rewrite CpfactorE rpredM ?rpredX ?monicXsubC. Qed.
+
+Lemma monic_realsubpfactor x : realsubpfactor x \is monic.
+Proof. by have := monic_Cpfactor x; rewrite map_monic. Qed.
+
+Lemma poly_realsub_pfactor (p : {poly realsubfield}) :
+  { r : seq C |
+    p ^^ realsubval = val (lead_coef p) *: \prod_(z <- r) Cpfactor z }.
+Proof.
+wlog p_monic : p / p \is monic => [hwlog|].
+  have [->|pN0] := eqVneq p 0.
+    by exists [::]; rewrite lead_coef0/= rmorph0 scale0r.
+  have [|r] := hwlog ((lead_coef p)^-1 *: p).
+    by rewrite monicE lead_coefZ mulVf ?lead_coef_eq0//.
+  rewrite !lead_coefZ mulVf ?lead_coef_eq0//= scale1r.
+  rewrite map_polyZ/=.
+  have lcN0 : realsubval (lead_coef p) != 0.
+    by rewrite fmorph_eq0 lead_coef_eq0.
+  by move=> /(canRL (scalerKV lcN0))->; exists r.
+suff: {r : seq C | p ^^ realsubval = \prod_(z <- r) Cpfactor z}.
+  by move=> [r rP]; exists r; rewrite rP (monicP _)// scale1r.
+have [/= r pr] := closed_field_poly_normal (p ^^ realsubval).
+rewrite (monicP _) ?monic_map ?scale1r// {p_monic} in pr *.
+have [n] := ubnP (size r).
+elim: n r => // n IHn [|x r]/= in p pr *.
+ by exists [::]; rewrite pr !big_nil.
+rewrite ltnS => r_lt.
+have xJxr : x^* \in x :: r.
+  rewrite -root_prod_XsubC -pr.
+  have /eq_map_poly-> : realsubval =1 Num.conj \o realsubval.
+    by move=> a /=; rewrite (CrealP (realsubvalP _)).
+  by rewrite map_poly_comp mapf_root pr root_prod_XsubC mem_head.
+have xJr : (x \isn't Num.real) ==> (x^* \in r) by rewrite implyNb CrealE.
+have pxdvdC : Cpfactor x %| p ^^ realsubval.
+  rewrite pr CpfactorE big_cons/= dvdp_mul2l ?polyXsubC_eq0//.
+  by case: (_ \is _) xJr; rewrite ?dvd1p// dvdp_XsubCl root_prod_XsubC.
+pose pr'x := p %/ realsubpfactor x.
+have [||r'] := IHn (if x \is Num.real then r else rem x^* r) pr'x;
+  last 2 first.
+- by case: (_ \is _) in xJr *;
+    rewrite ?size_rem// (leq_ltn_trans (leq_pred _)).
+- move=> /eqP; rewrite map_divp -dvdp_eq_mul ?Cpfactor_eq0//= => /eqP->.
+  by exists (x :: r'); rewrite big_cons mulrC.
+rewrite map_divp/= pr big_cons CpfactorE/=.
+rewrite divp_pmul2l ?expf_neq0 ?polyXsubC_eq0//.
+case: (_ \is _) => /= in xJr *; first by rewrite divp1//.
+by rewrite (big_rem _ xJr)/= mulKp ?polyXsubC_eq0.
+Qed.
+
+Definition realsubfield_rcfMixin : Num.real_closed_axiom realsubfield.
+Proof.
+move=> p a b le_ab /andP[pa_le0 pb_ge0]/=.
+case: ltgtP pa_le0 => //= pa0 _; last first.
+  by exists a; rewrite ?lexx// rootE pa0.
+case: ltgtP pb_ge0 => //= pb0 _; last first.
+  by exists b; rewrite ?lexx ?andbT// rootE -pb0.
+have p_neq0 : p != 0 by apply: contraTneq pa0 => ->; rewrite horner0 ltxx.
+have {pa0 pb0} pab0 : p.[a] * p.[b] < 0 by rewrite pmulr_llt0.
+wlog p_monic : p p_neq0 pab0 / p \is monic => [hwlog|].
+  have [|||x axb] := hwlog ((lead_coef p)^-1 *: p).
+  - by rewrite scaler_eq0 invr_eq0 lead_coef_eq0 (negPf p_neq0).
+  - rewrite !hornerE/= -mulrA mulrACA -expr2 pmulr_rlt0//.
+    by rewrite exprn_even_gt0//= invr_eq0 lead_coef_eq0.
+  - by rewrite monicE lead_coefZ mulVf ?lead_coef_eq0 ?eqxx.
+  by rewrite rootZ ?invr_eq0 ?lead_coef_eq0//; exists x.
+have /= [rs prs] := poly_realsub_pfactor p.
+rewrite (monicP _) ?monic_map// scale1r {p_monic} in prs.
+pose ab := [pred x | val a <= x <= val b].
+have abR : {subset ab <= Num.real}.
+  move=> x /andP[+ _].
+  by rewrite -subr_ge0 => /ger0_real; rewrite rpredBr// realsubvalP.
+wlog : p pab0 {p_neq0 prs} /
+    p ^^ realsubval = \prod_(x <- rs | x \in ab) ('X - x%:P) => [hw|].
+  move: prs; rewrite -!rmorph_prod => /map_poly_inj.
+  rewrite (bigID ab)/=; set q := (X in X * _); set u := (X in _ * X) => pqu.
+  have [||] := hw q; last first.
+  - by move=> x; exists x => //; rewrite pqu rootM q0.
+  - by rewrite rmorph_prod/=; under eq_bigr do rewrite CpfactorRE ?abR//.
+  have := pab0; rewrite pqu !hornerM mulrACA [_ * _ * _ < 0]pmulr_llt0//.
+  rewrite !horner_prod -big_split/= prodr_gt0// => x.
+  have [xR|xNR] := boolP (x \is Num.real); last first.
+    rewrite (_ : (0 < ?[a]) = (realsubval 0 < realsubval ?a))//=.
+    by rewrite -!horner_map/= mulr_gt0 ?CpfactorCgt0 ?realsubvalP.
+  apply: contraNT; rewrite -leNgt.
+  rewrite (_ : (?[a] <= 0) = (realsubval ?a <= realsubval 0))//= -!horner_map/=.
+  by rewrite realsubpfactorR_mul_gt0 ?realsubvalP.
+rewrite -big_filter; have := filter_all ab rs.
+set rsab := filter _ _.
+have: all (mem Num.real) rsab.
+  by apply/allP => x; rewrite mem_filter => /andP[/abR].
+case: rsab => [_ _|x rsab]/=; rewrite (big_nil, big_cons).
+  move=> pval1; move: pab0.
+  have /map_poly_inj-> : p ^^ realsubval = 1 ^^ realsubval by rewrite rmorph1.
+  by rewrite !hornerE ltr10.
+move=> /andP[xR rsabR] /andP[axb arsb] prsab.
+exists (Realsub xR) => //=.
+by rewrite -(mapf_root realsubval)//= prsab rootM root_XsubC eqxx.
+Qed.
+HB.instance Definition _ :=
+  Num.RealField_isClosed.Build realsubfield realsubfield_rcfMixin.
+
+End RealSubfield.
+
+Check (fun C : numClosedFieldType => realsubfield C : rcfType).
+Check (fun C : numClosedFieldType => realsubfield C : conjFieldType).
+Check (fun (C : numClosedFieldType) =>
+  (@realsubval C : realsubfield C -> C) : {rmorphism _ -> _}).

--- a/algebra/spectral.v
+++ b/algebra/spectral.v
@@ -31,6 +31,11 @@ From mathcomp Require Import numfield sesquilinear.
 (*                                 (schmidt (row_base V^!%MS))                *)
 (* spectralmx A, spectral_diag A == (M,X) s.t. A = M^-1 *m diag_mx X *m M     *)
 (*                          A : 'M[C]_n                                       *)
+(*        realsubfield C == the real subfield of a numClosedFieldType C,      *)
+(*                          endowed with an rcfType structure (the real       *)
+(*                          closed subfield of C).                            *)
+(* real_spectral_theorem == real symmetric matrices are orthogonally          *)
+(*                          diagonalizable                                    *)
 (******************************************************************************)
 
 Set Implicit Arguments.
@@ -271,6 +276,26 @@ Local Notation dotmx_def := (form_of_matrix (@conjC _) 1%:M).
 Definition dotmx (C : conjFieldType) n (u v : 'rV[C]_n) :=
   dotmx_def u%R v%R.
 
+(* The flag spanned by the first i+1 rows of M is the row space of            *)
+(* pid_mx i.+1 *m M (which selects those rows).                               *)
+Local Lemma flag_pid_mx (R : fieldType) m n (M : 'M[R]_(m, n)) (i : 'I_m) :
+  (\sum_(k < m | (k <= i)%N) <<row k M>> :=: (pid_mx i.+1 : 'M[R]_m) *m M)%MS.
+Proof.
+have rowkE (k : 'I_m) : (k <= i)%N -> row k (pid_mx i.+1 *m M) = row k M.
+  move=> ki; rewrite row_mul.
+  have -> : row k (pid_mx i.+1 : 'M[R]_m) = row k (1%:M : 'M[R]_m).
+    by apply/rowP=> l; rewrite !mxE ltnS ki andbT.
+  by rewrite row1 -rowE.
+apply/eqmxP/andP; split.
+  apply/sumsmx_subP => k ki; rewrite genmxE -(rowkE k ki); exact: row_sub.
+apply/row_subP => k; rewrite row_mul.
+have [ki|ki] := boolP (k <= i)%N.
+  by rewrite -row_mul (rowkE k ki) (sumsmx_sup k) ?genmxE.
+have rowk0 : row k (pid_mx i.+1 : 'M[R]_m) = 0.
+  by apply/rowP=> l; rewrite !mxE ltnS (negPf ki) andbF.
+by rewrite rowk0 mul0mx sub0mx.
+Qed.
+
 Section ConjSpectral.
 Variable (C : conjFieldType).
 Set Default Proof Using "C".
@@ -479,7 +504,8 @@ have [v /and4P [vBn v_neq0 dAv_ge0 dAsub]] :
       rewrite (submx_trans (proj_ortho_sub _ _)) //.
       by rewrite -{1}[B]addr0 addmx_sub_adds ?sub0mx.
   pose c := (sqrtr '[BoSn])^-1; have c_gt0 : c > 0.
-    by rewrite invr_gt0 sqrtr_gt0_dnorm ?dnorm_ge0// lt_def ?dnorm_eq0 ?dnorm_ge0 BoSn_neq0.
+    by rewrite invr_gt0 sqrtr_gt0_dnorm ?dnorm_ge0//
+       lt_def ?dnorm_eq0 ?dnorm_ge0 BoSn_neq0.
   exists BoSn; apply/and4P; split => //.
   - by rewrite orthomx_sym ?proj_ortho_sub // /gtr_eqF.
   - rewrite -pBE linearDl/=.
@@ -578,6 +604,23 @@ rewrite !(unitarymxP _) ?schmidt_unitarymx ?rank_leq_col //.
 move=> [:nsV]; rewrite !(orthomx1P _) -?scalar_mx_block //;
   [abstract: nsV|]; last by rewrite orthomx_sym.
 by do 2!rewrite eqmx_schmidt_free ?eq_row_base ?row_base_free // orthomx_sym.
+Qed.
+
+(* The Gram-Schmidt change of basis A *m (schmidt A)^t* is lower triangular   *)
+(* (it is the triangular matrix T such that A = T *m schmidt A).              *)
+Lemma schmidt_trig m n (A : 'M[C]_(m, n)) : (m <= n)%N ->
+  is_trig_mx (A *m (schmidt A)^t*).
+Proof.
+move=> mn; apply/is_trig_mxP => i j ij.
+have UUt : schmidt A *m (schmidt A)^t* = 1%:M.
+  apply/unitarymxP; exact: schmidt_unitarymx mn.
+have /submxP[c cE] : (row i A <= (pid_mx i.+1 : 'M[C]_m) *m schmidt A)%MS.
+  by rewrite -(flag_pid_mx (schmidt A) i); apply: row_schmidt_sub.
+have -> : (A *m (schmidt A)^t*) i j = (row i A *m (schmidt A)^t*) 0 j.
+  by symmetry; rewrite -row_mul; apply: mxE.
+rewrite cE -2!mulmxA UUt mulmx1 mxE big1// => k _; rewrite mxE ltnS.
+case: (leqP k i) => [ki|_]; last by rewrite andbF mulr0.
+by rewrite andbT (ltn_eqF (leq_ltn_trans ki ij)) mulr0.
 Qed.
 
 End ConjSpectral.
@@ -778,15 +821,15 @@ HB.instance Definition _ :=
   [SubIntegralDomain_isSubField of realsubfield by <:].
 HB.instance Definition _ : Order.isPOrder ring_display realsubfield :=
   Order.CancelPartial.Pcan _ valK.
-Lemma total_realsubfield :
+Fact total_realsubfield :
   total (<=%O : rel (realsubfield : porderType _)).
 Proof. by move=> x y; apply/real_leVge/valP/valP. Qed.
 HB.instance Definition _ :=
   Order.POrder_isTotal.Build _ realsubfield total_realsubfield.
 
-Lemma realsubval_is_zmod_morphism : zmod_morphism realsubval.
+Fact realsubval_is_zmod_morphism : zmod_morphism realsubval.
 Proof. by []. Qed.
-Lemma realsubval_is_monoid_morphism : monoid_morphism realsubval.
+Fact realsubval_is_monoid_morphism : monoid_morphism realsubval.
 Proof. by []. Qed.
 HB.instance Definition _ :=
   GRing.isZmodMorphism.Build realsubfield C realsubval
@@ -797,29 +840,29 @@ HB.instance Definition _ :=
 
 Definition realsubfield_norm (x : realsubfield) : realsubfield :=
   Realsub (normr_real (val x)).
-Lemma realsubfield_ler_norm_add x y :
+Fact realsubfield_ler_norm_add x y :
   realsubfield_norm (x + y) <= (realsubfield_norm x + realsubfield_norm y).
 Proof. exact: ler_normD. Qed.
-Lemma realsubfield_normr0_eq0 x : realsubfield_norm x = 0 -> x = 0.
+Fact realsubfield_normr0_eq0 x : realsubfield_norm x = 0 -> x = 0.
 Proof. by move=> /(congr1 val)/normr0_eq0 ?; apply/val_inj. Qed.
-Lemma realsubfield_normrMn x n :
+Fact realsubfield_normrMn x n :
   realsubfield_norm (x *+ n) = realsubfield_norm x *+ n.
 Proof. by apply/val_inj; rewrite /= !rmorphMn/= normrMn. Qed.
-Lemma realsubfield_normrN x : realsubfield_norm (- x) = realsubfield_norm x.
+Fact realsubfield_normrN x : realsubfield_norm (- x) = realsubfield_norm x.
 Proof. by apply/val_inj; apply: normrN. Qed.
 
 Section Num.
 
 Section withz.
 Let z : realsubfield := 0.
-Lemma realsubfield_addr_gt0 (x y : realsubfield) : z < x -> z < y -> z < x + y.
+Fact realsubfield_addr_gt0 (x y : realsubfield) : z < x -> z < y -> z < x + y.
 Proof. exact: addr_gt0. Qed.
-Lemma realsubfield_ger_leVge (x y : realsubfield) :
+Fact realsubfield_ger_leVge (x y : realsubfield) :
   z <= x -> z <= y -> (x <= y) || (y <= x).
 Proof. exact: ger_leVge. Qed.
-Lemma realsubfield_normrM : {morph realsubfield_norm : x y / x * y}.
+Fact realsubfield_normrM : {morph realsubfield_norm : x y / x * y}.
 Proof. by move=> *; apply/val_inj; apply: normrM. Qed.
-Lemma realsubfield_ler_def (x y : realsubfield) :
+Fact realsubfield_ler_def (x y : realsubfield) :
   (x <= y) = (realsubfield_norm (y - x) == y - x).
 Proof. by apply: ler_def. Qed.
 End withz.
@@ -1015,7 +1058,156 @@ HB.instance Definition _ :=
 
 End RealSubfield.
 
-Check (fun C : numClosedFieldType => realsubfield C : rcfType).
-Check (fun C : numClosedFieldType => realsubfield C : conjFieldType).
-Check (fun (C : numClosedFieldType) =>
-  (@realsubval C : realsubfield C -> C) : {rmorphism _ -> _}).
+Unset Default Proof Using.
+
+Section RealSpectral.
+
+(* Over a real closed field the conjugation is the identity. *)
+
+Local Lemma rcf_conjC_id (R : rcfType) (x : R) : conjC x = x.
+Proof.
+have key : forall y : R, conjC y = - y -> y = 0.
+  move=> y cy.
+  have : 0 <= y * conjC y by rewrite mul_conjC_ge0.
+  rewrite cy mulrN -expr2 oppr_ge0 => yle0.
+  by apply/eqP; rewrite -sqrf_eq0 eq_le yle0 sqr_ge0.
+apply/eqP; rewrite -subr_eq0; apply/eqP; apply: key.
+by rewrite rmorphB/= conjCK opprB.
+Qed.
+
+Local Lemma map_conjC_id (R : rcfType) m k (M : 'M[R]_(m, k)) : M ^ conjC = M.
+Proof. by apply/matrixP=> a b; rewrite mxE rcf_conjC_id. Qed.
+
+Local Lemma trmxC_trmx_id (R : rcfType) m k (M : 'M[R]_(m, k)) : M ^t* = M^T.
+Proof. by rewrite -map_trmx map_conjC_id. Qed.
+
+Lemma schmidt_diag_real (R : rcfType) n (A Q : 'M[R]_n) (d : 'rV[R]_n) :
+  A \is symmetricmx -> Q \in unitmx -> Q *m A *m invmx Q = diag_mx d ->
+  let P := schmidt Q in
+  (P \is unitarymx) /\ (P *m A *m invmx P = diag_mx d).
+Proof.
+move=> Asym Qu eqd P.
+have Pu : P \is unitarymx by apply: schmidt_unitarymx.
+have PinvT : invmx P = P^T by rewrite invmx_unitary// trmxC_trmx_id.
+have PPT : P *m P^T = 1%:M by move/unitarymxP: Pu; rewrite trmxC_trmx_id.
+have PTP : P^T *m P = 1%:M by rewrite -PinvT mulVmx ?unitarymx_unit.
+have AsymT : A^T = A.
+  move/is_hermitianmxP: Asym; rewrite expr0 scale1r => Asym'.
+  by rewrite {2}Asym' -map_trmx map_mx_id.
+have eigQ : Q *m A = diag_mx d *m Q.
+  by have := congr1 (mulmx^~ Q) eqd; rewrite -mulmxA mulVmx// mulmx1.
+pose S := Q *m P^T.
+have Slt : is_trig_mx S.
+  by rewrite /S /P -trmxC_trmx_id; apply: schmidt_trig.
+have Sunit : S \in unitmx.
+  by rewrite unitmx_mul Qu/= unitarymx_unit// trmx_unitary.
+have Sii i : S i i != 0.
+  move: Sunit; rewrite unitmxE (det_trig Slt) unitfE.
+  by move=> /prodf_neq0/(_ i isT).
+pose B := P *m A *m P^T.
+have Bsym : B^T = B by rewrite /B !trmx_mul trmxK AsymT mulmxA.
+have SBrel : S *m B = diag_mx d *m S.
+  by rewrite /S /B !mulmxA -[Q *m P^T *m P]mulmxA PTP mulmx1 eigQ -!mulmxA.
+have dSe i j : (diag_mx d *m S) i j = d 0 i * S i j.
+  rewrite mxE (bigD1 i)//= mxE eqxx mulr1n big1 ?addr0// => k ik.
+  by rewrite mxE eq_sym (negPf ik) mulr0n mul0r.
+have SBe i j : \sum_(k < n) S i k * B k j = d 0 i * S i j.
+  by rewrite -dSe -SBrel mxE.
+have Blt : is_trig_mx B.
+  apply/is_trig_mxP => i j.
+  have [k] := ubnP i; elim: k i j => // k IHk i j; rewrite ltnS => leik ij.
+  have key : S i i * B i j = 0.
+    transitivity (\sum_(l < n) S i l * B l j); last first.
+      by rewrite SBe (is_trig_mxP Slt _ _ ij) mulr0.
+    rewrite (bigD1 i)//= big1 ?addr0// => l li.
+    case: (ltngtP l i) => [li'|li'|/val_inj le].
+    - by rewrite (IHk _ _ (leq_trans li' leik) (ltn_trans li' ij)) mulr0.
+    - by rewrite (is_trig_mxP Slt _ _ li') mul0r.
+    - by rewrite le eqxx in li.
+  by move/eqP: key; rewrite mulf_eq0 (negPf (Sii i)) => /eqP.
+have Bii i : B i i = d 0 i.
+  have hsum : \sum_(k < n) S i k * B k i = S i i * B i i.
+    rewrite (bigD1 i)//= big1 ?addr0// => k ki.
+    case: (ltngtP k i) => [ki'|ki'|/val_inj ke].
+    - by rewrite (is_trig_mxP Blt _ _ ki') mulr0.
+    - by rewrite (is_trig_mxP Slt _ _ ki') mul0r.
+    - by rewrite ke eqxx in ki.
+  by apply: (mulfI (Sii i)); rewrite -hsum SBe mulrC.
+have Bdiag : B = diag_mx d.
+  apply/matrixP=> i j; rewrite [RHS]mxE.
+  case: (ltngtP i j) => [ij|ij|/val_inj->].
+  - by rewrite (is_trig_mxP Blt _ _ ij) -val_eqE/= ltn_eqF// mulr0n.
+  - rewrite -Bsym mxE (is_trig_mxP Blt _ _ ij) -val_eqE/=.
+    by rewrite gtn_eqF// mulr0n.
+  - by rewrite eqxx mulr1n Bii.
+by split=> //; rewrite PinvT -/B Bdiag.
+Qed.
+
+(* Pulling a real matrix back to the real subfield. *)
+
+Local Definition mxR (C : numClosedFieldType) p q (M : 'M[C]_(p, q)) :
+    'M[realsubfield C]_(p, q) := map_mx (insubd (0 : realsubfield C)) M.
+
+Local Lemma mxRK (C : numClosedFieldType) p q (M : 'M[C]_(p, q)) :
+  M \is a realmx -> map_mx (@realsubval C) (mxR M) = M.
+Proof.
+move=> Mreal; apply/matrixP=> i j; rewrite !mxE.
+by rewrite val_insubd (elimT mxOverP Mreal i j).
+Qed.
+
+Theorem real_spectral_theorem (C : numClosedFieldType) n (A : 'M[C]_n) :
+  A \is a realmx -> A \is symmetricmx ->
+  let sp := spectral_diag A in
+  exists2 P : 'M[C]_n,
+    P \is a realmx /\ P \in unitarymx &
+    A = invmx P *m diag_mx sp *m P.
+Proof.
+move=> Areal Asym sp.
+have Aherm := realsym_hermsym Asym Areal.
+have spreal : sp \is a realmx := hermitian_spectral_diag_real Aherm.
+have dreal : diag_mx sp \is a realmx by rewrite mxOver_diag.
+have sim0 : similar_in unitmx A (diag_mx sp).
+  exists (spectralmx A); first exact: spectral_unit.
+  apply/similarP; first exact: spectral_unit.
+  rewrite [X in _ *m X](orthomx_spectralP (symmetric_normalmx Asym Areal)).
+  by rewrite mulmxA mulmxA mulmxV ?spectral_unit// mul1mx.
+have [Q] := real_similar sim0 Areal dreal.
+rewrite inE/= => /andP[Qreal Qunit] /similarP -/(_ Qunit) simQ.
+have eqdC : Q *m A *m invmx Q = diag_mx sp.
+  by rewrite simQ -mulmxA mulmxV ?mulmx1.
+pose f := @realsubval C.
+pose AR := mxR A; pose Qint := mxR Q; pose dR := mxR sp.
+have fAR : map_mx f AR = A := mxRK Areal.
+have fQ : map_mx f Qint = Q := mxRK Qreal.
+have fd : map_mx f dR = sp := mxRK spreal.
+have AsymT : A^T = A.
+  move/is_hermitianmxP: Asym; rewrite expr0 scale1r => Asym'.
+  by rewrite {2}Asym' -map_trmx map_mx_id.
+have ARsymT : AR^T = AR.
+  apply: (@map_mx_inj _ _ f); apply/matrixP=> i j.
+  by rewrite -map_trmx fAR -[in RHS]AsymT !mxE.
+have ARsym : AR \is symmetricmx.
+  apply/is_hermitianmxP; rewrite expr0 scale1r.
+  by rewrite -[AR ^t idfun]map_trmx map_mx_id ?ARsymT.
+have Qintunit : Qint \in unitmx by rewrite -(map_unitmx f) fQ.
+have eqdR : Qint *m AR *m invmx Qint = diag_mx dR.
+  apply: (@map_mx_inj _ _ f).
+  by rewrite !map_mxM map_invmx fQ fAR map_diag_mx fd; exact: eqdC.
+have [PRu PReq] := schmidt_diag_real ARsym Qintunit eqdR.
+set PR := schmidt Qint in PRu PReq.
+pose P := map_mx f PR.
+have Preal : P \is a realmx.
+  by apply/mxOverP=> i j; rewrite mxE; apply: realsubvalP.
+have eqdP : P *m A *m invmx P = diag_mx sp.
+  have := congr1 (map_mx f) PReq.
+  by rewrite !map_mxM map_invmx fAR map_diag_mx fd.
+have Punit : P \in unitmx by rewrite /P map_unitmx unitarymx_unit.
+exists P; last by rewrite -eqdP !mulmxA mulVmx// mul1mx -mulmxA mulVmx// mulmx1.
+split=> //; apply/unitarymxP.
+have PTC : P ^t* = P^T by rewrite -map_trmx realmxC.
+have PRPT : PR *m PR^T = 1%:M by move/unitarymxP: PRu; rewrite trmxC_trmx_id.
+rewrite PTC.
+by have := congr1 (map_mx f) PRPT; rewrite map_mxM map_mx1 -map_trmx => <-.
+Qed.
+
+End RealSpectral.

--- a/doc/changelog/01-added/1611-spectral-real-symmetric.md
+++ b/doc/changelog/01-added/1611-spectral-real-symmetric.md
@@ -1,0 +1,23 @@
+- in `algebra/numeric_hierarchy/numfield.v`
+  + structures `conjFieldType` (`ConjField`) and `NumFieldConj`, a common
+    ancestor of `rcfType` and `numClosedFieldType` providing an involutive
+    conjugation `conj` with `|x| ^+ 2 = x * conj x` and a square root of
+    nonnegative elements
+  + mixins `NumField_hasConj`, `NumField_hasSqrt`, `NumField_hasImaginary` and
+    `RealField_hasPolyIvt`
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
+    by Guillaume Baudart and Cyril Cohen).
+
+- in `algebra/archimedean.v`
+  + join structures `ArchiNumFieldConj` and `ArchiConjField`
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
+    by Guillaume Baudart and Cyril Cohen).
+
+- in `algebra/spectral.v`
+  + definition `realsubfield` and injection `realsubval`, equipping the subfield
+    of real elements of a `numClosedFieldType` with an `rcfType` structure
+  + lemmas `flag_pid_mx` and `schmidt_trig` (the triangular Gram-Schmidt factor)
+  + lemma `schmidt_diag_real` and theorem `real_spectral_theorem`, the spectral
+    theorem for real symmetric matrices
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
+    by Guillaume Baudart and Cyril Cohen).

--- a/doc/changelog/01-added/1611-spectral-real-symmetric.md
+++ b/doc/changelog/01-added/1611-spectral-real-symmetric.md
@@ -5,13 +5,11 @@
     nonnegative elements
   + mixins `NumField_hasConj`, `NumField_hasSqrt`, `NumField_hasImaginary` and
     `RealField_hasPolyIvt`
-    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
-    by Guillaume Baudart and Cyril Cohen).
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611)).
 
 - in `algebra/archimedean.v`
   + join structures `ArchiNumFieldConj` and `ArchiConjField`
-    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
-    by Guillaume Baudart and Cyril Cohen).
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611)).
 
 - in `algebra/spectral.v`
   + definition `realsubfield` and injection `realsubval`, equipping the subfield
@@ -19,5 +17,4 @@
   + lemmas `flag_pid_mx` and `schmidt_trig` (the triangular Gram-Schmidt factor)
   + lemma `schmidt_diag_real` and theorem `real_spectral_theorem`, the spectral
     theorem for real symmetric matrices
-    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
-    by Guillaume Baudart and Cyril Cohen).
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611)).

--- a/doc/changelog/02-changed/1611-spectral-real-symmetric.md
+++ b/doc/changelog/02-changed/1611-spectral-real-symmetric.md
@@ -7,16 +7,14 @@
     `mul_conjC_gt0`, `mul_conjC_eq0`, `conjC_ge0`, `sqrtr_ge0`, `sqr_sqrtr`,
     `ler0_sqrtr`) generalized from `numClosedFieldType`/`rcfType` to
     `conjFieldType`
-    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
-    by Guillaume Baudart and Cyril Cohen).
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611)).
 
 - in `algebra/sesquilinear.v`
   + the `conjC` `involutive_rmorphism` instance, `map_mxCK`, the dot-norm theory
     (`dnorm_geiff0`, `dnorm_ge0`, `dnorm_eq0`, `dnorm_gt0`, `dnormZ`, `dnormD`,
     `dnormB`) and `hermitian1mx` generalized from `numClosedFieldType` to
     `conjFieldType`
-    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
-    by Guillaume Baudart and Cyril Cohen).
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611)).
 
 - in `algebra/spectral.v`
   + `trmxCK`, `dotmx`, `unitarymx`, the orthogonal-complement lemmas and the
@@ -24,5 +22,4 @@
     `eqmx_schmidt_full`, `eqmx_schmidt_free`, `schmidt_complete`, ...)
     generalized from `numClosedFieldType` to `conjFieldType`; lemma names and
     statements are preserved
-    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
-    by Guillaume Baudart and Cyril Cohen).
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611)).

--- a/doc/changelog/02-changed/1611-spectral-real-symmetric.md
+++ b/doc/changelog/02-changed/1611-spectral-real-symmetric.md
@@ -1,0 +1,28 @@
+- in `algebra/numeric_hierarchy/numfield.v`
+  + `NumField_isImaginary` and `RealField_isClosed` are now HB factories
+    (previously mixins) that rebuild the `conjFieldType` mixins, so that
+    `numClosedFieldType` and `rcfType` inherit `conjFieldType`; their existing
+    interfaces are otherwise unchanged
+  + `conj`, `sqrtr` and their theory (`conjCK`, `normCK`, `mul_conjC_ge0`,
+    `mul_conjC_gt0`, `mul_conjC_eq0`, `conjC_ge0`, `sqrtr_ge0`, `sqr_sqrtr`,
+    `ler0_sqrtr`) generalized from `numClosedFieldType`/`rcfType` to
+    `conjFieldType`
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
+    by Guillaume Baudart and Cyril Cohen).
+
+- in `algebra/sesquilinear.v`
+  + the `conjC` `involutive_rmorphism` instance, `map_mxCK`, the dot-norm theory
+    (`dnorm_geiff0`, `dnorm_ge0`, `dnorm_eq0`, `dnorm_gt0`, `dnormZ`, `dnormD`,
+    `dnormB`) and `hermitian1mx` generalized from `numClosedFieldType` to
+    `conjFieldType`
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
+    by Guillaume Baudart and Cyril Cohen).
+
+- in `algebra/spectral.v`
+  + `trmxCK`, `dotmx`, `unitarymx`, the orthogonal-complement lemmas and the
+    Gram-Schmidt process `schmidt` (with `schmidt_unitarymx`, `row_schmidt_sub`,
+    `eqmx_schmidt_full`, `eqmx_schmidt_free`, `schmidt_complete`, ...)
+    generalized from `numClosedFieldType` to `conjFieldType`; lemma names and
+    statements are preserved
+    ([#1611](https://github.com/math-comp/math-comp/pull/1611),
+    by Guillaume Baudart and Cyril Cohen).


### PR DESCRIPTION
##### Motivation for this change

This PR proves the spectral theorem for real symmetric matrices over a numClosedFieldType (real_spectral_theorem): such a matrix is diagonalized by a real orthogonal matrix, with the same spectral diagonal as the existing (complex) spectral theorem.

To reuse Gram–Schmidt for this, it is generalized from numClosedFieldType to a new common ancestor conjFieldType of rcfType and numClosedFieldType — a numFieldType with an involutive conjugation conj such that `|x| ^+ 2 = x * conj x` and a square root of nonnegatives. Existing interfaces are unchanged. As a building block, the PR also shows that the real subfield of a numClosedFieldType is an rcfType.

##### Minimal TODO list

- [X] added changelog entries with `doc/changelog/make-entry.sh`
- [X] added corresponding documentation in the headers
- [X] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [X] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
