### PR TITLE
Adapt to HB/mixin-tc

### DIFF
--- a/algebra/matrix.v
+++ b/algebra/matrix.v
@@ -2149,7 +2149,7 @@ Definition oppmx := @map_mx V V -%R m n.
 Lemma addNmx : left_inverse (const_mx 0) oppmx (@addmx V m n).
 Proof. by move=> A; apply/matrixP=> i j; rewrite !mxE addNr. Qed.
 
-HB.instance Definition _ := GRing.Nmodule_isZmodule.Build 'M[V]_(m, n) addNmx.
+HB.instance Definition _ := Algebra.Nmodule_isZmodule.Build 'M[V]_(m, n) addNmx.
 
 #[deprecated(since="mathcomp 2.5.0", use=raddfB)]
 Fact const_mx_is_zmod_morphism : zmod_morphism const_mx.

--- a/algebra/poly.v
+++ b/algebra/poly.v
@@ -1524,7 +1524,7 @@ Proof.
 by move=> p; apply/polyP => i; rewrite coefD coef_opp_poly coef0 addNr.
 Qed.
 
-HB.instance Definition _ := GRing.Nmodule_isZmodule.Build (polynomial R)
+HB.instance Definition _ := Algebra.Nmodule_isZmodule.Build (polynomial R)
   add_polyN.
 
 (* Size, leading coef, morphism properties of coef *)

--- a/algebra/ring_tactic.v
+++ b/algebra/ring_tactic.v
@@ -10,6 +10,7 @@ From mathcomp Require Import preorder.
 From mathcomp Require Export ssralg.
 From mathcomp Require Import ssrint binnums.
 From mathcomp.algebra Extra Dependency "ring_tactic.elpi" as ring_tactic.
+Elpi TC.AddClasses param_db.
 
 (******************************************************************************)
 (* This file provides the ring tactic.                                        *)

--- a/algebra/vector.v
+++ b/algebra/vector.v
@@ -1389,7 +1389,7 @@ Definition opp_lfun f := linfun (-%R \o f).
 Lemma lfun_addN : left_inverse zero_lfun opp_lfun add_lfun.
 Proof. by move=> f; apply/lfunP=> v; rewrite !lfunE /= lfunE addNr. Qed.
 
-HB.instance Definition _ := GRing.Nmodule_isZmodule.Build 'Hom(aT, rT)
+HB.instance Definition _ := Algebra.Nmodule_isZmodule.Build 'Hom(aT, rT)
   lfun_addN.
 
 Lemma opp_lfunE f x : (- f) x = - f x. Proof. exact: lfunE. Qed.

--- a/boot/eqtype.v
+++ b/boot/eqtype.v
@@ -678,25 +678,25 @@ Local Notation inlined_new_rect :=
 Reserved Notation "[ 'isSub' 'for' v ]" (format "[ 'isSub'  'for'  v ]").
 
 Notation "[ 'isSub' 'for' v ]" :=
-  (@isSub.phant_Build _ _ _ v _ inlined_sub_rect vrefl_rect)
+  (@isSub.phant_Build_ _ _ _ v _ inlined_sub_rect vrefl_rect)
   (only parsing) : form_scope.
 
 Notation "[ 'isSub' 'of'  T  'for' v ]" :=
-  (@isSub.phant_Build _ _ T v _ inlined_sub_rect vrefl_rect)
+  (@isSub.phant_Build_ _ _ T v _ inlined_sub_rect vrefl_rect)
   (only parsing) : form_scope.
 
 Notation "[ 'isSub' 'for' v 'by' rec ]" :=
- (@isSub.phant_Build _ _ _ v _ rec vrefl)
+ (@isSub.phant_Build_ _ _ _ v _ rec vrefl)
  (format "[ 'isSub'  'for'  v  'by'  rec ]") : form_scope.
 
