### PR TITLE
Generalized compose of linear maps w.r.t. to change of scalar

### DIFF
--- a/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
+++ b/algebra/algebraic_hierarchy/rings_modules_and_algebras.v
@@ -2185,8 +2185,8 @@ Definition wrap (f : map_class) := Wrap f.
 End Linear.
 End Linear.
 Notation "{ 'linear' U -> V | s }" := (@Linear.type _ U V s) : type_scope.
-Notation "{ 'linear' U -> V }" := {linear U -> V | *:%R} : type_scope.
-Notation "{ 'scalar' U }" := {linear U -> _ | *%R}
+Notation "{ 'linear' U -> V }" := {linear U -> V | idfun \; *:%R} : type_scope.
+Notation "{ 'scalar' U }" := {linear U -> _ | idfun \; *%R}
   (format "{ 'scalar'  U }") : type_scope.
 (* Support for right-to-left rewriting with the generic linearZ rule. *)
 Coercion Linear.map_for_map : Linear.map_for >-> Linear.type.
@@ -2312,14 +2312,18 @@ End Idfun.
 
 Section Plain.
 
-Variables (R : pzSemiRingType) (W U : lSemiModType R) (V : nmodType).
-Variables (s : R -> V -> V) (f : {linear U -> V | s}) (g : {linear W -> U}).
+Variables (R S T : pzSemiRingType)
+  (fRS : {rmorphism R -> S}) (fST : {rmorphism S -> T})
+  (W : lSemiModType R) (U : lSemiModType S)  (V : nmodType).
+Variables (g : {linear W -> U | fRS \; *:%R}).
+Variables (s : T -> V -> V) (f : {linear U -> V | fST \; s}).
 
-Lemma comp_is_scalable : scalable_for s (f \o g).
+Lemma comp_is_scalable : scalable_for (fST \o fRS \; s) (f \o g).
 Proof. by move=> a v /=; rewrite !linearZ_LR. Qed.
 
 #[export]
-HB.instance Definition _ := isScalable.Build R W V s (f \o g) comp_is_scalable.
+HB.instance Definition _ :=
+  isScalable.Build R W V (fST \o fRS \; s) (f \o g) comp_is_scalable.
 
 End Plain.
 
@@ -2407,9 +2411,6 @@ Section LRMorphismTheory.
 Variables (R : pzSemiRingType) (A B : pzLSemiAlgType R) (C : pzSemiRingType).
 Variables (s : R -> C -> C).
 Variables (f : {lrmorphism A -> B}) (g : {lrmorphism B -> C | s}).
-
-#[export] HB.instance Definition _ := RMorphism.on (@idfun A).
-#[export] HB.instance Definition _ := RMorphism.on (g \o f).
 
 Lemma rmorph_alg a : f a%:A = a%:A.
 Proof. by rewrite linearZ /= rmorph1. Qed.


### PR DESCRIPTION
##### Motivation for this change

This PR generalize the compose or linear morphism w.r.t. to change of scalar:

By "linear with change of scalar" I mean the following: suppose that I've two rings $$R$$ and $$S$$ together with a morphism $$f : R \to S$$, and two modules $$M_R$$ and $$M_S$$ respectively on $$R$$ and $$S$$. I'm considering maps $$\phi : M_R \to M_S$$ which are $$Z$$-module morphisms and moreover for all $$c \in R$$ and $$x\in M_R$$ verify $$\phi (c\cdot x) = f(c)\cdot\phi(x)$$ where "$$\cdot$$" denote scalar multiplication. Such a map would be of type ```{linear RM -> SM | f \; *:%R}``` with MC notations. If someone knows a better name than "linear with change of scalar" I'd like to know by the way.

So here is my attempt:
```
Variables
  (R S T : nzRingType) (f : {rmorphism R -> S}) (g : {rmorphism S -> T})
    (RM : lmodType R) (SM : lmodType S) (TM : lmodType T)
    (F : {linear RM -> SM | f \; *:%R}) (G : {linear SM -> TM | g \; *:%R}).

Check G \o F : {additive RM -> TM}.
```
So far so good. My problem is that the compose map is not linear:
```
Fail Check G \o F : {linear RM -> TM | g \o f \; *:%R}.
```
MC should be able to infer this instance.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [ ] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
