### PR TITLE
Remove `disp3` from the antisymmetry proof for the pointwise order on the product type

### DIFF
--- a/order/complemented_lattice_instances.v
+++ b/order/complemented_lattice_instances.v
@@ -482,10 +482,7 @@ Lemma leEprod x y : (x <= y) = (x.1 <= y.1) && (x.2 <= y.2). Proof. by []. Qed.
 
 Lemma ltEprod_pre x y :
   (x < y) = (x.1 < y.1) && (x.2 <= y.2) || (x.1 <= y.1) && (x.2 < y.2).
-Proof.
-rewrite lt_leAnge !leEprod negb_and andb_orr andbAC -lt_leAnge -andbA.
-by rewrite -lt_leAnge.
-Qed.
+Proof. by []. Qed.
 
 Lemma le_pair (x1 y1 : T1) (x2 y2 : T2) :
   ((x1, x2) <= (y1, y2) :> T1 * T2) = (x1 <= y1) && (x2 <= y2).
@@ -544,8 +541,7 @@ Context (T1 : porderType disp1) (T2 : porderType disp2).
 
 Fact anti : antisymmetric (@le _ _ T1 T2).
 Proof.
-case=> [? ?] [? ?].
-by rewrite andbAC andbA andbAC -andbA => /= /andP [] /le_anti -> /le_anti ->.
+by case=> [? ?] [? ?]; rewrite andbACA/= => /andP[] /le_anti-> /le_anti->.
 Qed.
 
 End POrder.

--- a/order/complemented_lattice_instances.v
+++ b/order/complemented_lattice_instances.v
@@ -441,9 +441,9 @@ Context (disp1 disp2 : disp_t).
 Context (T1 : preorderType disp1) (T2 : preorderType disp2).
 Implicit Types (x y : T1 * T2).
 
-Let le x y := (x.1 <= y.1) && (x.2 <= y.2).
+Definition le x y := (x.1 <= y.1) && (x.2 <= y.2).
 
-Let lt x y := (x.1 < y.1) && (x.2 <= y.2) || (x.1 <= y.1) && (x.2 < y.2).
+Definition lt x y := (x.1 < y.1) && (x.2 <= y.2) || (x.1 <= y.1) && (x.2 < y.2).
 
 Fact lt_def x y : lt x y = le x y && ~~ le y x.
 Proof.
@@ -472,12 +472,8 @@ HB.instance Definition _ := Preorder.on T1'.
 Let T2' : Type := T2.
 HB.instance Definition _ := Preorder.on T2'.
 
-Definition le x y := (x.1 <= y.1) && (x.2 <= y.2).
-
-Definition lt x y := (x.1 < y.1) && (x.2 <= y.2) || (x.1 <= y.1) && (x.2 < y.2).
-
 #[export] HB.instance Definition _ :=
-  @isDuallyPreorder.Build disp3 (T1 * T2) le lt
+  @isDuallyPreorder.Build disp3 (T1 * T2) (@le _ _ T1 T2) (@lt _ _ T1 T2)
     (@lt_def _ _ T1' T2') (@lt_def _ _ T1^d T2^d)
     (@refl _ _ T1' T2') (@refl _ _ T1^d T2^d)
     (@trans _ _ T1' T2') (@trans _ _ T1^d T2^d).
@@ -543,10 +539,10 @@ Lemma topEprod : \top = (\top, \top) :> T1 * T2. Proof. by []. Qed.
 End TPreorder.
 
 Section POrder.
-Context (disp1 disp2 disp3 : disp_t).
+Context (disp1 disp2 : disp_t).
 Context (T1 : porderType disp1) (T2 : porderType disp2).
 
-Fact anti : antisymmetric (@le disp1 disp2 disp2 T1 T2).
+Fact anti : antisymmetric (@le _ _ T1 T2).
 Proof.
 case=> [? ?] [? ?].
 by rewrite andbAC andbA andbAC -andbA => /= /andP [] /le_anti -> /le_anti ->.


### PR DESCRIPTION
##### Motivation for this change

@proux01 pointed out that `disp3` in the `POrder` section was unused.

I initially thought that the third argument of `le` in the section should be `disp3`. It turns out that we can eliminate the third argument of `le` by deduplicating the definitions of `le` and `lt` above.

I also simplified the proofs of `Lemma ltEprod_pre` and `Fact anti`.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- ~[ ] added changelog entries with `doc/changelog/make-entry.sh`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