-Notation "[ 'isSub' 'for' v ]" := (@isSub.phant_Build _ _ _ v _ _ _)
+Notation "[ 'isSub' 'for' v ]" := (@isSub.phant_Build_ _ _ _ v _ _ _)
   (only printing, format "[ 'isSub'  'for'  v ]") : form_scope.
 
 Reserved Notation "[ 'isNew' 'for' v ]" (format "[ 'isNew'  'for'  v ]").
 
 Definition NewMixin T U v c Urec sk :=
   let Urec' P IH := Urec P (fun x : T => IH x isT : P _) in
-  @isSub.phant_Build _ _ U v (fun x _ => c x) Urec' sk.
+  @isSub.phant_Build_ _ _ U v (fun x _ => c x) Urec' sk.
 
 Notation "[ 'isNew' 'for' v ]" :=
   (@NewMixin _ _ v _ inlined_new_rect vrefl_rect) (only parsing) : form_scope.

--- a/field/algebraics_fundamentals.v
+++ b/field/algebraics_fundamentals.v
@@ -322,7 +322,7 @@ have ofQ_K z: cancel (ofQ z) (inQ z).
 have sQring z: divring_closed (sQ z).
   have sQ_1: 1 \in sQ z by rewrite -(rmorph1 (ofQ z)) sQof.
   by split=> // x y /inQ_K<- /inQ_K<- /=; rewrite -(rmorphB, fmorph_div) sQof.
-pose sQzM z := GRing.isZmodClosed.Build _ _ (sQring z : zmod_closed _).
+pose sQzM z := Algebra.isZmodClosed.Build _ _ (sQring z : zmod_closed _).
 pose sQmM z := GRing.isMulClosed.Build _ _ (sQring z).
 pose sQiM z := GRing.isInvClosed.Build _ _ (sQring z).
 pose sQC z : divringClosed _ := HB.pack (sQ z)
