### PR TITLE
Make ring lemmas universe polymorphic

### DIFF
--- a/algebra/arithmetic_tactic.v
+++ b/algebra/arithmetic_tactic.v
@@ -1012,6 +1012,7 @@ Definition Formula_Q2Z (ff : Formula Q) : option (Formula Z) :=
     (fun l r => Build_Formula l (Fop ff) r)
     (PExpr_Q2Z (Flhs ff)) (PExpr_Q2Z (Frhs ff)).
 
+#[universes(polymorphic)]
 Fixpoint BFormula_Q2Z [k] (ff : BFormula (Formula Q) k) :
     option (BFormula (Formula Z) k) := match ff with
   | TT k => Some (TT k)

--- a/algebra/field_tactic.v
+++ b/algebra/field_tactic.v
@@ -691,6 +691,7 @@ End ZnumField.
 
 (* Everything below is essentially imported form algebra-tactics *)
 
+#[universes(polymorphic)]
 Lemma field_correct (F : fieldType) n env
     (lpe : seq ((RExpr F * RExpr F) * (PExpr Z * PExpr Z)))
     (re1 re2 : RExpr F) (fe1 fe2 : FExpr Z) lc :
@@ -732,6 +733,7 @@ rewrite -!(@Rnorm_correct (Field F) false _ erefl) re12.
 by case: lpe {IH relpe rple} => /=; rewrite eqxx.
 Qed.
 
+#[universes(polymorphic)]
 Lemma numField_correct (F : numFieldType) n env
     (lpe : seq ((RExpr F * RExpr F) * (PExpr Z * PExpr Z)))
     (re1 re2 : RExpr F) (fe1 fe2 : FExpr Z) lc :

--- a/algebra/ring_tactic.v
+++ b/algebra/ring_tactic.v
@@ -1587,6 +1587,7 @@ move: i f; elim e using (@RExpr_ind' P P0); rewrite {R e}/P {}/P0 //=.
 Qed.
 End correct.
 
+#[universes(polymorphic)]
 Lemma semiring_correct (R : comSemiRingType) n env
     (lpe : seq ((RExpr R * RExpr R) * (PExpr N * PExpr N)))
     (re1 re2 : RExpr R) (pe1 pe2 : PExpr N) :
@@ -1617,6 +1618,7 @@ rewrite -!(@Rnorm_correct (SemiRing R) false _ erefl) re12.
 by case: lpe {IH relpe rple} => //=; rewrite eqxx.
 Qed.
 
+#[universes(polymorphic)]
 Lemma ring_correct (R : comRingType) n env
     (lpe : seq ((RExpr R * RExpr R) * (PExpr Z * PExpr Z)))
     (re1 re2 : RExpr R) (pe1 pe2 : PExpr Z) :

--- a/doc/changelog/02-changed/1641-ringunivpoly.md
+++ b/doc/changelog/02-changed/1641-ringunivpoly.md
@@ -1,0 +1,9 @@
+- in `ring_tactic.v`
+  + made `semiring_correct` and `ring_correct` universe polymorphic
+    ([#1641](https://github.com/math-comp/math-comp/pull/1641)).
+- in `field_tactic.v`
+  + made `field_correct` and `numfield_correct` universe polymorphic
+    ([#1641](https://github.com/math-comp/math-comp/pull/1641)).
+- in `arithmetic_tactic.v`
+  + made `BFormula_Q2Z ` universe polymorphic
+    ([#1641](https://github.com/math-comp/math-comp/pull/1641)).


### PR DESCRIPTION
##### Motivation for this change

Otherwise, they add additional universe constraints that break the use of CoqEAL (seqmx compiles but becomes unusable in validsdp).

Successfully tested on https://github.com/validsdp/validsdp/pull/40

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->
<!-- you can use tickboxes for clarity -->

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [x] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
