### PR TITLE
Fix the `[SubChoice_isSubAlgebra of U by <:]` factory

### DIFF
--- a/algebra/algebraic_hierarchy/ssralg.v
+++ b/algebra/algebraic_hierarchy/ssralg.v
@@ -570,7 +570,7 @@ Notation "[ 'SubChoice_isSubSemiAlgebra' 'of' U 'by' <: ]" :=
 #[deprecated(since="mathcomp 2.6.0",
              note="Use [ SubChoice_isSubNzAlgebra of U by <: ] instead.")]
 Notation "[ 'SubChoice_isSubAlgebra' 'of' U 'by' <: ]" :=
-  (SubChoice_isSubNzAlgebra.Build _ _ _ U (subalgClosedP _))
+  (SubChoice_isSubNzAlgebra.Build _ _ _ U (subsemialgClosedP _))
   (format "[ 'SubChoice_isSubAlgebra'  'of'  U  'by'  <: ]")
  : form_scope.
 #[deprecated(since="mathcomp 2.4.0",


### PR DESCRIPTION
##### Motivation for this change

This should fix the issue reported by @proux01.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [ ] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