@@ -336,7 +336,7 @@ have QtoQ z x: x \in sQ z -> {Qxz : 'AHom(Q x, Q z) | morph_ofQ x z Qxz}.
   have Qxzm : monoid_morphism Qxz.
     by split=> [|u v]; apply: (canLR (ofQ_K z));
       rewrite ?rmorph1 ?rmorphM /= ?QxzE.
-  have QxzaM := GRing.isZmodMorphism.Build _ _ _ Qxza.
+  have QxzaM := Algebra.isZmodMorphism.Build _ _ _ Qxza.
   have QxzmM := GRing.isMonoidMorphism.Build _ _ _ Qxzm.
   have QxzlM := GRing.isScalable.Build _ _ _ _ _ (rat_linear Qxza).
   pose QxzLRM : {lrmorphism _ -> _} := HB.pack Qxz QxzaM QxzmM QxzlM.
@@ -596,7 +596,7 @@ have add_Rroot xR p c: {yR | extendsR xR yR & has_Rroot xR p c -> root_in yR p}.
       by rewrite v_gt0 /= -if_neg posNneg.
     by rewrite v_lt0 /= -if_neg -(opprK v) posN posNneg ?posN.
   have absE v: le 0 v -> abs v = v by rewrite /abs => ->.
-  pose RyM := Num.IntegralDomain_isLtReal.Build (Q y) posD
+  set RyM := Num.IntegralDomain_isLtReal.Build (Q y) posD
                 posM posNneg posB posVneg absN absE (rrefl _).
   pose Ry : realFieldType := HB.pack (Q y) RyM.
   have QisArchi : Num.NumDomain_bounded_isArchimedean Ry.
@@ -608,7 +608,7 @@ have some_realC: realC.
       exact: can2_zmod_morphism (inj_can_sym QfK (fmorph_inj _)) QfK.
     have fM : monoid_morphism f.
       exact: can2_monoid_morphism (inj_can_sym QfK (fmorph_inj _)) QfK.
-    pose faM := GRing.isZmodMorphism.Build _ _ _ fA.
+    pose faM := Algebra.isZmodMorphism.Build _ _ _ fA.
     pose fmM := GRing.isMonoidMorphism.Build _ _ _ fM.
     pose fRM : {rmorphism _ -> _} := HB.pack f faM fmM.
     by exists 0, rat; exact: fRM.

--- a/field/closed_field.v
+++ b/field/closed_field.v
@@ -701,7 +701,7 @@ have I_ideal : idealr_closed I.
   apply/memI; exists (maxn (pickle q1).+1 (pickle q2).+1); apply: dvdp_add.
     by apply: dvdp_mull; apply: dvdp_trans Iq1; apply/dv_d/leq_maxl.
   by apply: dvdp_trans Iq2; apply/dv_d/leq_maxr.
-pose IaM := GRing.isZmodClosed.Build _ I (idealr_closedB I_ideal).
+pose IaM := Algebra.isZmodClosed.Build _ I (idealr_closedB I_ideal).
 pose IpM := isProperIdeal.Build _ I (idealr_closed_nontrivial I_ideal).
 pose Iid : idealr _ := HB.pack I IaM IpM.
 pose E : comNzRingType := {ideal_quot Iid}.
@@ -724,7 +724,7 @@ have EmulV : forall x, x != 0 -> Einv x * x = 1.
   rewrite piE /= -[z]reprK -(rmorphM PtoE) -Quotient.idealrBE.
   rewrite -[X in _ - X]uv1 opprD addNKr -mulNr.
   by apply/memI; exists i; apply: dvdp_mull.
-pose EfieldMixin := GRing.ComNzRing_isField.Build _ EmulV Einv0.
+set EfieldMixin := GRing.ComNzRing_isField.Build _ EmulV Einv0.
 pose Efield : fieldType := HB.pack E EfieldMixin.
 pose EIsCountable := isCountable.Build E (pcan_pickleK (can_pcan (reprK))).
 pose Ecount : countFieldType := HB.pack E Efield EIsCountable.
@@ -852,7 +852,7 @@ have Kadd0: left_id (FtoK 0) Kadd.
   by move=> u; have [i [x ->]] := KtoE u; rewrite -(EtoK_0 i) -EtoK_D add0r.
 have KaddN: left_inverse (FtoK 0) Kopp Kadd.
   by move=> u; have [i [x ->]] := KtoE u; rewrite -EtoK_N -EtoK_D addNr EtoK_0.
-pose KzmodMixin := GRing.isZmodule.Build K KaddA KaddC Kadd0 KaddN.
+set KzmodMixin := Algebra.isZmodule.Build K KaddA KaddC Kadd0 KaddN.
 pose Kzmod : countZmodType := HB.pack K KzmodMixin.
 have KmulC: commutative Kmul.
   by move=> u v; have [i [x ->] [y ->]] := KtoE2 u v; rewrite -!EtoK_M mulrC.
@@ -865,20 +865,22 @@ have KmulD: left_distributive Kmul Kadd.
   move=> u v w; have [i [x ->] [[y ->] [z ->]]] := KtoE3 u v w.
   by rewrite -!(EtoK_M, EtoK_D) mulrDl.
 have Kone_nz: FtoK 1 != FtoK 0 by rewrite EtoKeq0 oner_neq0.
-pose KringMixin := GRing.Zmodule_isComNzRing.Build _
-  KmulA KmulC Kmul1 KmulD Kone_nz.
+(* N.B. : The mixins need to be inferred before typechecking the rest of the
+   arguments, hence the following hack. *)
+set KringMixin_subdef := GRing.Zmodule_isComNzRing.Build Kzmod.
+pose KringMixin := KringMixin_subdef _ _ KmulA KmulC Kmul1 KmulD Kone_nz.
 pose Kring : comNzRingType := HB.pack K Kzmod KringMixin cntK.
 have KmulV: forall x : Kring, x != 0 -> (Kinv x : Kring) * x = 1.
   move=> u; have [i [x ->]] := KtoE u; rewrite EtoKeq0 => nz_x.
   by rewrite -EtoK_V -[_ * _]EtoK_M mulVf ?EtoK_1.
 have Kinv0: Kinv (FtoK 0) = FtoK 0 by rewrite -EtoK_V invr0.
-pose KfieldMixin := GRing.ComNzRing_isField.Build _ KmulV Kinv0.
+set KfieldMixin := GRing.ComNzRing_isField.Build _ KmulV Kinv0.
 pose Kfield : fieldType := HB.pack K Kring KfieldMixin.
 have EtoKAdd i : zmod_morphism (EtoK i : E i -> Kfield).
   by move=> x y; rewrite EtoK_D EtoK_N.
 have EtoKMul i : monoid_morphism (EtoK i : E i -> Kfield).
   by split=> [|x y]; rewrite ?EtoK_M ?EtoK_1.
-pose EtoKMa i := GRing.isZmodMorphism.Build _ _ _ (EtoKAdd i).
+pose EtoKMa i := Algebra.isZmodMorphism.Build _ _ _ (EtoKAdd i).
 pose EtoKMm i := GRing.isMonoidMorphism.Build _ _ _ (EtoKMul i).
 pose EtoKM i : {rmorphism _ -> _} :=
   HB.pack (EtoK i : E i -> Kfield) (EtoKMa i) (EtoKMm i).
@@ -911,7 +913,7 @@ have Kclosed: GRing.closed_field_axiom Kfield.
   rewrite (eq_map_poly (toEleS _ _ _ _)) map_poly_comp {}IHk //= /incEp codeK.
   by rewrite -if_neg neq_ltn lemk.
 suffices{Kclosed} algF_K: {FtoK : {rmorphism F -> Kfield} | integralRange FtoK}.
-  pose Kcc := Field_isAlgClosed.Build Kfield Kclosed.
+  set Kcc := Field_isAlgClosed.Build Kfield Kclosed.
   by exists (HB.pack_for countClosedFieldType K Kfield Kcc).
 exists (EtoKM 0) => /= z; have [i [{}z ->]] := KtoE z.
 suffices{z} /(_ z)[p mon_p]: integralRange (toE 0 i isT).

--- a/field/fieldext.v
+++ b/field/fieldext.v
@@ -1349,7 +1349,7 @@ have mulD: left_distributive mul +%R.
   move=> x y z; apply: toPinj; rewrite /toPF raddfD /= -!/(toPF _).
   by rewrite !toL_K /toPF raddfD mulrDl modpD.
 have nzL1: L1 != 0 by rewrite -(inj_eq toPinj) L1K /toPF raddf0 oner_eq0.
-pose mulM := GRing.Zmodule_isComNzRing.Build _ mulA mulC mul1 mulD nzL1.
+set mulM := GRing.Zmodule_isComNzRing.Build _ mulA mulC mul1 mulD nzL1.
 pose rL : comNzRingType := HB.pack vL mulM.
 have mulZlM : GRing.LSemiModule_isComSemiAlgebra F rL.
   constructor => a x y; apply: toPinj.

--- a/group_representation/character.v
+++ b/group_representation/character.v
@@ -2511,7 +2511,7 @@ have mulA: associative mul by move=> u v w; apply: cFinj; rewrite !cFmul mulrA.
 have mul1: left_id one mul by move=> u; apply: cFinj; rewrite cFmul cFone mul1r.
 have mulV: left_inverse one inv mul.
   by move=> u; apply: cFinj; rewrite cFmul cFinv cFone mulVr ?lin_char_unitr.
-pose imA := Finite_isGroup.Build linT mulA mul1 mulV.
+set imA := Finite_isGroup.Build linT mulA mul1 mulV.
 pose linG : finGroupType := HB.pack linT imA.
 have cFexp k: {morph cF : u / ((u : linG) ^+ k)%g >-> u ^+ k}.
   by move=> u; elim: k => // k IHk; rewrite expgS exprS cFmul IHk.


### PR DESCRIPTION
##### Motivation for this change

Adapt to https://github.com/math-comp/hierarchy-builder/pull/596.
Most notably, the `Dummy` module in `rings_modules_and_algebras.v` breaks our inference strategy because it duplicates the mixin, which is now a typeclass, so we lose all the instances that were declared before the `Dummy` module.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
