### PR TITLE
Make individual package compilations less verbose

### DIFF
--- a/field/Make
+++ b/field/Make
@@ -24,5 +24,10 @@ qfpoly.v
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -notation-overridden
 -arg -w -arg -ambiguous-paths
+# introduced in Rocq 9.2
+-arg -w -arg +level-tolerance
+-arg -w -arg -notation-for-abbreviation
+-arg -w -arg -deprecated-lookup-elim-by-name
+-arg -w -arg -implicit-create-rewrite-hint-db
 # introduced in Rocq 9.3
 -arg -w -arg -rewrite-rw

--- a/finite_group/Make
+++ b/finite_group/Make
@@ -21,5 +21,10 @@ quotient.v
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -notation-overridden
 -arg -w -arg -ambiguous-paths
+# introduced in Rocq 9.2
+-arg -w -arg +level-tolerance
+-arg -w -arg -notation-for-abbreviation
+-arg -w -arg -deprecated-lookup-elim-by-name
+-arg -w -arg -implicit-create-rewrite-hint-db
 # introduced in Rocq 9.3
 -arg -w -arg -rewrite-rw

--- a/group_representation/Make
+++ b/group_representation/Make
@@ -20,5 +20,10 @@ vcharacter.v
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -notation-overridden
 -arg -w -arg -ambiguous-paths
+# introduced in Rocq 9.2
+-arg -w -arg +level-tolerance
+-arg -w -arg -notation-for-abbreviation
+-arg -w -arg -deprecated-lookup-elim-by-name
+-arg -w -arg -implicit-create-rewrite-hint-db
 # introduced in Rocq 9.3
 -arg -w -arg -rewrite-rw

--- a/solvable/Make
+++ b/solvable/Make
@@ -32,5 +32,10 @@ sylow.v
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -notation-overridden
 -arg -w -arg -ambiguous-paths
+# introduced in Rocq 9.2
+-arg -w -arg +level-tolerance
+-arg -w -arg -notation-for-abbreviation
+-arg -w -arg -deprecated-lookup-elim-by-name
+-arg -w -arg -implicit-create-rewrite-hint-db
 # introduced in Rocq 9.3
 -arg -w -arg -rewrite-rw


### PR DESCRIPTION
These compilation flags are in _CoqProject but were forgotten in individual packages Makefiles. This only affects verbosity of the build when building on a per package basis.

In the long run, we should probably find a way to avoid all that flag duplication business.
