### PR TITLE
reintroducing covariant and tensor product notations

### DIFF
--- a/algebra/tensor.v
+++ b/algebra/tensor.v
@@ -29,22 +29,37 @@ From mathcomp Require Import interval interval_inference numdomain.
 (*                          'oT[R]_([tuple of d1%:posnat :: .. :: dl%:posnat])*)
 (*           'sT[R], 'sT == scalar tensors (no contravariant nor covariant    *)
 (*                          dimensions), i.e. 'T[R]_([tuple], [tuple])        *)
-(*            nindex t i == the tensor obtained by fixing the first           *)
+(*                  t^^i == the tensor obtained by fixing the first           *)
 (*                          contravariant dimension of t to i                 *)
-(*            oindex t j == the tensor obtained by fixing the first           *)
-(*                          covariant dimension of t to j                     *)
-(*          nstack Expr == the 'T_([tuple of n :: _], _) tensor t such that   *)
-(*                         nindex t i = Expr i with i : 'I_n                  *)
-(*          ostack Expr == the 'T_(_, [tuple of n :: _]) tensor t such that   *)
-(*                         oindex t j = Expr j with j : 'I_n                  *)
+(*                  t\_i == the tensor obtained by fixing the first           *)
+(*                          covariant dimension of t to i                     *)
+(* \tensor^^(i < n) Expr(i) ==                                                *)
+(*                         the 'T_([tuple of n :: _], _) tensor t such that   *)
+(*                         t^^i = Expr(i) with i : 'I_n, the < n bound can    *)
+(*                         usually be omitted                                 *)
+(* \tensor\_(j < n) Expr(j) ==                                                *)
+(*                         the 'T_(_, [tuple of n :: _]) tensor t such that   *)
+(*                         t\_j = Expr(j) with j : 'I_n, the < n bound can    *)
+(*                         usually be omitted                                 *)
 (*            const_t v == the constant tensor whose entries are all v        *)
 (*                         (dimensions are inferred from context)             *)
 (*          castt eq_ud == reshape a tensor t : 'T[R]_(u_, d_) into one of    *)
 (*                         type 'T[R]_(u_', d_') given a pair eq_ud of        *)
 (*                         equalities on \prod_i u_ i and \prod_j d_ j;       *)
 (*                         mirrors castmx                                     *)
-(*         tensor_nil t == the value of the single entry in a                 *)
+(*               t.[::] == the value of the single entry in a                 *)
 (*                         tensor t : 'T_([tuple], [tuple])                   *)
+(*         t^^=i, t\_=i == variants of the indexing operations equivalent to  *)
+(*                         (t^^i).[::], (t\_i).[::], useful for indexing the  *)
+(*                         final dimensions of tensors                        *)
+(* \tensor^^(i < n) => Expr(i), \tensor\_(j < n) => Expr(j) ==                *)
+(*                         variant constructor equivalent to                  *)
+(*                         \tensor^^(i < n) const_t Expr(i)                   *)
+(* [tensor^^ t_0; ...; t_n], [tensor\_ t_0; ...; t_n] ==                      *)
+(*                         construction of a tensor from a sequence of        *)
+(*                         tensors                                            *)
+(* [tensor^^= x_0; ...; x_n], [tensor\_= x_0; ...; x_n] ==                    *)
+(*                         construction of a tensor from a sequence of values *)
 (* Tensors are instances of subType of matrix, and inherit all combinatorial  *)
 (* structures (including finType), as well as nmodType, zmodType,             *)
 (* lSemiModType, lModType, and ring instances where the underlying type       *)
@@ -53,10 +68,15 @@ From mathcomp Require Import interval interval_inference numdomain.
 (* Proper tensor product forms a bilinear structure.                          *)
 (*                                                                            *)
 (* Tensor operations:                                                         *)
-(* hmul t u == Hadamard product of t and u (element-wise multiplication),     *)
+(* t *h u == Hadamard product of t and u (element-wise multiplication),       *)
 (*           same as t * u (ring multiplication)                              *)
-(* mults t u == proper tensor product: combines dimensions,                   *)
-(*           'T_(u1, d1) -> 'T_(u2, d2) -> 'T_(u1 +++ u2, d1 +++ d2)          *)
+(* t *t u == proper tensor product: combines dimensions,                      *)
+(*           'T_(u1, d1) * 'T_(u2, d2) -> 'T_(u1 +++ u2, d1 +++ d2)           *)
+(*                                                                            *)
+(* Notations: indexing operations (^^, \_, ^^=, \_=), the stacking            *)
+(* constructors (\tensor^^, \tensor\_), the bracket constructors              *)
+(* ([tensor^^ ...], [tensor\_ ...], [tensor^^= ...], [tensor\_= ...]) and     *)
+(* the nullary projection (t.[::]) live in ring_scope.                        *)
 (******************************************************************************)
 
 Set Implicit Arguments.
@@ -80,11 +100,56 @@ Reserved Notation "''T[' R ]_ ( u_ , d_ )"
 Reserved Notation "''sT'" (at level 0, format "''sT'").
 Reserved Notation "''sT[' R ]" (at level 0). (* only parsing *)
 
+Reserved Notation "t ^^ i"
+  (at level 30, i at level 30, format "t ^^ i").
+Reserved Notation "t \_ i"
+  (at level 10, format "t \_ i").
+Reserved Notation "t ^^= i"
+  (at level 30, i at level 30, format "t ^^= i").
+Reserved Notation "t \_= i"
+  (at level 10, format "t \_= i").
+
+Reserved Notation "\tensor ^^ i E"
+  (at level 34, E at level 39, i binder, format "\tensor ^^ i  E").
+Reserved Notation "\tensor \_ i E"
+  (at level 34, E at level 39, i binder, format "\tensor \_ i  E").
+Reserved Notation "\tensor ^^ ( i < u ) E"
+  (at level 34, E at level 39, i, u at level 50). (* only parsing *)
+Reserved Notation "\tensor \_ ( i < d ) E"
+  (at level 34, E at level 39, i, d at level 50). (* only parsing *)
+Reserved Notation "\tensor ^^ i => E"
+  (at level 34, E at level 39, i binder, format "\tensor ^^ i  =>  E").
+Reserved Notation "\tensor \_ i => E"
+  (at level 34, E at level 39, i binder, format "\tensor \_ i  =>  E").
+Reserved Notation "\tensor ^^ ( i < u ) => E"
+  (E at level 39, i, u at level 50). (* only parsing *)
+Reserved Notation "\tensor \_ ( i < d ) => E"
+  (E at level 39, i, d at level 50). (* only parsing *)
+
+Reserved Notation "[ 'tensor' ^^ t ; .. ; tn ]"
+  (format "[ 'tensor' ^^ '['  t ; '/'  .. ; '/'  tn ']' ]").
+Reserved Notation "[ 'tensor' \_ t ; .. ; tn ]"
+  (format "[ 'tensor' \_ '['  t ; '/'  .. ; '/'  tn ']' ]").
+Reserved Notation "[ 'tensor' ^^= x ; .. ; xn ]"
+  (format "[ 'tensor' ^^= '['  x ; '/'  .. ; '/'  xn ']' ]").
+Reserved Notation "[ 'tensor' \_= x ; .. ; xn ]"
+  (format "[ 'tensor' \_= '['  x ; '/'  .. ; '/'  xn ']' ]").
+
+Reserved Notation "t .[::]".
+
+Reserved Notation "*h%R" (at level 0).
+Reserved Notation "x *h y"
+  (at level 40, left associativity, format "x  *h  y").
+Reserved Notation "*t%R" (at level 0).
+Reserved Notation "x *t y"
+  (at level 40, left associativity, format "x  *t  y").
+
 (* Coercion from tuples to finfun: allows writing tensor dimensions as tuples *)
 #[warning="-uniform-inheritance"]
 Coercion finfun_of_tuple : tuple_of >-> finfun_of.
 #[warning="-uniform-inheritance"]
 Coercion tuple_of_finfun : finfun_of >-> tuple_of.
+
 
 Local Open Scope ring_scope.
 
@@ -150,8 +215,10 @@ HB.instance Definition _ (R : pzRingType) := GRing.SubLSemiModule.on 'T[R].
 
 End SubtypeInstances.
 
+
 Definition const_t {R k l} {u_ : {posnum nat} ^ k} {d_ : {posnum nat} ^ l}
   (v : R) : 'T[R]_(u_, d_) := Tensor (const_mx v).
+
 
 Section TensorCast.
 
@@ -214,7 +281,10 @@ Proof. by move=> t; apply/val_inj; rewrite !val_castt castmxKV. Qed.
 
 End TensorCast.
 
+
 Section TensorRing.
+
+
 Context {l k : nat} (u_ : {posnum nat} ^ k) (d_ : {posnum nat} ^ l).
 Local Notation "''T[' R ]" := 'T[R]_(u_, d_).
 
@@ -312,6 +382,10 @@ HB.instance Definition _ {R : unitRingType} :=
 
 End TensorRing.
 
+(* Notations for Hadamard product *)
+Notation "*h%R" := hmul : function_scope.
+Notation "x *h y" := (hmul x y) : ring_scope.
+
 Section NilTensor.
 
 Context (R : Type).
@@ -338,12 +412,17 @@ Qed.
 
 End NilTensor.
 
+
+Notation "t .[::]" := (tensor_nil t) : ring_scope. 
+
+
 Section NilTensorTheory.
 
-Lemma tensor_nil_eqP {R : Type} t u : tensor_nil t = tensor_nil u :> R <-> t = u.
+Lemma tensor_nil_eqP {R : Type} t u : t.[::] = u.[::] :> R <-> t = u.
 Proof.
 by split=> [?|->//]; apply/val_inj/matrixP=> i j; rewrite !ord_prod_nil.
 Qed.
+
 
 Fact tensor_nil_is_nmod_morphism {U : nmodType} : nmod_morphism (@tensor_nil U).
 Proof. by split=> [|? ?]; rewrite /tensor_nil mxE. Qed.
@@ -361,7 +440,7 @@ HB.instance Definition _ {R : pzSemiRingType} :=
     tensor_nil_is_monoid_morphism.
 
 Lemma tensor_nilV {R : unitRingType} t
-  : tensor_nil (t^-1) = (tensor_nil t)^-1 :> R.
+  : (t^-1).[::] = t.[::]^-1 :> R.
 Proof.
 rewrite /tensor_nil {1}/GRing.inv/=/invt.
 case (t \in @unitt _ _ [tuple] [tuple] R) eqn:t_unit; rewrite t_unit.
@@ -373,8 +452,11 @@ Qed.
 
 End NilTensorTheory.
 
+
 Section ConstTensorTheory.
+
 Context {l k : nat} (u_ : {posnum nat} ^ k) (d_ : {posnum nat} ^ l).
+
 
 Fact const_t_is_nmod_morphism {U : nmodType} :
   nmod_morphism (@const_t U _ _ u_ d_).
@@ -406,9 +488,11 @@ Qed.
 
 End ConstTensorTheory.
 
+
 Section IndexTensor.
 
 Section IndexTensorBij.
+
 
 Context {k : nat} (u_ : {posnum nat} ^ k).
 
@@ -416,6 +500,7 @@ Local Notation fprod_u := (fprod (fun i : 'I_k => 'I_(u_ i)%:num)).
 
 Lemma card_fprod_u : #|fprod_u| = \prod_(i < k) (u_ i)%:num.
 Proof. by rewrite card_fprod; apply: eq_bigr => i _; rewrite card_ord. Qed.
+
 
 Definition tensor_index (f : fprod_u) : 'I_(\prod_(i < k) (u_ i)%:num) :=
   cast_ord card_fprod_u (enum_rank f).
@@ -467,6 +552,8 @@ Qed.
 End IndexTensorBij.
 
 Section IndexTensorConsBij.
+
+
 Context (u : {posnum nat}) {k : nat} (u_ : k.-tuple {posnum nat}).
 
 Local Notation u_cons := [tuple of u :: u_].
@@ -494,6 +581,7 @@ Proof. by move=> i; rewrite /tensormx_index enum_valK cast_ordKV. Qed.
 
 End IndexTensorConsBij.
 
+
 Context (R : Type) (u d : {posnum nat}) (k l : nat).
 Context (u_ : k.-tuple {posnum nat}) (d_ : l.-tuple {posnum nat}).
 Local Notation u_cons := [tuple of u :: u_].
@@ -515,13 +603,31 @@ Definition ostack (f : 'I_d%:num -> 'T[R]_(u_, d_)) : 'T[R]_(u_, d_cons) :=
 
 End IndexTensor.
 
+Notation "t ^^ i" := (nindex t i) : ring_scope.
+Notation "t \_ i" := (oindex t i) : ring_scope.
+Notation "t ^^= i" := ((t^^i).[::]) : ring_scope.
+Notation "t \_= i" := ((t\_i).[::]) : ring_scope.
+
+Notation "\tensor ^^ ( i < u ) E" := (nstack (fun i : 'I_u => E))
+  (only parsing) : ring_scope.
+Notation "\tensor \_ ( i < d ) E" := (ostack (fun i : 'I_d => E))
+  (only parsing) : ring_scope.
+Notation "\tensor ^^ i E" := (\tensor^^(i < _) E) : ring_scope.
+Notation "\tensor \_ i E" := (\tensor\_(i < _) E) : ring_scope.
+Notation "\tensor ^^ ( i < u ) => E" := (\tensor^^(i < u) const_t E)
+  (only parsing) : ring_scope.
+Notation "\tensor \_ ( i < d ) => E" := (\tensor\_(i < d) const_t E)
+  (only parsing) : ring_scope.
+Notation "\tensor ^^ i => E" := (\tensor^^i const_t E) : ring_scope.
+Notation "\tensor \_ i => E" := (\tensor\_i const_t E) : ring_scope.
+
 Section TensorIndexTheory.
 Context (R : Type).
 
 Lemma ntensorP (u : {posnum nat}) (k l : nat)
     (u_ : k.-tuple {posnum nat}) (d_ : l.-tuple {posnum nat})
     (t v : 'T[R]_([tuple of u :: u_], d_))
-  : t = v <-> forall i, nindex t i = nindex v i.
+  : t = v <-> forall i, t^^i = v^^i.
 Proof.
 split=> [->//|eq_i]; apply/val_inj/matrixP=> i j.
 move: (eq_i (tensormx_unindex i).1)=> [/matrixP] /(_ (tensormx_unindex i).2 j).
@@ -531,7 +637,7 @@ Qed.
 Lemma otensorP (d : {posnum nat}) (k l : nat)
     (u_ : k.-tuple {posnum nat}) (d_ : l.-tuple {posnum nat})
     (t v : 'T[R]_(u_, [tuple of d :: d_]))
-  : t = v <-> forall i, oindex t i = oindex v i.
+  : t = v <-> forall i, t\_i = v\_i.
 Proof.
 split=> [->//|eq_i]; apply/val_inj/matrixP=> i j.
 move: (eq_i (tensormx_unindex j).1)=> [/matrixP] /(_ i (tensormx_unindex j).2).
@@ -539,14 +645,14 @@ by rewrite !mxE -surjective_pairing tensormx_unindexK.
 Qed.
 
 Lemma ntensor_eqP (u : {posnum nat}) (t v : 'nT[R]_([tuple u]))
-  : t = v <-> forall i, tensor_nil (nindex t i) = tensor_nil (nindex v i).
+  : t = v <-> forall i, t^^=i = v^^=i.
 Proof.
 split=> [->//|eq_i]; apply/ntensorP=> i.
 by move: (eq_i i)=> /tensor_nil_eqP.
 Qed.
 
 Lemma otensor_eqP (d : {posnum nat}) (t v : 'oT[R]_([tuple d]))
-  : t = v <-> forall i, tensor_nil (oindex t i) = tensor_nil (oindex v i).
+  : t = v <-> forall i, t\_=i = v\_=i.
 Proof.
 split=> [->//|eq_i]; apply/otensorP=> i.
 by move: (eq_i i)=> /tensor_nil_eqP.
@@ -555,57 +661,59 @@ Qed.
 Lemma nstackE {u : {posnum nat}} {k l}
     {u_ : k.-tuple {posnum nat}} {d_ : l.-tuple {posnum nat}}
     (f : 'I_u%:num%R -> 'T[R]_(u_, d_)) i
-  : nindex (nstack f) i = f i.
+  : (nstack f)^^i = f i.
 Proof. by apply/val_inj/matrixP => x y; rewrite !mxE tensormx_indexK. Qed.
 
 Lemma ostackE {d : {posnum nat}} {k l}
     {u_ : k.-tuple {posnum nat}} {d_ : l.-tuple {posnum nat}}
     (f : 'I_d%:num%R -> 'T[R]_(u_, d_)) i
-  : oindex (ostack f) i = f i.
+  : (ostack f)\_i = f i.
 Proof. by apply/val_inj/matrixP => x y; rewrite !mxE tensormx_indexK. Qed.
 
 Lemma nstack_eqE {u : {posnum nat}} (f : 'I_u%:num%R -> R) i
-  : tensor_nil (nindex (nstack (fun i0 => const_t (f i0))) i) = f i.
+  : (\tensor^^i0 => f i0)^^=i = f i.
 Proof. by rewrite nstackE const_tK. Qed.
 
 Lemma ostack_eqE {d : {posnum nat}} (f : 'I_d%:num%R -> R) i
-  : tensor_nil (oindex (ostack (fun i0 => const_t (f i0))) i) = f i.
+  : (\tensor\_i0 => f i0)\_=i = f i.
 Proof. by rewrite ostackE const_tK. Qed.
 
 End TensorIndexTheory.
 
+
 Section TensorTuple.
+
 Context {R : Type} {x : {posnum nat}} (k l : nat).
 Context (u_ : k.-tuple {posnum nat}) (d_ : l.-tuple {posnum nat}).
 
 Definition ntensor_of_tuple (t : x%:num%R.-tuple R)
-  : 'nT[R]_([tuple x]) := nstack (fun i => const_t (tnth t i)).
+  : 'nT[R]_([tuple x]) := \tensor^^i => (tnth t i).
 
 Definition otensor_of_tuple (t : x%:num%R.-tuple R)
-  : 'oT[R]_([tuple x]) := ostack (fun i => const_t (tnth t i)).
+  : 'oT[R]_([tuple x]) := \tensor\_i => (tnth t i).
 
 Definition tuple_of_ntensor (t : 'nT[R]_([tuple x])) :=
-  [tuple tensor_nil (nindex t i) | i < x%:num%R].
+  [tuple t^^=i | i < x%:num%R].
 
 Definition tuple_of_otensor (t : 'oT[R]_([tuple x])) :=
-  [tuple tensor_nil (oindex t i) | i < x%:num%R].
+  [tuple t\_=i | i < x%:num%R].
 
-Lemma ntensor_of_tupleE t i : tensor_nil (nindex (ntensor_of_tuple t) i) = tnth t i.
+Lemma ntensor_of_tupleE t i : (ntensor_of_tuple t)^^=i = tnth t i.
 Proof. exact: nstack_eqE. Qed.
 
-Lemma otensor_of_tupleE t i : tensor_nil (oindex (otensor_of_tuple t) i) = tnth t i.
+Lemma otensor_of_tupleE t i : (otensor_of_tuple t)\_=i = tnth t i.
 Proof. exact: ostack_eqE. Qed.
 
 Definition nstack_tuple (t : x%:num%R.-tuple 'T[R]_(u_, d_)) :=
-  nstack (fun i => tnth t i).
+  \tensor^^i tnth t i.
 
 Definition ostack_tuple (t : x%:num%R.-tuple 'T[R]_(u_, d_)) :=
-  ostack (fun i => tnth t i).
+  \tensor\_i tnth t i.
 
-Lemma nstack_tupleE t i : nindex (nstack_tuple t) i = tnth t i.
+Lemma nstack_tupleE t i : (nstack_tuple t)^^i = tnth t i.
 Proof. exact: nstackE. Qed.
 
-Lemma ostack_tupleE t i : oindex (ostack_tuple t) i = tnth t i.
+Lemma ostack_tupleE t i : (ostack_tuple t)\_i = tnth t i.
 Proof. exact: ostackE. Qed.
 Lemma ntensor_of_tupleK : cancel ntensor_of_tuple tuple_of_ntensor.
 Proof.
@@ -629,15 +737,27 @@ Qed.
 
 End TensorTuple.
 
+
+Notation "[ 'tensor' ^^ t ; .. ; tn ]" :=
+  (nstack_tuple [tuple of t :: .. [:: tn] ..]) : ring_scope.
+Notation "[ 'tensor' ^^= x ; .. ; xn ]" :=
+  (ntensor_of_tuple [tuple of x :: .. [:: xn] ..]) : ring_scope.
+Notation "[ 'tensor' \_ t ; .. ; tn ]" :=
+  (ostack_tuple [tuple of t :: .. [:: tn] ..]) : ring_scope.
+Notation "[ 'tensor' \_= x ; .. ; xn ]" :=
+  (otensor_of_tuple [tuple of x :: .. [:: xn] ..]) : ring_scope.
+
+
 Section TensorMatrix.
+
 Context {R : Type} {n m : {posnum nat}}.
 
 Definition tensor_of_matrix (M : 'M_(_, _)) :
   'T[R]_([tuple n], [tuple m]) :=
-    nstack (fun i => ostack (fun j => const_t (M i j))).
+    \tensor^^i \tensor\_j => M i j.
 
 Definition matrix_of_tensor t : 'M[R]_(n%:num%R, m%:num%R) :=
-  \matrix_(i, j) tensor_nil (oindex (nindex t i) j).
+  \matrix_(i, j) (t^^i)\_=j.
 
 Lemma tensor_of_matrixK : cancel tensor_of_matrix matrix_of_tensor.
 Proof. by move=> M; apply/matrixP=> i j; rewrite mxE nstackE ostack_eqE. Qed.
@@ -651,6 +771,8 @@ Qed.
 End TensorMatrix.
 
 Section TensorProduct.
+
+
 Context {R : pzSemiRingType} {R' : pzRingType}.
 Context {k1 l1 k2 l2 : nat}.
 Context (u1_ : {posnum nat} ^ k1) (d1_ : {posnum nat} ^ l1).
@@ -713,16 +835,23 @@ Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE.
 Qed.
 
+
 End TensorProduct.
 
+Notation "*t%R" := mults : function_scope.
+Notation "x *t y" := (mults x y) : ring_scope.
+
 Section TensorProductBilinear.
+
+
 Context {R : comNzRingType}.
 Context {k1 l1 k2 l2 : nat}.
 Context (u1_ : {posnum nat} ^ k1) (d1_ : {posnum nat} ^ l1).
 Context (u2_ : {posnum nat} ^ k2) (d2_ : {posnum nat} ^ l2).
 
+
 Let mults_linear_l (u : 'T[R]_(u2_, d2_)) :
-  GRing.linear_for *:%R (fun t : 'T[R]_(u1_, d1_) => mults t u).
+  GRing.linear_for *:%R (fun t : 'T[R]_(u1_, d1_) => t *t u).
 Proof.
 move=> a x y; apply/val_inj/matrixP=> i j; rewrite /tensor_val/= !mxE/=.
 rewrite mulrDl; congr (_ + _);
@@ -730,7 +859,7 @@ rewrite mulrDl; congr (_ + _);
 Qed.
 
 Let mults_linear_r (t : 'T[R]_(u1_, d1_)) :
-  GRing.linear_for *:%R (fun u : 'T[R]_(u2_, d2_) => mults t u).
+  GRing.linear_for *:%R (fun u : 'T[R]_(u2_, d2_) => t *t u).
 Proof.
 move=> a x y; apply/val_inj/matrixP=> i j; rewrite /tensor_val/= !mxE/=.
 by rewrite mulrDr; congr (_ + _); rewrite mulrA (mulrCA a) mulrA.
@@ -745,13 +874,16 @@ HB.instance Definition _ := bilinear_isBilinear.Build
 End TensorProductBilinear.
 
 Section TensorProductHadamard.
+
+
 Context {R : comPzRingType}.
 Context {k1 l1 k2 l2 : nat}.
 Context (u1_ : {posnum nat} ^ k1) (d1_ : {posnum nat} ^ l1).
 Context (u2_ : {posnum nat} ^ k2) (d2_ : {posnum nat} ^ l2).
 
+
 Lemma mults_hmul (t1 u1 : 'T[R]_(u1_, d1_)) (t2 u2 : 'T[R]_(u2_, d2_)) :
-  mults (hmul t1 u1) (hmul t2 u2) = hmul (mults t1 t2) (mults u1 u2).
+  (t1 *h u1) *t (t2 *h u2) = (t1 *t t2) *h (u1 *t u2).
 Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE /= mulrACA.
 Qed.
@@ -759,32 +891,35 @@ Qed.
 End TensorProductHadamard.
 
 Section TensorProductRing.
+
+
 Context {k1 l1 k2 l2 : nat}.
 Context (u1_ : {posnum nat} ^ k1) (d1_ : {posnum nat} ^ l1).
 Context (u2_ : {posnum nat} ^ k2) (d2_ : {posnum nat} ^ l2).
 
+
 Lemma multsNl {R : pzRingType} (t : 'T[R]_(u1_, d1_)) (u : 'T[R]_(u2_, d2_)) :
-  mults (- t) u = - (mults t u).
+  (- t) *t u = - (t *t u).
 Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE /= mulNr.
 Qed.
 
 Lemma multsNr {R : pzRingType} (t : 'T[R]_(u1_, d1_)) (u : 'T[R]_(u2_, d2_)) :
-  mults t (- u) = - (mults t u).
+  t *t (- u) = - (t *t u).
 Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE /= mulrN.
 Qed.
 
 Lemma mults_scale {R : comPzSemiRingType} (a b : R)
     (t : 'T[R]_(u1_, d1_)) (u : 'T[R]_(u2_, d2_))
-  : mults (hmul (const_t a) t) (hmul (const_t b) u) = hmul (const_t (a * b)%R) (mults t u).
+  : (const_t a *h t) *t (const_t b *h u) = const_t (a * b)%R *h (t *t u).
 Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE /= mulrACA.
 Qed.
 
 Lemma mults_hmul_compat {R : comPzSemiRingType} 
     (t1 t2 : 'T[R]_(u1_, d1_)) (u1 u2 : 'T[R]_(u2_, d2_))
-  : mults (hmul t1 t2) (hmul u1 u2) = hmul (mults t1 u1) (mults t2 u2).
+  : (t1 *h t2) *t (u1 *h u2) = (t1 *t u1) *h (t2 *t u2).
 Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE /= mulrACA.
 Qed.

--- a/algebra/tensor.v
+++ b/algebra/tensor.v
@@ -29,37 +29,22 @@ From mathcomp Require Import interval interval_inference numdomain.
 (*                          'oT[R]_([tuple of d1%:posnat :: .. :: dl%:posnat])*)
 (*           'sT[R], 'sT == scalar tensors (no contravariant nor covariant    *)
 (*                          dimensions), i.e. 'T[R]_([tuple], [tuple])        *)
-(*                  t^^i == the tensor obtained by fixing the first           *)
+(*            nindex t i == the tensor obtained by fixing the first           *)
 (*                          contravariant dimension of t to i                 *)
-(*                  t`_i == the tensor obtained by fixing the first           *)
-(*                          covariant dimension of t to i                     *)
-(* \tensor^^(i < n) Expr(i) ==                                                *)
-(*                         the 'T_([tuple of n :: _], _) tensor t such that   *)
-(*                         t^^i = Expr(i) with i : 'I_n, the < n bound can    *)
-(*                         usually be omitted                                 *)
-(* \tensor`_(j < n) Expr(j) ==                                                *)
-(*                         the 'T_(_, [tuple of n :: _]) tensor t such that   *)
-(*                         t`_j = Expr(j) with j : 'I_n, the < n bound can    *)
-(*                         usually be omitted                                 *)
+(*            oindex t j == the tensor obtained by fixing the first           *)
+(*                          covariant dimension of t to j                     *)
+(*          nstack Expr == the 'T_([tuple of n :: _], _) tensor t such that   *)
+(*                         nindex t i = Expr i with i : 'I_n                  *)
+(*          ostack Expr == the 'T_(_, [tuple of n :: _]) tensor t such that   *)
+(*                         oindex t j = Expr j with j : 'I_n                  *)
 (*            const_t v == the constant tensor whose entries are all v        *)
 (*                         (dimensions are inferred from context)             *)
 (*          castt eq_ud == reshape a tensor t : 'T[R]_(u_, d_) into one of    *)
 (*                         type 'T[R]_(u_', d_') given a pair eq_ud of        *)
 (*                         equalities on \prod_i u_ i and \prod_j d_ j;       *)
 (*                         mirrors castmx                                     *)
-(*               t.[::] == the value of the single entry in a                 *)
+(*         tensor_nil t == the value of the single entry in a                 *)
 (*                         tensor t : 'T_([tuple], [tuple])                   *)
-(*         t^^=i, t`_=i == variants of the indexing operations equivalent to  *)
-(*                         (t^^i).[::], (t`_i).[::], useful for indexing the  *)
-(*                         final dimensions of tensors                        *)
-(* \tensor^^(i < n) => Expr(i), \tensor`_(j < n) => Expr(j) ==                *)
-(*                         variant constructor equivalent to                  *)
-(*                         \tensor^^(i < n) const_t Expr(i)                   *)
-(* [tensor^^ t_0; ...; t_n], [tensor`_ t_0; ...; t_n] ==                      *)
-(*                         construction of a tensor from a sequence of        *)
-(*                         tensors                                            *)
-(* [tensor^^= x_0; ...; x_n], [tensor`_= x_0; ...; x_n] ==                    *)
-(*                         construction of a tensor from a sequence of values *)
 (* Tensors are instances of subType of matrix, and inherit all combinatorial  *)
 (* structures (including finType), as well as nmodType, zmodType,             *)
 (* lSemiModType, lModType, and ring instances where the underlying type       *)
@@ -68,15 +53,10 @@ From mathcomp Require Import interval interval_inference numdomain.
 (* Proper tensor product forms a bilinear structure.                          *)
 (*                                                                            *)
 (* Tensor operations:                                                         *)
-(* t *h u == Hadamard product of t and u (element-wise multiplication),       *)
+(* hmul t u == Hadamard product of t and u (element-wise multiplication),     *)
 (*           same as t * u (ring multiplication)                              *)
-(* t *t u == proper tensor product: combines dimensions,                      *)
-(*           'T_(u1, d1) * 'T_(u2, d2) -> 'T_(u1 +++ u2, d1 +++ d2)           *)
-(*                                                                            *)
-(* Notations: indexing operations (^^, `_, ^^=, `_=), the stacking            *)
-(* constructors (\tensor^^, \tensor`_), the bracket constructors              *)
-(* ([tensor^^ ...], [tensor`_ ...], [tensor^^= ...], [tensor`_= ...]) and     *)
-(* the nullary projection (t.[::]) live in tensor_scope (delimited %tnsr).    *)
+(* mults t u == proper tensor product: combines dimensions,                   *)
+(*           'T_(u1, d1) -> 'T_(u2, d2) -> 'T_(u1 +++ u2, d1 +++ d2)          *)
 (******************************************************************************)
 
 Set Implicit Arguments.
@@ -100,61 +80,13 @@ Reserved Notation "''T[' R ]_ ( u_ , d_ )"
 Reserved Notation "''sT'" (at level 0, format "''sT'").
 Reserved Notation "''sT[' R ]" (at level 0). (* only parsing *)
 
-Reserved Notation "t ^^ i"
-  (at level 30, i at level 30, format "t ^^ i").
-Reserved Notation "t `_ i"
-  (at level 3, i at level 2, left associativity, format "t `_ i").
-Reserved Notation "t ^^= i"
-  (at level 30, i at level 30, format "t ^^= i").
-Reserved Notation "t `_= i"
-  (at level 3, i at level 2, left associativity, format "t `_= i").
-
-Reserved Notation "\tensor ^^ i E"
-  (at level 34, E at level 39, i binder, format "\tensor ^^ i  E").
-Reserved Notation "\tensor `_ i E"
-  (at level 34, E at level 39, i binder, format "\tensor `_ i  E").
-Reserved Notation "\tensor ^^ ( i < u ) E"
-  (at level 34, E at level 39, i, u at level 50). (* only parsing *)
-Reserved Notation "\tensor `_ ( i < d ) E"
-  (at level 34, E at level 39, i, d at level 50). (* only parsing *)
-Reserved Notation "\tensor ^^ i => E"
-  (at level 34, E at level 39, i binder, format "\tensor ^^ i  =>  E").
-Reserved Notation "\tensor `_ i => E"
-  (at level 34, E at level 39, i binder, format "\tensor `_ i  =>  E").
-Reserved Notation "\tensor ^^ ( i < u ) => E"
-  (E at level 39, i, u at level 50). (* only parsing *)
-Reserved Notation "\tensor `_ ( i < d ) => E"
-  (E at level 39, i, d at level 50). (* only parsing *)
-
-Reserved Notation "[ 'tensor' ^^ t ; .. ; tn ]"
-  (format "[ 'tensor' ^^ '['  t ; '/'  .. ; '/'  tn ']' ]").
-Reserved Notation "[ 'tensor' `_ t ; .. ; tn ]"
-  (format "[ 'tensor' `_ '['  t ; '/'  .. ; '/'  tn ']' ]").
-Reserved Notation "[ 'tensor' ^^= x ; .. ; xn ]"
-  (format "[ 'tensor' ^^= '['  x ; '/'  .. ; '/'  xn ']' ]").
-Reserved Notation "[ 'tensor' `_= x ; .. ; xn ]"
-  (format "[ 'tensor' `_= '['  x ; '/'  .. ; '/'  xn ']' ]").
-
-Reserved Notation "t .[::]".
-
-Reserved Notation "*h%R" (at level 0).
-Reserved Notation "x *h y"
-  (at level 40, left associativity, format "x  *h  y").
-Reserved Notation "*t%R" (at level 0).
-Reserved Notation "x *t y"
-  (at level 40, left associativity, format "x  *t  y").
-
 (* Coercion from tuples to finfun: allows writing tensor dimensions as tuples *)
 #[warning="-uniform-inheritance"]
 Coercion finfun_of_tuple : tuple_of >-> finfun_of.
 #[warning="-uniform-inheritance"]
 Coercion tuple_of_finfun : finfun_of >-> tuple_of.
 
-Declare Scope tensor_scope.
-Delimit Scope tensor_scope with tnsr.
-
 Local Open Scope ring_scope.
-Local Open Scope tensor_scope.
 
 Section TensorDef.
 
@@ -169,25 +101,26 @@ HB.instance Definition _ := [isNew for tensor_val].
 
 End TensorDef.
 
-Bind Scope tensor_scope with tensor.
+Bind Scope ring_scope with tensor.
 
-Notation "''T[' R ]_ ( u_ , d_ )" := (tensor u_ d_ R) (only parsing).
+Notation "''T[' R ]_ ( u_ , d_ )" := (tensor u_ d_ R) (only parsing) : type_scope.
 Notation "''T[' R ]_ [ u1 , .. , uk ; d1 , .. , dl ]"
   := (tensor [tuple of u1%:posnat :: .. [:: uk%:posnat] ..]
-             [tuple of d1%:posnat :: .. [:: dl%:posnat] ..] R) (only parsing).
-Notation "''T_' ( u_ , d_ )" := (tensor u_ d_ _).
-Notation "''nT[' R ]_ ( u_ )" := 'T[R]_( u_ , [tuple] ) (only parsing).
+             [tuple of d1%:posnat :: .. [:: dl%:posnat] ..] R)
+     (only parsing) : type_scope.
+Notation "''T_' ( u_ , d_ )" := (tensor u_ d_ _) : type_scope.
+Notation "''nT[' R ]_ ( u_ )" := 'T[R]_( u_ , [tuple] ) (only parsing) : type_scope.
 Notation "''nT[' R ]_ [ u1 , .. , uk ]"
   := 'T[R]_( [tuple of u1%:posnat :: .. [:: uk%:posnat] ..] , [tuple] )
-  (only parsing).
-Notation "''oT[' R ]_ ( d_ )" := 'T[R]_( [tuple] , d_ ) (only parsing).
+     (only parsing) : type_scope.
+Notation "''oT[' R ]_ ( d_ )" := 'T[R]_( [tuple] , d_ ) (only parsing) : type_scope.
 Notation "''oT[' R ]_ [ d1 , .. , dl ]"
   := 'T[R]_( [tuple] , [tuple of d1%:posnat :: .. [:: dl%:posnat] ..] )
-  (only parsing).
-Notation "''oT_' ( d_ )" := (tensor [tuple] d_ _).
-Notation "''nT_' ( u_ )" := (tensor u_ [tuple] _).
-Notation "''sT[' R ]" := (tensor [tuple] [tuple] R) (only parsing).
-Notation "''sT'" := (tensor [tuple] [tuple] _).
+     (only parsing) : type_scope.
+Notation "''oT_' ( d_ )" := (tensor [tuple] d_ _) : type_scope.
+Notation "''nT_' ( u_ )" := (tensor u_ [tuple] _) : type_scope.
+Notation "''sT[' R ]" := (tensor [tuple] [tuple] R) (only parsing) : type_scope.
+Notation "''sT'" := (tensor [tuple] [tuple] _) : type_scope.
 
 Section SubtypeInstances.
 
@@ -217,10 +150,8 @@ HB.instance Definition _ (R : pzRingType) := GRing.SubLSemiModule.on 'T[R].
 
 End SubtypeInstances.
 
-
 Definition const_t {R k l} {u_ : {posnum nat} ^ k} {d_ : {posnum nat} ^ l}
   (v : R) : 'T[R]_(u_, d_) := Tensor (const_mx v).
-
 
 Section TensorCast.
 
@@ -283,11 +214,7 @@ Proof. by move=> t; apply/val_inj; rewrite !val_castt castmxKV. Qed.
 
 End TensorCast.
 
-
 Section TensorRing.
-
-Local Open Scope ring_scope.
-
 Context {l k : nat} (u_ : {posnum nat} ^ k) (d_ : {posnum nat} ^ l).
 Local Notation "''T[' R ]" := 'T[R]_(u_, d_).
 
@@ -385,10 +312,6 @@ HB.instance Definition _ {R : unitRingType} :=
 
 End TensorRing.
 
-(* Notations for Hadamard product *)
-Notation "*h%R" := hmul : function_scope.
-Notation "x *h y" := (hmul x y) : ring_scope.
-
 Section NilTensor.
 
 Context (R : Type).
@@ -415,18 +338,12 @@ Qed.
 
 End NilTensor.
 
-
-Notation "t .[::]" := (tensor_nil t) : tensor_scope.
-
-
 Section NilTensorTheory.
 
-Lemma tensor_nil_eqP {R : Type} t u : t.[::] = u.[::] :> R <-> t = u.
+Lemma tensor_nil_eqP {R : Type} t u : tensor_nil t = tensor_nil u :> R <-> t = u.
 Proof.
 by split=> [?|->//]; apply/val_inj/matrixP=> i j; rewrite !ord_prod_nil.
 Qed.
-
-Local Open Scope ring_scope.
 
 Fact tensor_nil_is_nmod_morphism {U : nmodType} : nmod_morphism (@tensor_nil U).
 Proof. by split=> [|? ?]; rewrite /tensor_nil mxE. Qed.
@@ -444,7 +361,7 @@ HB.instance Definition _ {R : pzSemiRingType} :=
     tensor_nil_is_monoid_morphism.
 
 Lemma tensor_nilV {R : unitRingType} t
-  : (t^-1).[::] = t.[::]^-1 :> R.
+  : tensor_nil (t^-1) = (tensor_nil t)^-1 :> R.
 Proof.
 rewrite /tensor_nil {1}/GRing.inv/=/invt.
 case (t \in @unitt _ _ [tuple] [tuple] R) eqn:t_unit; rewrite t_unit.
@@ -456,12 +373,8 @@ Qed.
 
 End NilTensorTheory.
 
-
 Section ConstTensorTheory.
-
 Context {l k : nat} (u_ : {posnum nat} ^ k) (d_ : {posnum nat} ^ l).
-
-Local Open Scope ring_scope.
 
 Fact const_t_is_nmod_morphism {U : nmodType} :
   nmod_morphism (@const_t U _ _ u_ d_).
@@ -493,12 +406,9 @@ Qed.
 
 End ConstTensorTheory.
 
-
 Section IndexTensor.
 
 Section IndexTensorBij.
-
-Local Open Scope ring_scope.
 
 Context {k : nat} (u_ : {posnum nat} ^ k).
 
@@ -506,7 +416,6 @@ Local Notation fprod_u := (fprod (fun i : 'I_k => 'I_(u_ i)%:num)).
 
 Lemma card_fprod_u : #|fprod_u| = \prod_(i < k) (u_ i)%:num.
 Proof. by rewrite card_fprod; apply: eq_bigr => i _; rewrite card_ord. Qed.
-
 
 Definition tensor_index (f : fprod_u) : 'I_(\prod_(i < k) (u_ i)%:num) :=
   cast_ord card_fprod_u (enum_rank f).
@@ -558,9 +467,6 @@ Qed.
 End IndexTensorBij.
 
 Section IndexTensorConsBij.
-
-Local Open Scope ring_scope.
-
 Context (u : {posnum nat}) {k : nat} (u_ : k.-tuple {posnum nat}).
 
 Local Notation u_cons := [tuple of u :: u_].
@@ -588,8 +494,6 @@ Proof. by move=> i; rewrite /tensormx_index enum_valK cast_ordKV. Qed.
 
 End IndexTensorConsBij.
 
-Local Open Scope ring_scope.
-
 Context (R : Type) (u d : {posnum nat}) (k l : nat).
 Context (u_ : k.-tuple {posnum nat}) (d_ : l.-tuple {posnum nat}).
 Local Notation u_cons := [tuple of u :: u_].
@@ -611,31 +515,13 @@ Definition ostack (f : 'I_d%:num -> 'T[R]_(u_, d_)) : 'T[R]_(u_, d_cons) :=
 
 End IndexTensor.
 
-Notation "t ^^ i" := (nindex t i) : tensor_scope.
-Notation "t `_ i" := (oindex t i) : tensor_scope.
-Notation "t ^^= i" := ((t^^i).[::]) : tensor_scope.
-Notation "t `_= i" := ((t`_i).[::]) : tensor_scope.
-
-Notation "\tensor ^^ ( i < u ) E" := (nstack (fun i : 'I_u => E))
-  (only parsing) : tensor_scope.
-Notation "\tensor `_ ( i < d ) E" := (ostack (fun i : 'I_d => E))
-  (only parsing) : tensor_scope.
-Notation "\tensor ^^ i E" := (\tensor^^(i < _) E) : tensor_scope.
-Notation "\tensor `_ i E" := (\tensor`_(i < _) E) : tensor_scope.
-Notation "\tensor ^^ ( i < u ) => E" := (\tensor^^(i < u) const_t E)
-  (only parsing) : tensor_scope.
-Notation "\tensor `_ ( i < d ) => E" := (\tensor`_(i < d) const_t E)
-  (only parsing) : tensor_scope.
-Notation "\tensor ^^ i => E" := (\tensor^^i const_t E) : tensor_scope.
-Notation "\tensor `_ i => E" := (\tensor`_i const_t E) : tensor_scope.
-
 Section TensorIndexTheory.
 Context (R : Type).
 
 Lemma ntensorP (u : {posnum nat}) (k l : nat)
     (u_ : k.-tuple {posnum nat}) (d_ : l.-tuple {posnum nat})
     (t v : 'T[R]_([tuple of u :: u_], d_))
-  : t = v <-> forall i, t^^i = v^^i.
+  : t = v <-> forall i, nindex t i = nindex v i.
 Proof.
 split=> [->//|eq_i]; apply/val_inj/matrixP=> i j.
 move: (eq_i (tensormx_unindex i).1)=> [/matrixP] /(_ (tensormx_unindex i).2 j).
@@ -645,7 +531,7 @@ Qed.
 Lemma otensorP (d : {posnum nat}) (k l : nat)
     (u_ : k.-tuple {posnum nat}) (d_ : l.-tuple {posnum nat})
     (t v : 'T[R]_(u_, [tuple of d :: d_]))
-  : t = v <-> forall i, t`_i = v`_i.
+  : t = v <-> forall i, oindex t i = oindex v i.
 Proof.
 split=> [->//|eq_i]; apply/val_inj/matrixP=> i j.
 move: (eq_i (tensormx_unindex j).1)=> [/matrixP] /(_ i (tensormx_unindex j).2).
@@ -653,14 +539,14 @@ by rewrite !mxE -surjective_pairing tensormx_unindexK.
 Qed.
 
 Lemma ntensor_eqP (u : {posnum nat}) (t v : 'nT[R]_([tuple u]))
-  : t = v <-> forall i, t^^=i = v^^=i.
+  : t = v <-> forall i, tensor_nil (nindex t i) = tensor_nil (nindex v i).
 Proof.
 split=> [->//|eq_i]; apply/ntensorP=> i.
 by move: (eq_i i)=> /tensor_nil_eqP.
 Qed.
 
 Lemma otensor_eqP (d : {posnum nat}) (t v : 'oT[R]_([tuple d]))
-  : t = v <-> forall i, t`_=i = v`_=i.
+  : t = v <-> forall i, tensor_nil (oindex t i) = tensor_nil (oindex v i).
 Proof.
 split=> [->//|eq_i]; apply/otensorP=> i.
 by move: (eq_i i)=> /tensor_nil_eqP.
@@ -669,59 +555,57 @@ Qed.
 Lemma nstackE {u : {posnum nat}} {k l}
     {u_ : k.-tuple {posnum nat}} {d_ : l.-tuple {posnum nat}}
     (f : 'I_u%:num%R -> 'T[R]_(u_, d_)) i
-  : (nstack f)^^i = f i.
+  : nindex (nstack f) i = f i.
 Proof. by apply/val_inj/matrixP => x y; rewrite !mxE tensormx_indexK. Qed.
 
 Lemma ostackE {d : {posnum nat}} {k l}
     {u_ : k.-tuple {posnum nat}} {d_ : l.-tuple {posnum nat}}
     (f : 'I_d%:num%R -> 'T[R]_(u_, d_)) i
-  : (ostack f)`_i = f i.
+  : oindex (ostack f) i = f i.
 Proof. by apply/val_inj/matrixP => x y; rewrite !mxE tensormx_indexK. Qed.
 
 Lemma nstack_eqE {u : {posnum nat}} (f : 'I_u%:num%R -> R) i
-  : (\tensor^^i0 => f i0)^^=i = f i.
+  : tensor_nil (nindex (nstack (fun i0 => const_t (f i0))) i) = f i.
 Proof. by rewrite nstackE const_tK. Qed.
 
 Lemma ostack_eqE {d : {posnum nat}} (f : 'I_d%:num%R -> R) i
-  : (\tensor`_i0 => f i0)`_=i = f i.
+  : tensor_nil (oindex (ostack (fun i0 => const_t (f i0))) i) = f i.
 Proof. by rewrite ostackE const_tK. Qed.
 
 End TensorIndexTheory.
 
-
 Section TensorTuple.
-
 Context {R : Type} {x : {posnum nat}} (k l : nat).
 Context (u_ : k.-tuple {posnum nat}) (d_ : l.-tuple {posnum nat}).
 
 Definition ntensor_of_tuple (t : x%:num%R.-tuple R)
-  : 'nT[R]_([tuple x]) := \tensor^^i => (tnth t i).
+  : 'nT[R]_([tuple x]) := nstack (fun i => const_t (tnth t i)).
 
 Definition otensor_of_tuple (t : x%:num%R.-tuple R)
-  : 'oT[R]_([tuple x]) := \tensor`_i => (tnth t i).
+  : 'oT[R]_([tuple x]) := ostack (fun i => const_t (tnth t i)).
 
 Definition tuple_of_ntensor (t : 'nT[R]_([tuple x])) :=
-  [tuple t^^=i | i < x%:num%R].
+  [tuple tensor_nil (nindex t i) | i < x%:num%R].
 
 Definition tuple_of_otensor (t : 'oT[R]_([tuple x])) :=
-  [tuple t`_=i | i < x%:num%R].
+  [tuple tensor_nil (oindex t i) | i < x%:num%R].
 
-Lemma ntensor_of_tupleE t i : (ntensor_of_tuple t)^^=i = tnth t i.
+Lemma ntensor_of_tupleE t i : tensor_nil (nindex (ntensor_of_tuple t) i) = tnth t i.
 Proof. exact: nstack_eqE. Qed.
 
-Lemma otensor_of_tupleE t i : (otensor_of_tuple t)`_=i = tnth t i.
+Lemma otensor_of_tupleE t i : tensor_nil (oindex (otensor_of_tuple t) i) = tnth t i.
 Proof. exact: ostack_eqE. Qed.
 
 Definition nstack_tuple (t : x%:num%R.-tuple 'T[R]_(u_, d_)) :=
-  \tensor^^i tnth t i.
+  nstack (fun i => tnth t i).
 
 Definition ostack_tuple (t : x%:num%R.-tuple 'T[R]_(u_, d_)) :=
-  \tensor`_i tnth t i.
+  ostack (fun i => tnth t i).
 
-Lemma nstack_tupleE t i : (nstack_tuple t)^^i = tnth t i.
+Lemma nstack_tupleE t i : nindex (nstack_tuple t) i = tnth t i.
 Proof. exact: nstackE. Qed.
 
-Lemma ostack_tupleE t i : (ostack_tuple t)`_i = tnth t i.
+Lemma ostack_tupleE t i : oindex (ostack_tuple t) i = tnth t i.
 Proof. exact: ostackE. Qed.
 Lemma ntensor_of_tupleK : cancel ntensor_of_tuple tuple_of_ntensor.
 Proof.
@@ -745,27 +629,15 @@ Qed.
 
 End TensorTuple.
 
-
-Notation "[ 'tensor' ^^ t ; .. ; tn ]" :=
-  (nstack_tuple [tuple of t :: .. [:: tn] ..]) : tensor_scope.
-Notation "[ 'tensor' ^^= x ; .. ; xn ]" :=
-  (ntensor_of_tuple [tuple of x :: .. [:: xn] ..]) : tensor_scope.
-Notation "[ 'tensor' `_ t ; .. ; tn ]" :=
-  (ostack_tuple [tuple of t :: .. [:: tn] ..]) : tensor_scope.
-Notation "[ 'tensor' `_= x ; .. ; xn ]" :=
-  (otensor_of_tuple [tuple of x :: .. [:: xn] ..]) : tensor_scope.
-
-
 Section TensorMatrix.
-
 Context {R : Type} {n m : {posnum nat}}.
 
 Definition tensor_of_matrix (M : 'M_(_, _)) :
   'T[R]_([tuple n], [tuple m]) :=
-    \tensor^^i \tensor`_j => M i j.
+    nstack (fun i => ostack (fun j => const_t (M i j))).
 
 Definition matrix_of_tensor t : 'M[R]_(n%:num%R, m%:num%R) :=
-  \matrix_(i, j) (t^^i)`_=j.
+  \matrix_(i, j) tensor_nil (oindex (nindex t i) j).
 
 Lemma tensor_of_matrixK : cancel tensor_of_matrix matrix_of_tensor.
 Proof. by move=> M; apply/matrixP=> i j; rewrite mxE nstackE ostack_eqE. Qed.
@@ -779,8 +651,6 @@ Qed.
 End TensorMatrix.
 
 Section TensorProduct.
-
-
 Context {R : pzSemiRingType} {R' : pzRingType}.
 Context {k1 l1 k2 l2 : nat}.
 Context (u1_ : {posnum nat} ^ k1) (d1_ : {posnum nat} ^ l1).
@@ -811,7 +681,6 @@ Definition mults (t : 'T[R]_(u1_, d1_)) (u : 'T[R]_(u2_, d2_))
     let jj := prod_split (cast_ord (esym (prod_fcat _ _)) j) in
     (\val t ii.1 jj.1) * (\val u ii.2 jj.2))%R.
 
-Local Open Scope ring_scope.
 
 Lemma multsDl (t u : 'T[R]_(u1_, d1_)) (v : 'T[R]_(u2_, d2_)) :
   mults (t + u) v = (mults t v + mults u v).
@@ -844,24 +713,16 @@ Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE.
 Qed.
 
-
 End TensorProduct.
 
-Notation "*t%R" := mults : ring_scope.
-Notation "x *t y" := (mults x y) : tensor_scope.
-
 Section TensorProductBilinear.
-
-
 Context {R : comNzRingType}.
 Context {k1 l1 k2 l2 : nat}.
 Context (u1_ : {posnum nat} ^ k1) (d1_ : {posnum nat} ^ l1).
 Context (u2_ : {posnum nat} ^ k2) (d2_ : {posnum nat} ^ l2).
 
-Local Open Scope ring_scope.
-
 Let mults_linear_l (u : 'T[R]_(u2_, d2_)) :
-  GRing.linear_for *:%R (fun t : 'T[R]_(u1_, d1_) => t *t u).
+  GRing.linear_for *:%R (fun t : 'T[R]_(u1_, d1_) => mults t u).
 Proof.
 move=> a x y; apply/val_inj/matrixP=> i j; rewrite /tensor_val/= !mxE/=.
 rewrite mulrDl; congr (_ + _);
@@ -869,7 +730,7 @@ rewrite mulrDl; congr (_ + _);
 Qed.
 
 Let mults_linear_r (t : 'T[R]_(u1_, d1_)) :
-  GRing.linear_for *:%R (fun u : 'T[R]_(u2_, d2_) => t *t u).
+  GRing.linear_for *:%R (fun u : 'T[R]_(u2_, d2_) => mults t u).
 Proof.
 move=> a x y; apply/val_inj/matrixP=> i j; rewrite /tensor_val/= !mxE/=.
 by rewrite mulrDr; congr (_ + _); rewrite mulrA (mulrCA a) mulrA.
@@ -884,17 +745,13 @@ HB.instance Definition _ := bilinear_isBilinear.Build
 End TensorProductBilinear.
 
 Section TensorProductHadamard.
-
-
 Context {R : comPzRingType}.
 Context {k1 l1 k2 l2 : nat}.
 Context (u1_ : {posnum nat} ^ k1) (d1_ : {posnum nat} ^ l1).
 Context (u2_ : {posnum nat} ^ k2) (d2_ : {posnum nat} ^ l2).
 
-Local Open Scope ring_scope.
-
 Lemma mults_hmul (t1 u1 : 'T[R]_(u1_, d1_)) (t2 u2 : 'T[R]_(u2_, d2_)) :
-  (t1 *h u1) *t (t2 *h u2) = (t1 *t t2) *h (u1 *t u2).
+  mults (hmul t1 u1) (hmul t2 u2) = hmul (mults t1 t2) (mults u1 u2).
 Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE /= mulrACA.
 Qed.
@@ -902,36 +759,32 @@ Qed.
 End TensorProductHadamard.
 
 Section TensorProductRing.
-
-
 Context {k1 l1 k2 l2 : nat}.
 Context (u1_ : {posnum nat} ^ k1) (d1_ : {posnum nat} ^ l1).
 Context (u2_ : {posnum nat} ^ k2) (d2_ : {posnum nat} ^ l2).
 
-Local Open Scope ring_scope.
-
 Lemma multsNl {R : pzRingType} (t : 'T[R]_(u1_, d1_)) (u : 'T[R]_(u2_, d2_)) :
-  (- t) *t u = - (t *t u).
+  mults (- t) u = - (mults t u).
 Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE /= mulNr.
 Qed.
 
 Lemma multsNr {R : pzRingType} (t : 'T[R]_(u1_, d1_)) (u : 'T[R]_(u2_, d2_)) :
-  t *t (- u) = - (t *t u).
+  mults t (- u) = - (mults t u).
 Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE /= mulrN.
 Qed.
 
 Lemma mults_scale {R : comPzSemiRingType} (a b : R)
     (t : 'T[R]_(u1_, d1_)) (u : 'T[R]_(u2_, d2_))
-  : (const_t a *h t) *t (const_t b *h u) = const_t (a * b)%R *h (t *t u).
+  : mults (hmul (const_t a) t) (hmul (const_t b) u) = hmul (const_t (a * b)%R) (mults t u).
 Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE /= mulrACA.
 Qed.
 
 Lemma mults_hmul_compat {R : comPzSemiRingType} 
     (t1 t2 : 'T[R]_(u1_, d1_)) (u1 u2 : 'T[R]_(u2_, d2_))
-  : (t1 *h t2) *t (u1 *h u2) = (t1 *t u1) *h (t2 *t u2).
+  : mults (hmul t1 t2) (hmul u1 u2) = hmul (mults t1 u1) (mults t2 u2).
 Proof.
 by apply/val_inj/matrixP => i j; rewrite /tensor_val /= !mxE /= mulrACA.
 Qed.

--- a/doc/changelog/01-added/1535-tensor.md
+++ b/doc/changelog/01-added/1535-tensor.md
@@ -14,16 +14,7 @@
     and `tuple_of_finfun : finfun_of >-> tuple_of`, letting a
     `k.-tuple T` and a `{ffun 'I_k -> T}` flow into either context
     transparently
-  + new `tensor_scope` (delimited `%tnsr`) containing the indexing
-    operations `t^^i`, ``` ``t`_i`` ```, `t^^=i`, ``` ``t`_=i`` ```,
-    the nullary projection `t.[::]`, the stacking constructors
-    `\tensor^^`, ``` \tensor`_ ``` (with their `=>` variants), and
-    the bracket constructors `[tensor^^ ...]`, ``` [tensor`_ ...] ```,
-    `[tensor^^= ...]`, ``` [tensor`_= ...] ```; `tensor_scope` is
-    bound to the `tensor` type via `Bind Scope` so the indexing
-    notations resolve correctly under `ring_scope`
-  + underlying definitions for the indexing operations: `nindex`,
-    `oindex`, and `tensor_nil`
+  + indexing operations: `nindex`, `oindex`, and `tensor_nil`
   + tensor definitions `const_t`, `tensor1`, `nstack`, `ostack`,
     `nstack_tuple`, `ostack_tuple`, `ntensor_of_tuple`,
     `otensor_of_tuple`, `tuple_of_ntensor`, `tuple_of_otensor`,
@@ -31,10 +22,9 @@
   + tensor-reshaping operator `castt` (and lemmas `val_castt`,
     `castt_id`, `castt_comp`, `casttK`, `casttKV`), mirroring
     `castmx` at the tensor level
-  + Hadamard (element-wise) product `t *h u` (definition `hmul`,
-    notation in `ring_scope`) and tensor product `t *t u` (definition
-    `mults`), with `*%R` interpreted as the Hadamard product on
-    tensors
+  + Hadamard (element-wise) product `hmul` and tensor product `mults`
+    (both without notation), with `*%R` interpreted as the Hadamard
+    product on tensors
   + ring-instance support definitions `unitt`, `invt`
   + index bijections `tensor_index`, `tensor_unindex`,
     `tensor_dffun_index`, `tensor_dffun_unindex`, `tensormx_index`,

--- a/doc/changelog/01-added/1535-tensor.md
+++ b/doc/changelog/01-added/1535-tensor.md
@@ -14,7 +14,13 @@
     and `tuple_of_finfun : finfun_of >-> tuple_of`, letting a
     `k.-tuple T` and a `{ffun 'I_k -> T}` flow into either context
     transparently
-  + indexing operations: `nindex`, `oindex`, and `tensor_nil`
+  + indexing operations `t^^i`, `t\_i`, `t^^=i`, `t\_=i`, the nullary
+    projection `t.[::]`, the stacking constructors `\tensor^^`,
+    `\tensor\_` (with their `=>` variants), and the bracket
+    constructors `[tensor^^ ...]`, `[tensor\_ ...]`, `[tensor^^= ...]`,
+    `[tensor\_= ...]`, all in `ring_scope`
+  + underlying definitions for the indexing operations: `nindex`,
+    `oindex`, and `tensor_nil`
   + tensor definitions `const_t`, `tensor1`, `nstack`, `ostack`,
     `nstack_tuple`, `ostack_tuple`, `ntensor_of_tuple`,
     `otensor_of_tuple`, `tuple_of_ntensor`, `tuple_of_otensor`,
@@ -22,9 +28,10 @@
   + tensor-reshaping operator `castt` (and lemmas `val_castt`,
     `castt_id`, `castt_comp`, `casttK`, `casttKV`), mirroring
     `castmx` at the tensor level
-  + Hadamard (element-wise) product `hmul` and tensor product `mults`
-    (both without notation), with `*%R` interpreted as the Hadamard
-    product on tensors
+  + Hadamard (element-wise) product `t *h u` (definition `hmul`,
+    notation in `ring_scope`) and tensor product `t *t u` (definition
+    `mults`), with `*%R` interpreted as the Hadamard product on
+    tensors
   + ring-instance support definitions `unitt`, `invt`
   + index bijections `tensor_index`, `tensor_unindex`,
     `tensor_dffun_index`, `tensor_dffun_unindex`, `tensormx_index`,


### PR DESCRIPTION
##### Motivation for this change

This PR reintroduces covariant and tensor product notations, which were breaking downstream packages in the CI, and got removed in #1610 
It is not meant to be merged until after releasing 2.6.0 and the precise course of action needs to be discussed.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
