### PR TITLE
Fix the `Bind Scope` declaration for `Falgebra.sort`

### DIFF
--- a/field/falgebra.v
+++ b/field/falgebra.v
@@ -149,7 +149,7 @@ HB.builders Context K A & Algebra_isFalgebra K A.
 HB.end.
 
 Module FalgebraExports.
-Bind Scope ring_scope with sort.
+Bind Scope ring_scope with Falgebra.sort.
 End FalgebraExports.
 HB.export FalgebraExports.
 


### PR DESCRIPTION
##### Motivation for this change

If we write `sort` instead of `Falgebra.sort`, that refers to `path.sort`.

##### Minimal TODO list

<!-- please fill in the following checklist -->
- [ ] added changelog entries with `doc/changelog/make-entry.sh`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~
- [x] tried to abide by the [contribution guide](https://github.com/math-comp/math-comp/blob/master/CONTRIBUTING.md)
- [x] this PR contains an optimum number of meaningful commits

See [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) for details.

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs).
