### PR TITLE
add big_nat_dvdn and helper lemmas

### DIFF
--- a/boot/bigop.v
+++ b/boot/bigop.v
@@ -591,6 +591,10 @@ Canonical bigop_unlock := Unlockable bigop.unlock.
 
 Definition index_iota m n := iota m (n - m).
 
+Lemma index_iotaS m n :
+  m <= n -> index_iota m n.+1 = rcons (index_iota m n) n.
+Proof. by move=> ?; rewrite /index_iota subSn// iotaS subnKC. Qed.
+
 Lemma mem_index_iota m n i : (i \in index_iota m n) = (m <= i < n).
 Proof.
 rewrite mem_iota; case le_m_i: (m <= i) => //=.
@@ -1144,6 +1148,12 @@ Lemma big_nat_recl n m F : m <= n ->
      op (F m) (\big[op/idx]_(m <= i < n) F i.+1).
 Proof. by move=> lemn; rewrite big_ltn // big_add1. Qed.
 
+Lemma big_nat_recr_op n m (P : pred nat) F :
+  m <= n ->
+  let idx' := if P n then op (F n) idx else idx in
+  \big[op/idx]_(m <= i < n.+1 | P i) F i = \big[op/idx']_(m <= i < n | P i) F i.
+Proof. by move=> ?; rewrite index_iotaS// big_rcons_op. Qed.
+
 Lemma big_mkord n (P : pred nat) F :
   \big[op/idx]_(0 <= i < n | P i) F i = \big[op/idx]_(i < n | P i) F i.
 Proof.
@@ -1273,6 +1283,41 @@ Lemma big_nseq I n a (F : I -> R):
 Proof. exact: big_nseq_cond. Qed.
 
 End Extensionality.
+
+Section MoreOnExtensionality.
+
+Variables (R : Type) (idx : R) (op : R -> R -> R) (I : Type).
+
+Lemma big_nat_dvdn n d F :
+  \big[op/idx]_(0 <= i < n | d.+1 %| i) F i =
+  \big[op/idx]_(0 <= i < (n + d) %/ d.+1) F (d.+1 * i)%N.
+Proof.
+elim: n idx.
+  by move=> ?; rewrite divn_small// !big_nil.
+move=> n IHn idx0.
+rewrite addSn divnS// -addnS dvdn_addl// big_nat_recr_op// IHn.
+case/boolP: (d.+1 %| n) => H /=.
+  rewrite add1n big_nat_recr_op//.
+  rewrite divnDl// (@divn_small d)// addn0.
+  congr bigop.body; congr op; congr F.
+  by rewrite muln_divCA// divnn muln1.
+by rewrite add0n.
+Qed.
+
+Lemma big_ord_recr_op n (P : pred nat) F :
+  let idx' := if P n then op (F n) idx else idx in
+  \big[op/idx]_(i < n.+1 | P i) F i = \big[op/idx']_(i < n | P i) F i.
+Proof.
+rewrite big_mknat big_nat_recr_op//=.
+case: n => [|n]; first by rewrite inordK// big_nil big_ord0.
+rewrite big_mknat inordK//.
+rewrite [LHS]big_nat_cond [RHS]big_nat_cond.
+apply: eq_big => i.
+  by apply: andb_id2l => /andP[] ? in1; rewrite !inordK// (ltn_trans in1).
+by move=> /andP[] /andP[? in1]; rewrite !inordK// (ltn_trans in1).
+Qed.
+
+End MoreOnExtensionality.
 
 Variant big_enum_spec (I : finType) (P : pred I) : seq I -> Type :=
   BigEnumSpec e of

--- a/boot/bigop.v
+++ b/boot/bigop.v
@@ -1296,12 +1296,11 @@ elim: n idx.
   by move=> ?; rewrite divn_small// !big_nil.
 move=> n IHn idx0.
 rewrite addSn divnS// -addnS dvdn_addl// big_nat_recr_op// IHn.
-case/boolP: (d.+1 %| n) => H /=.
-  rewrite add1n big_nat_recr_op//.
-  rewrite divnDl// (@divn_small d)// addn0.
-  congr bigop.body; congr op; congr F.
-  by rewrite muln_divCA// divnn muln1.
-by rewrite add0n.
+case/boolP: (d.+1 %| n) => H /=; last by rewrite add0n.
+rewrite add1n big_nat_recr_op//.
+rewrite divnDl// (@divn_small d)// addn0.
+congr bigop.body; congr op; congr F.
+by rewrite muln_divCA// divnn muln1.
 Qed.
 
 Lemma big_ord_recr_op n (P : pred nat) F :

--- a/boot/seq.v
+++ b/boot/seq.v
@@ -3116,6 +3116,9 @@ Proof. by elim: n1 m => [|n1 IHn1] m; rewrite ?addn0 // -addSnnS /= -IHn1. Qed.
 Lemma iotaDl m1 m2 n : iota (m1 + m2) n = map (addn m1) (iota m2 n).
 Proof. by elim: n m2 => //= n IHn m2; rewrite -addnS IHn. Qed.
 
+Lemma iotaS m n : iota m n.+1 = rcons (iota m n) (m + n).
+Proof. by rewrite -addn1 iotaD cats1. Qed.
+
 Lemma nth_iota p m n i : i < n -> nth p (iota m n) i = m + i.
 Proof.
 by move/subnKC <-; rewrite addSnnS iotaD nth_cat size_iota ltnn subnn.
@@ -3183,7 +3186,7 @@ Proof. by rewrite size_map size_iota. Qed.
 
 Lemma mkseqS f n :
   mkseq f n.+1 = rcons (mkseq f n) (f n).
-Proof. by rewrite /mkseq -addn1 iotaD add0n map_cat cats1. Qed.
+Proof. by rewrite /mkseq iotaS map_rcons. Qed.
 
 Lemma eq_mkseq f g : f =1 g -> mkseq f =1 mkseq g.
 Proof. by move=> Efg n; apply: eq_map Efg _. Qed.

--- a/doc/changelog/01-added/1637-big_nat_dvdn.md
+++ b/doc/changelog/01-added/1637-big_nat_dvdn.md
@@ -1,0 +1,7 @@
+- in `seq.v`
+  + lemma `iotaS`
+    ([#1637](https://github.com/math-comp/math-comp/pull/1637)).
+
+- in `bigop.v`
+  + lemmas `index_iotaS, `big_nat_recr_op`, `big_nat_dvdn` and `big_ord_recr_op`
+    ([#1637](https://github.com/math-comp/math-comp/pull/1637)).

--- a/doc/changelog/01-added/1637-big_nat_dvdn.md
+++ b/doc/changelog/01-added/1637-big_nat_dvdn.md
@@ -3,5 +3,5 @@
     ([#1637](https://github.com/math-comp/math-comp/pull/1637)).
 
 - in `bigop.v`
-  + lemmas `index_iotaS, `big_nat_recr_op`, `big_nat_dvdn` and `big_ord_recr_op`
+  + lemmas `index_iotaS`, `big_nat_recr_op`, `big_nat_dvdn` and `big_ord_recr_op`
     ([#1637](https://github.com/math-comp/math-comp/pull/1637)).


### PR DESCRIPTION
##### Motivation for this change

This PR adds an extensionality lemma for bigop conditioned by `dvdn`:
```
\big[op/idx]_(0 <= i < n | d.+1 %| i) F i =
\big[op/idx]_(0 <= i < (n + d) %/ d.+1) F (d.+1 * i)
```
Some helper lemmas are added too.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
